### PR TITLE
feat(observability): M7 sisyphus checker dashboard SQL

### DIFF
--- a/observability/queries/sisyphus/01-stuck-checks.sql
+++ b/observability/queries/sisyphus/01-stuck-checks.sql
@@ -1,0 +1,35 @@
+-- Dashboard: stuck checks (sisyphus 内置 checker 钻牛角尖)
+--
+-- 数据源：sisyphus 主库（orchestrator）→ 表 artifact_checks（M1 PR #3 引入）
+-- 用途：找出最近 24h 同一 (req_id, stage) 上 checker 连续 fail 超过 3 次的组合，
+--   通常意味着 sisyphus 在一个修不动的地方循环重试，应人工介入。
+-- 推荐告警阈值（人工配 Metabase Alert 参考）：
+--   - 命中 1 行即可告警（任何 REQ 出现 fail_count ≥ 3 都值得看）
+--   - 进阶：只要求 fail_count ≥ 5 再告，过滤正常重试抖动
+--
+-- 列含义：
+--   req_id        卡住的需求 ID
+--   stage         对应的 sisyphus 阶段（staging-test / pr-ci-watch / ...）
+--   fail_count    24h 内 passed=false 次数
+--   total_count   24h 内总 check 次数（算 fail ratio 用）
+--   first_fail    最早一次 fail 的时间
+--   last_fail     最近一次 fail 的时间
+--   last_cmd      最近一次 fail 实际跑的命令（排查线索）
+--   last_stderr   最近一次 fail 的 stderr_tail
+
+SELECT
+    req_id,
+    stage,
+    COUNT(*) FILTER (WHERE passed = false) AS fail_count,
+    COUNT(*)                                AS total_count,
+    MIN(checked_at) FILTER (WHERE passed = false) AS first_fail,
+    MAX(checked_at) FILTER (WHERE passed = false) AS last_fail,
+    (ARRAY_AGG(cmd         ORDER BY checked_at DESC)
+        FILTER (WHERE passed = false))[1] AS last_cmd,
+    (ARRAY_AGG(stderr_tail ORDER BY checked_at DESC)
+        FILTER (WHERE passed = false))[1] AS last_stderr
+FROM artifact_checks
+WHERE checked_at > now() - interval '24 hours'
+GROUP BY req_id, stage
+HAVING COUNT(*) FILTER (WHERE passed = false) > 3
+ORDER BY fail_count DESC, last_fail DESC;

--- a/observability/queries/sisyphus/02-check-duration-anomaly.sql
+++ b/observability/queries/sisyphus/02-check-duration-anomaly.sql
@@ -1,0 +1,42 @@
+-- Dashboard: check duration anomaly (慢异常)
+--
+-- 数据源：sisyphus 主库（orchestrator）→ 表 artifact_checks
+-- 用途：找 duration_sec > 同 stage 7d P95 × 2 的 check 记录。
+--   这类异常常见原因：
+--     - staging 起不来一直等 timeout
+--     - 外部依赖（pypi / GH clone）偶发慢
+--     - agent 的脚本卡在 prompt 里
+-- 推荐告警阈值：
+--   - 每日 1 条内可接受（偶发抖动）
+--   - 出现 ≥ 3 条同 stage 慢异常，通常说明 P95 本身该重算或依赖普遍劣化
+--
+-- 列含义：
+--   req_id, stage, duration_sec  当次 check 的慢记录
+--   p95_sec                      同 stage 7d P95（对比基准）
+--   ratio                        duration_sec / p95_sec
+--   cmd                          具体命令
+--   checked_at                   发生时间
+
+WITH p95 AS (
+    SELECT
+        stage,
+        PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY duration_sec) AS p95_sec
+    FROM artifact_checks
+    WHERE checked_at > now() - interval '7 days'
+      AND duration_sec IS NOT NULL
+    GROUP BY stage
+    HAVING COUNT(*) >= 20  -- 样本不够 P95 不稳，直接跳过
+)
+SELECT
+    c.req_id,
+    c.stage,
+    ROUND(c.duration_sec::numeric, 1)    AS duration_sec,
+    ROUND(p95.p95_sec::numeric, 1)       AS p95_sec,
+    ROUND((c.duration_sec / NULLIF(p95.p95_sec, 0))::numeric, 2) AS ratio,
+    c.cmd,
+    c.checked_at
+FROM artifact_checks c
+JOIN p95 USING (stage)
+WHERE c.checked_at > now() - interval '24 hours'
+  AND c.duration_sec > p95.p95_sec * 2
+ORDER BY ratio DESC, c.checked_at DESC;

