### PR TITLE
feat(checker): M2 pr-ci-watch 自检（GH API 轮询替换 BKD agent）

### DIFF
--- a/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
@@ -1,24 +1,24 @@
-"""create_pr_ci_watch（v0.2）：staging-test pass → 下发 pr-ci-watch BKD agent。
+"""create_pr_ci_watch（v0.2 + M2 checker）：staging-test pass → 等 PR CI 全套绿。
 
-前置：staging-test agent 已 push branch 到各 source repo 并 gh pr create，
-manifest.yaml.pr_by_repo + sha_by_repo 应已填好。
+feature flag checker_pr_ci_watch_enabled:
+  False（默认）: 创建 BKD agent issue（老路，agent 用 gh CLI 轮询，报 tag）
+  True: sisyphus 自己调 GitHub REST API 轮询 check-runs，emit PR_CI_PASS/FAIL/TIMEOUT
 
-pr-ci-watch agent 职责：
-- 读 manifest.sources + pr_by_repo + sha_by_repo
-- 对每个 (repo, sha) 轮询 GitHub commit statuses（gh CLI）
-- 全绿 → 解析 image-publish status description 写 manifest.image_tags，贴 pr-ci:pass
-- 任一红 → 贴 pr-ci:fail
-- 超时（默认 30 min）→ 贴 pr-ci:timeout
+ctx 输入（checker 模式）：
+  pr_repo: "owner/name" 例 "phona/ubox-crosser"
+  pr_number: int
+M3 会改成统一从 manifest.yaml 读，M2 先硬编码 ctx 字段（dev/staging-test agent 写入）。
 """
 from __future__ import annotations
 
 import structlog
 
 from ..bkd import BKDClient
+from ..checkers import pr_ci_watch as checker
 from ..config import settings
 from ..prompts import render
 from ..state import Event
-from ..store import db, req_state
+from ..store import artifact_checks, db, req_state
 from . import register, short_title
 from ._skip import skip_if_enabled
 
@@ -30,6 +30,71 @@ async def create_pr_ci_watch(*, body, req_id, tags, ctx):
     if rv := skip_if_enabled("pr-ci", Event.PR_CI_PASS, req_id=req_id):
         return rv
 
+    if settings.checker_pr_ci_watch_enabled:
+        return await _run_checker(req_id=req_id, ctx=ctx)
+
+    return await _dispatch_bkd_agent(body=body, req_id=req_id, ctx=ctx)
+
+
+# ── 新路：sisyphus 自检 ────────────────────────────────────────────────────
+
+async def _run_checker(*, req_id: str, ctx: dict) -> dict:
+    pr_repo = ctx.get("pr_repo")
+    pr_number = ctx.get("pr_number")
+    if not pr_repo or not pr_number:
+        # ctx 缺字段：emit fail 进 bugfix（按 PR_CI_FAIL 路径走，跟老路报 pr-ci:fail tag 等价）
+        log.error("create_pr_ci_watch.checker_missing_ctx",
+                  req_id=req_id, pr_repo=pr_repo, pr_number=pr_number)
+        return {
+            "emit": Event.PR_CI_FAIL.value,
+            "reason": "missing pr_repo / pr_number in ctx",
+            "exit_code": -1,
+        }
+
+    log.info("create_pr_ci_watch.checker_path",
+             req_id=req_id, repo=pr_repo, pr=pr_number)
+
+    try:
+        result = await checker.watch_pr_ci(
+            repo=pr_repo,
+            pr_number=int(pr_number),
+            poll_interval_sec=settings.pr_ci_watch_poll_interval_sec,
+            timeout_sec=settings.pr_ci_watch_timeout_sec,
+        )
+    except Exception as e:
+        log.exception("create_pr_ci_watch.checker_error", req_id=req_id, error=str(e))
+        return {
+            "emit": Event.PR_CI_FAIL.value,
+            "reason": str(e)[:200],
+            "exit_code": -1,
+        }
+
+    pool = db.get_pool()
+    await artifact_checks.insert_check(pool, req_id, "pr-ci-watch", result)
+
+    if result.exit_code == 124:
+        emit = Event.PR_CI_TIMEOUT
+    elif result.passed:
+        emit = Event.PR_CI_PASS
+    else:
+        emit = Event.PR_CI_FAIL
+
+    log.info("create_pr_ci_watch.checker_done", req_id=req_id,
+             emit=emit.value, exit_code=result.exit_code,
+             duration_sec=round(result.duration_sec, 1))
+
+    return {
+        "emit": emit.value,
+        "passed": result.passed,
+        "exit_code": result.exit_code,
+        "cmd": result.cmd,
+        "duration_sec": result.duration_sec,
+    }
+
+
+# ── 老路：BKD agent（flag off 时走这里）────────────────────────────────────
+
+async def _dispatch_bkd_agent(*, body, req_id: str, ctx: dict) -> dict:
     proj = body.projectId
     source_issue_id = body.issueId   # 上游 staging-test issue
 
@@ -51,5 +116,5 @@ async def create_pr_ci_watch(*, body, req_id, tags, ctx):
     pool = db.get_pool()
     await req_state.update_context(pool, req_id, {"pr_ci_watch_issue_id": issue.id})
 
-    log.info("create_pr_ci_watch.done", req_id=req_id, pr_ci_issue=issue.id)
+    log.info("create_pr_ci_watch.bkd_agent_dispatched", req_id=req_id, pr_ci_issue=issue.id)
     return {"pr_ci_watch_issue_id": issue.id}

--- a/orchestrator/src/orchestrator/checkers/_types.py
+++ b/orchestrator/src/orchestrator/checkers/_types.py
@@ -1,0 +1,23 @@
+"""checker 共享类型。
+
+所有 artifact-driven checker 返回同一个 CheckResult shape，下游
+artifact_checks 表写入 / engine emit 决策都不用关心 checker 是哪种。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """checker 运行结果。
+
+    exit_code 语义按 checker 自定（staging-test = 命令退出码；
+    pr-ci-watch = 0 全绿 / 1 任一失败 / 124 超时），engine 只看 passed。
+    """
+    passed: bool
+    exit_code: int
+    stdout_tail: str
+    stderr_tail: str
+    duration_sec: float
+    cmd: str

