### PR TITLE
feat(checker): M1 staging-test 自检 (artifact-driven 重构第一步)

### DIFF
--- a/orchestrator/migrations/0003_artifact_checks.rollback.sql
+++ b/orchestrator/migrations/0003_artifact_checks.rollback.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS artifact_checks;

--- a/orchestrator/migrations/0003_artifact_checks.sql
+++ b/orchestrator/migrations/0003_artifact_checks.sql
@@ -1,0 +1,18 @@
+-- artifact_checks：记录 sisyphus 自检结果（M1 staging-test，后续扩 pr-ci-watch 等）。
+-- 用于 watchdog / audit，不影响主状态机（主状态机靠 emit event 驱动）。
+
+CREATE TABLE IF NOT EXISTS artifact_checks (
+    id              BIGSERIAL PRIMARY KEY,
+    req_id          TEXT NOT NULL,
+    stage           TEXT NOT NULL,
+    passed          BOOLEAN NOT NULL,
+    exit_code       INT,
+    cmd             TEXT,
+    stdout_tail     TEXT,
+    stderr_tail     TEXT,
+    duration_sec    REAL,
+    checked_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_artifact_checks_req ON artifact_checks(req_id);
+CREATE INDEX IF NOT EXISTS idx_artifact_checks_stage ON artifact_checks(stage, checked_at DESC);

--- a/orchestrator/src/orchestrator/actions/create_staging_test.py
+++ b/orchestrator/src/orchestrator/actions/create_staging_test.py
@@ -1,22 +1,25 @@
-"""create_staging_test（v0.2）：dev.done 后下发 staging-test BKD agent。
+"""create_staging_test（v0.2 + M1 checker）：dev.done 后验 staging 测试。
 
-staging-test 在调试环境（sisyphus-runners Pod）跑 unit + integration test。
-按 manifest.sources 遍历，每个 source repo 跑 make ci-lint / ci-unit-test /
-ci-integration-test。全绿 → result:pass；任一红 → result:fail + bug:pre-release。
+feature flag checker_staging_test_enabled:
+  False（默认）: 创建 BKD agent issue（老路，保证老行为不破）
+  True: sisyphus 自己在 runner pod 执行测试，根据退出码 emit STAGING_TEST_PASS/FAIL
 """
 from __future__ import annotations
 
 import structlog
 
 from ..bkd import BKDClient
+from ..checkers import staging_test as checker
 from ..config import settings
 from ..prompts import render
 from ..state import Event
-from ..store import db, req_state
+from ..store import artifact_checks, db, req_state
 from . import register, short_title
 from ._skip import skip_if_enabled
 
 log = structlog.get_logger(__name__)
+
+_TEST_CMD = "make test"   # M1 硬编码；M3 改成读 PVC manifest.yaml
 
 
 @register("create_staging_test")
@@ -24,8 +27,58 @@ async def create_staging_test(*, body, req_id, tags, ctx):
     if rv := skip_if_enabled("staging-test", Event.STAGING_TEST_PASS, req_id=req_id):
         return rv
 
+    if settings.checker_staging_test_enabled:
+        return await _run_checker(req_id=req_id)
+
+    return await _dispatch_bkd_agent(body=body, req_id=req_id, ctx=ctx)
+
+
+# ── 新路：sisyphus 自检 ────────────────────────────────────────────────────
+
+async def _run_checker(*, req_id: str) -> dict:
+    log.info("create_staging_test.checker_path", req_id=req_id, cmd=_TEST_CMD)
+
+    try:
+        result = await checker.run_staging_test(req_id, _TEST_CMD)
+    except TimeoutError:
+        log.error("create_staging_test.checker_timeout", req_id=req_id)
+        return {
+            "emit": Event.STAGING_TEST_FAIL.value,
+            "reason": "timeout",
+            "exit_code": -1,
+            "cmd": _TEST_CMD,
+        }
+    except Exception as e:
+        log.exception("create_staging_test.checker_error", req_id=req_id, error=str(e))
+        return {
+            "emit": Event.STAGING_TEST_FAIL.value,
+            "reason": str(e)[:200],
+            "exit_code": -1,
+            "cmd": _TEST_CMD,
+        }
+
+    pool = db.get_pool()
+    await artifact_checks.insert_check(pool, req_id, "staging-test", result)
+
+    emit = Event.STAGING_TEST_PASS if result.passed else Event.STAGING_TEST_FAIL
+    log.info("create_staging_test.checker_done", req_id=req_id,
+             passed=result.passed, exit_code=result.exit_code,
+             duration_sec=round(result.duration_sec, 1))
+
+    return {
+        "emit": emit.value,
+        "passed": result.passed,
+        "exit_code": result.exit_code,
+        "cmd": result.cmd,
+        "duration_sec": result.duration_sec,
+    }
+
+
+# ── 老路：BKD agent（flag off 时走这里）────────────────────────────────────
+
+async def _dispatch_bkd_agent(*, body, req_id: str, ctx: dict) -> dict:
     proj = body.projectId
-    source_issue_id = body.issueId   # 上游 dev issue（只读参考）
+    source_issue_id = body.issueId
 
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         issue = await bkd.create_issue(
@@ -45,5 +98,5 @@ async def create_staging_test(*, body, req_id, tags, ctx):
     pool = db.get_pool()
     await req_state.update_context(pool, req_id, {"staging_test_issue_id": issue.id})
 
-    log.info("create_staging_test.done", req_id=req_id, staging_issue=issue.id)
+    log.info("create_staging_test.bkd_agent_dispatched", req_id=req_id, staging_issue=issue.id)
     return {"staging_test_issue_id": issue.id}

--- a/orchestrator/src/orchestrator/checkers/__init__.py
+++ b/orchestrator/src/orchestrator/checkers/__init__.py
@@ -1,0 +1,1 @@
+"""Artifact-driven checkers：sisyphus 自己判断 stage 结果，不依赖 agent 自报。"""

--- a/orchestrator/src/orchestrator/checkers/staging_test.py
+++ b/orchestrator/src/orchestrator/checkers/staging_test.py
@@ -1,0 +1,60 @@
+"""staging-test 自检（M1）：sisyphus 在 runner pod 直接跑测试命令，收退出码决定 pass/fail。
+
+不起 BKD agent，不靠 result:pass tag，sisyphus 是唯一裁判。
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import structlog
+
+from .. import k8s_runner
+
+log = structlog.get_logger(__name__)
+
+_TAIL = 2048  # stdout/stderr 各截尾 2KB，防 OOM
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    passed: bool
+    exit_code: int
+    stdout_tail: str
+    stderr_tail: str
+    duration_sec: float
+    cmd: str
+
+
+async def run_staging_test(
+    req_id: str,
+    test_cmd: str,
+    timeout_sec: int = 600,
+) -> CheckResult:
+    """在 runner pod 里执行 test_cmd，收集结果。
+
+    timeout_sec 超时时抛 asyncio.TimeoutError（由 create_staging_test action 捕获）。
+    """
+    rc = k8s_runner.get_controller()
+    log.info("checker.staging_test.start", req_id=req_id, cmd=test_cmd, timeout=timeout_sec)
+
+    result = await asyncio.wait_for(
+        rc.exec_in_runner(req_id, test_cmd, timeout_sec=timeout_sec),
+        timeout=timeout_sec + 10,  # 比内部 deadline 多 10s，确保内部先超时返 -1
+    )
+
+    passed = result.exit_code == 0
+    log.info(
+        "checker.staging_test.done",
+        req_id=req_id, passed=passed, exit_code=result.exit_code,
+        duration_sec=round(result.duration_sec, 1),
+    )
+
+    return CheckResult(
+        passed=passed,
+        exit_code=result.exit_code,
+        stdout_tail=result.stdout[-_TAIL:],
+        stderr_tail=result.stderr[-_TAIL:],
+        duration_sec=result.duration_sec,
+        cmd=test_cmd,
+    )

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -88,5 +88,10 @@ class Settings(BaseSettings):
     # 全部 skip = 状态机几秒走完，验 transition + cleanup，不动 BKD agent
     test_mode: bool = False           # 等价于全部 skip_* = true
 
+    # ─── artifact-driven checker 开关（M1 灰度） ──────────────────────────
+    # True = staging-test 由 sisyphus 自己 kubectl exec 跑，不再起 BKD agent
+    # False（默认）= 走老路，创建 BKD agent issue（回滚：unset env / set false → rollout restart）
+    checker_staging_test_enabled: bool = False
+
 
 settings = Settings()  # type: ignore[call-arg]

--- a/orchestrator/src/orchestrator/store/artifact_checks.py
+++ b/orchestrator/src/orchestrator/store/artifact_checks.py
@@ -1,0 +1,24 @@
+"""artifact_checks 表写入 helper。"""
+from __future__ import annotations
+
+import asyncpg
+
+from ..checkers.staging_test import CheckResult
+
+
+async def insert_check(pool: asyncpg.Pool, req_id: str, stage: str, result: CheckResult) -> None:
+    await pool.execute(
+        """
+        INSERT INTO artifact_checks
+            (req_id, stage, passed, exit_code, cmd, stdout_tail, stderr_tail, duration_sec)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        """,
+        req_id,
+        stage,
+        result.passed,
+        result.exit_code,
+        result.cmd,
+        result.stdout_tail,
+        result.stderr_tail,
+        result.duration_sec,
+    )

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -385,6 +385,94 @@ async def test_create_accept_skipped(monkeypatch):
     fake.create_issue.assert_not_called()
 
 
+# ─── create_staging_test ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_create_staging_test_checker_pass(monkeypatch):
+    """checker_staging_test_enabled=True + checker pass → emit staging-test.pass。"""
+    from orchestrator.actions import create_staging_test as mod
+    from orchestrator.checkers.staging_test import CheckResult
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.checker_staging_test_enabled", True)
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.skip_staging_test", False)
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.test_mode", False)
+
+    fake_result = CheckResult(passed=True, exit_code=0, stdout_tail="ok\n", stderr_tail="", duration_sec=4.2, cmd="make test")
+
+    async def fake_run(req_id, test_cmd, timeout_sec=600):
+        return fake_result
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.checker.run_staging_test", fake_run)
+
+    insert_calls: list = []
+
+    async def fake_insert(pool, req_id, stage, result):
+        insert_calls.append((req_id, stage, result))
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.artifact_checks.insert_check", fake_insert)
+    patch_db(monkeypatch, "create_staging_test")
+
+    out = await mod.create_staging_test(body=make_body(), req_id="REQ-9", tags=[], ctx={})
+
+    assert out["emit"] == "staging-test.pass"
+    assert out["passed"] is True
+    assert out["exit_code"] == 0
+    assert len(insert_calls) == 1
+    assert insert_calls[0] == ("REQ-9", "staging-test", fake_result)
+
+
+@pytest.mark.asyncio
+async def test_create_staging_test_checker_fail(monkeypatch):
+    """checker_staging_test_enabled=True + checker fail → emit staging-test.fail。"""
+    from orchestrator.actions import create_staging_test as mod
+    from orchestrator.checkers.staging_test import CheckResult
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.checker_staging_test_enabled", True)
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.skip_staging_test", False)
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.test_mode", False)
+
+    fake_result = CheckResult(passed=False, exit_code=1, stdout_tail="FAIL\n", stderr_tail="panic\n", duration_sec=2.0, cmd="make test")
+
+    async def fake_run(req_id, test_cmd, timeout_sec=600):
+        return fake_result
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.checker.run_staging_test", fake_run)
+
+    async def fake_insert(pool, req_id, stage, result):
+        pass
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.artifact_checks.insert_check", fake_insert)
+    patch_db(monkeypatch, "create_staging_test")
+
+    out = await mod.create_staging_test(body=make_body(), req_id="REQ-9", tags=[], ctx={})
+
+    assert out["emit"] == "staging-test.fail"
+    assert out["passed"] is False
+    assert out["exit_code"] == 1
+
+
+@pytest.mark.asyncio
+async def test_create_staging_test_bkd_path(monkeypatch):
+    """checker_staging_test_enabled=False → 走老路创建 BKD agent issue。"""
+    from orchestrator.actions import create_staging_test as mod
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.checker_staging_test_enabled", False)
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.skip_staging_test", False)
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.test_mode", False)
+
+    fake_bkd = make_fake_bkd()
+    fake_bkd.create_issue.return_value = FakeIssue(id="st-1")
+    patch_bkd(monkeypatch, "create_staging_test", fake_bkd)
+    patch_db(monkeypatch, "create_staging_test")
+
+    out = await mod.create_staging_test(body=make_body(issue_id="dev-1"), req_id="REQ-9", tags=[], ctx={})
+
+    assert out == {"staging_test_issue_id": "st-1"}
+    fake_bkd.create_issue.assert_awaited_once()
+    fake_bkd.follow_up_issue.assert_awaited_once()
+    fake_bkd.update_issue.assert_awaited_once()
+
+
 # ─── 重要：BKD merge_tags_and_update 的 tag merge 逻辑 ─────────────────────
 @pytest.mark.asyncio
 async def test_bkd_merge_tags_preserves(monkeypatch):

--- a/orchestrator/tests/test_checkers_staging_test.py
+++ b/orchestrator/tests/test_checkers_staging_test.py
@@ -1,0 +1,96 @@
+"""checkers/staging_test.py 单测：mock RunnerController，验 CheckResult 字段。"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from orchestrator.checkers.staging_test import CheckResult, run_staging_test
+from orchestrator.k8s_runner import ExecResult
+
+
+def make_fake_controller(exit_code: int, stdout: str = "", stderr: str = "", duration: float = 1.0):
+    class FakeRC:
+        async def exec_in_runner(self, req_id, command, **kw):
+            return ExecResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration_sec=duration)
+    return FakeRC()
+
+
+# ── pass ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_run_staging_test_pass(monkeypatch):
+    monkeypatch.setattr(
+        "orchestrator.checkers.staging_test.k8s_runner.get_controller",
+        lambda: make_fake_controller(exit_code=0, stdout="ok\n", stderr="", duration=3.5),
+    )
+    result = await run_staging_test("REQ-1", "make test")
+
+    assert isinstance(result, CheckResult)
+    assert result.passed is True
+    assert result.exit_code == 0
+    assert result.stdout_tail == "ok\n"
+    assert result.stderr_tail == ""
+    assert result.duration_sec == 3.5
+    assert result.cmd == "make test"
+
+
+# ── fail ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_run_staging_test_fail(monkeypatch):
+    monkeypatch.setattr(
+        "orchestrator.checkers.staging_test.k8s_runner.get_controller",
+        lambda: make_fake_controller(exit_code=1, stdout="FAIL\n", stderr="panic: nil ptr\n", duration=2.0),
+    )
+    result = await run_staging_test("REQ-2", "make test")
+
+    assert result.passed is False
+    assert result.exit_code == 1
+    assert result.stdout_tail == "FAIL\n"
+    assert result.stderr_tail == "panic: nil ptr\n"
+
+
+# ── stdout/stderr tail 截尾 ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_run_staging_test_truncates_tails(monkeypatch):
+    big_out = "x" * 5000
+    big_err = "e" * 4000
+    monkeypatch.setattr(
+        "orchestrator.checkers.staging_test.k8s_runner.get_controller",
+        lambda: make_fake_controller(exit_code=0, stdout=big_out, stderr=big_err),
+    )
+    result = await run_staging_test("REQ-3", "make test")
+
+    assert len(result.stdout_tail) == 2048
+    assert len(result.stderr_tail) == 2048
+    assert result.stdout_tail == big_out[-2048:]
+    assert result.stderr_tail == big_err[-2048:]
+
+
+# ── timeout ───────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_run_staging_test_timeout(monkeypatch):
+    class SlowRC:
+        async def exec_in_runner(self, req_id, command, **kw):
+            await asyncio.sleep(9999)  # 永远不返回
+            return ExecResult(exit_code=0, stdout="", stderr="", duration_sec=0)
+
+    monkeypatch.setattr(
+        "orchestrator.checkers.staging_test.k8s_runner.get_controller",
+        lambda: SlowRC(),
+    )
+    with pytest.raises(TimeoutError):
+        # 为让测试不卡，patch asyncio.wait_for 直接模拟超时
+        async def fast_wait_for(coro, timeout):
+            task = asyncio.ensure_future(coro)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                raise TimeoutError() from None
+
+        monkeypatch.setattr("orchestrator.checkers.staging_test.asyncio.wait_for", fast_wait_for)
+        await run_staging_test("REQ-4", "make test", timeout_sec=1)


### PR DESCRIPTION
## Summary

- **关联 issue**: BKD #11 (noz2qm5w) — artifact-driven 状态机 + 混合重试，M1 milestone
- **核心变化**: `create_staging_test` action 加 feature flag 分叉。`SISYPHUS_CHECKER_STAGING_TEST_ENABLED=false`（默认）走老 BKD agent 路径；`=true` 时 sisyphus 自己在 runner pod 执行 `make test`，根据退出码直接 emit `staging-test.pass` 或 `staging-test.fail`，不起 agent，不靠 tag 自报
- **新增文件**: `checkers/staging_test.py` + `store/artifact_checks.py` + migration `0003_artifact_checks`

## 灰度切换方法

\`\`\`bash
# 开启新路（sisyphus 自检）
kubectl set env deployment/sisyphus-orchestrator \
  SISYPHUS_CHECKER_STAGING_TEST_ENABLED=true -n sisyphus
\`\`\`

## 回滚方法

\`\`\`bash
# 方式一：unset env
kubectl set env deployment/sisyphus-orchestrator \
  SISYPHUS_CHECKER_STAGING_TEST_ENABLED- -n sisyphus

# 方式二：set false
kubectl set env deployment/sisyphus-orchestrator \
  SISYPHUS_CHECKER_STAGING_TEST_ENABLED=false -n sisyphus

# rollout restart 确保生效
kubectl rollout restart deployment/sisyphus-orchestrator -n sisyphus
\`\`\`

## Test plan

- [x] \`uv run pytest -q\` — 178 passed (新增 7 个 test：4 checker 单测 + 3 action smoke)
- [x] \`uv run ruff check src/ tests/\` — 0 error
- [ ] 部署到 vm-node04 K3s，先 \`SISYPHUS_CHECKER_STAGING_TEST_ENABLED=false\` 确认老路不破
- [ ] 再 set \`=true\`，跑一个 REQ，验 staging_test_running → pass/fail 正常流转
- [ ] 验 artifact_checks 表有记录（\`SELECT * FROM artifact_checks ORDER BY checked_at DESC LIMIT 5\`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)