### PR TITLE
feat(bkd): REST 客户端 + transport 开关（适配 BKD ≥0.0.65）

### DIFF
--- a/orchestrator/src/orchestrator/bkd.py
+++ b/orchestrator/src/orchestrator/bkd.py
@@ -1,21 +1,19 @@
-"""BKD MCP 客户端：JSON-RPC over Streamable HTTP / SSE。
+"""BKD client facade — 按 transport 选 REST 或 MCP 实现。
 
-封装常用 tools/call：create-issue / update-issue / follow-up-issue /
-list-issues / cancel-issue / get-issue。
+新版 BKD（≥0.0.65）废弃了 `/api/mcp` HTTP 端点，全部改走 REST
+（`/api/projects/:projectId/issues/...`）。老版本 MCP 客户端保留，
+通过 `SISYPHUS_BKD_TRANSPORT=mcp` 切回（用于回退或对接老 BKD 实例）。
+
+调用方继续 `from .bkd import BKDClient, Issue` — 接口签名不变。
 """
 from __future__ import annotations
 
-import json
-import re
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Union
 
-import httpx
-import structlog
-
-log = structlog.get_logger(__name__)
-
-# SSE event line: `data: {...}` — 抠出 JSON
-_SSE_DATA_RE = re.compile(r"^data:\s*(.+)$", re.MULTILINE)
+if TYPE_CHECKING:
+    from .bkd_mcp import BKDMcpClient
+    from .bkd_rest import BKDRestClient
 
 
 @dataclass
@@ -32,187 +30,8 @@ class Issue:
     updated_at: str | None = None
 
 
-class BKDClient:
-    """One client per webhook handling. SID 在 init() 拿到，后续 tools/call 复用。"""
-
-    def __init__(self, base_url: str, token: str):
-        self.base_url = base_url.rstrip("/")
-        self.token = token
-        self.session_id: str | None = None
-        self._http = httpx.AsyncClient(timeout=30.0)
-        self._req_id = 0
-
-    async def __aenter__(self) -> BKDClient:
-        await self.initialize()
-        return self
-
-    async def __aexit__(self, *exc) -> None:
-        await self._http.aclose()
-
-    async def initialize(self) -> None:
-        """MCP initialize → 拿 mcp-session-id 头。"""
-        r = await self._http.post(
-            f"{self.base_url}/mcp",
-            headers={
-                "Content-Type": "application/json",
-                "Accept": "application/json, text/event-stream",
-                "Coder-Session-Token": self.token,
-            },
-            json={
-                "jsonrpc": "2.0",
-                "id": self._next_id(),
-                "method": "initialize",
-                "params": {
-                    "protocolVersion": "2025-03-26",
-                    "capabilities": {},
-                    "clientInfo": {"name": "sisyphus-orchestrator", "version": "0.1"},
-                },
-            },
-        )
-        r.raise_for_status()
-        sid = r.headers.get("mcp-session-id")
-        if not sid:
-            raise RuntimeError("BKD MCP init returned no mcp-session-id")
-        self.session_id = sid
-        # 通知 initialized（必需，否则后续 tools/call 报 "not initialized"）
-        await self._http.post(
-            f"{self.base_url}/mcp",
-            headers=self._headers(),
-            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
-        )
-        log.debug("bkd.initialized", session_id=sid)
-
-    async def call(self, tool: str, arguments: dict) -> dict:
-        """tools/call 通用入口。返回 result.content[0].text 解 JSON 后的对象。"""
-        r = await self._http.post(
-            f"{self.base_url}/mcp",
-            headers=self._headers(),
-            json={
-                "jsonrpc": "2.0",
-                "id": self._next_id(),
-                "method": "tools/call",
-                "params": {"name": tool, "arguments": arguments},
-            },
-        )
-        r.raise_for_status()
-        return _parse_mcp_response(r.text)
-
-    # ─── 高阶包装 ──────────────────────────────────────────────────────────
-    async def list_issues(self, project_id: str, limit: int = 200) -> list[Issue]:
-        data = await self.call("list-issues", {"projectId": project_id, "limit": limit})
-        return [_to_issue(i) for i in data] if isinstance(data, list) else []
-
-    async def get_issue(self, project_id: str, issue_id: str) -> Issue:
-        data = await self.call("get-issue", {"projectId": project_id, "issueId": issue_id})
-        return _to_issue(data)
-
-    async def create_issue(
-        self,
-        project_id: str,
-        title: str,
-        tags: list[str],
-        status_id: str = "todo",
-        use_worktree: bool = False,
-    ) -> Issue:
-        data = await self.call("create-issue", {
-            "projectId": project_id,
-            "title": title,
-            "statusId": status_id,
-            "useWorktree": use_worktree,
-            "tags": tags,
-        })
-        return _to_issue(data)
-
-    async def update_issue(
-        self,
-        project_id: str,
-        issue_id: str,
-        *,
-        status_id: str | None = None,
-        tags: list[str] | None = None,
-        title: str | None = None,
-    ) -> Issue:
-        args: dict = {"projectId": project_id, "issueId": issue_id}
-        if status_id is not None:
-            args["statusId"] = status_id
-        if tags is not None:
-            args["tags"] = tags
-        if title is not None:
-            args["title"] = title
-        data = await self.call("update-issue", args)
-        return _to_issue(data)
-
-    async def follow_up_issue(self, project_id: str, issue_id: str, prompt: str) -> dict:
-        return await self.call("follow-up-issue", {
-            "projectId": project_id,
-            "issueId": issue_id,
-            "prompt": prompt,
-        })
-
-    async def cancel_issue(self, project_id: str, issue_id: str) -> dict:
-        return await self.call("cancel-issue", {"projectId": project_id, "issueId": issue_id})
-
-    async def merge_tags_and_update(
-        self,
-        project_id: str,
-        issue_id: str,
-        *,
-        add: list[str] | None = None,
-        remove: list[str] | None = None,
-        status_id: str | None = None,
-    ) -> Issue:
-        """get-issue → merge tags → update-issue。
-
-        BKD update-issue 的 tags 是 *替换* 语义。要保留其他 tag 必须先取再合再写。
-        """
-        cur = await self.get_issue(project_id, issue_id)
-        new_tags = list(cur.tags)
-        for t in remove or []:
-            while t in new_tags:
-                new_tags.remove(t)
-        for t in add or []:
-            if t not in new_tags:
-                new_tags.append(t)
-        return await self.update_issue(
-            project_id, issue_id, tags=new_tags, status_id=status_id,
-        )
-
-    # ─── 内部 ──────────────────────────────────────────────────────────────
-    def _headers(self) -> dict[str, str]:
-        h = {
-            "Content-Type": "application/json",
-            "Accept": "application/json, text/event-stream",
-            "Coder-Session-Token": self.token,
-        }
-        if self.session_id:
-            h["Mcp-Session-Id"] = self.session_id
-        return h
-
-    def _next_id(self) -> int:
-        self._req_id += 1
-        return self._req_id
-
-
-def _parse_mcp_response(body: str) -> dict | list:
-    """SSE event-stream → 取最后一个 data 块的 JSON-RPC envelope → result.content[0].text 解 JSON。"""
-    matches = _SSE_DATA_RE.findall(body)
-    if not matches:
-        raise ValueError(f"no SSE data line in response: {body[:200]!r}")
-    envelope = json.loads(matches[-1])
-    if "error" in envelope:
-        raise RuntimeError(f"BKD MCP error: {envelope['error']}")
-    result = envelope.get("result", {})
-    content = result.get("content")
-    if not content or not isinstance(content, list):
-        return result  # 非 content 形式，直接返回 result
-    text = content[0].get("text", "")
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        return {"text": text}  # 非 JSON 形式（少见）
-
-
 def _to_issue(d: dict) -> Issue:
+    """两个 transport 共用的反序列化（BKD issue dict → Issue dataclass）。"""
     return Issue(
         id=d["id"],
         project_id=d["projectId"],
@@ -225,3 +44,19 @@ def _to_issue(d: dict) -> Issue:
         created_at=d.get("createdAt"),
         updated_at=d.get("updatedAt") or d.get("statusUpdatedAt"),
     )
+
+
+def BKDClient(base_url: str, token: str, transport: str | None = None) -> Union["BKDRestClient", "BKDMcpClient"]:
+    """Factory：按 settings.bkd_transport 选 REST（默认）或 MCP。
+
+    显式 transport 参数优先（测试可覆盖）；否则查 config。
+    """
+    from .config import settings
+    t = transport or settings.bkd_transport
+    if t == "mcp":
+        from .bkd_mcp import BKDMcpClient
+        return BKDMcpClient(base_url, token)
+    if t == "rest":
+        from .bkd_rest import BKDRestClient
+        return BKDRestClient(base_url, token)
+    raise ValueError(f"Unknown BKD transport: {t!r} (use 'rest' or 'mcp')")

--- a/orchestrator/src/orchestrator/bkd.py
+++ b/orchestrator/src/orchestrator/bkd.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .bkd_mcp import BKDMcpClient
@@ -46,7 +46,7 @@ def _to_issue(d: dict) -> Issue:
     )
 
 
-def BKDClient(base_url: str, token: str, transport: str | None = None) -> Union["BKDRestClient", "BKDMcpClient"]:
+def BKDClient(base_url: str, token: str, transport: str | None = None) -> BKDRestClient | BKDMcpClient:
     """Factory：按 settings.bkd_transport 选 REST（默认）或 MCP。
 
     显式 transport 参数优先（测试可覆盖）；否则查 config。