--- a/orchestrator/src/orchestrator/checkers/pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/checkers/pr_ci_watch.py
@@ -1,0 +1,176 @@
+"""pr-ci-watch 自检（M2）：sisyphus 直接调 GitHub REST API 轮询 PR check-runs，
+不再起 BKD agent 让它跑 `gh pr checks` 然后报 tag。
+
+GH API:
+- GET /repos/{owner}/{repo}/pulls/{pr_number}        → head.sha
+- GET /repos/{owner}/{repo}/commits/{sha}/check-runs → check_runs[]
+
+退出码：
+- 0   = 全绿（所有 check-run completed 且 conclusion 友好）
+- 1   = 至少一个失败（completed + conclusion 红）
+- 124 = 超时（到 timeout_sec 还有 check-run 没 completed）
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import httpx
+import structlog
+
+from ..config import settings
+from ._types import CheckResult
+
+log = structlog.get_logger(__name__)
+
+_GH_API = "https://api.github.com"
+_TAIL = 2048
+
+# check-run conclusion 分类
+# https://docs.github.com/en/rest/checks/runs#about-check-runs
+_PASS_CONCLUSIONS = {"success", "neutral", "skipped"}
+_FAIL_CONCLUSIONS = {"failure", "cancelled", "timed_out", "action_required", "stale"}
+
+
+async def watch_pr_ci(
+    repo: str,
+    pr_number: int,
+    poll_interval_sec: int = 30,
+    timeout_sec: int = 1800,
+) -> CheckResult:
+    """轮询 PR 的 check-runs，全绿 / 任一失败 / 超时返 CheckResult。
+
+    Args:
+        repo: "owner/name" 形如 "phona/ubox-crosser"
+        pr_number: PR 编号
+        poll_interval_sec: 每轮轮询间隔
+        timeout_sec: 总超时；过期返 exit_code=124，passed=False
+
+    通过 settings.github_token 认证。
+    """
+    cmd_label = f"watch-pr-ci {repo}#{pr_number}"
+    start = time.monotonic()
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if settings.github_token:
+        headers["Authorization"] = f"Bearer {settings.github_token}"
+
+    log.info("checker.pr_ci_watch.start", repo=repo, pr=pr_number,
+             poll=poll_interval_sec, timeout=timeout_sec)
+
+    async with httpx.AsyncClient(base_url=_GH_API, headers=headers, timeout=30.0) as client:
+        try:
+            sha = await _get_pr_head_sha(client, repo, pr_number)
+        except httpx.HTTPError as e:
+            log.exception("checker.pr_ci_watch.pr_lookup_failed", repo=repo, pr=pr_number)
+            return CheckResult(
+                passed=False, exit_code=1,
+                stdout_tail="", stderr_tail=f"PR lookup failed: {e}"[:_TAIL],
+                duration_sec=time.monotonic() - start, cmd=cmd_label,
+            )
+
+        cmd_label = f"watch-pr-ci {repo}#{pr_number}@{sha[:8]}"
+        deadline = start + timeout_sec
+        last_runs: list[dict] = []
+
+        while True:
+            try:
+                last_runs = await _get_check_runs(client, repo, sha)
+            except httpx.HTTPError as e:
+                log.warning("checker.pr_ci_watch.api_error", repo=repo, sha=sha[:8], error=str(e))
+                # 临时网络错误不立即失败，下一轮重试；超时再返 124
+                if time.monotonic() >= deadline:
+                    return CheckResult(
+                        passed=False, exit_code=124,
+                        stdout_tail="", stderr_tail=f"API error at deadline: {e}"[:_TAIL],
+                        duration_sec=time.monotonic() - start, cmd=cmd_label,
+                    )
+                await asyncio.sleep(poll_interval_sec)
+                continue
+
+            verdict = _classify(last_runs)
+            log.info("checker.pr_ci_watch.poll", repo=repo, sha=sha[:8],
+                     verdict=verdict, run_count=len(last_runs))
+
+            if verdict == "pass":
+                return CheckResult(
+                    passed=True, exit_code=0,
+                    stdout_tail=_summarize(last_runs)[:_TAIL], stderr_tail="",
+                    duration_sec=time.monotonic() - start, cmd=cmd_label,
+                )
+            if verdict == "fail":
+                return CheckResult(
+                    passed=False, exit_code=1,
+                    stdout_tail=_summarize(last_runs, failed_only=True)[:_TAIL],
+                    stderr_tail="",
+                    duration_sec=time.monotonic() - start, cmd=cmd_label,
+                )
+
+            # pending：再等一轮
+            if time.monotonic() + poll_interval_sec >= deadline:
+                return CheckResult(
+                    passed=False, exit_code=124,
+                    stdout_tail=_summarize(last_runs)[:_TAIL],
+                    stderr_tail=f"timeout after {timeout_sec}s, still pending",
+                    duration_sec=time.monotonic() - start, cmd=cmd_label,
+                )
+            await asyncio.sleep(poll_interval_sec)
+
+
+# ── GH API helpers ───────────────────────────────────────────────────────
+
+async def _get_pr_head_sha(client: httpx.AsyncClient, repo: str, pr_number: int) -> str:
+    r = await client.get(f"/repos/{repo}/pulls/{pr_number}")
+    r.raise_for_status()
+    return r.json()["head"]["sha"]
+
+
+async def _get_check_runs(client: httpx.AsyncClient, repo: str, sha: str) -> list[dict]:
+    r = await client.get(f"/repos/{repo}/commits/{sha}/check-runs", params={"per_page": 100})
+    r.raise_for_status()
+    return r.json().get("check_runs", [])
+
+
+# ── verdict 计算 ─────────────────────────────────────────────────────────
+
+def _classify(runs: list[dict]) -> str:
+    """返 'pass' / 'fail' / 'pending'。
+
+    - 任一 completed 且 conclusion 红 → fail（fail 优先：早死早超生）
+    - 任一未 completed → pending
+    - 全 completed 且 conclusion 全绿 → pass
+    - 空 → pending（PR 刚开 GHA 没触发，先等）
+    """
+    if not runs:
+        return "pending"
+
+    has_fail = False
+    has_pending = False
+    for r in runs:
+        if r.get("status") != "completed":
+            has_pending = True
+            continue
+        if r.get("conclusion") in _FAIL_CONCLUSIONS:
+            has_fail = True
+
+    if has_fail:
+        return "fail"
+    if has_pending:
+        return "pending"
+    return "pass"
+
+
+def _summarize(runs: list[dict], failed_only: bool = False) -> str:
+    """渲染 check-run 列表为 'name=conclusion' 一行串，给 stdout_tail。"""
+    parts = []
+    for r in runs:
+        name = r.get("name", "?")
+        status = r.get("status", "?")
+        conclusion = r.get("conclusion") or status
+        if failed_only and conclusion not in _FAIL_CONCLUSIONS:
+            continue
+        parts.append(f"{name}={conclusion}")
+    return " ".join(parts)

--- a/orchestrator/src/orchestrator/checkers/staging_test.py
+++ b/orchestrator/src/orchestrator/checkers/staging_test.py
@@ -5,25 +5,15 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
 
 import structlog
 
 from .. import k8s_runner
+from ._types import CheckResult
 
 log = structlog.get_logger(__name__)
 
 _TAIL = 2048  # stdout/stderr 各截尾 2KB，防 OOM
-
-
-@dataclass(frozen=True)
-class CheckResult:
-    passed: bool
-    exit_code: int
-    stdout_tail: str
-    stderr_tail: str
-    duration_sec: float
-    cmd: str
 
 
 async def run_staging_test(

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -93,5 +93,13 @@ class Settings(BaseSettings):
     # False（默认）= 走老路，创建 BKD agent issue（回滚：unset env / set false → rollout restart）
     checker_staging_test_enabled: bool = False
 
+    # ─── M2：pr-ci-watch 自检 ────────────────────────────────────────────
+    # True = sisyphus 用 GitHub REST API 轮询 PR check-runs，不再起 BKD agent
+    # False（默认）= 走老路 BKD agent。回滚同上。
+    checker_pr_ci_watch_enabled: bool = False
+    # 轮询参数（仅 checker 模式下用）
+    pr_ci_watch_poll_interval_sec: int = 30
+    pr_ci_watch_timeout_sec: int = 1800   # 30 min
+
 
 settings = Settings()  # type: ignore[call-arg]

--- a/orchestrator/src/orchestrator/store/artifact_checks.py
+++ b/orchestrator/src/orchestrator/store/artifact_checks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncpg
 
-from ..checkers.staging_test import CheckResult
+from ..checkers._types import CheckResult
 
 
 async def insert_check(pool: asyncpg.Pool, req_id: str, stage: str, result: CheckResult) -> None:

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -391,7 +391,7 @@ async def test_create_accept_skipped(monkeypatch):
 async def test_create_staging_test_checker_pass(monkeypatch):
     """checker_staging_test_enabled=True + checker pass → emit staging-test.pass。"""
     from orchestrator.actions import create_staging_test as mod
-    from orchestrator.checkers.staging_test import CheckResult
+    from orchestrator.checkers._types import CheckResult
 
     monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.checker_staging_test_enabled", True)
     monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.skip_staging_test", False)
@@ -425,7 +425,7 @@ async def test_create_staging_test_checker_pass(monkeypatch):
 async def test_create_staging_test_checker_fail(monkeypatch):
     """checker_staging_test_enabled=True + checker fail → emit staging-test.fail。"""
     from orchestrator.actions import create_staging_test as mod
-    from orchestrator.checkers.staging_test import CheckResult
+    from orchestrator.checkers._types import CheckResult
 
     monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.checker_staging_test_enabled", True)
     monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.skip_staging_test", False)

--- a/orchestrator/tests/test_checkers_pr_ci_watch.py
+++ b/orchestrator/tests/test_checkers_pr_ci_watch.py
@@ -1,0 +1,243 @@
+"""checkers/pr_ci_watch.py 单测：mock GitHub API，验全绿/任一失败/全失败/超时。"""
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.checkers import pr_ci_watch
+from orchestrator.checkers._types import CheckResult
+
+
+def _pr_response(sha: str = "deadbeef" * 5):
+    return {"head": {"sha": sha}, "number": 42}
+
+
+def _runs_payload(*runs: dict) -> dict:
+    return {"total_count": len(runs), "check_runs": list(runs)}
+
+
+def _run(name: str, status: str = "completed", conclusion: str | None = "success") -> dict:
+    return {"name": name, "status": status, "conclusion": conclusion}
+
+
+# ── 单轮直绿 ──────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_all_green(httpx_mock, monkeypatch):
+    monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/pulls/42",
+        json=_pr_response(),
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/commits/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/check-runs?per_page=100",
+        json=_runs_payload(_run("lint"), _run("unit"), _run("integration")),
+    )
+
+    result = await pr_ci_watch.watch_pr_ci("phona/ubox-crosser", 42, poll_interval_sec=1, timeout_sec=60)
+
+    assert isinstance(result, CheckResult)
+    assert result.passed is True
+    assert result.exit_code == 0
+    assert "lint=success" in result.stdout_tail
+    assert "integration=success" in result.stdout_tail
+    assert result.cmd.startswith("watch-pr-ci phona/ubox-crosser#42@deadbeef")
+
+
+# ── 单轮失败 ──────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_any_failed(httpx_mock, monkeypatch):
+    monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/pulls/42",
+        json=_pr_response(),
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/commits/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/check-runs?per_page=100",
+        json=_runs_payload(
+            _run("lint"),
+            _run("unit", conclusion="failure"),
+            _run("integration"),
+        ),
+    )
+
+    result = await pr_ci_watch.watch_pr_ci("phona/ubox-crosser", 42, poll_interval_sec=1, timeout_sec=60)
+
+    assert result.passed is False
+    assert result.exit_code == 1
+    # failed_only 模式：只列失败的
+    assert "unit=failure" in result.stdout_tail
+    assert "lint=success" not in result.stdout_tail
+
+
+# ── 全失败 ────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_all_failed(httpx_mock, monkeypatch):
+    monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/pulls/42",
+        json=_pr_response(),
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/commits/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/check-runs?per_page=100",
+        json=_runs_payload(
+            _run("lint", conclusion="failure"),
+            _run("unit", conclusion="cancelled"),
+        ),
+    )
+
+    result = await pr_ci_watch.watch_pr_ci("phona/ubox-crosser", 42, poll_interval_sec=1, timeout_sec=60)
+
+    assert result.passed is False
+    assert result.exit_code == 1
+    assert "lint=failure" in result.stdout_tail
+    assert "unit=cancelled" in result.stdout_tail
+
+
+# ── pending → 超时 ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_timeout(httpx_mock, monkeypatch):
+    """所有 check-run 都还 in_progress，到 timeout 返 124。"""
+    monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+
+    # 让 sleep 立即返回，避免真等
+    async def fast_sleep(_):
+        return None
+    monkeypatch.setattr(pr_ci_watch.asyncio, "sleep", fast_sleep)
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/pulls/42",
+        json=_pr_response(),
+    )
+    # check-runs 永远 pending：让 mock 复用同一个响应
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/commits/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/check-runs?per_page=100",
+        json=_runs_payload(_run("integration", status="in_progress", conclusion=None)),
+        is_reusable=True,
+    )
+
+    result = await pr_ci_watch.watch_pr_ci(
+        "phona/ubox-crosser", 42, poll_interval_sec=0, timeout_sec=0,
+    )
+
+    assert result.passed is False
+    assert result.exit_code == 124
+    assert "timeout" in result.stderr_tail.lower()
+    assert "integration=in_progress" in result.stdout_tail
+
+
+# ── pending → 中途变绿 ───────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_pending_then_pass(httpx_mock, monkeypatch):
+    """前一轮 pending，后一轮全绿。"""
+    monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+
+    async def fast_sleep(_):
+        return None
+    monkeypatch.setattr(pr_ci_watch.asyncio, "sleep", fast_sleep)
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/pulls/42",
+        json=_pr_response(),
+    )
+    # 第一次：pending
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/commits/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/check-runs?per_page=100",
+        json=_runs_payload(_run("lint", status="in_progress", conclusion=None)),
+    )
+    # 第二次：成功
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/commits/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/check-runs?per_page=100",
+        json=_runs_payload(_run("lint")),
+    )
+
+    result = await pr_ci_watch.watch_pr_ci("phona/ubox-crosser", 42, poll_interval_sec=1, timeout_sec=60)
+
+    assert result.passed is True
+    assert result.exit_code == 0
+
+
+# ── PR 不存在（404）→ fail ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_pr_not_found(httpx_mock, monkeypatch):
+    monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/pulls/999",
+        status_code=404,
+        json={"message": "Not Found"},
+    )
+
+    result = await pr_ci_watch.watch_pr_ci(
+        "phona/ubox-crosser", 999, poll_interval_sec=1, timeout_sec=60,
+    )
+
+    assert result.passed is False
+    assert result.exit_code == 1
+    assert "PR lookup failed" in result.stderr_tail
+
+
+# ── 空 check-runs → pending → 超时 ────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_empty_runs_times_out(httpx_mock, monkeypatch):
+    """PR 刚开 GHA 还没触发，check-runs 为空 → pending → 超时。"""
+    monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+
+    async def fast_sleep(_):
+        return None
+    monkeypatch.setattr(pr_ci_watch.asyncio, "sleep", fast_sleep)
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/pulls/42",
+        json=_pr_response(),
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/commits/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/check-runs?per_page=100",
+        json=_runs_payload(),
+        is_reusable=True,
+    )
+
+    result = await pr_ci_watch.watch_pr_ci(
+        "phona/ubox-crosser", 42, poll_interval_sec=0, timeout_sec=0,
+    )
+    assert result.exit_code == 124
+
+
+# ── _classify 单测 ───────────────────────────────────────────────────────
+
+def test_classify_empty_is_pending():
+    assert pr_ci_watch._classify([]) == "pending"
+
+
+def test_classify_all_green():
+    assert pr_ci_watch._classify([
+        _run("a"), _run("b", conclusion="neutral"), _run("c", conclusion="skipped"),
+    ]) == "pass"
+
+
+def test_classify_any_fail_wins_over_pending():
+    """fail 优先，即使还有 pending 没跑完。"""
+    assert pr_ci_watch._classify([
+        _run("a", conclusion="failure"),
+        _run("b", status="in_progress", conclusion=None),
+    ]) == "fail"
+
+
+def test_classify_pending_when_any_in_progress():
+    assert pr_ci_watch._classify([
+        _run("a"),
+        _run("b", status="in_progress", conclusion=None),
+    ]) == "pending"
+
+
+def test_classify_recognizes_all_fail_conclusions():
+    for c in ["failure", "cancelled", "timed_out", "action_required", "stale"]:
+        assert pr_ci_watch._classify([_run("x", conclusion=c)]) == "fail", c

--- a/orchestrator/tests/test_checkers_staging_test.py
+++ b/orchestrator/tests/test_checkers_staging_test.py
@@ -5,7 +5,8 @@ import asyncio
 
 import pytest
 
-from orchestrator.checkers.staging_test import CheckResult, run_staging_test
+from orchestrator.checkers._types import CheckResult
+from orchestrator.checkers.staging_test import run_staging_test
 from orchestrator.k8s_runner import ExecResult
 
 


### PR DESCRIPTION
承接 #11 设计 + M1 PR #3。

## 改动
- checkers/_types.py — CheckResult dataclass 共享
- checkers/pr_ci_watch.py — GH API 轮询实现
- create_pr_ci_watch.py — feature flag fork
- config.py — checker_pr_ci_watch_enabled
- 测试

## Test plan
- [ ] CI lint/test 全绿
- [ ] 灰度部署：set SISYPHUS_CHECKER_PR_CI_WATCH_ENABLED=true 跑一个 REQ 验

🤖 由 BKD agent (claude-opus-4-7[1m]) 完成主要改动