### PR TITLE
feat(admission): M3 analyze/spec artifact 验证

### DIFF
--- a/orchestrator/src/orchestrator/checkers/_types.py
+++ b/orchestrator/src/orchestrator/checkers/_types.py
@@ -13,7 +13,9 @@ class CheckResult:
     """checker 运行结果。
 
     exit_code 语义按 checker 自定（staging-test = 命令退出码；
-    pr-ci-watch = 0 全绿 / 1 任一失败 / 124 超时），engine 只看 passed。
+    pr-ci-watch = 0 全绿 / 1 任一失败 / 124 超时；
+    manifest = 0 合法 / 1 schema 不符 / 2 yaml 解析挂 / -1 读 PVC 超时；
+    openspec = openspec CLI 退出码），engine 只看 passed。
     """
     passed: bool
     exit_code: int

--- a/orchestrator/src/orchestrator/checkers/manifest_validate.py
+++ b/orchestrator/src/orchestrator/checkers/manifest_validate.py
@@ -1,0 +1,156 @@
+"""manifest 自检（M3）：sisyphus 把 PVC 上的 manifest.yaml 拉回来用 jsonschema 验。
+
+analyze-agent 完成后，sisyphus 是唯一裁判：能不能进 fanout_specs 不靠 agent tag，
+靠这里 admission gate emit 的事件。
+
+设计要点：
+- jsonschema draft-07 验结构（required / type / pattern / enum）
+- jsonschema 表达不了的跨字段约束（"sources 里恰好 1 个 leader"、"repo 不重复"）
+  在本模块手写，跟 schema 一起组成完整规则
+- 行为与 scripts/validate-manifest.py 对齐，避免 runner 内 / orchestrator 侧两套口径
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections.abc import Iterable
+from importlib import resources
+from typing import Any
+
+import structlog
+import yaml
+from jsonschema import Draft7Validator
+
+from .. import k8s_runner
+from ._types import CheckResult
+
+log = structlog.get_logger(__name__)
+
+_TAIL = 2048
+_MANIFEST_PATH = "/workspace/.sisyphus/manifest.yaml"
+_READ_CMD = f"cat {_MANIFEST_PATH}"
+
+_validator: Draft7Validator | None = None
+
+
+def _get_validator() -> Draft7Validator:
+    global _validator
+    if _validator is None:
+        raw = resources.files("orchestrator.schemas").joinpath("manifest.json").read_text()
+        _validator = Draft7Validator(json.loads(raw))
+    return _validator
+
+
+def _format_error_path(path: Iterable[Any]) -> str:
+    """jsonschema deque 路径 → 'sources[0].repo' 形式。"""
+    out: list[str] = []
+    for p in path:
+        if isinstance(p, int):
+            out.append(f"[{p}]")
+        else:
+            out.append(f".{p}" if out else str(p))
+    return "".join(out) or "<root>"
+
+
+def _collect_errors(manifest: Any) -> list[str]:
+    """跑 jsonschema + 跨字段约束。返回中文错误列表（空 = 合法）。"""
+    if not isinstance(manifest, dict):
+        return ["manifest 根必须是 object / dict"]
+
+    errs: list[str] = []
+    for err in sorted(_get_validator().iter_errors(manifest), key=lambda e: list(e.absolute_path)):
+        loc = _format_error_path(err.absolute_path)
+        errs.append(f"{loc}: {err.message}")
+
+    # jsonschema draft-07 表达不了：sources 必须正好 1 个 leader、repo 不重复
+    sources = manifest.get("sources")
+    if isinstance(sources, list) and sources:
+        leaders = sum(
+            1 for s in sources
+            if isinstance(s, dict) and s.get("role") == "leader"
+        )
+        if leaders != 1:
+            errs.append(f"sources 必须正好有 1 个 role=leader，实际 {leaders} 个")
+
+        seen: set[str] = set()
+        for s in sources:
+            if not isinstance(s, dict):
+                continue
+            repo = s.get("repo")
+            if not isinstance(repo, str):
+                continue
+            if repo in seen:
+                errs.append(f"sources 里 repo {repo!r} 重复出现")
+            else:
+                seen.add(repo)
+
+    return errs
+
+
+async def run_manifest_validate(req_id: str, *, timeout_sec: int = 30) -> CheckResult:
+    """kubectl exec runner cat manifest.yaml → jsonschema validate → CheckResult。
+
+    所有失败原因（pod 不可达 / cat 返非 0 / yaml 解析挂 / schema 不符）
+    都收成 passed=False，stderr_tail 带原因。engine 拿 passed 决策即可。
+    """
+    rc = k8s_runner.get_controller()
+    started = time.monotonic()
+
+    try:
+        exec_result = await asyncio.wait_for(
+            rc.exec_in_runner(req_id, _READ_CMD, timeout_sec=timeout_sec),
+            timeout=timeout_sec + 10,
+        )
+    except TimeoutError:
+        log.error("checker.manifest_validate.read_timeout", req_id=req_id)
+        return CheckResult(
+            passed=False, exit_code=-1,
+            stdout_tail="", stderr_tail=f"read timeout after {timeout_sec}s",
+            duration_sec=time.monotonic() - started, cmd=_READ_CMD,
+        )
+
+    if exec_result.exit_code != 0:
+        log.warning(
+            "checker.manifest_validate.read_failed",
+            req_id=req_id, exit_code=exec_result.exit_code,
+        )
+        return CheckResult(
+            passed=False, exit_code=exec_result.exit_code,
+            stdout_tail=exec_result.stdout[-_TAIL:],
+            stderr_tail=(exec_result.stderr or f"cat {_MANIFEST_PATH} exit {exec_result.exit_code}")[-_TAIL:],
+            duration_sec=exec_result.duration_sec, cmd=_READ_CMD,
+        )
+
+    try:
+        manifest = yaml.safe_load(exec_result.stdout)
+    except yaml.YAMLError as e:
+        log.warning("checker.manifest_validate.yaml_error", req_id=req_id, error=str(e))
+        return CheckResult(
+            passed=False, exit_code=2,
+            stdout_tail=exec_result.stdout[-_TAIL:],
+            stderr_tail=f"YAML 解析失败: {e}"[-_TAIL:],
+            duration_sec=exec_result.duration_sec, cmd=_READ_CMD,
+        )
+
+    errs = _collect_errors(manifest)
+    duration = time.monotonic() - started
+    if errs:
+        log.info(
+            "checker.manifest_validate.invalid",
+            req_id=req_id, error_count=len(errs),
+        )
+        joined = "\n".join(f"  - {e}" for e in errs)
+        return CheckResult(
+            passed=False, exit_code=1,
+            stdout_tail=exec_result.stdout[-_TAIL:],
+            stderr_tail=f"manifest 验证失败 ({len(errs)} 项):\n{joined}"[-_TAIL:],
+            duration_sec=duration, cmd=_READ_CMD,
+        )
+
+    log.info("checker.manifest_validate.ok", req_id=req_id, duration_sec=round(duration, 2))
+    return CheckResult(
+        passed=True, exit_code=0,
+        stdout_tail=exec_result.stdout[-_TAIL:],
+        stderr_tail="", duration_sec=duration, cmd=_READ_CMD,
+    )

--- a/orchestrator/src/orchestrator/checkers/openspec_validate.py
+++ b/orchestrator/src/orchestrator/checkers/openspec_validate.py
@@ -1,0 +1,82 @@
+"""openspec 自检（M3）：sisyphus 在 runner pod 直接跑 `openspec validate`，吃退出码定 pass/fail。
+
+spec-agent 写完 openspec/changes/<REQ>/ 下的 spec 文件后，sisyphus 不靠 ci-passed tag，
+靠这里 admission gate emit 的事件。两个 spec issue（contract / acceptance）共用本 checker：
+传 spec_stage 只是用于打日志和写 artifact_checks 表。
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import structlog
+
+from .. import k8s_runner
+from ._types import CheckResult
+
+log = structlog.get_logger(__name__)
+
+_TAIL = 2048
+
+
+def _build_cmd(req_id: str) -> str:
+    """跑 openspec validate <change-id>。
+
+    spec-agent 把文件写在 leader source repo 的 openspec/changes/<REQ>/ 下，
+    cwd 切到那个 repo 才能让 openspec 找到 openspec/ 配置。leader repo 路径从
+    manifest.yaml 现读，避免 sisyphus 缓存 / agent 改 manifest 不一致。
+    """
+    return (
+        f"set -e; "
+        f"leader_repo=$(yq -r '.sources[] | select(.role==\"leader\") | .repo' "
+        f"/workspace/.sisyphus/manifest.yaml); "
+        f"name=$(basename \"$leader_repo\"); "
+        f"cd \"/workspace/source/$name\" && openspec validate openspec/changes/{req_id}"
+    )
+
+
+async def run_openspec_validate(
+    req_id: str,
+    *,
+    spec_stage: str,
+    timeout_sec: int = 120,
+) -> CheckResult:
+    """kubectl exec runner -- openspec validate ...，收 stdout/stderr/exit。"""
+    rc = k8s_runner.get_controller()
+    cmd = _build_cmd(req_id)
+    log.info(
+        "checker.openspec_validate.start",
+        req_id=req_id, spec_stage=spec_stage, timeout=timeout_sec,
+    )
+    started = time.monotonic()
+
+    try:
+        exec_result = await asyncio.wait_for(
+            rc.exec_in_runner(req_id, cmd, timeout_sec=timeout_sec),
+            timeout=timeout_sec + 10,
+        )
+    except TimeoutError:
+        log.error(
+            "checker.openspec_validate.timeout", req_id=req_id, spec_stage=spec_stage,
+        )
+        return CheckResult(
+            passed=False, exit_code=-1,
+            stdout_tail="", stderr_tail=f"openspec validate 超时 {timeout_sec}s",
+            duration_sec=time.monotonic() - started, cmd=cmd,
+        )
+
+    passed = exec_result.exit_code == 0
+    log.info(
+        "checker.openspec_validate.done",
+        req_id=req_id, spec_stage=spec_stage,
+        passed=passed, exit_code=exec_result.exit_code,
+        duration_sec=round(exec_result.duration_sec, 2),
+    )
+    return CheckResult(
+        passed=passed,
+        exit_code=exec_result.exit_code,
+        stdout_tail=exec_result.stdout[-_TAIL:],
+        stderr_tail=exec_result.stderr[-_TAIL:],
+        duration_sec=exec_result.duration_sec,
+        cmd=cmd,
+    )