--- a/orchestrator/src/orchestrator/bkd_mcp.py
+++ b/orchestrator/src/orchestrator/bkd_mcp.py
@@ -1,0 +1,201 @@
+"""BKD MCP 客户端（v1）：JSON-RPC over Streamable HTTP / SSE。
+
+封装常用 tools/call：create-issue / update-issue / follow-up-issue /
+list-issues / cancel-issue / get-issue。
+
+适配 BKD <0.0.65 的版本（带 `/api/mcp` 端点）。新版本走 bkd_rest.BKDRestClient。
+"""
+from __future__ import annotations
+
+import json
+import re
+
+import httpx
+import structlog
+
+from .bkd import Issue, _to_issue
+
+log = structlog.get_logger(__name__)
+
+# SSE event line: `data: {...}` — 抠出 JSON
+_SSE_DATA_RE = re.compile(r"^data:\s*(.+)$", re.MULTILINE)
+
+
+class BKDMcpClient:
+    """One client per webhook handling. SID 在 init() 拿到，后续 tools/call 复用。"""
+
+    def __init__(self, base_url: str, token: str):
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.session_id: str | None = None
+        self._http = httpx.AsyncClient(timeout=30.0)
+        self._req_id = 0
+
+    async def __aenter__(self) -> BKDMcpClient:
+        await self.initialize()
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        await self._http.aclose()
+
+    async def initialize(self) -> None:
+        """MCP initialize → 拿 mcp-session-id 头。"""
+        r = await self._http.post(
+            f"{self.base_url}/mcp",
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+                "Coder-Session-Token": self.token,
+            },
+            json={
+                "jsonrpc": "2.0",
+                "id": self._next_id(),
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "sisyphus-orchestrator", "version": "0.1"},
+                },
+            },
+        )
+        r.raise_for_status()
+        sid = r.headers.get("mcp-session-id")
+        if not sid:
+            raise RuntimeError("BKD MCP init returned no mcp-session-id")
+        self.session_id = sid
+        # 通知 initialized（必需，否则后续 tools/call 报 "not initialized"）
+        await self._http.post(
+            f"{self.base_url}/mcp",
+            headers=self._headers(),
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+        log.debug("bkd.initialized", session_id=sid)
+
+    async def call(self, tool: str, arguments: dict) -> dict:
+        """tools/call 通用入口。返回 result.content[0].text 解 JSON 后的对象。"""
+        r = await self._http.post(
+            f"{self.base_url}/mcp",
+            headers=self._headers(),
+            json={
+                "jsonrpc": "2.0",
+                "id": self._next_id(),
+                "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments},
+            },
+        )
+        r.raise_for_status()
+        return _parse_mcp_response(r.text)
+
+    # ─── 高阶包装 ──────────────────────────────────────────────────────────
+    async def list_issues(self, project_id: str, limit: int = 200) -> list[Issue]:
+        data = await self.call("list-issues", {"projectId": project_id, "limit": limit})
+        return [_to_issue(i) for i in data] if isinstance(data, list) else []
+
+    async def get_issue(self, project_id: str, issue_id: str) -> Issue:
+        data = await self.call("get-issue", {"projectId": project_id, "issueId": issue_id})
+        return _to_issue(data)
+
+    async def create_issue(
+        self,
+        project_id: str,
+        title: str,
+        tags: list[str],
+        status_id: str = "todo",
+        use_worktree: bool = False,
+    ) -> Issue:
+        data = await self.call("create-issue", {
+            "projectId": project_id,
+            "title": title,
+            "statusId": status_id,
+            "useWorktree": use_worktree,
+            "tags": tags,
+        })
+        return _to_issue(data)
+
+    async def update_issue(
+        self,
+        project_id: str,
+        issue_id: str,
+        *,
+        status_id: str | None = None,
+        tags: list[str] | None = None,
+        title: str | None = None,
+    ) -> Issue:
+        args: dict = {"projectId": project_id, "issueId": issue_id}
+        if status_id is not None:
+            args["statusId"] = status_id
+        if tags is not None:
+            args["tags"] = tags
+        if title is not None:
+            args["title"] = title
+        data = await self.call("update-issue", args)
+        return _to_issue(data)
+
+    async def follow_up_issue(self, project_id: str, issue_id: str, prompt: str) -> dict:
+        return await self.call("follow-up-issue", {
+            "projectId": project_id,
+            "issueId": issue_id,
+            "prompt": prompt,
+        })
+
+    async def cancel_issue(self, project_id: str, issue_id: str) -> dict:
+        return await self.call("cancel-issue", {"projectId": project_id, "issueId": issue_id})
+
+    async def merge_tags_and_update(
+        self,
+        project_id: str,
+        issue_id: str,
+        *,
+        add: list[str] | None = None,
+        remove: list[str] | None = None,
+        status_id: str | None = None,
+    ) -> Issue:
+        """get-issue → merge tags → update-issue。
+
+        BKD update-issue 的 tags 是 *替换* 语义。要保留其他 tag 必须先取再合再写。
+        """
+        cur = await self.get_issue(project_id, issue_id)
+        new_tags = list(cur.tags)
+        for t in remove or []:
+            while t in new_tags:
+                new_tags.remove(t)
+        for t in add or []:
+            if t not in new_tags:
+                new_tags.append(t)
+        return await self.update_issue(
+            project_id, issue_id, tags=new_tags, status_id=status_id,
+        )
+
+    # ─── 内部 ──────────────────────────────────────────────────────────────
+    def _headers(self) -> dict[str, str]:
+        h = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            "Coder-Session-Token": self.token,
+        }
+        if self.session_id:
+            h["Mcp-Session-Id"] = self.session_id
+        return h
+
+    def _next_id(self) -> int:
+        self._req_id += 1
+        return self._req_id
+
+
+def _parse_mcp_response(body: str) -> dict | list:
+    """SSE event-stream → 取最后一个 data 块的 JSON-RPC envelope → result.content[0].text 解 JSON。"""
+    matches = _SSE_DATA_RE.findall(body)
+    if not matches:
+        raise ValueError(f"no SSE data line in response: {body[:200]!r}")
+    envelope = json.loads(matches[-1])
+    if "error" in envelope:
+        raise RuntimeError(f"BKD MCP error: {envelope['error']}")
+    result = envelope.get("result", {})
+    content = result.get("content")
+    if not content or not isinstance(content, list):
+        return result  # 非 content 形式，直接返回 result
+    text = content[0].get("text", "")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return {"text": text}  # 非 JSON 形式（少见）

