### PR TITLE
feat(runner): M10 terminal state 即时 cleanup runner pod

### DIFF
--- a/orchestrator/src/orchestrator/engine.py
+++ b/orchestrator/src/orchestrator/engine.py
@@ -5,18 +5,46 @@ action handler 可以返回 {"emit": "<event-name>"} 触发链式推进
 """
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any
 
 import asyncpg
 import structlog
 
+from . import k8s_runner
 from . import observability as obs
 from .actions import REGISTRY
 from .state import Event, ReqState, decide
 from .store import req_state
 
 log = structlog.get_logger(__name__)
+
+
+# 进 terminal state 时立即清 runner（fire-and-forget；runner_gc 仍周期兜底）
+# escalated 保 PVC 给人工 debug，过期由 runner_gc 按 pvc_retain_on_escalate_days 清
+_TERMINAL_STATES = {ReqState.DONE, ReqState.ESCALATED}
+
+# 持引用防 fire-and-forget task 被 GC（done_callback 自清）
+_cleanup_tasks: set[asyncio.Task] = set()
+
+
+async def _cleanup_runner_on_terminal(req_id: str, terminal_state: ReqState) -> None:
+    try:
+        rc = k8s_runner.get_controller()
+    except RuntimeError as e:
+        log.debug("runner.cleanup_no_controller", req_id=req_id, error=str(e))
+        return
+    try:
+        await rc.cleanup_runner(
+            req_id,
+            retain_pvc=(terminal_state == ReqState.ESCALATED),
+        )
+        log.info("runner.cleanup_on_terminal",
+                 req_id=req_id, terminal_state=terminal_state.value)
+    except Exception as e:
+        # cleanup 失败别回压状态机；runner_gc 兜底
+        log.warning("runner.cleanup_failed", req_id=req_id, error=str(e))
 
 
 async def step(
@@ -61,6 +89,15 @@ async def step(
         evt=event.value,
         action=transition.action,
     )
+
+    # M10：转 terminal state 时立即清 runner（fire-and-forget）
+    if transition.next_state in _TERMINAL_STATES:
+        task = asyncio.create_task(
+            _cleanup_runner_on_terminal(req_id, transition.next_state)
+        )
+        _cleanup_tasks.add(task)
+        task.add_done_callback(_cleanup_tasks.discard)
+
     await obs.record_event(
         "router.decision",
         req_id=req_id, issue_id=getattr(body, "issueId", None), tags=tags,

--- a/orchestrator/src/orchestrator/k8s_runner.py
+++ b/orchestrator/src/orchestrator/k8s_runner.py
@@ -325,8 +325,12 @@ class RunnerController:
         """重建 Pod（PVC 复用）。"""
         return await self.ensure_runner(req_id, wait_ready=True)
 
-    async def destroy(self, req_id: str) -> None:
-        """终态清理：删 Pod + PVC。幂等。"""
+    async def cleanup_runner(self, req_id: str, *, retain_pvc: bool = False) -> None:
+        """终态清理：删 Pod，PVC 按 retain_pvc 决定。幂等。
+
+        retain_pvc=True：escalated 时保留 PVC，给人翻 workspace；过期由 runner_gc 兜底
+        retain_pvc=False：done 时立即销 PVC（无 debug 价值），释放磁盘
+        """
         pod_deleted = pvc_deleted = False
         try:
             await asyncio.to_thread(
@@ -337,17 +341,22 @@ class RunnerController:
         except ApiException as e:
             if e.status != 404:
                 raise
-        try:
-            await asyncio.to_thread(
-                self.core_v1.delete_namespaced_persistent_volume_claim,
-                self.pvc_name(req_id), self.namespace,
-            )
-            pvc_deleted = True
-        except ApiException as e:
-            if e.status != 404:
-                raise
-        log.info("runner.destroyed", req_id=req_id,
+        if not retain_pvc:
+            try:
+                await asyncio.to_thread(
+                    self.core_v1.delete_namespaced_persistent_volume_claim,
+                    self.pvc_name(req_id), self.namespace,
+                )
+                pvc_deleted = True
+            except ApiException as e:
+                if e.status != 404:
+                    raise
+        log.info("runner.cleanup", req_id=req_id, retain_pvc=retain_pvc,
                  pod_deleted=pod_deleted, pvc_deleted=pvc_deleted)
+
+    async def destroy(self, req_id: str) -> None:
+        """向后兼容：等价 cleanup_runner(retain_pvc=False)。"""
+        await self.cleanup_runner(req_id, retain_pvc=False)
 
     async def get_runner_status(self, req_id: str) -> RunnerStatus | None:
         pod_name = self.pod_name(req_id)
@@ -423,7 +432,8 @@ class RunnerController:
             if not req_label or req_label in keep_lower:
                 continue
             req_id = req_label.upper() if req_label.lower().startswith("req-") else req_label
-            await self.destroy(req_id)
+            # 兜底 sweep：done 已立即清，escalated 过期才到这；都该硬删 PVC
+            await self.cleanup_runner(req_id, retain_pvc=False)
             cleaned.append(req_id)
 
         if cleaned:

--- a/orchestrator/tests/test_engine.py
+++ b/orchestrator/tests/test_engine.py
@@ -4,12 +4,14 @@
 """
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from orchestrator import engine
+from orchestrator import engine, k8s_runner
 from orchestrator.actions import REGISTRY
 from orchestrator.state import Event, ReqState
 