--- a/observability/queries/sisyphus/03-stage-success-rate.sql
+++ b/observability/queries/sisyphus/03-stage-success-rate.sql
@@ -1,0 +1,36 @@
+-- Dashboard: stage success rate (7d 各 stage checker 通过率)
+--
+-- 数据源：sisyphus 主库（orchestrator）→ 表 artifact_checks
+-- 用途：看每个 sisyphus 阶段的 checker 7 天通过率，找出质量最差的 stage 优先改进。
+--   "通过率" = passed=true 次数 / 总 check 次数。
+--   注意：同一个 (req_id, stage) 会被多次 check（admission 通过前反复跑），
+--         这里算的是 check 粒度通过率，不是 REQ 粒度一把过率。
+-- 推荐告警阈值：
+--   - 通过率 < 50% 的 stage 视为亚健康，需要看是 checker 太严还是 agent 太弱
+--   - 通过率突降（本周 vs 上周 Δ > 20pp）应人工介入
+--
+-- 列含义：
+--   stage           sisyphus 阶段
+--   total_checks    7d 内该 stage 总 check 次数
+--   passed_checks   其中 passed=true 的次数
+--   failed_checks   其中 passed=false 的次数
+--   pass_rate_pct   通过率百分比（两位小数）
+--   unique_reqs     涉及到的 REQ 数
+--   avg_duration    平均耗时（秒）
+
+SELECT
+    stage,
+    COUNT(*)                                 AS total_checks,
+    COUNT(*) FILTER (WHERE passed = true)    AS passed_checks,
+    COUNT(*) FILTER (WHERE passed = false)   AS failed_checks,
+    ROUND(
+        100.0 * COUNT(*) FILTER (WHERE passed = true)
+              / NULLIF(COUNT(*), 0),
+        2
+    )                                        AS pass_rate_pct,
+    COUNT(DISTINCT req_id)                   AS unique_reqs,
+    ROUND(AVG(duration_sec)::numeric, 2)     AS avg_duration
+FROM artifact_checks
+WHERE checked_at > now() - interval '7 days'
+GROUP BY stage
+ORDER BY pass_rate_pct ASC, total_checks DESC;

