### PR TITLE
feat(admission): M6 analyze 阶段歧义检测 + escalate human

### DIFF
--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -18,7 +18,7 @@ RUN uv venv $VIRTUAL_ENV && \
     uv pip install \
         fastapi 'uvicorn[standard]' pydantic pydantic-settings httpx \
         asyncpg jinja2 structlog yoyo-migrations psycopg2-binary \
-        'kubernetes>=31.0'
+        'kubernetes>=31.0' 'jsonschema>=4.0' 'pyyaml>=6.0'
 
 # 装本包（不重装 deps）
 COPY src/ ./src/

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "yoyo-migrations>=9.0",
     "psycopg2-binary>=2.9",  # yoyo 的 postgres 驱动
     "kubernetes>=31.0",      # v0.2 K8s runner（pod/pvc/exec）
+    "jsonschema>=4.0",       # M3 manifest/openspec admission（schema validate）
+    "pyyaml>=6.0",           # M3 读 PVC 上 manifest.yaml
 ]
 
 [project.optional-dependencies]

--- a/orchestrator/src/orchestrator/actions/fanout_specs.py
+++ b/orchestrator/src/orchestrator/actions/fanout_specs.py
@@ -1,12 +1,16 @@
 """fanout_specs: analyze done → 创建 contract-spec + acceptance-spec 两个 spec issue。
 
 把 analyze issue 推 done（防 BKD 重投递再触发 routeAnalyze）。
+
+M6：开 spec issue 前先跑 manifest_validate 检查 open_questions；非空 → emit
+ANALYZE_PENDING_HUMAN 回 analyzing-pending-human 态等人答，不创建 spec issue。
 """
 from __future__ import annotations
 
 import structlog
 
 from ..bkd import BKDClient
+from ..checkers import manifest_validate
 from ..config import settings
 from ..prompts import render
 from ..state import Event
@@ -23,6 +27,30 @@ SPEC_STAGES = ("contract-spec", "acceptance-spec")
 async def fanout_specs(*, body, req_id, tags, ctx):
     if rv := skip_if_enabled("spec", Event.SPEC_ALL_PASSED, req_id=req_id):
         return rv
+
+    # M6 admission：检 manifest 里的 open_questions 是否清零。flag off 时完全跳过。
+    if settings.admission_analyze_pending_questions:
+        try:
+            check = await manifest_validate.run_manifest_validate(req_id)
+        except Exception as e:
+            # 读 PVC/kubectl 挂了不是 ambiguity 问题，不走 pending_human；记录后继续让
+            # 下游 admission（M3 schema fail）或 skip 逻辑兜底。
+            log.warning("fanout_specs.admission_error", req_id=req_id, error=str(e))
+        else:
+            if (
+                not check.passed
+                and check.reason == manifest_validate.REASON_OPEN_QUESTIONS_PENDING
+            ):
+                log.info(
+                    "fanout_specs.pending_human",
+                    req_id=req_id, stderr_tail=check.stderr_tail[:500],
+                )
+                return {
+                    "emit": Event.ANALYZE_PENDING_HUMAN.value,
+                    "reason": check.reason,
+                    "stderr_tail": check.stderr_tail,
+                }
+
     proj = body.projectId
     workdir = f"{settings.workdir_root}/feat-{req_id}"
     spec_issue_ids = {}

--- a/orchestrator/src/orchestrator/checkers/_types.py
+++ b/orchestrator/src/orchestrator/checkers/_types.py
@@ -14,8 +14,12 @@ class CheckResult:
 
     exit_code 语义按 checker 自定（staging-test = 命令退出码；
     pr-ci-watch = 0 全绿 / 1 任一失败 / 124 超时；
-    manifest = 0 合法 / 1 schema 不符 / 2 yaml 解析挂 / -1 读 PVC 超时；
+    manifest = 0 合法 / 1 schema 不符 / 2 yaml 解析挂 / 3 open_questions 待人答 / -1 读 PVC 超时；
     openspec = openspec CLI 退出码），engine 只看 passed。