@@ -143,6 +145,128 @@ async def test_cas_failure_skips(stub_actions):
     )
     assert result["action"] == "skip"
     assert "concurrent" in result["reason"]
+
+
+# ─── M10: terminal state 即时 cleanup ─────────────────────────────────
+
+
+@pytest.fixture
+def mock_runner_controller():
+    """注入 fake controller，断言 cleanup_runner 调用参数。"""
+    fake = MagicMock()
+    fake.cleanup_runner = AsyncMock(return_value=None)
+    k8s_runner.set_controller(fake)
+    yield fake
+    k8s_runner.set_controller(None)
+
+
+async def _drain_tasks() -> None:
+    """让 fire-and-forget 的 asyncio.create_task 跑完。"""
+    # 收集除当前外所有 task；engine.step 用 create_task 起 cleanup
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_terminal_done_triggers_cleanup_no_retain(stub_actions, mock_runner_controller):
+    """ARCHIVING + ARCHIVE_DONE → DONE 应触发 cleanup_runner(retain_pvc=False)。"""
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ARCHIVING.value)})
+    body = type("B", (), {"issueId": "x", "projectId": "p", "event": "session.completed"})()
+    await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.ARCHIVING, ctx={}, event=Event.ARCHIVE_DONE,
+    )
+    await _drain_tasks()
+
+    assert pool.rows["REQ-1"].state == ReqState.DONE.value
+    mock_runner_controller.cleanup_runner.assert_awaited_once_with(
+        "REQ-1", retain_pvc=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_terminal_escalated_triggers_cleanup_retain_pvc(
+    stub_actions, mock_runner_controller,
+):
+    """SESSION_FAILED → ESCALATED 应触发 cleanup_runner(retain_pvc=True)。"""
+    calls, reg = stub_actions
+
+    async def escalate(*, body, req_id, tags, ctx):
+        calls.append(("escalate", {"req_id": req_id}))
+        return {"escalated": True}
+
+    reg["escalate"] = escalate
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.DEV_RUNNING.value)})
+    body = type("B", (), {"issueId": "x", "projectId": "p", "event": "session.failed"})()
+    await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.DEV_RUNNING, ctx={}, event=Event.SESSION_FAILED,
+    )
+    await _drain_tasks()
+
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+    mock_runner_controller.cleanup_runner.assert_awaited_once_with(
+        "REQ-1", retain_pvc=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_terminal_does_not_trigger_cleanup(
+    stub_actions, mock_runner_controller,
+):
+    """非 terminal 转移不该 cleanup（如 DEV_RUNNING + DEV_DONE → STAGING_TEST_RUNNING）。"""
+    calls, reg = stub_actions
+
+    async def create_staging_test(*, body, req_id, tags, ctx):
+        calls.append(("create_staging_test", {"req_id": req_id}))
+        return {"ok": True}
+
+    reg["create_staging_test"] = create_staging_test
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.DEV_RUNNING.value)})
+    body = type("B", (), {"issueId": "x", "projectId": "p", "event": "session.completed"})()
+    await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.DEV_RUNNING, ctx={}, event=Event.DEV_DONE,
+    )
+    await _drain_tasks()
+
+    mock_runner_controller.cleanup_runner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_no_controller_safe(stub_actions, monkeypatch):
+    """没 K8s controller（dev / 测试）→ 静默跳过，不报错。"""
+    k8s_runner.set_controller(None)
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ARCHIVING.value)})
+    body = type("B", (), {"issueId": "x", "projectId": "p", "event": "session.completed"})()
+    # 不抛 = ok
+    await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.ARCHIVING, ctx={}, event=Event.ARCHIVE_DONE,
+    )
+    await _drain_tasks()
+    assert pool.rows["REQ-1"].state == ReqState.DONE.value
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_does_not_block_engine(stub_actions, mock_runner_controller):
+    """cleanup_runner 抛错 → engine 不受影响（fire-and-forget）。"""
+    mock_runner_controller.cleanup_runner = AsyncMock(side_effect=RuntimeError("kapow"))
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ARCHIVING.value)})
+    body = type("B", (), {"issueId": "x", "projectId": "p", "event": "session.completed"})()
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.ARCHIVING, ctx={}, event=Event.ARCHIVE_DONE,
+    )
+    await _drain_tasks()
+
+    assert pool.rows["REQ-1"].state == ReqState.DONE.value
+    assert result["next_state"] == ReqState.DONE.value
 
 
 @pytest.mark.asyncio

