### PR TITLE
feat(retry): M4 故障分级重试

### DIFF
--- a/orchestrator/src/orchestrator/actions/create_staging_test.py
+++ b/orchestrator/src/orchestrator/actions/create_staging_test.py
@@ -1,8 +1,13 @@
-"""create_staging_test（v0.2 + M1 checker）：dev.done 后验 staging 测试。
+"""create_staging_test（v0.2 + M1 checker + M4 retry）：dev.done 后验 staging 测试。
 
 feature flag checker_staging_test_enabled:
   False（默认）: 创建 BKD agent issue（老路，保证老行为不破）
   True: sisyphus 自己在 runner pod 执行测试，根据退出码 emit STAGING_TEST_PASS/FAIL
+
+feature flag retry_enabled（仅 checker 路径生效）:
+  False（默认）: checker fail 直 emit STAGING_TEST_FAIL（老行为，进 bugfix 链）
+  True: checker fail 走 retry.executor 分级决策；follow_up/diagnose 不 emit fail，
+        状态留在 STAGING_TEST_RUNNING 等 dev agent 修完再触发重跑
 """
 from __future__ import annotations
 
@@ -12,6 +17,8 @@ from ..bkd import BKDClient
 from ..checkers import staging_test as checker
 from ..config import settings
 from ..prompts import render
+from ..retry import executor as retry_exec
+from ..retry.executor import RetryContext
 from ..state import Event
 from ..store import artifact_checks, db, req_state
 from . import register, short_title
@@ -20,6 +27,7 @@ from ._skip import skip_if_enabled
 log = structlog.get_logger(__name__)
 
 _TEST_CMD = "make test"   # M1 硬编码；M3 改成读 PVC manifest.yaml
+_STAGE = "staging-test"
 
 
 @register("create_staging_test")
@@ -28,50 +36,95 @@ async def create_staging_test(*, body, req_id, tags, ctx):
         return rv
 
     if settings.checker_staging_test_enabled:
-        return await _run_checker(req_id=req_id)
+        return await _run_checker(body=body, req_id=req_id, ctx=ctx or {})
 
     return await _dispatch_bkd_agent(body=body, req_id=req_id, ctx=ctx)
 
 
 # ── 新路：sisyphus 自检 ────────────────────────────────────────────────────
 
-async def _run_checker(*, req_id: str) -> dict:
+async def _run_checker(*, body, req_id: str, ctx: dict) -> dict:
     log.info("create_staging_test.checker_path", req_id=req_id, cmd=_TEST_CMD)
 
     try:
         result = await checker.run_staging_test(req_id, _TEST_CMD)
     except TimeoutError:
         log.error("create_staging_test.checker_timeout", req_id=req_id)
-        return {
-            "emit": Event.STAGING_TEST_FAIL.value,
-            "reason": "timeout",
-            "exit_code": -1,
-            "cmd": _TEST_CMD,
-        }
+        return await _handle_fail(
+            body=body, req_id=req_id, ctx=ctx,
+            fail_kind="flaky",   # timeout 归 flaky；不烦 agent，sisyphus 自己重跑
+            details={"reason": "timeout", "exit_code": -1, "cmd": _TEST_CMD},
+        )
     except Exception as e:
         log.exception("create_staging_test.checker_error", req_id=req_id, error=str(e))
-        return {
-            "emit": Event.STAGING_TEST_FAIL.value,
-            "reason": str(e)[:200],
-            "exit_code": -1,
-            "cmd": _TEST_CMD,
-        }
+        return await _handle_fail(
+            body=body, req_id=req_id, ctx=ctx,
+            fail_kind="test",
+            details={"reason": str(e)[:200], "exit_code": -1, "cmd": _TEST_CMD},
+        )
 
     pool = db.get_pool()
-    await artifact_checks.insert_check(pool, req_id, "staging-test", result)
+    await artifact_checks.insert_check(pool, req_id, _STAGE, result)
 
-    emit = Event.STAGING_TEST_PASS if result.passed else Event.STAGING_TEST_FAIL
+    if result.passed:
+        # admission pass：清零 round 计数，保下一阶段 / 后续 REQ 干净
+        if settings.retry_enabled:
+            await retry_exec.reset_stage(req_id, _STAGE)
+        log.info("create_staging_test.checker_done", req_id=req_id,
+                 passed=True, exit_code=result.exit_code,
+                 duration_sec=round(result.duration_sec, 1))
+        return {
+            "emit": Event.STAGING_TEST_PASS.value,
+            "passed": True,
+            "exit_code": result.exit_code,
+            "cmd": result.cmd,
+            "duration_sec": result.duration_sec,
+        }
+
     log.info("create_staging_test.checker_done", req_id=req_id,
-             passed=result.passed, exit_code=result.exit_code,
+             passed=False, exit_code=result.exit_code,
              duration_sec=round(result.duration_sec, 1))
+    return await _handle_fail(
+        body=body, req_id=req_id, ctx=ctx,
+        fail_kind="test",
+        details={
+            "cmd": result.cmd,
+            "exit_code": result.exit_code,
+            "stdout_tail": result.stdout_tail,
+            "stderr_tail": result.stderr_tail,
+            "duration_sec": result.duration_sec,
+        },
+    )
 
-    return {
-        "emit": emit.value,
-        "passed": result.passed,
-        "exit_code": result.exit_code,
-        "cmd": result.cmd,
-        "duration_sec": result.duration_sec,
-    }
+
+async def _handle_fail(*, body, req_id: str, ctx: dict, fail_kind: str, details: dict) -> dict:
+    """checker fail 统一出口：按 retry_enabled 决定走 retry.executor 还是直接 emit FAIL。
+
+    retry_enabled=False 时返老 shape（`passed`/`exit_code`/`cmd`/`emit`），保
+    既有 test_create_staging_test_checker_fail 兼容。
+    """
+    if not settings.retry_enabled:
+        out = {
+            "emit": Event.STAGING_TEST_FAIL.value,
+            "passed": False,
+            "exit_code": details.get("exit_code", -1),
+            "cmd": details.get("cmd", _TEST_CMD),
+        }
+        if "reason" in details:
+            out["reason"] = details["reason"]
+        return out
+
+    retry_result = await retry_exec.run(RetryContext(
+        req_id=req_id,
+        project_id=body.projectId,
+        stage=_STAGE,
+        fail_kind=fail_kind,
+        issue_id=(ctx or {}).get("dev_issue_id"),   # follow_up / fresh_start 的目标
+        details=details,
+    ))
+    log.info("create_staging_test.retry_dispatched",
+             req_id=req_id, retry_action=retry_result.get("retry_action"))
+    return retry_result
 
 
 # ── 老路：BKD agent（flag off 时走这里）────────────────────────────────────

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -101,5 +101,15 @@ class Settings(BaseSettings):
     pr_ci_watch_poll_interval_sec: int = 30
     pr_ci_watch_timeout_sec: int = 1800   # 30 min
 
+    # ─── M4：故障分级重试 ────────────────────────────────────────────────
+    # False（默认）= checker fail 直接 emit FAIL event（老行为）
+    # True = checker fail 调 retry.executor，按 policy 决定 follow_up / diagnose / escalate
+    # 回滚：set false → rollout restart
+    retry_enabled: bool = False
+    # 到/超过即 escalate 人工（含本次在内的总轮次）
+    retry_max_rounds: int = 5
+    # 测试失败从第 N 轮起改走 diagnose agent（分流 spec-bug/env-bug/code-bug）
+    retry_diagnose_threshold: int = 3
+
 
 settings = Settings()  # type: ignore[call-arg]

--- a/orchestrator/src/orchestrator/prompts/retry_diagnose.md.j2
+++ b/orchestrator/src/orchestrator/prompts/retry_diagnose.md.j2
@@ -1,0 +1,33 @@
+# [{{ req_id }}] {{ stage }} 连败 {{ round }} 轮，请分流诊断
+
+前面已经重试过 {{ round - 1 }} 轮，{{ stage }} 还是不过。不要自己试图修，
+**先分流出这到底是哪类 bug**。读已有的 BKD issue 历史 + 失败详情，分流：
+
+- **spec-bug**：需求/契约本身有问题，dev 正确实现但契约错了 → 打 tag `diagnosis:spec-bug`
+- **env-bug**：runner / 测试环境 / 依赖镜像问题，代码没错 → 打 tag `diagnosis:env-bug`
+- **code-bug**：代码确实错了，前面几轮修得不对 → 打 tag `diagnosis:code-bug`，**同时**给出修改建议
+
+## 最后一次失败
+
+{% if details.cmd %}- 执行命令：`{{ details.cmd }}`{% endif %}
+{% if details.exit_code is not none %}- exit code：`{{ details.exit_code }}`{% endif %}
+
+{% if details.stdout_tail %}
+### stdout 尾
+```
+{{ details.stdout_tail }}
+```
+{% endif %}
+
+{% if details.stderr_tail %}
+### stderr 尾
+```
+{{ details.stderr_tail }}
+```
+{% endif %}
+
+## 要求
+
+- 只做分流；不要动代码
+- 结论只能是上面三个 diagnosis tag 之一
+- code-bug 时必须附修改建议；spec-bug / env-bug 直接 escalate 人工

--- a/orchestrator/src/orchestrator/prompts/retry_follow_up.md.j2
+++ b/orchestrator/src/orchestrator/prompts/retry_follow_up.md.j2
@@ -1,0 +1,31 @@
+# [{{ req_id }}] {{ stage }} 失败（第 {{ round }} 轮），请修正
+
+你上一轮的产物没通过 sisyphus 的自检（`{{ stage }}`）。错误类型：`{{ fail_kind }}`。
+
+## 失败详情
+
+{% if details.cmd %}- 执行命令：`{{ details.cmd }}`{% endif %}
+{% if details.exit_code is not none %}- exit code：`{{ details.exit_code }}`{% endif %}
+{% if details.duration_sec %}- 耗时：{{ details.duration_sec }}s{% endif %}
+
+{% if details.stdout_tail %}
+### stdout 尾
+```
+{{ details.stdout_tail }}
+```
+{% endif %}
+
+{% if details.stderr_tail %}
+### stderr 尾
+```
+{{ details.stderr_tail }}
+```
+{% endif %}
+
+## 要求
+
+1. 根据上面的错误详情定位问题，做最小修改
+2. push 到同一个分支
+3. 不要重复已经做过的工作；focus 在让 `{{ stage }}` 通过即可
+
+修好 push 后 BKD session 自动结束，sisyphus 会重新跑 `{{ stage }}` 自检。

--- a/orchestrator/src/orchestrator/prompts/retry_fresh_start.md.j2
+++ b/orchestrator/src/orchestrator/prompts/retry_fresh_start.md.j2
@@ -1,0 +1,30 @@
+# [{{ req_id }}] {{ stage }} 重开 session（第 {{ round }} 轮）
+
+上一个 session 的 prompt 太长已被 sisyphus cancel。这是一个**新开的**
+session，上下文已清空。
+
+## 此前进展摘要
+
+{% if details.prior_summary %}
+{{ details.prior_summary }}
+{% else %}
+（上轮未提供摘要；请读 BKD 里同 REQ 的已关闭 issue 了解历史）
+{% endif %}
+
+## 最后一次失败
+
+{% if details.cmd %}- 执行命令：`{{ details.cmd }}`{% endif %}
+{% if details.exit_code is not none %}- exit code：`{{ details.exit_code }}`{% endif %}
+
+{% if details.stderr_tail %}
+### stderr 尾
+```
+{{ details.stderr_tail }}
+```
+{% endif %}
+
+## 要求
+
+1. 先 `git status` + 查看上一个 session 留下的改动
+2. 不要重新做已经做过的工作；直接从失败点继续
+3. 让 `{{ stage }}` 通过

--- a/orchestrator/src/orchestrator/retry/__init__.py
+++ b/orchestrator/src/orchestrator/retry/__init__.py
@@ -1,0 +1,8 @@
+"""M4 故障分级重试。
+
+`policy.decide(stage, fail_kind, round)` 返回一个 RetryDecision（纯函数，好单测）；
+`executor.run(ctx)` 按 decision 调 BKDClient / 持久化 round / 可选 emit 事件。
+
+接入点：M1/M2/M3 等 checker 的 fail 路径在 feature flag 打开时改调 executor，
+不再直接 emit FAIL event。老 BKD agent 路径保持不变（retry_enabled=False 时）。
+"""

--- a/orchestrator/src/orchestrator/retry/executor.py
+++ b/orchestrator/src/orchestrator/retry/executor.py
@@ -1,0 +1,194 @@
+"""M4 执行器：按 policy.decide 的结果操作 BKD / 推进状态。
+
+调用方（M1/M2/M3 checker fail 路径）把 RetryContext 传进来，executor 内部：
+1. 读 ctx.retries[stage] + 1 = 本次 round（持久化到 req_state.context.retries）
+2. policy.decide 得到 RetryDecision
+3. 按 action 分发：
+   - follow_up: BKDClient.follow_up_issue（同 agent 附错误详情）
+   - fresh_start: cancel 旧 issue + 新开 issue + 摘要 prompt
+   - diagnose: 新开 diagnose issue（tag 里带 stage）
+   - skip_check_retry: 返回 hint 给调用方自己重跑
+   - escalate: emit SESSION_FAILED 事件
+
+返回 dict 给上层 action handler；含 `emit` 就让 engine 链式推进，无 emit 则
+state 原地不动等下一轮。
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+import structlog
+
+from ..bkd import BKDClient
+from ..config import settings
+from ..prompts import render
+from ..state import Event
+from ..store import db
+from . import store as retry_store
+from .policy import RetryDecision, decide
+
+log = structlog.get_logger(__name__)
+
+
+@dataclass
+class RetryContext:
+    """M4 executor 入参：caller 持有的所有必要信息。"""
+
+    req_id: str
+    project_id: str
+    stage: str                      # checker 标识（"staging-test" / "pr-ci" / ...）
+    fail_kind: str                  # policy 可识别的分类
+    issue_id: str | None = None     # 要 follow_up / cancel 的 agent issue
+    details: dict = field(default_factory=dict)   # cmd / exit_code / stdout_tail / stderr_tail / ...
+
+
+async def run(ctx: RetryContext) -> dict:
+    """执行一次重试决策，返回上层 action handler 直接用的 dict。
+
+    返回 dict 含 `emit` 时，engine 会链式推进状态机；不含 `emit` 时 state
+    原地留在当前（比如 STAGING_TEST_RUNNING），等后续 agent session 回调
+    再驱动。
+    """
+    pool = db.get_pool()
+    round = await retry_store.increment_round(pool, ctx.req_id, ctx.stage)
+    decision = decide(
+        ctx.stage, ctx.fail_kind, round,
+        max_rounds=settings.retry_max_rounds,
+        diagnose_threshold=settings.retry_diagnose_threshold,
+    )
+    log.info(
+        "retry.decide",
+        req_id=ctx.req_id, stage=ctx.stage, fail_kind=ctx.fail_kind,
+        round=round, action=decision.action, reason=decision.reason,
+    )
+
+    dispatcher = _DISPATCH.get(decision.action)
+    if dispatcher is None:
+        log.error("retry.unknown_action", action=decision.action)
+        return {"action": "error", "reason": f"unknown decision {decision.action}"}
+
+    return await dispatcher(ctx, decision, round)
+
+
+async def reset_stage(req_id: str, stage: str) -> None:
+    """admission pass 后清零某 stage 的 round 计数。"""
+    await retry_store.reset_round(db.get_pool(), req_id, stage)
+
+
+async def _follow_up(ctx: RetryContext, decision: RetryDecision, round: int) -> dict:
+    if not ctx.issue_id:
+        log.warning("retry.follow_up_no_issue_id", req_id=ctx.req_id, stage=ctx.stage)
+        return {
+            "retry_action": "follow_up",
+            "stage": ctx.stage, "round": round,
+            "skipped": True, "reason": "missing issue_id; cannot follow_up",
+        }
+    prompt = render(
+        "retry_follow_up.md.j2",
+        req_id=ctx.req_id, stage=ctx.stage,
+        fail_kind=ctx.fail_kind, round=round,
+        details=ctx.details,
+    )
+    async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+        await bkd.follow_up_issue(
+            project_id=ctx.project_id, issue_id=ctx.issue_id, prompt=prompt,
+        )
+    return {
+        "retry_action": "follow_up",
+        "stage": ctx.stage, "round": round,
+        "issue_id": ctx.issue_id, "reason": decision.reason,
+    }
+
+
+async def _fresh_start(ctx: RetryContext, decision: RetryDecision, round: int) -> dict:
+    """prompt_too_long：cancel 旧 issue + 开新 issue，带摘要 prompt。"""
+    prompt = render(
+        "retry_fresh_start.md.j2",
+        req_id=ctx.req_id, stage=ctx.stage, round=round,
+        details=ctx.details,
+    )
+    async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+        if ctx.issue_id:
+            try:
+                await bkd.cancel_issue(ctx.project_id, ctx.issue_id)
+            except Exception as e:
+                # cancel 失败不阻塞重开；老 session 自己最终 timeout
+                log.warning(
+                    "retry.fresh_start.cancel_failed",
+                    req_id=ctx.req_id, issue_id=ctx.issue_id, error=str(e),
+                )
+        new_issue = await bkd.create_issue(
+            project_id=ctx.project_id,
+            title=f"[{ctx.req_id}] [{ctx.stage}][retry-r{round}]",
+            tags=[ctx.stage, ctx.req_id, f"retry:r{round}"],
+            status_id="todo",
+        )
+        await bkd.follow_up_issue(
+            project_id=ctx.project_id, issue_id=new_issue.id, prompt=prompt,
+        )
+        await bkd.update_issue(
+            project_id=ctx.project_id, issue_id=new_issue.id, status_id="working",
+        )
+    return {
+        "retry_action": "fresh_start",
+        "stage": ctx.stage, "round": round,
+        "new_issue_id": new_issue.id, "reason": decision.reason,
+    }
+
+
+async def _diagnose(ctx: RetryContext, decision: RetryDecision, round: int) -> dict:
+    """≥diagnose_threshold 轮测试失败：起轻量 diagnose agent 分流。"""
+    prompt = render(
+        "retry_diagnose.md.j2",
+        req_id=ctx.req_id, stage=ctx.stage, round=round,
+        details=ctx.details,
+    )
+    async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+        diag_issue = await bkd.create_issue(
+            project_id=ctx.project_id,
+            title=f"[{ctx.req_id}] [diagnose][{ctx.stage}]",
+            tags=["diagnose", ctx.stage, ctx.req_id, f"retry:r{round}"],
+            status_id="todo",
+        )
+        await bkd.follow_up_issue(
+            project_id=ctx.project_id, issue_id=diag_issue.id, prompt=prompt,
+        )
+        await bkd.update_issue(
+            project_id=ctx.project_id, issue_id=diag_issue.id, status_id="working",
+        )
+    return {
+        "retry_action": "diagnose",
+        "stage": ctx.stage, "round": round,
+        "diagnose_issue_id": diag_issue.id, "reason": decision.reason,
+    }
+
+
+async def _skip_check_retry(ctx: RetryContext, decision: RetryDecision, round: int) -> dict:
+    """flaky：sisyphus 自己重跑 check，不烦 agent。caller 检测 hint 后再次 run_checker。"""
+    return {
+        "retry_action": "skip_check_retry",
+        "stage": ctx.stage, "round": round,
+        "reason": decision.reason,
+        "hint": "caller should re-run the checker",
+    }
+
+
+async def _escalate(ctx: RetryContext, decision: RetryDecision, round: int) -> dict:
+    """超过 max_rounds 或未知 fail_kind：emit SESSION_FAILED 进 escalate 路径。"""
+    return {
+        "emit": Event.SESSION_FAILED.value,
+        "retry_action": "escalate",
+        "stage": ctx.stage, "round": round,
+        "reason": decision.reason,
+        "escalated_at": time.time(),
+    }
+
+
+_DISPATCH = {
+    "follow_up": _follow_up,
+    "fresh_start": _fresh_start,
+    "diagnose": _diagnose,
+    "skip_check_retry": _skip_check_retry,
+    "escalate": _escalate,
+}