--- a/observability/queries/sisyphus/04-fail-kind-distribution.sql
+++ b/observability/queries/sisyphus/04-fail-kind-distribution.sql
@@ -1,0 +1,64 @@
+-- Dashboard: fail kind distribution (按关键词分类失败频次)
+--
+-- 数据源：sisyphus 主库（orchestrator）→ 表 artifact_checks
+-- 用途：把 passed=false 的记录按 stderr_tail 里的关键词分桶，快速看"最近主要栽在哪"。
+--   分桶是启发式的，命中第一个匹配桶即归类；未命中进 other。
+-- 推荐告警阈值：
+--   - other 占比 > 40% 说明桶覆盖不够，该补新关键词
+--   - schema 桶突然飙升通常意味着契约变更未同步 → 优先排查
+--   - timeout 桶飙升通常是外部依赖 / 网络问题
+--
+-- 列含义：
+--   fail_kind        分类桶：schema / test / lint / build / timeout / perm / other
+--   fail_count       近 7d 该桶命中次数
+--   pct              该桶占所有失败的百分比
+--   affected_stages  涉及的 stage 列表（去重）
+--   sample_stderr    一条样本 stderr_tail（限 200 字符，排查用）
+
+WITH failed AS (
+    SELECT
+        req_id,
+        stage,
+        stderr_tail,
+        CASE
+            WHEN stderr_tail ILIKE '%schema%'
+              OR stderr_tail ILIKE '%validation%'
+              OR stderr_tail ILIKE '%openapi%'
+              OR stderr_tail ILIKE '%contract%'      THEN 'schema'
+            WHEN stderr_tail ILIKE '%test%fail%'
+              OR stderr_tail ILIKE '%assertion%'
+              OR stderr_tail ILIKE '%pytest%'
+              OR stderr_tail ILIKE '%expect%'        THEN 'test'
+            WHEN stderr_tail ILIKE '%lint%'
+              OR stderr_tail ILIKE '%ruff%'
+              OR stderr_tail ILIKE '%eslint%'
+              OR stderr_tail ILIKE '%mypy%'
+              OR stderr_tail ILIKE '%type%error%'    THEN 'lint'
+            WHEN stderr_tail ILIKE '%timeout%'
+              OR stderr_tail ILIKE '%timed out%'
+              OR stderr_tail ILIKE '%deadline%'      THEN 'timeout'
+            WHEN stderr_tail ILIKE '%compile%error%'
+              OR stderr_tail ILIKE '%build fail%'
+              OR stderr_tail ILIKE '%cannot find%module%'
+              OR stderr_tail ILIKE '%import%error%'  THEN 'build'
+            WHEN stderr_tail ILIKE '%permission denied%'
+              OR stderr_tail ILIKE '%unauthorized%'
+              OR stderr_tail ILIKE '%forbidden%'     THEN 'perm'
+            ELSE                                          'other'
+        END AS fail_kind
+    FROM artifact_checks
+    WHERE checked_at > now() - interval '7 days'
+      AND passed = false
+)
+SELECT
+    fail_kind,
+    COUNT(*)                               AS fail_count,
+    ROUND(
+        100.0 * COUNT(*) / NULLIF(SUM(COUNT(*)) OVER (), 0),
+        2
+    )                                      AS pct,
+    ARRAY_AGG(DISTINCT stage)              AS affected_stages,
+    LEFT(MAX(stderr_tail), 200)            AS sample_stderr
+FROM failed
+GROUP BY fail_kind
+ORDER BY fail_count DESC;

--- a/observability/queries/sisyphus/05-active-req-overview.sql
+++ b/observability/queries/sisyphus/05-active-req-overview.sql
@@ -1,0 +1,62 @@
+-- Dashboard: active REQ overview (当前在飞 REQ + 卡在哪个 stage 多久)
+--
+-- 数据源：sisyphus 主库（orchestrator）
+--   - req_state：REQ 生命周期状态（state / context / 最近 history ts）
+--   - artifact_checks：最近一次 check 的 stage / passed / checked_at
+--
+-- 用途：一眼看出当前所有在飞 REQ 正卡在哪个 stage、最近 check 的结果。
+--   运维早上开 Metabase 先看这张，发现超过阈值的优先处理。
+-- 推荐告警阈值：
+--   - stuck_min > 30 且 last_passed=false → 大概率卡死，应介入
+--   - 同一 stage 有 ≥ 3 条 REQ 并发卡住 → 该 stage 可能整体劣化
+--
+-- 列含义：
+--   req_id           REQ ID
+--   project_id       项目 ID（来自 req_state）
+--   state            当前状态机 state（analyzing / dev-running / ...）
+--   last_stage       最近一次 check 的 stage
+--   last_passed      最近一次 check 是否通过
+--   last_cmd         最近一次 check 跑的命令
+--   last_checked_at  最近一次 check 时间
+--   stuck_min        REQ 从上次 state 变化到现在的分钟数
+--   bugfix_rounds    已用 bugfix round 数（context 里）
+--   recent_fail_24h  近 24h 该 REQ 在 last_stage 上 fail 次数
+
+WITH last_check AS (
+    SELECT DISTINCT ON (req_id)
+        req_id,
+        stage        AS last_stage,
+        passed       AS last_passed,
+        cmd          AS last_cmd,
+        stderr_tail  AS last_stderr,
+        checked_at   AS last_checked_at
+    FROM artifact_checks
+    ORDER BY req_id, checked_at DESC
+),
+recent_fail AS (
+    SELECT
+        req_id,
+        stage,
+        COUNT(*) AS fail_count_24h
+    FROM artifact_checks
+    WHERE checked_at > now() - interval '24 hours'
+      AND passed = false
+    GROUP BY req_id, stage
+)
+SELECT
+    r.req_id,
+    r.project_id,
+    r.state,
+    lc.last_stage,
+    lc.last_passed,
+    lc.last_cmd,
+    lc.last_checked_at,
+    ROUND(EXTRACT(EPOCH FROM (now() - r.updated_at)) / 60)::INT AS stuck_min,
+    COALESCE((r.context->>'bugfix_round')::INT, 0) AS bugfix_rounds,
+    COALESCE(rf.fail_count_24h, 0) AS recent_fail_24h
+FROM req_state r
+LEFT JOIN last_check lc USING (req_id)
+LEFT JOIN recent_fail rf
+    ON rf.req_id = r.req_id AND rf.stage = lc.last_stage
+WHERE r.state NOT IN ('done', 'escalated')
+ORDER BY stuck_min DESC;