--- a/orchestrator/src/orchestrator/bkd_rest.py
+++ b/orchestrator/src/orchestrator/bkd_rest.py
@@ -1,0 +1,164 @@
+"""BKD REST 客户端（v2）：纯 HTTP，配套 BKD ≥0.0.65。
+
+新版 BKD 不再暴露 `/api/mcp` MCP HTTP 端点（仍然有本地 stdio MCP，给本地工具用）。
+所有操作改走 `/api/projects/:projectId/issues/...` REST 端点，response 走
+`{success, data} | {success: false, error}` 信封。
+
+接口签名与 BKDMcpClient 对齐，调用方零修改即可切换。
+"""
+from __future__ import annotations
+
+import httpx
+import structlog
+
+from .bkd import Issue, _to_issue
+
+log = structlog.get_logger(__name__)
+
+
+class BKDRestClient:
+    """REST 客户端。无 session，每次请求带 Coder-Session-Token header。"""
+
+    def __init__(self, base_url: str, token: str):
+        # base_url 形如 https://.../api（与 MCP 客户端共用 config）
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self._http = httpx.AsyncClient(timeout=30.0)
+
+    async def __aenter__(self) -> BKDRestClient:
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        await self._http.aclose()
+
+    async def initialize(self) -> None:
+        """No-op — REST 没有 init 握手。保留方法供与 MCP 客户端互换调用。"""
+        return
+
+    # ─── 高阶包装（与 BKDMcpClient 同签名）────────────────────────────────
+    async def list_issues(self, project_id: str, limit: int = 200) -> list[Issue]:
+        data = await self._get(f"/projects/{project_id}/issues")
+        if not isinstance(data, list):
+            return []
+        return [_to_issue(i) for i in data[:limit]]
+
+    async def get_issue(self, project_id: str, issue_id: str) -> Issue:
+        data = await self._get(f"/projects/{project_id}/issues/{issue_id}")
+        return _to_issue(data)
+
+    async def create_issue(
+        self,
+        project_id: str,
+        title: str,
+        tags: list[str],
+        status_id: str = "todo",
+        use_worktree: bool = False,
+        engine_type: str | None = None,
+        model: str | None = None,
+    ) -> Issue:
+        body: dict = {
+            "title": title,
+            "statusId": status_id,
+            "useWorktree": use_worktree,
+            "tags": tags,
+        }
+        if engine_type:
+            body["engineType"] = engine_type
+        if model:
+            body["model"] = model
+        data = await self._post(f"/projects/{project_id}/issues", body)
+        return _to_issue(data)
+
+    async def update_issue(
+        self,
+        project_id: str,
+        issue_id: str,
+        *,
+        status_id: str | None = None,
+        tags: list[str] | None = None,
+        title: str | None = None,
+    ) -> Issue:
+        body: dict = {}
+        if status_id is not None:
+            body["statusId"] = status_id
+        if tags is not None:
+            body["tags"] = tags
+        if title is not None:
+            body["title"] = title
+        if not body:
+            # 没东西要改，直接 get 返回当前
+            return await self.get_issue(project_id, issue_id)
+        data = await self._patch(f"/projects/{project_id}/issues/{issue_id}", body)
+        return _to_issue(data)
+
+    async def follow_up_issue(
+        self,
+        project_id: str,
+        issue_id: str,
+        prompt: str,
+    ) -> dict:
+        return await self._post(
+            f"/projects/{project_id}/issues/{issue_id}/follow-up",
+            {"prompt": prompt},
+        )
+
+    async def cancel_issue(self, project_id: str, issue_id: str) -> dict:
+        return await self._post(
+            f"/projects/{project_id}/issues/{issue_id}/cancel",
+            {},
+        )
+
+    async def merge_tags_and_update(
+        self,
+        project_id: str,
+        issue_id: str,
+        *,
+        add: list[str] | None = None,
+        remove: list[str] | None = None,
+        status_id: str | None = None,
+    ) -> Issue:
+        """get_issue → 合 tags → update_issue。BKD update tags 是替换语义，必须先取再合。"""
+        cur = await self.get_issue(project_id, issue_id)
+        new_tags = list(cur.tags)
+        for t in remove or []:
+            while t in new_tags:
+                new_tags.remove(t)
+        for t in add or []:
+            if t not in new_tags:
+                new_tags.append(t)
+        return await self.update_issue(
+            project_id, issue_id, tags=new_tags, status_id=status_id,
+        )
+
+    # ─── 内部 ──────────────────────────────────────────────────────────────
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Content-Type": "application/json",
+            "Coder-Session-Token": self.token,
+        }
+
+    async def _get(self, path: str) -> dict | list:
+        r = await self._http.get(f"{self.base_url}{path}", headers=self._headers())
+        return _unwrap(r)
+
+    async def _post(self, path: str, body: dict) -> dict | list:
+        r = await self._http.post(f"{self.base_url}{path}", headers=self._headers(), json=body)
+        return _unwrap(r)
+
+    async def _patch(self, path: str, body: dict) -> dict | list:
+        r = await self._http.patch(f"{self.base_url}{path}", headers=self._headers(), json=body)
+        return _unwrap(r)
+
+
+def _unwrap(r: httpx.Response) -> dict | list:
+    """剥 BKD REST 信封：{success: true, data} | {success: false, error}。"""
+    try:
+        payload = r.json()
+    except Exception as e:
+        r.raise_for_status()  # 先看是不是 HTTP 错
+        raise RuntimeError(f"BKD REST: response not JSON: {r.text[:200]!r}") from e
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"BKD REST: unexpected response type {type(payload).__name__}")
+    if not payload.get("success"):
+        raise RuntimeError(f"BKD REST error ({r.status_code}): {payload.get('error', 'unknown')}")
+    return payload.get("data")

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -15,6 +15,8 @@ class Settings(BaseSettings):
     # BKD
     bkd_base_url: str = "https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/api"
     bkd_token: str = Field(..., description="Coder-Session-Token")
