### PR TITLE
refactor(start_analyze): 标题改用 short_title 与下游 stage 统一

### DIFF
--- a/orchestrator/src/orchestrator/actions/start_analyze.py
+++ b/orchestrator/src/orchestrator/actions/start_analyze.py
@@ -5,7 +5,7 @@ kubectl exec 进去能立刻用。Pod 生命周期绑本 REQ 直到 done/escalat
 
 行为：
 1. ensure_runner（K8s：建 PVC + Pod，等 Ready）
-2. update-issue 把 intent issue 改名 [REQ-xxx] [ANALYZE] xxx + tags=[analyze, REQ-xxx]
+2. update-issue 把 intent issue 改名 [REQ-xxx] [ANALYZE] — <title> + tags=[analyze, REQ-xxx]
 3. follow-up-issue 发 analyze prompt
 4. update-issue statusId=working 触发 agent
 """
@@ -18,7 +18,7 @@ from ..bkd import BKDClient
 from ..config import settings
 from ..prompts import render
 from ..state import Event
-from . import register
+from . import register, short_title
 from ._skip import skip_if_enabled
 
 log = structlog.get_logger(__name__)
@@ -30,7 +30,6 @@ async def start_analyze(*, body, req_id, tags, ctx):
         return rv
     proj = body.projectId
     issue_id = body.issueId
-    raw_title = body.title or ""   # 用户创建 intent 时输入的原文
 
     # 1. 拉 K8s Pod + PVC（幂等；已存在就跳）
     try:
@@ -47,7 +46,7 @@ async def start_analyze(*, body, req_id, tags, ctx):
         await bkd.update_issue(
             project_id=proj,
             issue_id=issue_id,
-            title=f"[{req_id}] [ANALYZE] {raw_title}",
+            title=f"[{req_id}] [ANALYZE]{short_title(ctx)}",
             tags=["analyze", req_id],
         )
         prompt = render("analyze.md.j2", req_id=req_id)

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -78,6 +78,37 @@ async def test_start_analyze(monkeypatch):
     assert fake.follow_up_issue.await_count == 1
 
 
+@pytest.mark.asyncio
+async def test_start_analyze_title_format(monkeypatch):
+    """验证 start_analyze 标题使用 short_title 格式（ — 分隔 + 截断）。"""
+    from orchestrator.actions import start_analyze as mod
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, "start_analyze", fake)
+
+    # 场景1：有 intent_title，长度正常
+    body = make_body(issue_id="intent-1", title="加个登录端点")
+    ctx = {"intent_title": "加个登录端点"}
+    await mod.start_analyze(body=body, req_id="REQ-9", tags=["intent:analyze"], ctx=ctx)
+    _, kwargs = fake.update_issue.call_args_list[0]
+    assert kwargs["title"] == "[REQ-9] [ANALYZE] — 加个登录端点"
+
+    # 场景2：intent_title 超过 50 字符，需要截断 + 省略号
+    long_title = "a" * 60
+    ctx = {"intent_title": long_title}
+    await mod.start_analyze(body=body, req_id="REQ-10", tags=["intent:analyze"], ctx=ctx)
+    _, kwargs = fake.update_issue.call_args_list[2]
+    title = kwargs["title"]
+    assert title.startswith("[REQ-10] [ANALYZE] — ")
+    assert "…" in title
+    assert len(title) < 100  # 合理长度
+
+    # 场景3：ctx 为空，标题应该只有 [REQ-xx] [ANALYZE] 部分
+    ctx = {}
+    await mod.start_analyze(body=body, req_id="REQ-11", tags=["intent:analyze"], ctx=ctx)
+    _, kwargs = fake.update_issue.call_args_list[4]
+    assert kwargs["title"] == "[REQ-11] [ANALYZE]"
+
+
 # ─── fanout_specs ────────────────────────────────────────────────────────
 @pytest.mark.asyncio
 async def test_fanout_specs_creates_two(monkeypatch):


### PR DESCRIPTION
## 背景

BKD 看板上 sisyphus 各 stage issue 标题格式不统一：
- `start_analyze`: `[REQ] [ANALYZE] {raw_title}` — 直接拼，无 — 分隔，无截断
- 其他 action: `[REQ] [stage]{short_title(ctx)}` — 带 ` — ` 分隔，截 50 字符

详见 BKD issue #10（项目 ttposhwt）。

## 改动

- `start_analyze.py`: title 改用 `f"[{req_id}] [ANALYZE]{short_title(ctx)}"`，与下游一致
- 删未用变量 `raw_title`（ctx.intent_title 已经是 raw_title 来源）
- 测试补 3 场景：正常、超长截断、ctx 空

## 测试

- 171 tests pass
- ruff clean

## Test plan

- [ ] CI lint/test 全绿
- [ ] 部署后跑一个真 intent，看 BKD 看板上 ANALYZE issue 标题与 spec/dev 风格一致

🤖 由 BKD agent #10 (haiku) 完成主要改动