### PR TITLE
feat(watchdog): M8 卡死 stage 兜底 escalate

### DIFF
--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -117,5 +117,13 @@ class Settings(BaseSettings):
     # 回滚：unset env / set false → rollout restart
     admission_analyze_pending_questions: bool = False
 
+    # ─── M8：watchdog 兜底卡死 stage ────────────────────────────────────
+    # 周期扫 req_state，发现某 stage 超过阈值没 transition 且关联 BKD session
+    # 不在 running → emit SESSION_FAILED 走 escalate。兜底 BKD spawn-time
+    # 失败不发 webhook 的场景（M4 retry policy 假设"失败事件总会到"被打破）。
+    watchdog_enabled: bool = True             # 默认开（兜底必须开）
+    watchdog_interval_sec: int = 60           # 每 60s 扫一次
+    watchdog_stuck_threshold_sec: int = 1800  # 30 min 无 transition 视为卡死
+
 
 settings = Settings()  # type: ignore[call-arg]

--- a/orchestrator/src/orchestrator/main.py
+++ b/orchestrator/src/orchestrator/main.py
@@ -7,7 +7,7 @@ import logging
 import structlog
 from fastapi import FastAPI
 
-from . import k8s_runner, runner_gc, snapshot
+from . import k8s_runner, runner_gc, snapshot, watchdog
 from .admin import admin as admin_api
 from .config import settings
 from .migrate import apply_pending
@@ -68,11 +68,15 @@ async def startup() -> None:
     except Exception as e:
         # dev / 单机 / 没 kubeconfig 的场景允许失败（调 action 会抛，但 http 主进程能起）
         log.warning("k8s_runner.init_failed", error=str(e))