--- a/orchestrator/tests/test_k8s_runner.py
+++ b/orchestrator/tests/test_k8s_runner.py
@@ -212,6 +212,62 @@ async def test_destroy_deletes_both_idempotent():
     core.delete_namespaced_persistent_volume_claim.assert_called_once()
 
 
+# ─── M10: cleanup_runner ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cleanup_runner_default_deletes_both():
+    """retain_pvc 默认 False → 删 pod + PVC（done 路径）。"""
+    core = MagicMock()
+    core.delete_namespaced_pod = MagicMock(return_value=None)
+    core.delete_namespaced_persistent_volume_claim = MagicMock(return_value=None)
+    rc = _make_controller(core)
+    await rc.cleanup_runner("REQ-9")
+    core.delete_namespaced_pod.assert_called_once_with("runner-req-9", "sisyphus-runners")
+    core.delete_namespaced_persistent_volume_claim.assert_called_once_with(
+        "workspace-req-9", "sisyphus-runners",
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_runner_retain_pvc_only_deletes_pod():
+    """retain_pvc=True → 只删 pod，PVC 留给人翻（escalated 路径）。"""
+    core = MagicMock()
+    core.delete_namespaced_pod = MagicMock(return_value=None)
+    core.delete_namespaced_persistent_volume_claim = MagicMock(return_value=None)
+    rc = _make_controller(core)
+    await rc.cleanup_runner("REQ-9", retain_pvc=True)
+    core.delete_namespaced_pod.assert_called_once_with("runner-req-9", "sisyphus-runners")
+    core.delete_namespaced_persistent_volume_claim.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_runner_idempotent_on_404():
+    """pod / PVC 已不在 → 吃 404，不抛。"""
+    core = MagicMock()
+    core.delete_namespaced_pod = MagicMock(
+        side_effect=ApiException(status=404, reason="Not Found")
+    )
+    core.delete_namespaced_persistent_volume_claim = MagicMock(
+        side_effect=ApiException(status=404, reason="Not Found")
+    )
+    rc = _make_controller(core)
+    await rc.cleanup_runner("REQ-1")  # 不抛 = ok
+    core.delete_namespaced_pod.assert_called_once()
+    core.delete_namespaced_persistent_volume_claim.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_runner_raises_on_other_api_error():
+    core = MagicMock()
+    core.delete_namespaced_pod = MagicMock(
+        side_effect=ApiException(status=500, reason="server error")
+    )
+    rc = _make_controller(core)
+    with pytest.raises(ApiException):
+        await rc.cleanup_runner("REQ-1")
+
+
 # ─── gc_orphans ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- 状态机转 `done` / `escalated` 时 fire-and-forget cleanup runner pod，不再等 `runner_gc` 每 1h sweep。
- `done` 全销 PVC（无 debug 价值，立即释放磁盘）；`escalated` 保 PVC 给人工翻 workspace（按 `pvc_retain_on_escalate_days` 由 GC 兜底过期清）。
- `k8s_runner` 抽 `cleanup_runner(retain_pvc)` 公共方法，`destroy` + `gc_orphans` 都改用同函数（DRY）。

## 背景
端到端测试踩到 vm-node04 累积 4 个 runner pod，3 个对应的 REQ 已 done/escalated 但 runner pod 没清，挤满 memory request 导致新 REQ runner Pending 20+ min。`runner_gc.loop` 1h 才扫一次太慢。

refs #11

## Test plan
- [x] `pytest` 全套绿（298 通过）
- [x] `ruff check` 改动文件干净
- [ ] dev 环境跑一个端到端 REQ → done → 看 runner pod 立即被删（PVC 也删）
- [ ] 故意触发 escalate → 看 runner pod 删但 PVC 留
- [ ] `runner_gc.loop` 仍跑兜底（不动 cron）

🤖 Generated with [Claude Code](https://claude.com/claude-code)