### PR TITLE
fix(rbac): pods/exec 加 get verb（websocket handshake 需要）

### DIFF
--- a/orchestrator/helm/templates/runner-rbac.yaml
+++ b/orchestrator/helm/templates/runner-rbac.yaml
@@ -26,7 +26,8 @@ rules:
     verbs: ["get", "list", "watch", "create", "delete", "patch"]
   - apiGroups: [""]
     resources: ["pods/exec"]
-    verbs: ["create"]
+    # websocket exec handshake 是 GET，纯 create 不够（M1/M2 sisyphus checker 直 exec runner pod）
+    verbs: ["create", "get"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "delete", "patch"]


### PR DESCRIPTION
实测 REQ-fresh staging-test 触发 sisyphus checker 时报 403 — websocket exec handshake 是 GET，原 RBAC verb 只有 create 不够。

线上 cluster 已 patch 紧急修复，本 PR 同步 helm template 防 helm upgrade 回退。

## Test plan
- [ ] CI 全绿
- [ ] 部署后 helm template orchestrator/helm 包含 verbs: [create, get]