--- a/orchestrator/src/orchestrator/retry/policy.py
+++ b/orchestrator/src/orchestrator/retry/policy.py
@@ -1,0 +1,101 @@
+"""M4 故障分级路由：按失败类型 + 轮次返回 RetryDecision。
+
+纯函数，不碰 IO。方便单测每种组合。
+
+决策表（见 #11 设计）：
+| fail_kind                | 处理                          |
+|--------------------------|-------------------------------|
+| schema / lint / typecheck| follow_up 同 agent（外科手术）|
+| test（round < diag_thr） | follow_up 同 agent            |
+| test（round ≥ diag_thr） | diagnose（分流 spec/env/code）|
+| prompt_too_long          | fresh_start（cancel + 新开）  |
+| flaky                    | skip_check_retry（sisyphus 自重）|
+| 任意（round ≥ max_rounds）| escalate                     |
+| 未知 fail_kind            | escalate（保守兜底）          |
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+RetryAction = Literal[
+    "follow_up",
+    "fresh_start",
+    "diagnose",
+    "skip_check_retry",
+    "escalate",
+]
+
+SURGICAL_KINDS: frozenset[str] = frozenset({"schema", "lint", "typecheck"})
+FAIL_KIND_TEST = "test"
+FAIL_KIND_PROMPT_TOO_LONG = "prompt_too_long"
+FAIL_KIND_FLAKY = "flaky"
+
+
+@dataclass(frozen=True)
+class RetryDecision:
+    action: RetryAction
+    prompt: str | None   # follow-up 时传给 agent（decide 留空，executor 渲模板填）
+    reason: str
+
+
+def decide(
+    stage: str,
+    fail_kind: str,
+    round: int,
+    *,
+    max_rounds: int = 5,
+    diagnose_threshold: int = 3,
+) -> RetryDecision:
+    """按 (stage, fail_kind, round) 决策重试行为。
+
+    Args:
+        stage: checker 标识（"staging-test" / "pr-ci" / ...）只用于 reason/log
+        fail_kind: 失败类别（见常量）。未知值默认 escalate
+        round: 当前失败轮次（1-based；第 N 次失败传 N）
+        max_rounds: 到/超过即升级人工
+        diagnose_threshold: 测试失败第 N 轮起改走 diagnose agent
+
+    Returns:
+        RetryDecision（action + reason；prompt 始终 None，由 executor 渲染）
+    """
+    if round >= max_rounds:
+        return RetryDecision(
+            "escalate", None,
+            f"round {round} ≥ max_rounds {max_rounds}",
+        )
+
+    if fail_kind == FAIL_KIND_PROMPT_TOO_LONG:
+        return RetryDecision(
+            "fresh_start", None,
+            "prompt_too_long → cancel + fresh agent + 摘要",
+        )
+
+    if fail_kind == FAIL_KIND_FLAKY:
+        return RetryDecision(
+            "skip_check_retry", None,
+            "flaky → sisyphus 自己重跑 check，不烦 agent",
+        )
+
+    if fail_kind in SURGICAL_KINDS:
+        return RetryDecision(
+            "follow_up", None,
+            f"{fail_kind} 外科手术类 → follow-up 同 agent（round {round}）",
+        )
+
+    if fail_kind == FAIL_KIND_TEST:
+        if round >= diagnose_threshold:
+            return RetryDecision(
+                "diagnose", None,
+                f"test fail round {round} ≥ {diagnose_threshold} → diagnose agent",
+            )
+        return RetryDecision(
+            "follow_up", None,
+            f"test fail round {round} < {diagnose_threshold} → follow-up 同 agent",
+        )
+
+    # 未识别的 fail_kind：保守 escalate（宁可误升级也不做未定义重试）
+    return RetryDecision(
+        "escalate", None,
+        f"unknown fail_kind {fail_kind!r} → escalate",
+    )

--- a/orchestrator/src/orchestrator/retry/store.py
+++ b/orchestrator/src/orchestrator/retry/store.py
@@ -1,0 +1,65 @@
+"""M4 round 计数持久化：把 retries[stage] 存进 req_state.context。
+
+放在 retry/ 模块内而不是 store/req_state.py，保 M4 模块自治、不污染老 store API。
+JSONB || 是浅合并会整体替换 retries 子 dict，所以用 jsonb_set + jsonb_build_object
+原地合并单 key。
+"""
+from __future__ import annotations
+
+import asyncpg
+
+
+async def increment_round(pool: asyncpg.Pool, req_id: str, stage: str) -> int:
+    """原子递增 ctx.retries[stage]，返回新 round 值（1-based）。
+
+    Row 不存在返 0（上层自己校验）。stage 名任意字符串，通过参数绑定避免注入。
+    """
+    row = await pool.fetchrow(
+        """
+        UPDATE req_state
+        SET context = jsonb_set(
+            context,
+            '{retries}',
+            COALESCE(context->'retries', '{}'::jsonb) ||
+            jsonb_build_object(
+                $2::text,
+                COALESCE((context#>>ARRAY['retries', $2])::int, 0) + 1
+            ),
+            true
+        ),
+        updated_at = now()
+        WHERE req_id = $1
+        RETURNING (context#>>ARRAY['retries', $2])::int AS new_round
+        """,
+        req_id, stage,
+    )
+    return int(row["new_round"]) if row else 0
+
+
+async def reset_round(pool: asyncpg.Pool, req_id: str, stage: str) -> None:
+    """清零某 stage 的 round（admission pass 后调）。key 不存在则 no-op。"""
+    await pool.execute(
+        """
+        UPDATE req_state
+        SET context = jsonb_set(
+            context,
+            '{retries}',
+            COALESCE(context->'retries', '{}'::jsonb) - $2::text,
+            true
+        ),
+        updated_at = now()
+        WHERE req_id = $1
+        """,
+        req_id, stage,
+    )
+
+
+async def get_round(pool: asyncpg.Pool, req_id: str, stage: str) -> int:
+    """当前 round 值（不存在返 0）。用于测试/观测，不影响决策。"""
+    row = await pool.fetchrow(
+        "SELECT (context#>>ARRAY['retries', $2])::int AS r FROM req_state WHERE req_id = $1",
+        req_id, stage,
+    )
+    if row is None or row["r"] is None:
+        return 0
+    return int(row["r"])

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -452,6 +452,125 @@ async def test_create_staging_test_checker_fail(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_create_staging_test_checker_fail_retry_enabled(monkeypatch):
+    """retry_enabled=True + checker fail → 调 retry.executor.run，不 emit staging-test.fail。"""
+    from orchestrator.actions import create_staging_test as mod
+    from orchestrator.checkers.staging_test import CheckResult
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.checker_staging_test_enabled", True)
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.retry_enabled", True)
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.skip_staging_test", False)
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.test_mode", False)
+
+    fake_result = CheckResult(passed=False, exit_code=1, stdout_tail="FAIL\n", stderr_tail="panic\n", duration_sec=2.0, cmd="make test")
+
+    async def fake_run_check(req_id, test_cmd, timeout_sec=600):
+        return fake_result
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.checker.run_staging_test", fake_run_check)
+
+    async def fake_insert(pool, req_id, stage, result):
+        pass
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.artifact_checks.insert_check", fake_insert)
+    patch_db(monkeypatch, "create_staging_test")
+
+    retry_calls: list = []
+
+    async def fake_retry_run(rctx):
+        retry_calls.append(rctx)
+        return {"retry_action": "follow_up", "stage": rctx.stage, "round": 1}
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.retry_exec.run", fake_retry_run)
+
+    out = await mod.create_staging_test(
+        body=make_body(project_id="proj-x"),
+        req_id="REQ-9", tags=[], ctx={"dev_issue_id": "dev-1"},
+    )
+
+    assert len(retry_calls) == 1
+    rctx = retry_calls[0]
+    assert rctx.req_id == "REQ-9"
+    assert rctx.project_id == "proj-x"
+    assert rctx.stage == "staging-test"
+    assert rctx.fail_kind == "test"
+    assert rctx.issue_id == "dev-1"
+    assert rctx.details["exit_code"] == 1
+    assert "emit" not in out   # follow_up 不 emit；state 留在 STAGING_TEST_RUNNING
+    assert out["retry_action"] == "follow_up"
+
+
+@pytest.mark.asyncio
+async def test_create_staging_test_checker_pass_retry_enabled_resets_round(monkeypatch):
+    """retry_enabled=True + checker pass → 清 round 计数 + emit staging-test.pass。"""
+    from orchestrator.actions import create_staging_test as mod
+    from orchestrator.checkers.staging_test import CheckResult
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.checker_staging_test_enabled", True)
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.retry_enabled", True)
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.skip_staging_test", False)
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.test_mode", False)
+
+    fake_result = CheckResult(passed=True, exit_code=0, stdout_tail="ok\n", stderr_tail="", duration_sec=3.0, cmd="make test")
+
+    async def fake_run_check(req_id, test_cmd, timeout_sec=600):
+        return fake_result
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.checker.run_staging_test", fake_run_check)
+
+    async def fake_insert(pool, req_id, stage, result):
+        pass
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.artifact_checks.insert_check", fake_insert)
+    patch_db(monkeypatch, "create_staging_test")
+
+    reset_calls: list = []
+
+    async def fake_reset(req_id, stage):
+        reset_calls.append((req_id, stage))
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.retry_exec.reset_stage", fake_reset)
+
+    out = await mod.create_staging_test(
+        body=make_body(), req_id="REQ-9", tags=[], ctx={},
+    )
+
+    assert out["emit"] == "staging-test.pass"
+    assert reset_calls == [("REQ-9", "staging-test")]
+
+
+@pytest.mark.asyncio
+async def test_create_staging_test_checker_timeout_retry_enabled_flaky(monkeypatch):
+    """retry_enabled=True + checker timeout → retry 走 flaky 分支。"""
+    from orchestrator.actions import create_staging_test as mod
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.checker_staging_test_enabled", True)
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.retry_enabled", True)
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.skip_staging_test", False)
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.test_mode", False)
+
+    async def fake_run_check(req_id, test_cmd, timeout_sec=600):
+        raise TimeoutError()
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.checker.run_staging_test", fake_run_check)
+    patch_db(monkeypatch, "create_staging_test")
+
+    retry_calls: list = []
+
+    async def fake_retry_run(rctx):
+        retry_calls.append(rctx)
+        return {"retry_action": "skip_check_retry", "stage": rctx.stage, "round": 1, "hint": "retry"}
+
+    monkeypatch.setattr("orchestrator.actions.create_staging_test.retry_exec.run", fake_retry_run)
+
+    out = await mod.create_staging_test(
+        body=make_body(), req_id="REQ-9", tags=[], ctx={},
+    )
+
+    assert len(retry_calls) == 1
+    assert retry_calls[0].fail_kind == "flaky"
+    assert out["retry_action"] == "skip_check_retry"
+
+
+@pytest.mark.asyncio
 async def test_create_staging_test_bkd_path(monkeypatch):
     """checker_staging_test_enabled=False → 走老路创建 BKD agent issue。"""
     from orchestrator.actions import create_staging_test as mod

--- a/orchestrator/tests/test_retry_executor.py
+++ b/orchestrator/tests/test_retry_executor.py
@@ -1,0 +1,277 @@
+"""retry.executor 单测：mock BKDClient + retry_store，验不同 decision 分发的行为。"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from unittest.mock import AsyncMock
+
+import pytest
+
+from orchestrator.retry.executor import RetryContext, run
+
+
+@dataclass
+class FakeIssue:
+    id: str
+    project_id: str = "p"
+    issue_number: int = 0
+    title: str = ""
+    status_id: str = "todo"
+    tags: list | None = None
+    session_status: str | None = None
+    description: str | None = None
+
+    def __post_init__(self):
+        if self.tags is None:
+            self.tags = []
+
+
+def make_fake_bkd() -> AsyncMock:
+    bkd = AsyncMock()
+    bkd.create_issue = AsyncMock(return_value=FakeIssue(id="new-1"))
+    bkd.update_issue = AsyncMock(return_value=FakeIssue(id="new-1"))
+    bkd.follow_up_issue = AsyncMock(return_value={})
+    bkd.cancel_issue = AsyncMock(return_value={})
+    return bkd
+
+
+def patch_bkd(monkeypatch, fake):
+    @asynccontextmanager
+    async def _ctx(*a, **kw):
+        yield fake
+    monkeypatch.setattr("orchestrator.retry.executor.BKDClient", _ctx)
+
+
+class FakePool:
+    async def execute(self, *a, **kw):
+        return None
+
+    async def fetchrow(self, *a, **kw):
+        return None
+
+
+def patch_round(monkeypatch, round: int):
+    """mock retry_store.increment_round 返预设 round 值。"""
+    async def fake_inc(pool, req_id, stage):
+        return round
+    monkeypatch.setattr(
+        "orchestrator.retry.executor.retry_store.increment_round", fake_inc,
+    )
+    monkeypatch.setattr("orchestrator.retry.executor.db.get_pool", lambda: FakePool())
+
+
+def base_ctx(issue_id: str | None = "dev-1", fail_kind: str = "test") -> RetryContext:
+    return RetryContext(
+        req_id="REQ-9",
+        project_id="proj-1",
+        stage="staging-test",
+        fail_kind=fail_kind,
+        issue_id=issue_id,
+        details={
+            "cmd": "make test",
+            "exit_code": 1,
+            "stdout_tail": "FAIL\n",
+            "stderr_tail": "panic\n",
+            "duration_sec": 2.0,
+        },
+    )
+
+
+# ─── follow_up：调 follow_up_issue，不 emit ───────────────────────────────
+@pytest.mark.asyncio
+async def test_follow_up_calls_bkd_follow_up(monkeypatch):
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, fake)
+    patch_round(monkeypatch, round=1)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_max_rounds", 5)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_diagnose_threshold", 3)
+
+    out = await run(base_ctx(issue_id="dev-1", fail_kind="test"))
+
+    assert out["retry_action"] == "follow_up"
+    assert out["issue_id"] == "dev-1"
+    assert "emit" not in out
+    fake.follow_up_issue.assert_awaited_once()
+    call = fake.follow_up_issue.call_args
+    assert call.kwargs["issue_id"] == "dev-1"
+    assert call.kwargs["project_id"] == "proj-1"
+    assert "REQ-9" in call.kwargs["prompt"]
+    assert "staging-test" in call.kwargs["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_follow_up_without_issue_id_skips(monkeypatch):
+    """follow_up 决策但 ctx 没 issue_id → skipped，不炸。"""
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, fake)
+    patch_round(monkeypatch, round=1)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_max_rounds", 5)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_diagnose_threshold", 3)
+
+    out = await run(base_ctx(issue_id=None, fail_kind="test"))
+
+    assert out["retry_action"] == "follow_up"
+    assert out["skipped"] is True
+    fake.follow_up_issue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_surgical_kind_follow_up(monkeypatch):
+    """schema 错 → follow_up（不看 round 早晚，只要没越 max_rounds）。"""
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, fake)
+    patch_round(monkeypatch, round=3)  # diagnose_threshold 但外科手术类不 diagnose
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_max_rounds", 5)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_diagnose_threshold", 3)
+
+    out = await run(base_ctx(fail_kind="schema"))
+
+    assert out["retry_action"] == "follow_up"
+    fake.follow_up_issue.assert_awaited_once()
+
+
+# ─── diagnose：新开 issue with diagnose tag ───────────────────────────────
+@pytest.mark.asyncio
+async def test_diagnose_creates_new_issue(monkeypatch):
+    fake = make_fake_bkd()
+    fake.create_issue.return_value = FakeIssue(id="diag-1")
+    patch_bkd(monkeypatch, fake)
+    patch_round(monkeypatch, round=3)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_max_rounds", 5)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_diagnose_threshold", 3)
+
+    out = await run(base_ctx(fail_kind="test"))
+
+    assert out["retry_action"] == "diagnose"
+    assert out["diagnose_issue_id"] == "diag-1"
+    fake.create_issue.assert_awaited_once()
+    create_call = fake.create_issue.call_args
+    assert "diagnose" in create_call.kwargs["tags"]
+    assert "staging-test" in create_call.kwargs["tags"]
+    assert "REQ-9" in create_call.kwargs["tags"]
+    fake.follow_up_issue.assert_awaited_once()
+    # diagnose issue 最终推到 working
+    fake.update_issue.assert_awaited_once()
+
+
+# ─── fresh_start：cancel 旧 issue + 开新 ────────────────────────────────
+@pytest.mark.asyncio
+async def test_fresh_start_cancels_old_and_creates_new(monkeypatch):
+    fake = make_fake_bkd()
+    fake.create_issue.return_value = FakeIssue(id="fresh-1")
+    patch_bkd(monkeypatch, fake)
+    patch_round(monkeypatch, round=1)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_max_rounds", 5)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_diagnose_threshold", 3)
+
+    out = await run(base_ctx(issue_id="dev-1", fail_kind="prompt_too_long"))
+
+    assert out["retry_action"] == "fresh_start"
+    assert out["new_issue_id"] == "fresh-1"
+    fake.cancel_issue.assert_awaited_once_with("proj-1", "dev-1")
+    fake.create_issue.assert_awaited_once()
+    fake.follow_up_issue.assert_awaited_once()
+    fake.update_issue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fresh_start_cancel_failure_still_creates_new(monkeypatch):
+    """cancel 失败（老 issue 不存在了）不能阻塞新开 — 走日志警告继续。"""
+    fake = make_fake_bkd()
+    fake.cancel_issue.side_effect = RuntimeError("not found")
+    fake.create_issue.return_value = FakeIssue(id="fresh-2")
+    patch_bkd(monkeypatch, fake)
+    patch_round(monkeypatch, round=1)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_max_rounds", 5)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_diagnose_threshold", 3)
+
+    out = await run(base_ctx(issue_id="dev-1", fail_kind="prompt_too_long"))
+
+    assert out["retry_action"] == "fresh_start"
+    assert out["new_issue_id"] == "fresh-2"
+    fake.cancel_issue.assert_awaited_once()
+    fake.create_issue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fresh_start_without_issue_id_just_creates(monkeypatch):
+    fake = make_fake_bkd()
+    fake.create_issue.return_value = FakeIssue(id="fresh-3")
+    patch_bkd(monkeypatch, fake)
+    patch_round(monkeypatch, round=1)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_max_rounds", 5)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_diagnose_threshold", 3)
+
+    out = await run(base_ctx(issue_id=None, fail_kind="prompt_too_long"))
+
+    assert out["retry_action"] == "fresh_start"
+    fake.cancel_issue.assert_not_called()
+    fake.create_issue.assert_awaited_once()
+
+
+# ─── skip_check_retry：返 hint，不碰 BKD ─────────────────────────────────
+@pytest.mark.asyncio
+async def test_flaky_skip_check_retry_no_bkd_call(monkeypatch):
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, fake)
+    patch_round(monkeypatch, round=1)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_max_rounds", 5)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_diagnose_threshold", 3)
+
+    out = await run(base_ctx(fail_kind="flaky"))
+
+    assert out["retry_action"] == "skip_check_retry"
+    assert "hint" in out
+    fake.follow_up_issue.assert_not_called()
+    fake.create_issue.assert_not_called()
+
+
+# ─── escalate：round ≥ max_rounds 发 SESSION_FAILED ──────────────────────
+@pytest.mark.asyncio
+async def test_escalate_emits_session_failed(monkeypatch):
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, fake)
+    patch_round(monkeypatch, round=5)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_max_rounds", 5)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_diagnose_threshold", 3)
+
+    out = await run(base_ctx(fail_kind="test"))
+
+    assert out["retry_action"] == "escalate"
+    assert out["emit"] == "session.failed"
+    fake.follow_up_issue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unknown_fail_kind_escalates(monkeypatch):
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, fake)
+    patch_round(monkeypatch, round=1)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_max_rounds", 5)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_diagnose_threshold", 3)
+
+    out = await run(base_ctx(fail_kind="mystery"))
+
+    assert out["retry_action"] == "escalate"
+    assert out["emit"] == "session.failed"
+
+
+# ─── round 递增被调用（间接证明持久化被触发）──────────────────────────
+@pytest.mark.asyncio
+async def test_increment_round_is_called(monkeypatch):
+    calls: list = []
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, fake)
+
+    async def fake_inc(pool, req_id, stage):
+        calls.append((req_id, stage))
+        return 1
+
+    monkeypatch.setattr("orchestrator.retry.executor.retry_store.increment_round", fake_inc)
+    monkeypatch.setattr("orchestrator.retry.executor.db.get_pool", lambda: FakePool())
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_max_rounds", 5)
+    monkeypatch.setattr("orchestrator.retry.executor.settings.retry_diagnose_threshold", 3)
+
+    await run(base_ctx(fail_kind="test"))
+
+    assert calls == [("REQ-9", "staging-test")]