+    # transport: 'rest'（BKD ≥0.0.65 默认）/ 'mcp'（老版本，带 /api/mcp 端点）
+    bkd_transport: str = "rest"
 
     # 入站 webhook 共享 token（BKD webhook 配置里加 `Authorization: Bearer <token>` header）
     webhook_token: str = Field(..., description="Bearer token expected in Authorization header on /bkd-events")

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -357,7 +357,8 @@ async def test_create_accept_skipped(monkeypatch):
 # ─── 重要：BKD merge_tags_and_update 的 tag merge 逻辑 ─────────────────────
 @pytest.mark.asyncio
 async def test_bkd_merge_tags_preserves(monkeypatch):
-    from orchestrator.bkd import BKDClient
+    # 直接拿具体实现 class — merge_tags_and_update 在 REST/MCP 两侧逻辑一致，任挑一个测
+    from orchestrator.bkd_rest import BKDRestClient
 
     captured = {}
 
@@ -368,9 +369,9 @@ async def test_bkd_merge_tags_preserves(monkeypatch):
         captured.update(kw)
         return FakeIssue(id=issue_id, tags=kw.get("tags", []))
 
-    monkeypatch.setattr(BKDClient, "get_issue", fake_get_issue)
-    monkeypatch.setattr(BKDClient, "update_issue", fake_update_issue)
-    bkd = BKDClient.__new__(BKDClient)
+    monkeypatch.setattr(BKDRestClient, "get_issue", fake_get_issue)
+    monkeypatch.setattr(BKDRestClient, "update_issue", fake_update_issue)
+    bkd = BKDRestClient.__new__(BKDRestClient)
     await bkd.merge_tags_and_update(
         "p", "i1", add=["ci-passed"], remove=["existing"], status_id="done",
     )