+    # 6. 起 watchdog 兜底任务（M8：BKD 不发 session.failed 时周期性 escalate 卡死 REQ）
+    if settings.watchdog_enabled and settings.watchdog_interval_sec > 0:
+        _bg_tasks.append(asyncio.create_task(watchdog.run_loop(), name="watchdog"))
     log.info(
         "startup.ok",
         port=settings.port,
         obs_enabled=bool(settings.obs_pg_dsn),
         snapshot_interval=settings.snapshot_interval_sec,
+        watchdog_enabled=settings.watchdog_enabled,
     )
 
 

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -1,0 +1,202 @@
+"""M8 watchdog 后台任务：兜底卡死的 stage。
+
+背景：dev BKD agent spawn 失败（session=failed 但 0 logs）时 BKD 不发
+session.failed webhook，orchestrator 永远卡在 in-flight state 等不来事件。
+M4 retry policy 假设"失败事件总会到"被打破 — watchdog 作为独立兜底。
+
+每 N 秒扫一次 req_state，发现某 REQ：
+1. state 在 in-flight（非 done / 非 escalated / 非 analyzing-pending-human / 非 init）
+2. updated_at 距今超过 watchdog_stuck_threshold_sec
+3. 关联 BKD issue 的 session_status 不在 'running' 状态
+
+→ 写一条 artifact_checks 记录 + 通过 engine.step 发 SESSION_FAILED 走 escalate。
+
+不 restart agent（restart 归 M4 retry policy 管），只 escalate。
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+
+import structlog
+
+from . import engine
+from .bkd import BKDClient
+from .checkers._types import CheckResult
+from .config import settings
+from .state import Event, ReqState
+from .store import artifact_checks, db
+
+log = structlog.get_logger(__name__)
+
+
+# state → ctx 里追踪该 stage 当前 agent issue 的 key
+# None 表示没 issue 可查（直接 escalate）
+_STATE_ISSUE_KEY: dict[ReqState, str | None] = {
+    ReqState.ANALYZING: "intent_issue_id",
+    ReqState.SPECS_RUNNING: None,                # fanout 多 issue，不单查
+    ReqState.DEV_RUNNING: "dev_issue_id",
+    ReqState.STAGING_TEST_RUNNING: "staging_test_issue_id",
+    ReqState.PR_CI_RUNNING: "pr_ci_watch_issue_id",
+    ReqState.ACCEPT_RUNNING: "accept_issue_id",
+    ReqState.ACCEPT_TEARING_DOWN: "accept_issue_id",
+    ReqState.BUGFIX_RUNNING: "bugfix_issue_id",
+    ReqState.DIAGNOSE_RUNNING: "diagnose_issue_id",
+    ReqState.ARCHIVING: "archive_issue_id",
+}
+
+# 排除：终态 + 等人态 + 未入链
+_SKIP_STATES = {
+    ReqState.DONE.value,
+    ReqState.ESCALATED.value,
+    ReqState.ANALYZING_PENDING_HUMAN.value,
+    ReqState.GH_INCIDENT_OPEN.value,
+    ReqState.INIT.value,
+}
+
+
+@dataclass
+class _SyntheticBody:
+    """engine.step / escalate action 对 body 的最小字段依赖。"""
+    projectId: str
+    issueId: str
+    event: str = "watchdog.stuck"
+
+
+async def _tick() -> dict:
+    """单次扫描 + escalate 卡死 REQ。返回 {checked, escalated}。"""
+    pool = db.get_pool()
+    threshold = settings.watchdog_stuck_threshold_sec
+    # psql 语法：INTERVAL '1 second' * N 把 int 参数转成 interval
+    rows = await pool.fetch(
+        """
+        SELECT req_id, project_id, state, context,
+               EXTRACT(EPOCH FROM (NOW() - updated_at))::BIGINT AS stuck_sec
+          FROM req_state
+         WHERE state <> ALL($1::text[])
+           AND updated_at < NOW() - INTERVAL '1 second' * $2
+        """,
+        list(_SKIP_STATES), threshold,
+    )
+    escalated = 0
+    for row in rows:
+        if await _check_and_escalate(row):
+            escalated += 1
+    return {"checked": len(rows), "escalated": escalated}
+
+
+async def _check_and_escalate(row) -> bool:
+    """检查一条 stuck row：session 仍 running 就 skip，否则 escalate。返 True = 真 escalate。"""
+    req_id = row["req_id"]
+    project_id = row["project_id"]
+    state_str = row["state"]
+    ctx_raw = row["context"] or {}
+    # asyncpg 返回 JSONB 可能是 dict 或 str
+    ctx = json.loads(ctx_raw) if isinstance(ctx_raw, str) else ctx_raw
+    stuck_sec = int(row["stuck_sec"])
+
+    try:
+        state = ReqState(state_str)
+    except ValueError:
+        log.warning("watchdog.unknown_state", req_id=req_id, state=state_str)
+        return False
+
+    issue_key = _STATE_ISSUE_KEY.get(state)
+    issue_id: str | None = None
+    if issue_key:
+        issue_id = ctx.get(issue_key)
+
+    # 1. 查 BKD session 状态（有 issue_id 才查）
+    still_running = False
+    if issue_id:
+        try:
+            async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+                issue = await bkd.get_issue(project_id, issue_id)
+            session_status = issue.session_status
+            if session_status == "running":
+                still_running = True
+                log.debug(
+                    "watchdog.still_running",
+                    req_id=req_id, state=state_str,
+                    issue_id=issue_id, stuck_sec=stuck_sec,
+                )
+        except Exception as e:
+            # 查不到（issue 删了 / BKD 挂了）→ 保守按 failed 处理，走 escalate
+            log.warning(
+                "watchdog.bkd_get_issue_failed",
+                req_id=req_id, issue_id=issue_id, error=str(e),
+            )
+
+    if still_running:
+        return False
+
+    # 2. 写 artifact_checks 记一笔，给 dashboard M7 04-fail-kind-distribution 抓
+    pool = db.get_pool()
+    check = CheckResult(
+        passed=False,
+        exit_code=-1,
+        cmd=f"watchdog:{state_str}",
+        stdout_tail="",
+        stderr_tail=f"stuck for {stuck_sec}s in state {state_str}",
+        duration_sec=0.0,
+        reason="watchdog_stuck",
+    )
+    try:
+        await artifact_checks.insert_check(
+            pool, req_id, f"watchdog:{state_str}", check,
+        )
+    except Exception as e:
+        log.warning("watchdog.artifact_insert_failed", req_id=req_id, error=str(e))
+
+    # 3. 通过 engine.step 发 SESSION_FAILED → 走 escalate transition
+    body = _SyntheticBody(
+        projectId=project_id,
+        issueId=issue_id or ctx.get("intent_issue_id") or "",
+    )
+    log.warning(
+        "watchdog.escalating",
+        req_id=req_id, state=state_str,
+        issue_id=issue_id, stuck_sec=stuck_sec,
+    )
+    try:
+        await engine.step(
+            pool,
+            body=body,
+            req_id=req_id,
+            project_id=project_id,
+            tags=[req_id, f"watchdog:{state_str}"],
+            cur_state=state,
+            ctx=ctx,
+            event=Event.SESSION_FAILED,
+        )
+    except Exception as e:
+        log.exception("watchdog.engine_step_failed", req_id=req_id, error=str(e))
+        return False
+    return True
+
+
+async def run_loop() -> None:
+    """orchestrator 启动起的后台任务。"""
+    if not settings.watchdog_enabled:
+        log.info("watchdog.disabled")
+        return
+    interval = settings.watchdog_interval_sec
+    log.info(
+        "watchdog.loop.started",
+        interval_sec=interval,
+        stuck_threshold_sec=settings.watchdog_stuck_threshold_sec,
+    )
+    while True:
+        try:
+            result = await _tick()
+            if result.get("escalated"):
+                log.warning("watchdog.swept", **result)
+            else:
+                log.debug("watchdog.tick", **result)
+        except asyncio.CancelledError:
+            log.info("watchdog.loop.stopped")
+            raise
+        except Exception as e:
+            log.exception("watchdog.loop.error", error=str(e))
+        await asyncio.sleep(interval)

--- a/orchestrator/tests/test_watchdog.py
+++ b/orchestrator/tests/test_watchdog.py
@@ -1,0 +1,284 @@
+"""watchdog 单测：mock PG fetch + BKD get_issue + engine.step，
+验不同 stuck row 的分流（escalate / skip / session-running）。"""
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock
+
+import pytest
+
+from orchestrator import watchdog
+from orchestrator.state import Event, ReqState
+
+
+# ─── Fake pool（只实现 fetch + execute，watchdog 用到这两）──────────────────
+@dataclass
+class FakePool:
+    rows: list = field(default_factory=list)
+    executed: list = field(default_factory=list)
+
+    async def fetch(self, sql, *args):
+        return self.rows
+
+    async def execute(self, sql, *args):
+        self.executed.append((sql, args))
+        return None
+
+
+def _row(req_id, state, ctx=None, stuck_sec=2000):
+    return {
+        "req_id": req_id,
+        "project_id": "proj-1",
+        "state": state,
+        "context": json.dumps(ctx or {}),
+        "stuck_sec": stuck_sec,
+    }
+
+
+@dataclass
+class FakeIssue:
+    session_status: str | None = "failed"
+    id: str = "dev-1"
+    project_id: str = "proj-1"
+    issue_number: int = 0
+    title: str = ""
+    status_id: str = "todo"
+    tags: list = field(default_factory=list)
+
+
+def _patch_bkd(monkeypatch, issue: FakeIssue | None, side_effect: Exception | None = None):
+    fake = AsyncMock()
+    if side_effect:
+        fake.get_issue = AsyncMock(side_effect=side_effect)
+    else:
+        fake.get_issue = AsyncMock(return_value=issue)
+
+    @asynccontextmanager
+    async def _ctx(*a, **kw):
+        yield fake
+
+    monkeypatch.setattr("orchestrator.watchdog.BKDClient", _ctx)
+    return fake
+
+
+def _patch_pool(monkeypatch, pool):
+    monkeypatch.setattr("orchestrator.watchdog.db.get_pool", lambda: pool)
+
+
+def _patch_engine(monkeypatch):
+    """捕获 engine.step 调用，不真推状态机（避免依赖 actions）。"""
+    calls: list = []
+
+    async def fake_step(pool, *, body, req_id, project_id, tags, cur_state, ctx, event, depth=0):
+        calls.append({
+            "req_id": req_id,
+            "project_id": project_id,
+            "cur_state": cur_state,
+            "event": event,
+            "body_issue": getattr(body, "issueId", None),
+            "body_proj": getattr(body, "projectId", None),
+        })
+        return {"action": "escalate", "next_state": "escalated"}
+
+    monkeypatch.setattr("orchestrator.watchdog.engine.step", fake_step)
+    return calls
+
+
+def _patch_artifact(monkeypatch):
+    calls: list = []
+
+    async def fake_insert(pool, req_id, stage, result):
+        calls.append({"req_id": req_id, "stage": stage, "result": result})
+
+    monkeypatch.setattr(
+        "orchestrator.watchdog.artifact_checks.insert_check", fake_insert,
+    )
+    return calls
+
+
+# ─── Case 1：session=failed → escalate（写 artifact + engine.step SESSION_FAILED）
+@pytest.mark.asyncio
+async def test_stuck_with_failed_session_escalates(monkeypatch):
+    pool = FakePool(rows=[
+        _row("REQ-1", ReqState.DEV_RUNNING.value,
+             ctx={"dev_issue_id": "dev-1", "intent_issue_id": "intent-1"}),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, FakeIssue(session_status="failed", id="dev-1"))
+    step_calls = _patch_engine(monkeypatch)
+    art_calls = _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    # engine 被调且是 SESSION_FAILED
+    assert len(step_calls) == 1
+    assert step_calls[0]["event"] == Event.SESSION_FAILED
+    assert step_calls[0]["cur_state"] == ReqState.DEV_RUNNING
+    assert step_calls[0]["body_issue"] == "dev-1"
+    assert step_calls[0]["body_proj"] == "proj-1"
+    # artifact_checks 写了一笔 stage=watchdog:dev-running
+    assert len(art_calls) == 1
+    assert art_calls[0]["stage"] == "watchdog:dev-running"
+    assert art_calls[0]["result"].passed is False
+    assert art_calls[0]["result"].reason == "watchdog_stuck"
+
+
+# ─── Case 2：session=running → skip，不 escalate
+@pytest.mark.asyncio
+async def test_stuck_but_session_running_skips(monkeypatch):
+    pool = FakePool(rows=[
+        _row("REQ-2", ReqState.DEV_RUNNING.value,
+             ctx={"dev_issue_id": "dev-2"}),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, FakeIssue(session_status="running", id="dev-2"))
+    step_calls = _patch_engine(monkeypatch)
+    art_calls = _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 0}
+    assert step_calls == []
+    assert art_calls == []
+
+
+# ─── Case 3：BKD get_issue 抛异常 → 保守 escalate
+@pytest.mark.asyncio
+async def test_stuck_bkd_lookup_fails_escalates(monkeypatch):
+    pool = FakePool(rows=[
+        _row("REQ-3", ReqState.STAGING_TEST_RUNNING.value,
+             ctx={"staging_test_issue_id": "st-3"}),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, None, side_effect=RuntimeError("404 not found"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    assert len(step_calls) == 1
+    assert step_calls[0]["event"] == Event.SESSION_FAILED
+
+
+# ─── Case 4：state 无 issue_key 映射（SPECS_RUNNING）→ 不查 BKD 直接 escalate
+@pytest.mark.asyncio
+async def test_specs_running_escalates_without_bkd_lookup(monkeypatch):
+    pool = FakePool(rows=[
+        _row("REQ-4", ReqState.SPECS_RUNNING.value,
+             ctx={"intent_issue_id": "intent-4"}),
+    ])
+    _patch_pool(monkeypatch, pool)
+    fake_bkd = _patch_bkd(monkeypatch, FakeIssue(session_status="running"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    # 没 issue_key → 不查 BKD
+    fake_bkd.get_issue.assert_not_called()
+    assert len(step_calls) == 1
+    # body.issueId 回落到 intent_issue_id
+    assert step_calls[0]["body_issue"] == "intent-4"
+
+
+# ─── Case 5：ctx 里没 issue_id（比如 create_dev 还没落 ctx 就挂了）→ escalate
+@pytest.mark.asyncio
+async def test_missing_issue_id_in_ctx_escalates(monkeypatch):
+    pool = FakePool(rows=[
+        _row("REQ-5", ReqState.DEV_RUNNING.value, ctx={}),
+    ])
+    _patch_pool(monkeypatch, pool)
+    fake_bkd = _patch_bkd(monkeypatch, FakeIssue(session_status="running"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    # 无 issue_id 不查
+    fake_bkd.get_issue.assert_not_called()
+    assert len(step_calls) == 1
+
+
+# ─── Case 6：SQL 过滤（未到阈值的不返回）由 DB 负责 — 空 rows 直接 0
+@pytest.mark.asyncio
+async def test_no_stuck_rows_does_nothing(monkeypatch):
+    pool = FakePool(rows=[])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, FakeIssue())
+    step_calls = _patch_engine(monkeypatch)
+    art_calls = _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 0, "escalated": 0}
+    assert step_calls == []
+    assert art_calls == []
+
+
+# ─── Case 7：SQL 参数正确下发（_SKIP_STATES 含终态 + pending-human + init）────
+@pytest.mark.asyncio
+async def test_tick_passes_skip_states_and_threshold_to_sql(monkeypatch):
+    captured: dict = {}
+
+    class _CapturingPool:
+        async def fetch(self, sql, *args):
+            captured["sql"] = sql
+            captured["args"] = args
+            return []
+
+    _patch_pool(monkeypatch, _CapturingPool())
+    monkeypatch.setattr(
+        "orchestrator.watchdog.settings.watchdog_stuck_threshold_sec", 1800,
+    )
+
+    await watchdog._tick()
+
+    skip_arr, threshold = captured["args"]
+    assert threshold == 1800
+    assert "done" in skip_arr
+    assert "escalated" in skip_arr
+    assert "analyzing-pending-human" in skip_arr
+    assert "init" in skip_arr
+
+
+# ─── Case 8：watchdog_enabled=False → run_loop 立即 return 不跑循环 ─────────
+@pytest.mark.asyncio
+async def test_loop_disabled_returns_immediately(monkeypatch):
+    monkeypatch.setattr("orchestrator.watchdog.settings.watchdog_enabled", False)
+    # 无需 mock _tick / asyncio.sleep — 直接 return 不进 while
+    await watchdog.run_loop()   # 不应 hang
+
+
+# ─── Case 9：engine.step 抛异常不阻塞后续 row ─────────────────────────────
+@pytest.mark.asyncio
+async def test_engine_step_failure_isolated(monkeypatch):
+    pool = FakePool(rows=[
+        _row("REQ-A", ReqState.DEV_RUNNING.value, ctx={"dev_issue_id": "d-a"}),
+        _row("REQ-B", ReqState.DEV_RUNNING.value, ctx={"dev_issue_id": "d-b"}),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, FakeIssue(session_status="failed"))
+    _patch_artifact(monkeypatch)
+
+    calls: list = []
+
+    async def flaky_step(pool, **kw):
+        calls.append(kw["req_id"])
+        if kw["req_id"] == "REQ-A":
+            raise RuntimeError("downstream boom")
+        return {}
+
+    monkeypatch.setattr("orchestrator.watchdog.engine.step", flaky_step)
+
+    result = await watchdog._tick()
+
+    # 两行都被处理，但只有 REQ-B 成功 escalate（REQ-A engine.step 抛异常返 False）
+    assert result["checked"] == 2
+    assert result["escalated"] == 1
+    assert calls == ["REQ-A", "REQ-B"]


### PR DESCRIPTION
## Summary
- 新增 `orchestrator/watchdog.py`：周期（默认 60s）扫 `req_state`，发现 in-flight REQ `updated_at` 超过阈值（默认 30min）且关联 BKD issue `session_status` 不在 `running` → 写一条 `artifact_checks`（`stage=watchdog:<state>`，`reason=watchdog_stuck`）+ 经 `engine.step` 发 `SESSION_FAILED` 走 escalate transition。
- `config.py` 加三个 flag：`watchdog_enabled=True` / `watchdog_interval_sec=60` / `watchdog_stuck_threshold_sec=1800`。
- `main.py` 启动时起 background task（跟 `runner_gc.run_loop` 同模式），`shutdown` hook 里已有统一取消逻辑。

## Background
端到端 REQ-test-1776855620 暴露真实问题：dev BKD agent spawn 失败（session=failed 但 0 logs）时 BKD **不发 session.failed webhook**（推测：spawn-time 失败不在 webhook 触发链路里）。M4 retry policy 假设"失败事件总会到"被打破，sisyphus 永远卡在 dev-running。需要一个独立 watchdog 兜底，不依赖 BKD 事件驱动。

## 设计边界
- **不 restart agent**：restart 决策归 M4 retry policy，watchdog 只 escalate（不重复职责）。
- **不发飞书通知**：按指示不接通知渠道，依赖 dashboard SQL（M7 加的 `04-fail-kind-distribution`）通过 `stage=watchdog:*` 前缀抓取。
- **SPECS_RUNNING 等多 issue stage**：`_STATE_ISSUE_KEY[SPECS_RUNNING]=None`，不查单 issue 的 BKD session，到阈值直接 escalate。
- **排除态**：`done / escalated / analyzing-pending-human / gh-incident-open / init`（前两是终态，中间俩是主动等人，init 没入链）。

## Test plan
- [x] 单测 `test_watchdog.py` 覆盖 9 个 case：
  - session=failed → escalate + 写 artifact
  - session=running → skip
  - BKD lookup 抛异常 → 保守 escalate
  - SPECS_RUNNING 无 issue_key → 直接 escalate，不查 BKD
  - ctx 缺 issue_id → 直接 escalate
  - 空 rows → no-op
  - SQL 参数（skip states + threshold）正确下发
  - `watchdog_enabled=False` → `run_loop` 立即 return
  - engine.step 抛异常只影响单行，不阻塞后续 row
- [x] `uv run pytest -q`：全部 268 个测试 pass
- [x] `uv run ruff check`：All checks passed
- [ ] 部署到 vm-node04 K3s → 起一个 REQ → kubectl delete BKD agent pod 模拟 spawn 失败 → 30 min 内 sisyphus 自动写 artifact + escalate（生产验收条件）

## 回滚
- `SISYPHUS_WATCHDOG_ENABLED=false` → `rollout restart`。
- 或彻底撤：revert 本 PR（`watchdog.py` 独立模块，不改主状态机）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)