--- a/orchestrator/tests/test_retry_policy.py
+++ b/orchestrator/tests/test_retry_policy.py
@@ -1,0 +1,126 @@
+"""retry.policy.decide 单测：每种 fail_kind × round 组合验路由。"""
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.retry.policy import (
+    FAIL_KIND_FLAKY,
+    FAIL_KIND_PROMPT_TOO_LONG,
+    FAIL_KIND_TEST,
+    SURGICAL_KINDS,
+    RetryDecision,
+    decide,
+)
+
+
+# ─── escalate：round ≥ max_rounds，一切压过 ────────────────────────────────
+@pytest.mark.parametrize("fail_kind", [
+    "test", "schema", "lint", "typecheck", "flaky", "prompt_too_long", "unknown",
+])
+def test_round_at_or_above_max_always_escalates(fail_kind):
+    d = decide("staging-test", fail_kind, round=5, max_rounds=5)
+    assert d.action == "escalate"
+    assert "max_rounds" in d.reason
+
+
+def test_round_beyond_max_escalates():
+    d = decide("staging-test", "test", round=10, max_rounds=5)
+    assert d.action == "escalate"
+
+
+# ─── 外科手术类：schema / lint / typecheck ────────────────────────────────
+@pytest.mark.parametrize("kind", sorted(SURGICAL_KINDS))
+def test_surgical_kind_follow_up(kind):
+    d = decide("dev", kind, round=1)
+    assert d.action == "follow_up"
+    assert kind in d.reason
+
+
+@pytest.mark.parametrize("kind", sorted(SURGICAL_KINDS))
+def test_surgical_kind_still_follow_up_at_round_4(kind):
+    """外科手术类不走 diagnose 分流，直到 max_rounds 才 escalate。"""
+    d = decide("dev", kind, round=4, max_rounds=5, diagnose_threshold=3)
+    assert d.action == "follow_up"
+
+
+# ─── test fail：round 分 diagnose_threshold 前后 ──────────────────────────
+def test_test_fail_round_1_follow_up():
+    d = decide("staging-test", FAIL_KIND_TEST, round=1, diagnose_threshold=3)
+    assert d.action == "follow_up"
+    assert "round 1" in d.reason
+
+
+def test_test_fail_round_2_still_follow_up():
+    d = decide("staging-test", FAIL_KIND_TEST, round=2, diagnose_threshold=3)
+    assert d.action == "follow_up"
+
+
+def test_test_fail_at_diagnose_threshold_diagnose():
+    d = decide("staging-test", FAIL_KIND_TEST, round=3, diagnose_threshold=3)
+    assert d.action == "diagnose"
+    assert "diagnose" in d.reason
+
+
+def test_test_fail_above_diagnose_threshold_still_diagnose_until_max():
+    d = decide("staging-test", FAIL_KIND_TEST, round=4, diagnose_threshold=3, max_rounds=5)
+    assert d.action == "diagnose"
+
+
+# ─── prompt_too_long：不管 round 都 fresh_start（直到 max_rounds）─────────
+def test_prompt_too_long_fresh_start_round_1():
+    d = decide("dev", FAIL_KIND_PROMPT_TOO_LONG, round=1)
+    assert d.action == "fresh_start"
+
+
+def test_prompt_too_long_fresh_start_round_4():
+    d = decide("dev", FAIL_KIND_PROMPT_TOO_LONG, round=4, max_rounds=5)
+    assert d.action == "fresh_start"
+
+
+# ─── flaky：skip_check_retry（sisyphus 自重，不烦 agent）──────────────────
+def test_flaky_skip_check_retry():
+    d = decide("staging-test", FAIL_KIND_FLAKY, round=1)
+    assert d.action == "skip_check_retry"
+
+
+def test_flaky_still_skip_at_round_4():
+    d = decide("staging-test", FAIL_KIND_FLAKY, round=4, max_rounds=5)
+    assert d.action == "skip_check_retry"
+
+
+# ─── 未知 fail_kind：保守 escalate ────────────────────────────────────────
+def test_unknown_fail_kind_escalates():
+    d = decide("staging-test", "kaboom", round=1)
+    assert d.action == "escalate"
+    assert "unknown fail_kind" in d.reason
+
+
+def test_empty_fail_kind_escalates():
+    d = decide("staging-test", "", round=1)
+    assert d.action == "escalate"
+
+
+# ─── RetryDecision：prompt 始终 None（由 executor 渲染）───────────────────
+def test_decision_prompt_is_always_none():
+    for kind in ["test", "schema", "prompt_too_long", "flaky", "unknown"]:
+        d = decide("s", kind, round=1)
+        assert isinstance(d, RetryDecision)
+        assert d.prompt is None
+
+
+# ─── 自定义 max_rounds / diagnose_threshold ──────────────────────────────
+def test_custom_max_rounds_1():
+    """max_rounds=1 时 round=1 就 escalate（配置极严）。"""
+    d = decide("s", "test", round=1, max_rounds=1)
+    assert d.action == "escalate"
+
+
+def test_custom_diagnose_threshold_2():
+    """diagnose_threshold=2 时 round=2 即 diagnose。"""
+    d = decide("s", "test", round=2, diagnose_threshold=2, max_rounds=5)
+    assert d.action == "diagnose"
+
+
+def test_high_max_allows_more_rounds():
+    d = decide("s", "test", round=4, diagnose_threshold=3, max_rounds=10)
+    assert d.action == "diagnose"   # 不 escalate，还在 diagnose 窗口

