### PR TITLE
fix(teardown): skip_accept=true 时 emit teardown-done.pass 而非 fail

### DIFF
--- a/orchestrator/src/orchestrator/actions/teardown_accept_env.py
+++ b/orchestrator/src/orchestrator/actions/teardown_accept_env.py
@@ -14,6 +14,7 @@ from .. import k8s_runner
 from ..state import Event
 from ..store import db, req_state
 from . import register
+from ._skip import skip_if_enabled
 
 log = structlog.get_logger(__name__)
 
@@ -21,6 +22,13 @@ log = structlog.get_logger(__name__)
 @register("teardown_accept_env")
 async def teardown_accept_env(*, body, req_id, tags, ctx):
     """跑 ci-accept-env-down 清 lab，然后按 accept_result emit 下一步事件。"""
+    # accept 被 skip 时（skip_accept=true，ttpos-arch-lab 没接前的常态），
+    # teardown 也跳：没真 env 可拆，也没 result:pass tag 可读 — 强行读会默认 fail
+    # 误推 bugfix 链。复用 skip_accept flag，emit TEARDOWN_DONE_PASS（accept 既然跳过被
+    # 视为通过，teardown 也应通过）。
+    if rv := skip_if_enabled("accept", Event.TEARDOWN_DONE_PASS, req_id=req_id):
+        return rv
+
     # 1. 从 tags 推 accept_result：result:pass / result:fail 肯定有一个
     tagset = set(tags or [])
     accept_result = "fail"

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -473,6 +473,47 @@ async def test_create_staging_test_bkd_path(monkeypatch):
     fake_bkd.update_issue.assert_awaited_once()
 
 
+# ─── teardown_accept_env skip 路径 ────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_teardown_skipped_when_accept_skipped(monkeypatch):
+    """skip_accept=True 时 teardown 必 skip，emit teardown-done.pass（不能误推 fail）。"""
+    from orchestrator.actions import teardown_accept_env as mod
+    from orchestrator.config import settings
+
+    monkeypatch.setattr(settings, "skip_accept", True)
+    monkeypatch.setattr(settings, "test_mode", False)
+
+    out = await mod.teardown_accept_env(body=make_body(), req_id="REQ-9", tags=[], ctx={})
+
+    assert out.get("skipped") is True
+    assert out["emit"] == "teardown-done.pass"
+
+
+@pytest.mark.asyncio
+async def test_teardown_runs_normally_when_accept_not_skipped(monkeypatch):
+    """skip_accept=False + tags 含 result:pass → 正常跑 env-down + emit teardown-done.pass。"""
+    from orchestrator.actions import teardown_accept_env as mod
+    from orchestrator.config import settings
+
+    monkeypatch.setattr(settings, "skip_accept", False)
+    monkeypatch.setattr(settings, "test_mode", False)
+
+    # k8s_runner.get_controller 抛 → teardown 走 best-effort 路径（test 跳真 exec）
+    def fake_controller():
+        raise RuntimeError("no k8s in test")
+    monkeypatch.setattr(mod.k8s_runner, "get_controller", fake_controller)
+    patch_db(monkeypatch, "teardown_accept_env")
+
+    out = await mod.teardown_accept_env(
+        body=make_body(), req_id="REQ-9", tags=["accept", "REQ-9", "result:pass"], ctx={},
+    )
+
+    assert out.get("skipped") is None  # 没走 skip 路径
+    assert out["emit"] == "teardown-done.pass"
+    assert out["accept_result"] == "pass"
+    assert out["env_down_ok"] is False  # controller 抛了，best-effort 失败但不阻塞
+
+
 # ─── 重要：BKD merge_tags_and_update 的 tag merge 逻辑 ─────────────────────
 @pytest.mark.asyncio
 async def test_bkd_merge_tags_preserves(monkeypatch):


### PR DESCRIPTION
实测 REQ-haiku-1776846225 端到端验证时发现 — 部署 env 含 skip_accept=true（生产默认）时，teardown_accept_env 错误推 bugfix-running 状态。

## 根因
`teardown_accept_env.py:24-28` 假设 tags 必含 result:pass/fail，但 skip 路径没真 agent 跑 → tags 没 result:* → 默认 fail。

## 修复
teardown 也走 `skip_if_enabled("accept", TEARDOWN_DONE_PASS)`：accept 跳了 teardown 必跳，emit pass 不 fail。

## Test plan
- [ ] CI 全绿
- [ ] 部署后跑一个 REQ 推到 accept 阶段，验状态走 archiving 而不是 bugfix-running