--- a/orchestrator/src/orchestrator/checkers/staging_test.py
+++ b/orchestrator/src/orchestrator/checkers/staging_test.py
@@ -11,6 +11,8 @@ import structlog
 from .. import k8s_runner
 from ._types import CheckResult
 
+__all__ = ["CheckResult", "run_staging_test"]
+
 log = structlog.get_logger(__name__)
 
 _TAIL = 2048  # stdout/stderr 各截尾 2KB，防 OOM

--- a/orchestrator/src/orchestrator/schemas/__init__.py
+++ b/orchestrator/src/orchestrator/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""JSON schemas（draft-07）— 跟 checkers 配套，admission gate 拿来验 PVC 产物。"""

--- a/orchestrator/src/orchestrator/schemas/manifest.json
+++ b/orchestrator/src/orchestrator/schemas/manifest.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://sisyphus.dev/schemas/manifest.json",
+  "title": "Sisyphus workspace manifest (post-analyze)",
+  "type": "object",
+  "required": ["schema_version", "req_id", "sources"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "req_id": {
+      "type": "string",
+      "pattern": "^REQ-[\\w-]+$"
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/definitions/source"}
+    },
+    "integration": {
+      "type": "object",
+      "required": ["repo", "path"],
+      "additionalProperties": true,
+      "properties": {
+        "repo": {"$ref": "#/definitions/repo_id"},
+        "path": {
+          "type": "string",
+          "pattern": "^integration/.+"
+        }
+      }
+    },
+    "sha_by_repo": {"type": "object"},
+    "pr_by_repo": {"type": "object"},
+    "image_tags": {"type": "object"},
+    "merge_order": {"type": "array"}
+  },
+  "definitions": {
+    "repo_id": {
+      "type": "string",
+      "pattern": "^[\\w.-]+/[\\w.-]+$"
+    },
+    "source": {
+      "type": "object",
+      "required": ["repo", "path", "role", "branch"],
+      "additionalProperties": true,
+      "properties": {
+        "repo": {"$ref": "#/definitions/repo_id"},
+        "path": {
+          "type": "string",
+          "pattern": "^source/.+"
+        },
+        "role": {
+          "type": "string",
+          "enum": ["leader", "source"]
+        },
+        "branch": {
+          "type": "string",
+          "pattern": "^stage/.+"
+        },
+        "depends_on": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/repo_id"}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
承接 #11 + M1 PR #3 + M2 (PR pending)。

## 改动
- checkers/manifest_validate.py + openspec_validate.py
- schemas/manifest.json (jsonschema)
- config: admission_analyze/spec_enabled flags

## 依赖
跟 M2 同时改了 checkers/_types.py — 需要看 M2 合并顺序，可能要 rebase。

## Test plan
- [ ] CI lint/test 全绿
- [ ] 灰度部署测真 admission

🤖 由 BKD agent (claude-opus-4-7[1m]) 完成主要改动