--- a/orchestrator/tests/test_retry_store.py
+++ b/orchestrator/tests/test_retry_store.py
@@ -1,0 +1,86 @@
+"""retry.store 单测：mock asyncpg Pool，验 SQL 参数 / row 解析。
+
+真正的 JSONB 合并行为在集成测里（有真 pg 才能测）；这里只证调用 shape
++ row=None 的退化路径。
+"""
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.retry import store as retry_store
+
+
+class StubRow(dict):
+    """既像 dict 也像 asyncpg.Record（都支持 ["key"] 访问）。"""
+
+
+class FakePool:
+    def __init__(self, fetchrow_return=None, execute_sink=None):
+        self._fetchrow_return = fetchrow_return
+        self._execute_sink = execute_sink if execute_sink is not None else []
+        self.fetchrow_calls: list = []
+
+    async def fetchrow(self, sql, *args):
+        self.fetchrow_calls.append((sql, args))
+        return self._fetchrow_return
+
+    async def execute(self, sql, *args):
+        self._execute_sink.append((sql, args))
+        return None
+
+
+# ─── increment_round ─────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_increment_round_returns_new_value():
+    pool = FakePool(fetchrow_return=StubRow({"new_round": 3}))
+    r = await retry_store.increment_round(pool, "REQ-1", "staging-test")
+    assert r == 3
+    assert len(pool.fetchrow_calls) == 1
+    sql, args = pool.fetchrow_calls[0]
+    assert args == ("REQ-1", "staging-test")
+    assert "jsonb_set" in sql
+    assert "retries" in sql
+
+
+@pytest.mark.asyncio
+async def test_increment_round_row_missing_returns_zero():
+    """req_state 里没这个 req_id → row=None，返 0（不炸）。"""
+    pool = FakePool(fetchrow_return=None)
+    r = await retry_store.increment_round(pool, "REQ-nope", "staging-test")
+    assert r == 0
+
+
+# ─── reset_round ─────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_reset_round_executes_delete():
+    sink: list = []
+    pool = FakePool(execute_sink=sink)
+    await retry_store.reset_round(pool, "REQ-1", "staging-test")
+    assert len(sink) == 1
+    sql, args = sink[0]
+    assert args == ("REQ-1", "staging-test")
+    assert "jsonb_set" in sql
+    # 用 - 操作符 drop key
+    assert "- $2::text" in sql
+
+
+# ─── get_round ───────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_get_round_returns_value():
+    pool = FakePool(fetchrow_return=StubRow({"r": 2}))
+    r = await retry_store.get_round(pool, "REQ-1", "staging-test")
+    assert r == 2
+
+
+@pytest.mark.asyncio
+async def test_get_round_null_returns_zero():
+    pool = FakePool(fetchrow_return=StubRow({"r": None}))
+    r = await retry_store.get_round(pool, "REQ-1", "staging-test")
+    assert r == 0
+
+
+@pytest.mark.asyncio
+async def test_get_round_no_row_returns_zero():
+    pool = FakePool(fetchrow_return=None)
+    r = await retry_store.get_round(pool, "REQ-nope", "staging-test")
+    assert r == 0