--- a/orchestrator/tests/test_bkd_parser.py
+++ b/orchestrator/tests/test_bkd_parser.py
@@ -5,7 +5,8 @@ import json
 
 import pytest
 
-from orchestrator.bkd import _parse_mcp_response, _to_issue
+from orchestrator.bkd import _to_issue
+from orchestrator.bkd_mcp import _parse_mcp_response
 
 
 def _sse(envelope: dict) -> str:

--- a/orchestrator/tests/test_bkd_rest.py
+++ b/orchestrator/tests/test_bkd_rest.py
@@ -1,0 +1,186 @@
+"""BKDRestClient 单测：URL 拼接 + payload 形状 + envelope 解析。"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from orchestrator.bkd_rest import BKDRestClient, _unwrap
+
+
+def _resp(status: int, body: dict | list) -> httpx.Response:
+    return httpx.Response(status_code=status, text=json.dumps({"success": status < 400, "data": body}) if status < 400 else json.dumps({"success": False, "error": body}))
+
+
+def test_unwrap_success():
+    r = httpx.Response(200, text='{"success":true,"data":{"id":"x"}}')
+    assert _unwrap(r) == {"id": "x"}
+
+
+def test_unwrap_failure_raises():
+    r = httpx.Response(400, text='{"success":false,"error":"boom"}')
+    with pytest.raises(RuntimeError, match="boom"):
+        _unwrap(r)
+
+
+def test_unwrap_non_json_raises():
+    r = httpx.Response(500, text="<html>oops</html>")
+    with pytest.raises(Exception):
+        _unwrap(r)
+
+
+@pytest.mark.asyncio
+async def test_create_issue_payload_shape(monkeypatch):
+    """create_issue 应该 POST 到 /projects/{pid}/issues 带 title/statusId/tags/useWorktree。"""
+    captured = {}
+
+    class FakeHttp:
+        async def post(self, url, headers=None, json=None):
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["json"] = json
+            return httpx.Response(
+                201,
+                text='{"success":true,"data":{"id":"new-1","projectId":"p","issueNumber":1,"title":"t","statusId":"todo","tags":["a"]}}',
+            )
+
+        async def get(self, url, headers=None):
+            return httpx.Response(404, text='{"success":false,"error":"nope"}')
+
+        async def patch(self, url, headers=None, json=None):
+            return httpx.Response(404, text='{"success":false,"error":"nope"}')
+
+        async def aclose(self):
+            pass
+
+    client = BKDRestClient("https://bkd.example/api", "tok123")
+    client._http = FakeHttp()  # type: ignore[assignment]
+
+    issue = await client.create_issue(
+        "myproj", "Add /version", ["intent:analyze", "REQ-1"],
+    )
+
+    assert captured["url"] == "https://bkd.example/api/projects/myproj/issues"
+    assert captured["headers"]["Coder-Session-Token"] == "tok123"
+    assert captured["json"] == {
+        "title": "Add /version",
+        "statusId": "todo",
+        "useWorktree": False,
+        "tags": ["intent:analyze", "REQ-1"],
+    }
+    assert issue.id == "new-1"
+
+
+@pytest.mark.asyncio
+async def test_create_issue_with_engine_and_model():
+    """显式 engine_type + model 透传到 BKD。"""
+    captured = {}
+
+    class FakeHttp:
+        async def post(self, url, headers=None, json=None):
+            captured["json"] = json
+            return httpx.Response(
+                201,
+                text='{"success":true,"data":{"id":"new-1","projectId":"p","issueNumber":1,"title":"t","statusId":"todo","tags":[]}}',
+            )
+
+        async def aclose(self):
+            pass
+
+    client = BKDRestClient("https://bkd.example/api", "tok")
+    client._http = FakeHttp()  # type: ignore[assignment]
+    await client.create_issue(
+        "p", "T", [], engine_type="claude-code", model="claude-haiku-4-5",
+    )
+    assert captured["json"]["engineType"] == "claude-code"
+    assert captured["json"]["model"] == "claude-haiku-4-5"
+
+
+@pytest.mark.asyncio
+async def test_update_issue_only_sends_provided_fields():
+    captured = {}
+
+    class FakeHttp:
+        async def patch(self, url, headers=None, json=None):
+            captured["url"] = url
+            captured["json"] = json
+            return httpx.Response(
+                200,
+                text='{"success":true,"data":{"id":"i1","projectId":"p","issueNumber":1,"title":"x","statusId":"working","tags":["a"]}}',
+            )
+
+        async def aclose(self):
+            pass
+
+    client = BKDRestClient("https://bkd.example/api", "tok")
+    client._http = FakeHttp()  # type: ignore[assignment]
+    await client.update_issue("p", "i1", status_id="working")
+
+    assert captured["url"] == "https://bkd.example/api/projects/p/issues/i1"
+    assert captured["json"] == {"statusId": "working"}
+
+
+@pytest.mark.asyncio
+async def test_follow_up_issue_url_and_body():
+    captured = {}
+
+    class FakeHttp:
+        async def post(self, url, headers=None, json=None):
+            captured["url"] = url
+            captured["json"] = json
+            return httpx.Response(200, text='{"success":true,"data":{"executionId":"e1"}}')
+
+        async def aclose(self):
+            pass
+
+    client = BKDRestClient("https://bkd.example/api", "tok")
+    client._http = FakeHttp()  # type: ignore[assignment]
+    out = await client.follow_up_issue("p", "i1", "more details")
+
+    assert captured["url"] == "https://bkd.example/api/projects/p/issues/i1/follow-up"
+    assert captured["json"] == {"prompt": "more details"}
+    assert out == {"executionId": "e1"}
+
+
+@pytest.mark.asyncio
+async def test_cancel_issue_posts_to_cancel_endpoint():
+    captured = {}
+
+    class FakeHttp:
+        async def post(self, url, headers=None, json=None):
+            captured["url"] = url
+            return httpx.Response(200, text='{"success":true,"data":{"issueId":"i1","status":"cancelled"}}')
+
+        async def aclose(self):
+            pass
+
+    client = BKDRestClient("https://bkd.example/api", "tok")
+    client._http = FakeHttp()  # type: ignore[assignment]
+    out = await client.cancel_issue("p", "i1")
+    assert captured["url"] == "https://bkd.example/api/projects/p/issues/i1/cancel"
+    assert out["status"] == "cancelled"
+
+
+def test_factory_picks_rest_by_default(monkeypatch):
+    """BKDClient(...) 默认应返回 REST 实例（settings.bkd_transport 默认 'rest'）。"""
+    from orchestrator.bkd import BKDClient
+    from orchestrator.bkd_rest import BKDRestClient
+
+    c = BKDClient("https://bkd.example/api", "tok")
+    assert isinstance(c, BKDRestClient)
+
+
+def test_factory_explicit_mcp():
+    """显式 transport='mcp' 应返回 MCP 客户端。"""
+    from orchestrator.bkd import BKDClient
+    from orchestrator.bkd_mcp import BKDMcpClient
+
+    c = BKDClient("https://bkd.example/api", "tok", transport="mcp")
+    assert isinstance(c, BKDMcpClient)
+
+
+def test_factory_unknown_transport_raises():
+    from orchestrator.bkd import BKDClient
+    with pytest.raises(ValueError, match="Unknown BKD transport"):
+        BKDClient("https://bkd.example/api", "tok", transport="grpc")

--- a/orchestrator/tests/test_bkd_rest.py
+++ b/orchestrator/tests/test_bkd_rest.py
@@ -25,8 +25,10 @@ def test_unwrap_failure_raises():
 
 
 def test_unwrap_non_json_raises():
-    r = httpx.Response(500, text="<html>oops</html>")
-    with pytest.raises(Exception):
+    # 500 + 非 JSON：_unwrap 先 try .json() 失败，再 raise_for_status() → HTTPStatusError
+    req = httpx.Request("GET", "https://example/api/x")
+    r = httpx.Response(500, text="<html>oops</html>", request=req)
+    with pytest.raises(httpx.HTTPStatusError):
         _unwrap(r)
 
 


### PR DESCRIPTION
## 背景

新版 BKD（≥0.0.65 / commit f983eb7）废弃了 `/api/mcp` HTTP 端点，全部走 REST（`/api/projects/:projectId/issues/...`）。
现 sisyphus orch 调 BKD 100% 失败 — webhook 收到后 `_push_upstream_done`、`get_issue`、所有 `create_issue` 都 404。

实测路径：
- `GET /api/health` → 200 + `version: 0.0.65`
- `GET /api/projects/{alias}` → 200 ✓ REST 干净
- `POST /api/mcp` 任何变种 → 404

本地 stdio MCP 还在（`mcp__bkd__*` 走的就是它），跟 sisyphus 远程调用是两码事。

## 改动

- 新增 `bkd_rest.BKDRestClient`：纯 REST，对齐 MCP 客户端方法签名，调用方零修改。
- 现 `bkd.BKDClient` 重命名为 `bkd_mcp.BKDMcpClient`（保留 v1）。
- 新 `bkd.BKDClient` 是 factory，按 `SISYPHUS_BKD_TRANSPORT` 选 transport（默认 `rest`，可设 `mcp` 回退）。
- `bkd.Issue` + `_to_issue` 提到 facade 层共享。
- `create_issue` 加可选 `engine_type` + `model` 参数（REST 端，给后面强制走 haiku 测试做准备；MCP 端不改）。

## 测试

- 全套 170 tests pass（含新增 `test_bkd_rest.py` 11 例）
- Factory 行为：默认 → REST，`transport='mcp'` → MCP，未知 → ValueError
- URL/payload 形状对齐 BKD `/apps/api/src/routes/issues/` 的 zod schema
- `merge_tags_and_update` 测试改成测 BKDRestClient（两侧逻辑一致）

## 部署

合并到 main 后：
1. CI build + push GHCR `:main`
2. vm-node04 `kubectl rollout restart deploy/orch-sisyphus-orchestrator`（默认 `bkd_transport=rest` 自动生效）
3. 回退：`kubectl set env ... SISYPHUS_BKD_TRANSPORT=mcp`（如果发现新 client 有 bug）

## Test plan

- [ ] CI lint/test 全绿
- [ ] vm-node04 rollout 后 healthz=200，启动日志无错
- [ ] 在 test_mode 下重发 intent webhook，状态机一路 skip 到 done（含 `teardown_accept_env`，之前在 MCP 调用 404）
- [ ] 关 test_mode，触发真 intent，看 `start_analyze` 能成功 create BKD issue