--- a/observability/sisyphus-dashboard.md
+++ b/observability/sisyphus-dashboard.md
@@ -1,0 +1,113 @@
+# Sisyphus checker 可观测性看板（M7）
+
+围绕 `artifact_checks` 表（M1 PR #3 引入，定义在 [orchestrator/migrations/0003_artifact_checks.sql](../orchestrator/migrations/0003_artifact_checks.sql)）的 Metabase 看板设计。
+
+**目的**：让运维"一眼看出 sisyphus 内置 checker 在哪些 REQ / stage 上钻牛角尖"。
+
+**不接通知渠道**（飞书 / 邮件）。此版本只输出 SQL + Question 配置，人工看板兜底。通知通道另起 issue。
+
+## 数据源
+
+| 库 | 位置 | 用到的表 |
+|---|---|---|
+| `sisyphus` | orchestrator 主库 | `artifact_checks`, `req_state` |
+
+`bkd_snapshot` / `event_log` 不在本看板里，在 [queries/alert-*.sql](queries/alert-*.sql) 那套看板里。
+
+**Metabase 接入**：`Admin → Databases → Add database`，Engine 选 PostgreSQL，Host 指向
+`sisyphus-postgresql.sisyphus.svc.cluster.local`，Database 填 `sisyphus`，账号和现有
+sisyphus_obs 一致（见 `values/postgresql.yaml`）。后文 Question 都基于这个数据源。
+
+## 5 条 SQL → 5 个 Question
+
+所有 SQL 在 [queries/sisyphus/](queries/sisyphus/)。Metabase 里 **New Question → SQL 模式
+→ 选 sisyphus 数据源 → 粘贴 SQL → Save**。
+
+### Q1. Stuck checks（钻牛角尖的 REQ × stage）
+
+- **SQL**：[queries/sisyphus/01-stuck-checks.sql](queries/sisyphus/01-stuck-checks.sql)
+- **Visualization**：Table（列顺序：`req_id, stage, fail_count, total_count, last_fail, last_cmd, last_stderr`）
+- **条件格式**：`fail_count ≥ 5` 行标红
+- **过滤器**：无（SQL 已限 24h）
+- **人工介入阈值**：看板出现 ≥ 1 行即应人工介入。若 fail_count ≥ 5 视为高优。
+
+### Q2. Check duration anomaly（慢异常）
+
+- **SQL**：[queries/sisyphus/02-check-duration-anomaly.sql](queries/sisyphus/02-check-duration-anomaly.sql)
+- **Visualization**：Table（按 `ratio DESC` 排序）
+- **次选 Visualization**：Bar chart，X = `checked_at` 按小时 bin，Y = COUNT，按 stage 分组
+- **人工介入阈值**：单日 ≥ 3 条同 stage 慢异常 → 先看外部依赖，其次重算该 stage 的 P95 基线。
+
+### Q3. Stage success rate（7d 各 stage 通过率）
+
+- **SQL**：[queries/sisyphus/03-stage-success-rate.sql](queries/sisyphus/03-stage-success-rate.sql)
+- **Visualization**：Bar chart
+  - X = `stage`
+  - Y = `pass_rate_pct`
+  - 条件格式：红（< 50%）/ 黄（50–80%）/ 绿（> 80%）
+- **次选 Visualization**：Table 展示完整列，放看板右下角
+- **人工介入阈值**：`pass_rate_pct < 50%` 的 stage 进入待改进清单；突降 ≥ 20pp（和上周同查询对比）应立刻排查。
+
+### Q4. Fail kind distribution（失败原因分桶）
+
+- **SQL**：[queries/sisyphus/04-fail-kind-distribution.sql](queries/sisyphus/04-fail-kind-distribution.sql)
+- **Visualization**：Pie chart，Dimension = `fail_kind`，Metric = `fail_count`
+- **次选 Visualization**：Row chart（横向柱）按 `fail_count DESC`，额外展示 `sample_stderr` 作为 Tooltip
+- **人工介入阈值**：
+  - `other` 占比 > 40% → 补关键词桶（改 SQL 里的 CASE WHEN）
+  - `schema` 桶飙升（周比 > 50% 上涨）→ 契约变更未同步，优先拉齐
+  - `timeout` 桶飙升 → 外部依赖或网络问题
+
+### Q5. Active REQ overview（在飞 REQ + 卡多久）
+
+- **SQL**：[queries/sisyphus/05-active-req-overview.sql](queries/sisyphus/05-active-req-overview.sql)
+- **Visualization**：Table（列顺序：`req_id, state, last_stage, last_passed, stuck_min, recent_fail_24h, bugfix_rounds, last_checked_at, last_cmd`）
+- **条件格式**：
+  - `stuck_min > 30` 且 `last_passed = false` → 整行标红
+  - `bugfix_rounds ≥ 3` → 该列底色黄
+- **人工介入阈值**：
+  - 单 REQ 红行持续 30 min 未变化 → 介入
+  - 同一 `last_stage` 同时有 ≥ 3 条 REQ 红行 → 该 stage 整体劣化，查 checker / agent
+
+## 看板布局
+
+推荐两列布局（Metabase Dashboard，gridsize 18×? 自适应）：
+
+```
+┌──────────────────────────────┬──────────────────────────────┐
+│  Q5. Active REQ overview     │  Q1. Stuck checks            │
+│  (table, 全宽左列)            │  (table)                     │
+├──────────────────────────────┼──────────────────────────────┤
+│  Q3. Stage success rate      │  Q4. Fail kind distribution  │
+│  (bar chart)                 │  (pie chart)                 │
+├──────────────────────────────┴──────────────────────────────┤
+│  Q2. Check duration anomaly                                 │
+│  (table 全宽，按需下钻)                                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Q5 放显眼处（运维最先看）；Q1 右上辅证；Q3/Q4 是周度趋势；Q2 最细粒度，出问题时下钻。
+
+## 刷新频率
+
+- Q5 / Q1：每 1 分钟（运维实时盯）
+- Q3 / Q4：每 5 分钟
+- Q2：每 5 分钟
+
+Metabase Question 设置 `Results cache TTL`：Q5/Q1 设 30s，其余设 120s。
+
+## 告警（后续 issue，不在 M7 范围）
+
+本 issue 明确不接通知渠道。后续新 issue 把以下 Question 升成 Metabase Alert：
+
+- Q1：`row count > 0 AND max(fail_count) ≥ 5` → Lark
+- Q5：`row count > 0` WHERE `stuck_min > 30 AND last_passed = false` → Lark
+- Q3：新建 Question "任何 stage pass_rate_pct < 50%" → Lark
+
+阈值都可在 Metabase UI 里直接改，不用动 SQL。
+
+## 维护须知
+
+- 4 条桶匹配是启发式，日常看 `other` 占比：若持续 > 40%，改 04 SQL 的 CASE WHEN 补关键词
+- P95 基线在 02 SQL 里内联计算，stage 样本 < 20 次时跳过，避免小样本噪声
+- 05 SQL 的 `state NOT IN ('done','escalated')` 列表要和 [state.py](../orchestrator/src/orchestrator/state.py) 的终态保持一致


### PR DESCRIPTION
M1 PR #3 引入的 artifact_checks 表配套 dashboard。

## 改动
- observability/queries/sisyphus/ 5 条 SQL
- observability/sisyphus-dashboard.md Metabase 接入说明

不接飞书/邮件通知（按需求）。

## 依赖
独立，不依赖其他 milestone PR。

## Test plan
- [ ] CI lint/helm 全绿
- [ ] 部署后在 Metabase 配 5 个 question 验 SQL 跑得过