### PR DESCRIPTION
## Summary

- 新增 `orchestrator/retry/` 模块（policy + executor + store），按 #11 设计的失败分级决策表，checker fail 走 follow_up / fresh_start / diagnose / skip_check_retry / escalate，而非直 emit FAIL
- round 计数持久化到 `req_state.context.retries[stage]`，admission pass 清零
- M1 staging-test 接入；M2/M3 未进 main 本期不接，模块通用后续两行代码接入
- retry_enabled 默认 false 灰度，老 BKD agent 路径不动

## 决策表

| fail_kind | round < 3 | round ≥ 3 | round ≥ 5 |
|---|---|---|---|
| schema / lint / typecheck | follow_up | follow_up | escalate |
| test | follow_up | diagnose | escalate |
| prompt_too_long | fresh_start | fresh_start | escalate |
| flaky | skip_check_retry | skip_check_retry | escalate |
| 未知 | escalate | escalate | escalate |

阈值由 `retry_max_rounds`（5）+ `retry_diagnose_threshold`（3）配置。

## 验收

- [x] `retry/policy.py` + `retry/executor.py` + `retry/store.py`
- [x] round 持久化到 `req_state.ctx.retries`（原子 jsonb_set，不跨 REQ 串）
- [x] 接入 M1 staging-test fail 路径（M2/M3 未 merge，后续跟进）
- [x] feature flag `retry_enabled` 默认 false，老 BKD path 不动
- [x] PR 标题 `feat(retry): M4 故障分级重试`

## MUST NOT（已遵守）

- 不改老 BKD path ✅（flag off 时老 shape 原样返）
- 不动 M5 的 bugfix 链 ✅（状态机 transitions 完全没碰）

## Test plan

- [x] `uv run --extra dev pytest` — 226 passed（新增 51：policy 28 + executor 11 + store 6 + 接入点 6）
- [x] `ruff check .` clean
- [ ] （待人工）retry_enabled=true 在 dev cluster 跑一轮真 REQ，验 follow_up / diagnose 两条分支

## 后续（单独 PR）

- M2 pr-ci-watch / M3 admission（analyze / spec）落地后，同一个 `_handle_fail` 模式接 retry.executor
- 决策结果写观测表（artifact_checks + event_log），Metabase 看 `retry_action` 分布

🤖 Generated with [Claude Code](https://claude.com/claude-code)