+
+    reason：可选语义标签，下游用来区分"该失败要不要走常规 fail 路径"。
+    例：manifest 的 ``open_questions_pending`` 要路由到 pending-human，
+    schema 不符才走常规 admission fail。老 checker 不设即 None，兼容。
     """
     passed: bool
     exit_code: int
@@ -23,3 +27,4 @@ class CheckResult:
     stderr_tail: str
     duration_sec: float
     cmd: str
+    reason: str | None = None

--- a/orchestrator/src/orchestrator/checkers/manifest_validate.py
+++ b/orchestrator/src/orchestrator/checkers/manifest_validate.py
@@ -23,6 +23,7 @@ import yaml
 from jsonschema import Draft7Validator
 
 from .. import k8s_runner
+from ..config import settings
 from ._types import CheckResult
 
 log = structlog.get_logger(__name__)
@@ -30,6 +31,9 @@ log = structlog.get_logger(__name__)
 _TAIL = 2048
 _MANIFEST_PATH = "/workspace/.sisyphus/manifest.yaml"
 _READ_CMD = f"cat {_MANIFEST_PATH}"
+
+# 语义 reason：CheckResult.reason 可选值
+REASON_OPEN_QUESTIONS_PENDING = "open_questions_pending"
 
 _validator: Draft7Validator | None = None
 
@@ -147,6 +151,27 @@ async def run_manifest_validate(req_id: str, *, timeout_sec: int = 30) -> CheckR
             stderr_tail=f"manifest 验证失败 ({len(errs)} 项):\n{joined}"[-_TAIL:],
             duration_sec=duration, cmd=_READ_CMD,
         )
+
+    # M6 ambiguity admission：schema 过了才看 open_questions。
+    # 非空 → 歧义未清 → 路由 pending-human（区别于 schema-fail 的 bugfix 重做）。
+    # 由 settings.admission_analyze_pending_questions 灰度控制。
+    if settings.admission_analyze_pending_questions:
+        questions = manifest.get("open_questions") or []
+        if isinstance(questions, list) and questions:
+            joined = "\n".join(f"  - {q}" for q in questions if isinstance(q, str))
+            log.info(
+                "checker.manifest_validate.pending_human",
+                req_id=req_id, count=len(questions),
+            )
+            return CheckResult(
+                passed=False, exit_code=3,
+                stdout_tail=exec_result.stdout[-_TAIL:],
+                stderr_tail=(
+                    f"{REASON_OPEN_QUESTIONS_PENDING}: {len(questions)} 项\n{joined}"
+                )[-_TAIL:],
+                duration_sec=duration, cmd=_READ_CMD,
+                reason=REASON_OPEN_QUESTIONS_PENDING,
+            )
 
     log.info("checker.manifest_validate.ok", req_id=req_id, duration_sec=round(duration, 2))
     return CheckResult(

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -110,5 +110,12 @@ class Settings(BaseSettings):
     # 测试失败从第 N 轮起改走 diagnose agent（分流 spec-bug/env-bug/code-bug）
     retry_diagnose_threshold: int = 3
 
+    # ─── M6：analyze 歧义 admission（跟 M3 manifest schema 协同） ─────────
+    # True = fanout_specs 开 spec issue 前先跑 manifest_validate，
+    #        open_questions 非空 → emit ANALYZE_PENDING_HUMAN → 挂 analyzing-pending-human
+    # False（默认）= 老路，analyze-agent tag → 直接 fanout_specs，不验歧义
+    # 回滚：unset env / set false → rollout restart
+    admission_analyze_pending_questions: bool = False
+
 
 settings = Settings()  # type: ignore[call-arg]

--- a/orchestrator/src/orchestrator/prompts/analyze.md.j2
+++ b/orchestrator/src/orchestrator/prompts/analyze.md.j2
@@ -81,9 +81,44 @@ sources:
 integration:
   repo: <owner>/<integration-repo>
   path: integration/<integration-repo>
+
+# ↓ ambiguity admission（M6 强制三段，三段都必须存在，内容为空数组 [] 亦合法）
+open_questions: []            # 需求里还没敲定的歧义点；**非空直接 hold REQ 等人答**
+assumptions: []               # 你为了能继续推进所做的假设（给人事后审）
+out_of_scope: []              # 主动划出的边界，避免 scope creep
 ```
 
 如果没 integration（纯 source repo REQ），省略整个 `integration:` 段。
+
+#### Step A4.1: ambiguity admission（硬要求，不写三段 validator 会拒）
+
+**你必须认真扫三类歧义**，每一类都要自证"查过了"：
+
+1. **open_questions**（阻塞项）：任何你看了 intent description 后**说不清楚**的点
+   都必须列这里。举例：
+   - "登录支持手机号还是邮箱？两个都支持还是二选一？"
+   - "失败后要不要重试？重试几次？"
+   - "accept 拿线上 prod 库还是 staging 库？"
+
+   **不要靠猜推进。** 哪怕只有一个 open_question，sisyphus 都会把 REQ 挂在
+   `analyzing-pending-human` 状态等人答完再推进。
+
+   如果你认真查了 intent description / 相关 repo 代码 / 相关 openspec，
+   **确信没歧义**，也要留**至少一条**自证：比如
+   `"已检查 intent description / 代码注释 / openspec 变更历史，无歧义"`。
+   **不允许 `open_questions: []` 配空白说明** —— 要么有歧义，要么有自证。
+
+2. **assumptions**（推进前提）：你为了能写出 tasks 骨架而**隐含做的假设**，
+   哪怕 open_questions 都清零，也得列给人审。举例：
+   - "假设 REQ 只改 ttpos-server-go，不动 ttpos-flutter"
+   - "假设现有 user table 已经有 phone 字段"
+
+3. **out_of_scope**（边界）：相关但本 REQ 不做的东西。举例：
+   - "不改 admin 后台的用户列表显示"
+   - "不动 OAuth 第三方登录"
+
+**三个字段都必须存在**（空数组 `[]` 也算合法），schema validator 会强制。
+内容质量靠 review 人把关。
 
 ### Step A5: 跑 validator 确认 manifest 合法
 

--- a/orchestrator/src/orchestrator/router.py
+++ b/orchestrator/src/orchestrator/router.py
@@ -30,6 +30,10 @@ def derive_event(event_type: str, tags: Iterable[str], result_tags_only: bool = 
     if event_type == "issue.updated":
         if "intent:analyze" in tagset and "analyze" not in tagset:
             return Event.INTENT_ANALYZE
+        # M6：analyzing-pending-human 下人答完 open_questions → 打 resume:analyze
+        # 触发 re-kick analyze。走 INTENT_ANALYZE 事件让状态机统一入口。
+        if "resume:analyze" in tagset:
+            return Event.INTENT_ANALYZE
         # 其他 issue.updated 一律忽略（避免自指 loop）
         return None
 

--- a/orchestrator/src/orchestrator/schemas/manifest.json
+++ b/orchestrator/src/orchestrator/schemas/manifest.json
@@ -3,7 +3,14 @@
   "$id": "https://sisyphus.dev/schemas/manifest.json",
   "title": "Sisyphus workspace manifest (post-analyze)",
   "type": "object",
-  "required": ["schema_version", "req_id", "sources"],
+  "required": [
+    "schema_version",
+    "req_id",
+    "sources",
+    "open_questions",
+    "assumptions",
+    "out_of_scope"
+  ],
   "additionalProperties": true,
   "properties": {
     "schema_version": {
@@ -30,6 +37,18 @@
           "pattern": "^integration/.+"
         }
       }
+    },
+    "open_questions": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1, "maxLength": 500}
+    },
+    "assumptions": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1, "maxLength": 500}
+    },
+    "out_of_scope": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1, "maxLength": 500}
     },
     "sha_by_repo": {"type": "object"},
     "pr_by_repo": {"type": "object"},

--- a/orchestrator/src/orchestrator/state.py
+++ b/orchestrator/src/orchestrator/state.py
@@ -30,6 +30,8 @@ from enum import StrEnum
 class ReqState(StrEnum):
     INIT = "init"                               # 还没 analyze
     ANALYZING = "analyzing"                     # analyze-agent 在跑
+    # M6：manifest admission 发现 open_questions 非空 → 卡这里等人答
+    ANALYZING_PENDING_HUMAN = "analyzing-pending-human"
     SPECS_RUNNING = "specs-running"             # contract + acceptance spec-agent
     DEV_RUNNING = "dev-running"                 # SPG gate 通过，dev-agent 只写代码
     STAGING_TEST_RUNNING = "staging-test-running"  # 调试环境 build + unit + int test
@@ -47,6 +49,8 @@ class ReqState(StrEnum):
 class Event(StrEnum):
     INTENT_ANALYZE = "intent.analyze"               # 人在 BKD 打 intent:analyze tag
     ANALYZE_DONE = "analyze.done"                   # analyze-agent 完成
+    # M6：analyze manifest admission 发现 open_questions 非空 → fanout_specs 不进，回挂起
+    ANALYZE_PENDING_HUMAN = "analyze.pending-human"
     SPEC_DONE = "spec.done"                         # 单个 spec-agent 完成
     SPEC_ALL_PASSED = "spec.all-passed"             # 聚合事件：N/N ci-passed
     DEV_DONE = "dev.done"                           # dev-agent push 完毕
@@ -87,6 +91,18 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
 
     (ReqState.ANALYZING, Event.ANALYZE_DONE):
         Transition(ReqState.SPECS_RUNNING, "fanout_specs", "create 2 spec issues"),
+
+    # M6：fanout_specs 跑 admission 发现 open_questions 非空 → chained emit 挂起等人
+    # (两步走：先按 ANALYZE_DONE 转到 SPECS_RUNNING 启动 fanout_specs，fanout_specs
+    # 检出歧义回 emit ANALYZE_PENDING_HUMAN，SPECS_RUNNING 在此再跳挂起态)
+    (ReqState.SPECS_RUNNING, Event.ANALYZE_PENDING_HUMAN):
+        Transition(ReqState.ANALYZING_PENDING_HUMAN, None,
+                   "open_questions pending human answer"),
+
+    # M6：人打 resume:analyze / 重加 intent:analyze → 重跑 analyze（带新答案）
+    (ReqState.ANALYZING_PENDING_HUMAN, Event.INTENT_ANALYZE):
+        Transition(ReqState.ANALYZING, "start_analyze",
+                   "human answered open_questions, re-kick analyze"),
 
     (ReqState.SPECS_RUNNING, Event.SPEC_DONE):
         Transition(ReqState.SPECS_RUNNING, "mark_spec_reviewed_and_check", "tag + maybe gate"),

--- a/orchestrator/tests/test_checkers_manifest_validate.py
+++ b/orchestrator/tests/test_checkers_manifest_validate.py
@@ -1,0 +1,242 @@
+"""checkers/manifest_validate.py 单测：
+
+- schema 合法 + admission flag off → passed
+- schema 合法 + admission flag on + open_questions 非空 → pending_human
+- schema 合法 + admission flag on + open_questions 空 → passed
+- schema 缺 open_questions/assumptions/out_of_scope → 被拒（fail with exit 1）
+- 读 PVC 挂 / yaml 坏 → 按原语义 fail（reason 不设）
+"""
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from orchestrator.checkers import manifest_validate
+from orchestrator.checkers._types import CheckResult
+from orchestrator.k8s_runner import ExecResult
+
+
+def _yaml_min(open_questions_line: str = "open_questions: []") -> str:
+    # 注意：open_questions_line 必须是顶层 YAML（可多行），不能依赖 textwrap.dedent
+    base = textwrap.dedent(
+        """\
+        schema_version: 1
+        req_id: REQ-9
+        sources:
+          - repo: phona/foo
+            path: source/foo
+            role: leader
+            branch: stage/REQ-9-dev
+        """
+    )
+    tail = textwrap.dedent(
+        """\
+        assumptions: []
+        out_of_scope: []
+        """
+    )
+    return base + open_questions_line.rstrip() + "\n" + tail
+
+
+def _fake_controller(exit_code: int, stdout: str, stderr: str = "", duration: float = 0.1):
+    class FakeRC:
+        async def exec_in_runner(self, req_id, command, **kw):
+            return ExecResult(
+                exit_code=exit_code, stdout=stdout, stderr=stderr, duration_sec=duration,
+            )
+    return FakeRC()
+
+
+@pytest.fixture(autouse=True)
+def _reset_admission_flag(monkeypatch):
+    """测试默认关 flag；单测自己按需开。"""
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.settings.admission_analyze_pending_questions",
+        False,
+    )
+
+
+# ── happy path ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_passes_when_schema_valid_and_flag_off(monkeypatch):
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.k8s_runner.get_controller",
+        lambda: _fake_controller(0, _yaml_min()),
+    )
+    result = await manifest_validate.run_manifest_validate("REQ-9")
+    assert isinstance(result, CheckResult)
+    assert result.passed is True
+    assert result.reason is None
+
+
+@pytest.mark.asyncio
+async def test_passes_when_open_questions_empty_and_flag_on(monkeypatch):
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.settings.admission_analyze_pending_questions",
+        True,
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.k8s_runner.get_controller",
+        lambda: _fake_controller(0, _yaml_min()),
+    )
+    result = await manifest_validate.run_manifest_validate("REQ-9")
+    assert result.passed is True
+    assert result.reason is None
+
+
+# ── pending_human ────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_pending_human_when_open_questions_not_empty(monkeypatch):
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.settings.admission_analyze_pending_questions",
+        True,
+    )
+    yaml_body = _yaml_min(
+        "open_questions:\n  - 登录支持手机号还是邮箱？\n  - 失败重试几次？"
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.k8s_runner.get_controller",
+        lambda: _fake_controller(0, yaml_body),
+    )
+    result = await manifest_validate.run_manifest_validate("REQ-9")
+    assert result.passed is False
+    assert result.reason == manifest_validate.REASON_OPEN_QUESTIONS_PENDING
+    assert result.exit_code == 3
+    # stderr_tail 必须能让 oncall 看到具体歧义项（不能裸退出码）
+    assert "登录支持手机号还是邮箱" in result.stderr_tail
+    assert "失败重试几次" in result.stderr_tail
+
+
+@pytest.mark.asyncio
+async def test_flag_off_ignores_open_questions(monkeypatch):
+    """admission flag off 时，即使 open_questions 非空也不 pending（给老路径兜底）。"""
+    yaml_body = _yaml_min("open_questions:\n  - 还没决定\n")
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.k8s_runner.get_controller",
+        lambda: _fake_controller(0, yaml_body),
+    )
+    result = await manifest_validate.run_manifest_validate("REQ-9")
+    assert result.passed is True
+    assert result.reason is None
+
+
+# ── schema fail（缺 M6 新字段） ──────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_missing_open_questions_is_schema_fail(monkeypatch):
+    """少了 open_questions/assumptions/out_of_scope 任一都应被 jsonschema 拒。
+    这是 schema fail（exit 1），不是 pending_human（exit 3）；reason 也不该设。
+    """
+    yaml_body = textwrap.dedent(
+        """\
+        schema_version: 1
+        req_id: REQ-9
+        sources:
+          - repo: phona/foo
+            path: source/foo
+            role: leader
+            branch: stage/REQ-9-dev
+        assumptions: []
+        out_of_scope: []
+        """
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.settings.admission_analyze_pending_questions",
+        True,  # 开 flag 也应该是 schema fail 而不是 pending_human
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.k8s_runner.get_controller",
+        lambda: _fake_controller(0, yaml_body),
+    )
+    result = await manifest_validate.run_manifest_validate("REQ-9")
+    assert result.passed is False
+    assert result.reason is None
+    assert result.exit_code == 1
+    assert "open_questions" in result.stderr_tail
+
+
+@pytest.mark.asyncio
+async def test_missing_assumptions_is_schema_fail(monkeypatch):
+    yaml_body = textwrap.dedent(
+        """\
+        schema_version: 1
+        req_id: REQ-9
+        sources:
+          - repo: phona/foo
+            path: source/foo
+            role: leader
+            branch: stage/REQ-9-dev
+        open_questions: []
+        out_of_scope: []
+        """
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.k8s_runner.get_controller",
+        lambda: _fake_controller(0, yaml_body),
+    )
+    result = await manifest_validate.run_manifest_validate("REQ-9")
+    assert result.passed is False
+    assert result.reason is None
+    assert "assumptions" in result.stderr_tail
+
+
+@pytest.mark.asyncio
+async def test_missing_out_of_scope_is_schema_fail(monkeypatch):
+    yaml_body = textwrap.dedent(
+        """\
+        schema_version: 1
+        req_id: REQ-9
+        sources:
+          - repo: phona/foo
+            path: source/foo
+            role: leader
+            branch: stage/REQ-9-dev
+        open_questions: []
+        assumptions: []
+        """
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.k8s_runner.get_controller",
+        lambda: _fake_controller(0, yaml_body),
+    )
+    result = await manifest_validate.run_manifest_validate("REQ-9")
+    assert result.passed is False
+    assert result.reason is None
+    assert "out_of_scope" in result.stderr_tail
+
+
+# ── infra fail：读 PVC 挂（reason 保持 None，走老语义） ─────────────────
+
+@pytest.mark.asyncio
+async def test_read_failure_keeps_reason_none(monkeypatch):
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.settings.admission_analyze_pending_questions",
+        True,
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.k8s_runner.get_controller",
+        lambda: _fake_controller(2, "", stderr="cat: No such file"),
+    )
+    result = await manifest_validate.run_manifest_validate("REQ-9")
+    assert result.passed is False
+    assert result.reason is None  # 不是 pending_human
+    assert result.exit_code == 2
+
+
+@pytest.mark.asyncio
+async def test_yaml_parse_failure_keeps_reason_none(monkeypatch):
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.settings.admission_analyze_pending_questions",
+        True,
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.k8s_runner.get_controller",
+        lambda: _fake_controller(0, "::: not valid yaml :::\n  - ["),
+    )
+    result = await manifest_validate.run_manifest_validate("REQ-9")
+    assert result.passed is False
+    assert result.reason is None
+    assert result.exit_code == 2

--- a/orchestrator/tests/test_router.py
+++ b/orchestrator/tests/test_router.py
@@ -11,6 +11,9 @@ CASES: list[tuple[str, list[str], Event | None]] = [
     ("issue.updated",     ["intent:analyze"],                                Event.INTENT_ANALYZE),
     # intent 已被 analyze 接管 → 不再发
     ("issue.updated",     ["intent:analyze", "analyze", "REQ-1"],            None),
+    # M6：人答完 open_questions 后打 resume:analyze → 重新走 INTENT_ANALYZE
+    # （状态机在 ANALYZING_PENDING_HUMAN 接收，其他状态自然 skip）
+    ("issue.updated",     ["resume:analyze", "analyze", "REQ-1"],            Event.INTENT_ANALYZE),
     # 普通 issue.updated 一律忽略（避免自指）
     ("issue.updated",     ["dev", "REQ-1"],                                  None),
 

--- a/orchestrator/tests/test_state.py
+++ b/orchestrator/tests/test_state.py
@@ -10,6 +10,9 @@ EXPECTED = [
     # state, event, next_state, action
     (ReqState.INIT,                 Event.INTENT_ANALYZE,      ReqState.ANALYZING,           "start_analyze"),
     (ReqState.ANALYZING,            Event.ANALYZE_DONE,        ReqState.SPECS_RUNNING,       "fanout_specs"),
+    # M6：fanout_specs 查出 open_questions → chained emit → 回挂起
+    (ReqState.SPECS_RUNNING,        Event.ANALYZE_PENDING_HUMAN, ReqState.ANALYZING_PENDING_HUMAN, None),
+    (ReqState.ANALYZING_PENDING_HUMAN, Event.INTENT_ANALYZE,   ReqState.ANALYZING,           "start_analyze"),
     (ReqState.SPECS_RUNNING,        Event.SPEC_DONE,           ReqState.SPECS_RUNNING,       "mark_spec_reviewed_and_check"),
     (ReqState.SPECS_RUNNING,        Event.SPEC_ALL_PASSED,     ReqState.DEV_RUNNING,         "create_dev"),
     (ReqState.DEV_RUNNING,          Event.DEV_DONE,            ReqState.STAGING_TEST_RUNNING, "create_staging_test"),
@@ -90,6 +93,23 @@ def test_v02_no_legacy_ci_events():
     legacy_values = {"ci-unit.pass", "ci-unit.fail", "ci-int.pass", "ci-int.fail"}
     for e in Event:
         assert e.value not in legacy_values, f"v0.2 应彻底删 {e.value}"
+
+
+def test_m6_pending_human_not_in_session_failed_running_list():
+    """M6：pending-human 没有 agent 在跑，不应被 session.failed 连带 escalate。"""
+    t = decide(ReqState.ANALYZING_PENDING_HUMAN, Event.SESSION_FAILED)
+    assert t is None
+
+
+def test_m6_pending_human_stable_without_resume():
+    """M6：挂起态只接受 INTENT_ANALYZE（人打 resume:analyze / intent:analyze），
+    其他 event 一律 skip（不会被 analyze-agent 的 session.completed 抢跑）。"""
+    stable_events = [
+        Event.ANALYZE_DONE, Event.SPEC_DONE, Event.DEV_DONE,
+        Event.ANALYZE_PENDING_HUMAN,
+    ]
+    for ev in stable_events:
+        assert decide(ReqState.ANALYZING_PENDING_HUMAN, ev) is None, ev
 
 
 def test_no_orphan_actions():


### PR DESCRIPTION
承接 #11 + M3 PR #7 (已合)。

## 改动
- schemas/manifest.json 加 open_questions/assumptions/out_of_scope 必填
- analyze prompt 强制 agent 列歧义
- manifest_validate 增 open_questions 非空 check → emit ANALYZE_PENDING_HUMAN
- state/router 新事件
- 灰度 flag admission_analyze_pending_questions

## 依赖
M3 PR #7（已合并到 main）— 本 PR 已 rebase

## Test plan
- [ ] CI 全绿
- [ ] 灰度部署测真 intent 含 open_questions → state 进 pending-human