### PR TITLE
feat(retry): M9 action-fail 重试 + ensure_runner 多 attempt

### DIFF
--- a/orchestrator/src/orchestrator/actions/__init__.py
+++ b/orchestrator/src/orchestrator/actions/__init__.py
@@ -4,16 +4,27 @@
     async def handler(*, body: WebhookBody, req_id: str, tags: list[str], ctx: dict) -> dict
 
 webhook.py 根据 transition.action 名查表派发。
+
+M9：register 带 idempotent kwarg，engine.step 捕到 action 异常后用
+ACTION_META[name]["idempotent"] 决定是否重试（见 retry.policy.decide_action_fail）。
+非幂等 action（create_* 类：会重复建 BKD issue / GH PR）默认直接 escalate，
+不自动重试。
 """
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, TypedDict
 
 # Forward import 避免循环（webhook 依赖 actions，actions 不能依赖 webhook）
 ActionHandler = Callable[..., Awaitable[dict[str, Any]]]
 
+
+class ActionMeta(TypedDict):
+    idempotent: bool
+
+
 REGISTRY: dict[str, ActionHandler] = {}
+ACTION_META: dict[str, ActionMeta] = {}
 
 
 def short_title(ctx: dict | None, max_len: int = 50) -> str:
@@ -31,9 +42,18 @@ def short_title(ctx: dict | None, max_len: int = 50) -> str:
     return f" — {t}"
 
 
-def register(name: str):
+def register(name: str, *, idempotent: bool = False):
+    """注册 action handler + 声明幂等性。
+
+    idempotent=True 代表：重试该 handler 不会产生重复副作用
+    （例如 ensure_runner 是 409-safe；mark_spec 只查询 + emit）。
+    M9 engine.step 异常路径只重试 idempotent=True 的 action。
+
+    默认 False（保守：创建新 BKD issue / GH PR 的 action 重试会重复建）。
+    """
     def deco(fn: ActionHandler) -> ActionHandler:
         REGISTRY[name] = fn
+        ACTION_META[name] = {"idempotent": idempotent}
         return fn
     return deco
 

--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -26,7 +26,7 @@ from ._skip import skip_if_enabled
 log = structlog.get_logger(__name__)
 
 
-@register("create_accept")
+@register("create_accept", idempotent=False)  # 创建新 accept issue + env-up 副作用
 async def create_accept(*, body, req_id, tags, ctx):
     if rv := skip_if_enabled("accept", Event.ACCEPT_PASS, req_id=req_id):
         pool = db.get_pool()

--- a/orchestrator/src/orchestrator/actions/create_dev.py
+++ b/orchestrator/src/orchestrator/actions/create_dev.py
@@ -14,7 +14,7 @@ from ._skip import skip_if_enabled
 log = structlog.get_logger(__name__)
 
 
-@register("create_dev")
+@register("create_dev", idempotent=False)  # 创建新 BKD dev issue
 async def create_dev(*, body, req_id, tags, ctx):
     if rv := skip_if_enabled("dev", Event.DEV_DONE, req_id=req_id):
         return rv

--- a/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
@@ -25,7 +25,7 @@ from ._skip import skip_if_enabled
 log = structlog.get_logger(__name__)
 
 
-@register("create_pr_ci_watch")
+@register("create_pr_ci_watch", idempotent=False)  # 老路创 BKD issue；checker 模式安全但保守 False
 async def create_pr_ci_watch(*, body, req_id, tags, ctx):
     if rv := skip_if_enabled("pr-ci", Event.PR_CI_PASS, req_id=req_id):
         return rv

--- a/orchestrator/src/orchestrator/actions/create_staging_test.py
+++ b/orchestrator/src/orchestrator/actions/create_staging_test.py
@@ -30,7 +30,7 @@ _TEST_CMD = "make test"   # M1 硬编码；M3 改成读 PVC manifest.yaml
 _STAGE = "staging-test"
 
 
-@register("create_staging_test")
+@register("create_staging_test", idempotent=False)  # 老路创 BKD issue；checker 模式安全但保守 False
 async def create_staging_test(*, body, req_id, tags, ctx):
     if rv := skip_if_enabled("staging-test", Event.STAGING_TEST_PASS, req_id=req_id):
         return rv

--- a/orchestrator/src/orchestrator/actions/done_archive.py
+++ b/orchestrator/src/orchestrator/actions/done_archive.py
@@ -14,7 +14,7 @@ from ._skip import skip_if_enabled
 log = structlog.get_logger(__name__)
 
 
-@register("done_archive")
+@register("done_archive", idempotent=False)  # 创建新 archive issue + 开 PR
 async def done_archive(*, body, req_id, tags, ctx):
     if rv := skip_if_enabled("archive", Event.ARCHIVE_DONE, req_id=req_id):
         return rv

--- a/orchestrator/src/orchestrator/actions/escalate.py
+++ b/orchestrator/src/orchestrator/actions/escalate.py
@@ -18,7 +18,7 @@ from . import register
 log = structlog.get_logger(__name__)
 
 
-@register("escalate")
+@register("escalate", idempotent=True)
 async def escalate(*, body, req_id, tags, ctx):
     proj = body.projectId
     intent_issue_id = (ctx or {}).get("intent_issue_id") or body.issueId

--- a/orchestrator/src/orchestrator/actions/fanout_specs.py
+++ b/orchestrator/src/orchestrator/actions/fanout_specs.py
@@ -23,7 +23,7 @@ log = structlog.get_logger(__name__)
 SPEC_STAGES = ("contract-spec", "acceptance-spec")
 
 
-@register("fanout_specs")
+@register("fanout_specs", idempotent=False)  # 创建两个新 spec issue
 async def fanout_specs(*, body, req_id, tags, ctx):
     if rv := skip_if_enabled("spec", Event.SPEC_ALL_PASSED, req_id=req_id):
         return rv

--- a/orchestrator/src/orchestrator/actions/mark_spec_reviewed_and_check.py
+++ b/orchestrator/src/orchestrator/actions/mark_spec_reviewed_and_check.py
@@ -17,7 +17,7 @@ log = structlog.get_logger(__name__)
 SPEC_TAGS = ("contract-spec", "acceptance-spec")
 
 
-@register("mark_spec_reviewed_and_check")
+@register("mark_spec_reviewed_and_check", idempotent=True)
 async def mark_spec_reviewed_and_check(*, body, req_id, tags, ctx):
     proj = body.projectId
     triggering_issue = body.issueId

--- a/orchestrator/src/orchestrator/actions/open_gh_and_bugfix.py
+++ b/orchestrator/src/orchestrator/actions/open_gh_and_bugfix.py
@@ -21,7 +21,7 @@ log = structlog.get_logger(__name__)
 CB_THRESHOLD = 3
 
 
-@register("open_gh_and_bugfix")
+@register("open_gh_and_bugfix", idempotent=False)  # 创建 GH issue + bugfix BKD issue
 async def open_gh_and_bugfix(*, body, req_id, tags, ctx):
     proj = body.projectId
     ctx = ctx or {}

--- a/orchestrator/src/orchestrator/actions/spawn_diagnose.py
+++ b/orchestrator/src/orchestrator/actions/spawn_diagnose.py
@@ -19,7 +19,7 @@ from . import register, short_title
 log = structlog.get_logger(__name__)
 
 
-@register("spawn_diagnose")
+@register("spawn_diagnose", idempotent=False)  # 创建新 diagnose BKD issue
 async def spawn_diagnose(*, body, req_id, tags, ctx):
     proj = body.projectId
     branch = (ctx or {}).get("branch") or f"feat/{req_id}"

--- a/orchestrator/src/orchestrator/actions/start_analyze.py
+++ b/orchestrator/src/orchestrator/actions/start_analyze.py
@@ -24,7 +24,7 @@ from ._skip import skip_if_enabled
 log = structlog.get_logger(__name__)
 
 
-@register("start_analyze")
+@register("start_analyze", idempotent=True)
 async def start_analyze(*, body, req_id, tags, ctx):
     if rv := skip_if_enabled("analyze", Event.ANALYZE_DONE, req_id=req_id):
         return rv

--- a/orchestrator/src/orchestrator/actions/teardown_accept_env.py
+++ b/orchestrator/src/orchestrator/actions/teardown_accept_env.py
@@ -19,7 +19,7 @@ from ._skip import skip_if_enabled
 log = structlog.get_logger(__name__)
 
 
-@register("teardown_accept_env")
+@register("teardown_accept_env", idempotent=True)
 async def teardown_accept_env(*, body, req_id, tags, ctx):
     """跑 ci-accept-env-down 清 lab，然后按 accept_result emit 下一步事件。"""
     # accept 被 skip 时（skip_accept=true，ttpos-arch-lab 没接前的常态），

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -103,12 +103,21 @@ class Settings(BaseSettings):
     # ─── M4：故障分级重试 ────────────────────────────────────────────────
     # False（默认）= checker fail 直接 emit FAIL event（老行为）
     # True = checker fail 调 retry.executor，按 policy 决定 follow_up / diagnose / escalate
+    # M9：同一 flag 启用 engine.step action-handler 异常重试（decide_action_fail）
     # 回滚：set false → rollout restart
     retry_enabled: bool = False
     # 到/超过即 escalate 人工（含本次在内的总轮次）
     retry_max_rounds: int = 5
     # 测试失败从第 N 轮起改走 diagnose agent（分流 spec-bug/env-bug/code-bug）
     retry_diagnose_threshold: int = 3
+    # M9：幂等 action 抛 transient 异常时最多重试 N 轮（0/1/2 → retry，round=3 → escalate）
+    retry_action_max_rounds: int = 3
+
+    # ─── M9：runner ready 重试 ──────────────────────────────────────────
+    # ensure_runner 等 Pod Ready 的外层 attempts：N × runner_ready_timeout_sec
+    # 总等待；最后一次抛 TimeoutError 让 engine 的 retry policy 接手。
+    # 默认 3 × 120s = 6min，覆盖 K3s 节点偶发慢启动；生产可调更高。
+    runner_ready_attempts: int = 3
 
     # ─── M6：analyze 歧义 admission（跟 M3 manifest schema 协同） ─────────
     # True = fanout_specs 开 spec issue 前先跑 manifest_validate，

--- a/orchestrator/src/orchestrator/engine.py
+++ b/orchestrator/src/orchestrator/engine.py
@@ -2,6 +2,11 @@
 
 action handler 可以返回 {"emit": "<event-name>"} 触发链式推进
 （例如 mark_spec_reviewed_and_check 检测到 N/N 后 emit spec.all-passed → create_dev）。
+
+M9：action handler 抛异常时，若 retry_enabled + action 标了 idempotent，
+按 retry.policy.decide_action_fail 决策 retry（带 backoff 原地重试 handler）或
+escalate（链式 emit SESSION_FAILED 进状态机 → ESCALATED）。非幂等 action 异常
+或超 max_rounds 一律 escalate。
 """
 from __future__ import annotations
 
@@ -14,7 +19,9 @@ import structlog
 
 from . import k8s_runner
 from . import observability as obs
-from .actions import REGISTRY
+from .actions import ACTION_META, REGISTRY
+from .config import settings
+from .retry import policy as retry_policy
 from .state import Event, ReqState, decide
 from .store import req_state
 
@@ -117,27 +124,22 @@ async def step(
         log.error("engine.action_not_registered", action=transition.action)
         return {"action": "error", "reason": f"action {transition.action} not registered"}
 
-    started = time.monotonic()
-    try:
-        result = await handler(body=body, req_id=req_id, tags=tags, ctx=ctx)
-    except Exception as e:
-        log.exception("engine.action_failed", action=transition.action, error=str(e))
-        await obs.record_event(
-            "action.failed",
-            req_id=req_id, issue_id=getattr(body, "issueId", None), tags=tags,
-            router_action=transition.action,
-            duration_ms=int((time.monotonic() - started) * 1000),
-            error_msg=str(e)[:500],
-        )
-        return {"action": "error", "reason": str(e)}
-
-    await obs.record_event(
-        "action.executed",
-        req_id=req_id, issue_id=getattr(body, "issueId", None), tags=tags,
-        router_action=transition.action,
-        duration_ms=int((time.monotonic() - started) * 1000),
-        extras=result if isinstance(result, dict) else None,
+    ok, result = await _dispatch_with_retry(
+        pool,
+        body=body,
+        req_id=req_id,
+        project_id=project_id,
+        tags=tags,
+        action_name=transition.action,
+        handler=handler,
+        ctx=ctx,
+        next_state=transition.next_state,
+        depth=depth,
     )
+    # action terminal fail → _dispatch_with_retry 内部已 emit SESSION_FAILED 走 escalate；
+    # 上层直接把 escalate 的 chained 结果原样返回，不再做后续 handler result 的 emit chain
+    if not ok:
+        return result
 
     base_result = {
         "action": transition.action,
@@ -171,3 +173,153 @@ async def step(
         base_result["chained"] = chain
 
     return base_result
+
+
+async def _dispatch_with_retry(
+    pool: asyncpg.Pool,
+    *,
+    body,
+    req_id: str,
+    project_id: str,
+    tags: list[str],
+    action_name: str,
+    handler,
+    ctx: dict,
+    next_state: ReqState,
+    depth: int,
+) -> tuple[bool, dict[str, Any]]:
+    """跑 handler；按 retry.policy 决策 retry 原地 / escalate（emit SESSION_FAILED）。
+
+    retry_enabled=False 时保留老行为：抛到第一次 fail 就 record + 返回 error。
+
+    返回 (ok, payload)：
+        ok=True, payload = handler 的 result dict（上层继续做 emit chain）
+        ok=False, payload = escalate 汇总字典（error / escalated / chained 等），
+                            上层应直接返回不再处理
+    """
+    meta = ACTION_META.get(action_name, {"idempotent": False})
+    idempotent = bool(meta.get("idempotent"))
+    # round = 已重试轮次（0-based；首次 handler 调用 round=0）
+    round_ = 0
+    issue_id = getattr(body, "issueId", None)
+
+    while True:
+        started = time.monotonic()
+        try:
+            result = await handler(body=body, req_id=req_id, tags=tags, ctx=ctx)
+        except Exception as e:
+            duration_ms = int((time.monotonic() - started) * 1000)
+
+            if not settings.retry_enabled:
+                # 老行为：不自动重试，直接记 + 返回 error
+                log.exception("engine.action_failed", action=action_name, error=str(e))
+                await obs.record_event(
+                    "action.failed",
+                    req_id=req_id, issue_id=issue_id, tags=tags,
+                    router_action=action_name,
+                    duration_ms=duration_ms, error_msg=str(e)[:500],
+                )
+                return False, {"action": "error", "reason": str(e)}
+
+            decision = retry_policy.decide_action_fail(
+                action_name, exc=e, round=round_,
+                idempotent=idempotent,
+                max_rounds=settings.retry_action_max_rounds,
+            )
+            log.warning(
+                "engine.action_fail_decide",
+                req_id=req_id, action=action_name,
+                error=str(e)[:200], round=round_,
+                decision=decision.action, reason=decision.reason,
+                idempotent=idempotent,
+            )
+            await obs.record_event(
+                "action.failed",
+                req_id=req_id, issue_id=issue_id, tags=tags,
+                router_action=action_name,
+                duration_ms=duration_ms, error_msg=str(e)[:500],
+                extras={
+                    "retry_round": round_,
+                    "retry_decision": decision.action,
+                    "retry_reason": decision.reason,
+                    "idempotent": idempotent,
+                },
+            )
+
+            if decision.action == "retry":
+                await req_state.bump_action_retry(pool, req_id, action_name)
+                await asyncio.sleep(decision.backoff_sec)
+                round_ += 1
+                continue
+
+            # escalate：链式 emit SESSION_FAILED，让状态机走 ESCALATED + escalate action
+            log.error(
+                "engine.action_escalate",
+                req_id=req_id, action=action_name,
+                error=str(e)[:200], reason=decision.reason,
+            )
+            chained = await _emit_escalate(
+                pool, body=body, req_id=req_id, project_id=project_id,
+                tags=tags, fallback_state=next_state, depth=depth,
+                error_reason=decision.reason,
+            )
+            return False, {
+                "action": "error",
+                "reason": str(e),
+                "escalated": True,
+                "retry_round": round_,
+                "chained": chained,
+            }
+
+        # 成功：清 round 计数，观测 executed
+        if round_ > 0:
+            await req_state.reset_action_retry(pool, req_id, action_name)
+            log.info(
+                "engine.action_retry_succeeded",
+                req_id=req_id, action=action_name, rounds=round_,
+            )
+        await obs.record_event(
+            "action.executed",
+            req_id=req_id, issue_id=issue_id, tags=tags,
+            router_action=action_name,
+            duration_ms=int((time.monotonic() - started) * 1000),
+            extras=result if isinstance(result, dict) else None,
+        )
+        return True, (result if isinstance(result, dict) else {})
+
+
+async def _emit_escalate(
+    pool: asyncpg.Pool,
+    *,
+    body,
+    req_id: str,
+    project_id: str,
+    tags: list[str],
+    fallback_state: ReqState,
+    depth: int,
+    error_reason: str,
+) -> dict[str, Any]:
+    """action handler 彻底失败 → 从当前状态 emit SESSION_FAILED 进 escalate 链。
+
+    读最新 state（cas 已推进到 next_state；handler 部分执行可能有 ctx 改动）。
+    SESSION_FAILED 对所有 *_RUNNING 态都有 transition → ESCALATED + escalate action。
+    """
+    new_row = await req_state.get(pool, req_id)
+    cur_state = new_row.state if new_row else fallback_state
+    cur_ctx = new_row.context if new_row else {}
+    # 把失败原因暴露给 escalate action（ctx + body.event）— escalate 读 body.event 打 tag
+    # 这里不改 body.event（signature 限制）；仅保留 ctx 里的诊断信息
+    await req_state.update_context(pool, req_id, {
+        "action_escalate_reason": error_reason[:200],
+    })
+    return await step(
+        pool,
+        body=body,
+        req_id=req_id,
+        project_id=project_id,
+        tags=tags,
+        cur_state=cur_state,
+        ctx=cur_ctx,
+        event=Event.SESSION_FAILED,
+        depth=depth + 1,
+    )

--- a/orchestrator/src/orchestrator/k8s_runner.py
+++ b/orchestrator/src/orchestrator/k8s_runner.py
@@ -88,6 +88,7 @@ class RunnerController:
         runner_secret_name: str,
         image_pull_secrets: list[str] | None = None,
         ready_timeout_sec: int = 120,
+        ready_attempts: int = 3,
         in_cluster: bool = True,
         core_v1: client.CoreV1Api | None = None,
     ):
@@ -100,6 +101,9 @@ class RunnerController:
         self.runner_secret_name = runner_secret_name
         self.image_pull_secrets = list(image_pull_secrets or [])
         self.ready_timeout_sec = ready_timeout_sec
+        # M9：Pod Ready 外层 attempts（每次等 ready_timeout_sec）。超全部 attempts 抛
+        # TimeoutError，让 engine.step 的 retry policy 接手决策 retry/escalate。
+        self.ready_attempts = max(1, ready_attempts)
 
         if core_v1 is not None:
             # 测试注入 mock client
@@ -244,8 +248,14 @@ class RunnerController:
     async def ensure_runner(
         self, req_id: str, *, wait_ready: bool = True,
         timeout_sec: int | None = None,
+        attempts: int | None = None,
     ) -> str:
-        """幂等创建 PVC + Pod。返回 pod name。"""
+        """幂等创建 PVC + Pod。返回 pod name。
+
+        M9：wait_ready=True 时外层跑 `attempts` 轮 _wait_pod_ready，每轮
+        timeout_sec 秒。总等待 ≈ attempts × timeout_sec。全超时后抛最后一次的
+        TimeoutError，由 engine.step retry policy 决定 retry / escalate。
+        """
         pod_name = self.pod_name(req_id)
 
         # PVC 先建（Pod 挂它；PVC 落不下来 Pod 会 Pending）
@@ -273,7 +283,24 @@ class RunnerController:
             log.debug("runner.pod.exists", req_id=req_id)
 
         if wait_ready:
-            await self._wait_pod_ready(pod_name, timeout_sec or self.ready_timeout_sec)
+            per_attempt = timeout_sec or self.ready_timeout_sec
+            total_attempts = attempts or self.ready_attempts
+            last_err: TimeoutError | None = None
+            for attempt in range(total_attempts):
+                try:
+                    await self._wait_pod_ready(pod_name, per_attempt)
+                    return pod_name
+                except TimeoutError as e:
+                    last_err = e
+                    log.warning(
+                        "runner.ready_attempt_failed",
+                        req_id=req_id, pod=pod_name,
+                        attempt=attempt + 1, total=total_attempts,
+                        timeout_sec=per_attempt,
+                    )
+            # 所有 attempts 都超时：抛最后一次的 TimeoutError（engine retry 会 catch）
+            assert last_err is not None
+            raise last_err
 
         return pod_name
 

--- a/orchestrator/src/orchestrator/main.py
+++ b/orchestrator/src/orchestrator/main.py
@@ -58,6 +58,7 @@ async def startup() -> None:
             runner_secret_name=settings.runner_secret_name,
             image_pull_secrets=settings.runner_image_pull_secrets,
             ready_timeout_sec=settings.runner_ready_timeout_sec,
+            ready_attempts=settings.runner_ready_attempts,
             in_cluster=settings.k8s_in_cluster,
         )
         k8s_runner.set_controller(controller)

--- a/orchestrator/src/orchestrator/retry/policy.py
+++ b/orchestrator/src/orchestrator/retry/policy.py
@@ -1,8 +1,8 @@
-"""M4 故障分级路由：按失败类型 + 轮次返回 RetryDecision。
+"""M4/M9 故障分级路由：按失败类型 + 轮次返回 RetryDecision。
 
 纯函数，不碰 IO。方便单测每种组合。
 
-决策表（见 #11 设计）：
+M4（decide）— checker/admission fail 分级决策：
 | fail_kind                | 处理                          |
 |--------------------------|-------------------------------|
 | schema / lint / typecheck| follow_up 同 agent（外科手术）|
@@ -12,11 +12,23 @@
 | flaky                    | skip_check_retry（sisyphus 自重）|
 | 任意（round ≥ max_rounds）| escalate                     |
 | 未知 fail_kind            | escalate（保守兜底）          |
+
+M9（decide_action_fail）— engine action handler 抛异常分级：
+| 条件                              | 处理                             |
+|-----------------------------------|----------------------------------|
+| 非幂等 action                     | escalate（重试会重复副作用）     |
+| transient exception + 未超 max    | retry with backoff               |
+| transient + 超 max_rounds         | escalate                         |
+| 非 transient exception            | escalate（bug, 不自动重试）      |
 """
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import Literal
+
+import httpx
+from kubernetes.client.exceptions import ApiException as K8sApiException
 
 RetryAction = Literal[
     "follow_up",
@@ -25,6 +37,18 @@ RetryAction = Literal[
     "skip_check_retry",
     "escalate",
 ]
+
+ActionFailAction = Literal["retry", "escalate"]
+
+# 网络 / K8s API / 异步超时类异常：重试可能救活。
+# 注：RuntimeError (比如 k8s pod 拒启动后 phase=Failed) 不在此列，直接 escalate。
+TRANSIENT_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    TimeoutError,            # 含 asyncio.TimeoutError（3.11+ 起是同一个）
+    asyncio.TimeoutError,    # 显式列出兼容更老 traceback
+    K8sApiException,         # k8s API 抖动（5xx/超时 + 4xx 某些情况）
+    httpx.HTTPError,         # httpx 根异常类（含 TimeoutException / ConnectError 等）
+    ConnectionError,         # 网络层兜底
+)
 
 SURGICAL_KINDS: frozenset[str] = frozenset({"schema", "lint", "typecheck"})
 FAIL_KIND_TEST = "test"
@@ -98,4 +122,69 @@ def decide(
     return RetryDecision(
         "escalate", None,
         f"unknown fail_kind {fail_kind!r} → escalate",
+    )
+
+
+# ── M9: engine action-fail 决策 ─────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ActionFailDecision:
+    """engine.step 捕到 action handler 异常后的处理决策。"""
+    action: ActionFailAction
+    backoff_sec: float
+    reason: str
+
+
+def decide_action_fail(
+    action: str,
+    *,
+    exc: BaseException,
+    round: int,
+    idempotent: bool,
+    max_rounds: int = 3,
+) -> ActionFailDecision:
+    """action handler 抛异常 → 决定 retry / escalate。
+
+    Args:
+        action: 触发异常的 action 名（仅用于 reason/log）
+        exc: handler 抛出的异常
+        round: 已重试轮次（0-based；第一次失败 round=0）
+        idempotent: 重试该 action 是否安全（由 ACTION_META[action]["idempotent"] 传入）
+        max_rounds: 最多重试轮次（不含首次；round == max_rounds 就 escalate）
+
+    Returns:
+        ActionFailDecision（action="retry"|"escalate" + backoff + reason）
+
+    决策规则（顺序即优先级）：
+        1. 非幂等 action → escalate（重试 create_dev 会重复建 BKD issue）
+        2. transient 异常 + round < max_rounds → retry（退避 30/60/90/120s）
+        3. 其他（非 transient / 超轮） → escalate
+    """
+    if not idempotent:
+        return ActionFailDecision(
+            action="escalate", backoff_sec=0.0,
+            reason=f"non-idempotent action {action}; retry would duplicate side effects",
+        )
+
+    is_transient = isinstance(exc, TRANSIENT_EXCEPTIONS)
+    exc_name = type(exc).__name__
+
+    if is_transient and round < max_rounds:
+        # 30, 60, 90, 120（上限），递增退避
+        backoff = min(30.0 * (round + 1), 120.0)
+        return ActionFailDecision(
+            action="retry", backoff_sec=backoff,
+            reason=f"transient {exc_name} round {round + 1}/{max_rounds}",
+        )
+
+    if is_transient:
+        return ActionFailDecision(
+            action="escalate", backoff_sec=0.0,
+            reason=f"transient {exc_name} exceeded max_rounds {max_rounds}",
+        )
+
+    return ActionFailDecision(
+        action="escalate", backoff_sec=0.0,
+        reason=f"non-transient {exc_name}: {str(exc)[:200]}",
     )

--- a/orchestrator/src/orchestrator/store/req_state.py
+++ b/orchestrator/src/orchestrator/store/req_state.py
@@ -98,3 +98,62 @@ async def update_context(pool: asyncpg.Pool, req_id: str, patch: dict) -> None:
         "UPDATE req_state SET context = context || $2::jsonb, updated_at = now() WHERE req_id = $1",
         req_id, json.dumps(patch),
     )
+
+
+# ── M9: action 抛异常时的 per-action retry 计数 ─────────────────────────
+# 存在 context.action_retries = {"<action_name>": <round>}，engine.step 读 / 增 / 清。
+# 跟 M4 的 context.retries（stage → round）区分：M4 counter 是 checker fail 路径，
+# M9 counter 是 engine 捕到的 action handler 异常。
+
+
+async def bump_action_retry(pool: asyncpg.Pool, req_id: str, action_name: str) -> int:
+    """原子递增 ctx.action_retries[action_name]，返回新 round 值（1-based）。"""
+    row = await pool.fetchrow(
+        """
+        UPDATE req_state
+        SET context = jsonb_set(
+            context,
+            '{action_retries}',
+            COALESCE(context->'action_retries', '{}'::jsonb) ||
+            jsonb_build_object(
+                $2::text,
+                COALESCE((context#>>ARRAY['action_retries', $2])::int, 0) + 1
+            ),
+            true
+        ),
+        updated_at = now()
+        WHERE req_id = $1
+        RETURNING (context#>>ARRAY['action_retries', $2])::int AS new_round
+        """,
+        req_id, action_name,
+    )
+    return int(row["new_round"]) if row else 0
+
+
+async def reset_action_retry(pool: asyncpg.Pool, req_id: str, action_name: str) -> None:
+    """action 重试成功后清零 counter，不污染后续 stage。key 不存在则 no-op。"""
+    await pool.execute(
+        """
+        UPDATE req_state
+        SET context = jsonb_set(
+            context,
+            '{action_retries}',
+            COALESCE(context->'action_retries', '{}'::jsonb) - $2::text,
+            true
+        ),
+        updated_at = now()
+        WHERE req_id = $1
+        """,
+        req_id, action_name,
+    )
+
+
+async def get_action_retry(pool: asyncpg.Pool, req_id: str, action_name: str) -> int:
+    """读当前 round（用于观测 / debug）。"""
+    row = await pool.fetchrow(
+        "SELECT (context#>>ARRAY['action_retries', $2])::int AS r FROM req_state WHERE req_id = $1",
+        req_id, action_name,
+    )
+    if row is None or row["r"] is None:
+        return 0
+    return int(row["r"])

--- a/orchestrator/tests/test_engine.py
+++ b/orchestrator/tests/test_engine.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from orchestrator import engine, k8s_runner
-from orchestrator.actions import REGISTRY
+from orchestrator.actions import ACTION_META, REGISTRY
 from orchestrator.state import Event, ReqState
 
 
@@ -25,14 +25,23 @@ class FakeReq:
 
 
 class FakePool:
-    """模拟 asyncpg.Pool 的 fetchrow / execute，仅支持 req_state 的 CAS UPDATE 和 SELECT。"""
+    """模拟 asyncpg.Pool 的 fetchrow / execute，支持 req_state CAS + ctx patch + M9 action_retries。"""
 
     def __init__(self, initial: dict[str, FakeReq]):
         self.rows = initial
 
     async def fetchrow(self, sql: str, *args):
-        sql = sql.strip()
-        if sql.startswith("SELECT"):
+        sql_stripped = sql.strip()
+        # M9：action_retries bump — `UPDATE req_state SET context = jsonb_set(...) RETURNING new_round`
+        if "action_retries" in sql and "RETURNING" in sql:
+            req_id, action_name = args
+            r = self.rows.get(req_id)
+            if r is None:
+                return None
+            retries = r.context.setdefault("action_retries", {})
+            retries[action_name] = int(retries.get(action_name, 0)) + 1
+            return {"new_round": retries[action_name]}
+        if sql_stripped.startswith("SELECT"):
             req_id = args[0]
             r = self.rows.get(req_id)
             if r is None:
@@ -42,7 +51,7 @@ class FakePool:
                 "history": json.dumps(r.history), "context": json.dumps(r.context),
                 "created_at": None, "updated_at": None,
             }
-        if sql.startswith("UPDATE req_state"):
+        if sql_stripped.startswith("UPDATE req_state"):
             # 4 个参数（无 ctx_patch）或 5 个参数（带 ctx_patch）— 跟真实 cas_transition 对齐
             req_id, expected, next_state, history_json, *rest = args
             r = self.rows.get(req_id)
@@ -61,8 +70,18 @@ class FakePool:
         raise NotImplementedError(sql[:60])
 
     async def execute(self, sql: str, *args):
-        sql = sql.strip()
-        if sql.startswith("UPDATE req_state SET context"):
+        sql_stripped = sql.strip()
+        # M9：reset_action_retry — `UPDATE req_state SET context = jsonb_set(context, '{action_retries}', ... - $2)`
+        if "action_retries" in sql and "jsonb_set" in sql:
+            req_id, action_name = args
+            r = self.rows.get(req_id)
+            if r:
+                retries = r.context.get("action_retries", {})
+                if isinstance(retries, dict):
+                    retries.pop(action_name, None)
+            return
+        # update_context：`UPDATE req_state SET context = context || $2::jsonb`
+        if sql_stripped.startswith("UPDATE req_state SET context"):
             req_id, patch_json = args
             patch = json.loads(patch_json)
             r = self.rows.get(req_id)
@@ -83,11 +102,15 @@ def stub_actions(monkeypatch):
             return {"emit": emit} if emit else {"ok": True}
         return _stub
 
-    saved = dict(REGISTRY)
+    saved_reg = dict(REGISTRY)
+    saved_meta = dict(ACTION_META)
     REGISTRY.clear()
+    ACTION_META.clear()
     yield calls, REGISTRY
     REGISTRY.clear()
-    REGISTRY.update(saved)
+    ACTION_META.clear()
+    REGISTRY.update(saved_reg)
+    ACTION_META.update(saved_meta)
 
 
 @pytest.mark.asyncio
@@ -267,6 +290,199 @@ async def test_cleanup_failure_does_not_block_engine(stub_actions, mock_runner_c
 
     assert pool.rows["REQ-1"].state == ReqState.DONE.value
     assert result["next_state"] == ReqState.DONE.value
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# M9: engine action-fail retry / escalate
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def enable_retry(monkeypatch):
+    """临时打开 retry_enabled，缩短测试 backoff。"""
+    from orchestrator import engine as eng
+    from orchestrator.config import settings as cfg
+    monkeypatch.setattr(cfg, "retry_enabled", True)
+    monkeypatch.setattr(cfg, "retry_action_max_rounds", 3)
+    # 用 0 backoff 加速测试（policy 会根据 round 计出 backoff，我们 patch asyncio.sleep）
+    orig_sleep = eng.asyncio.sleep
+
+    async def _fast_sleep(_sec):
+        await orig_sleep(0)
+
+    monkeypatch.setattr(eng.asyncio, "sleep", _fast_sleep)
+
+
+@pytest.mark.asyncio
+async def test_action_fail_retries_transient_then_succeeds(stub_actions, enable_retry):
+    """idempotent action 抛 TimeoutError → policy retry → 第 2 次成功 → 状态推进。"""
+    _calls, reg = stub_actions
+    from orchestrator.actions import ACTION_META
+
+    attempts = {"n": 0}
+
+    async def flaky(*, body, req_id, tags, ctx):
+        attempts["n"] += 1
+        if attempts["n"] < 2:
+            raise TimeoutError("pod not ready in 120s")
+        return {"issue_id": "i-1"}
+
+    # 注册 start_analyze stub + 标 idempotent=True
+    reg["start_analyze"] = flaky
+    ACTION_META["start_analyze"] = {"idempotent": True}
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.INIT.value)})
+    body = type("B", (), {"issueId": "i-intent", "projectId": "p", "event": "intent.analyze"})()
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=["intent:analyze", "REQ-1"],
+        cur_state=ReqState.INIT, ctx={}, event=Event.INTENT_ANALYZE,
+    )
+
+    assert attempts["n"] == 2, "handler should be retried once after first TimeoutError"
+    # 成功路径：action 字段 = 注册的 transition.action
+    assert result["action"] == "start_analyze"
+    # 状态已推进到 ANALYZING（cas 在重试前就做过，不会回滚）
+    assert pool.rows["REQ-1"].state == ReqState.ANALYZING.value
+    # counter 已清零（成功后 reset）
+    assert pool.rows["REQ-1"].context.get("action_retries", {}).get("start_analyze", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_action_fail_non_idempotent_escalates_immediately(stub_actions, enable_retry):
+    """非幂等 action（create_dev）抛任何异常 → 不重试，直接 emit SESSION_FAILED。"""
+    calls, reg = stub_actions
+    from orchestrator.actions import ACTION_META
+
+    attempts = {"n": 0}
+
+    async def broken_create_dev(*, body, req_id, tags, ctx):
+        attempts["n"] += 1
+        raise TimeoutError("BKD API timeout")
+
+    async def escalate_stub(*, body, req_id, tags, ctx):
+        calls.append(("escalate", {"req_id": req_id}))
+        return {"escalated": True, "reason": "action_fail"}
+
+    reg["create_dev"] = broken_create_dev
+    reg["escalate"] = escalate_stub
+    ACTION_META["create_dev"] = {"idempotent": False}
+    ACTION_META["escalate"] = {"idempotent": True}
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.SPECS_RUNNING.value)})
+    body = type("B", (), {"issueId": "x", "projectId": "p", "event": "spec.all-passed"})()
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.SPECS_RUNNING, ctx={}, event=Event.SPEC_ALL_PASSED,
+    )
+
+    assert attempts["n"] == 1, "non-idempotent should not retry"
+    assert result["action"] == "error"
+    assert result["escalated"] is True
+    # 链式 SESSION_FAILED → ESCALATED + escalate action 被调用
+    assert any(n == "escalate" for n, _ in calls)
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+
+
+@pytest.mark.asyncio
+async def test_action_fail_exceeds_max_rounds_escalates(stub_actions, enable_retry, monkeypatch):
+    """idempotent action + 一直 fail → 超 max_rounds → escalate。"""
+    calls, reg = stub_actions
+    from orchestrator.actions import ACTION_META
+    from orchestrator.config import settings as cfg
+
+    # 把 max_rounds 缩到 2，加速测试
+    monkeypatch.setattr(cfg, "retry_action_max_rounds", 2)
+
+    attempts = {"n": 0}
+
+    async def always_fails(*, body, req_id, tags, ctx):
+        attempts["n"] += 1
+        raise TimeoutError(f"still not ready attempt={attempts['n']}")
+
+    async def escalate_stub(*, body, req_id, tags, ctx):
+        calls.append(("escalate", {"req_id": req_id}))
+        return {"escalated": True}
+
+    reg["start_analyze"] = always_fails
+    reg["escalate"] = escalate_stub
+    ACTION_META["start_analyze"] = {"idempotent": True}
+    ACTION_META["escalate"] = {"idempotent": True}
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.INIT.value)})
+    body = type("B", (), {"issueId": "x", "projectId": "p", "event": "intent.analyze"})()
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.INIT, ctx={}, event=Event.INTENT_ANALYZE,
+    )
+
+    # max_rounds=2 → round 0 retry, round 1 retry, round 2 escalate = 3 次调用
+    assert attempts["n"] == 3, f"expected 3 attempts (2 retries + 1 final), got {attempts['n']}"
+    assert result["action"] == "error"
+    assert result["escalated"] is True
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+
+
+@pytest.mark.asyncio
+async def test_action_fail_non_transient_escalates_no_retry(stub_actions, enable_retry):
+    """idempotent action 抛非 transient 异常（ValueError）→ 不重试，直接 escalate。"""
+    calls, reg = stub_actions
+    from orchestrator.actions import ACTION_META
+
+    attempts = {"n": 0}
+
+    async def bad_handler(*, body, req_id, tags, ctx):
+        attempts["n"] += 1
+        raise ValueError("bad ctx field")
+
+    async def escalate_stub(*, body, req_id, tags, ctx):
+        calls.append(("escalate", {"req_id": req_id}))
+        return {"escalated": True}
+
+    reg["start_analyze"] = bad_handler
+    reg["escalate"] = escalate_stub
+    ACTION_META["start_analyze"] = {"idempotent": True}
+    ACTION_META["escalate"] = {"idempotent": True}
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.INIT.value)})
+    body = type("B", (), {"issueId": "x", "projectId": "p", "event": "intent.analyze"})()
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.INIT, ctx={}, event=Event.INTENT_ANALYZE,
+    )
+
+    assert attempts["n"] == 1, "non-transient should not retry"
+    assert result["escalated"] is True
+
+
+@pytest.mark.asyncio
+async def test_action_fail_retry_disabled_keeps_old_behavior(stub_actions):
+    """retry_enabled=False（默认）→ 旧行为：一次 fail 就 error，不重试，不 escalate。"""
+    _calls, reg = stub_actions
+    from orchestrator.actions import ACTION_META
+
+    async def flaky(*, body, req_id, tags, ctx):
+        raise TimeoutError("pod not ready")
+
+    reg["start_analyze"] = flaky
+    ACTION_META["start_analyze"] = {"idempotent": True}
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.INIT.value)})
+    body = type("B", (), {"issueId": "x", "projectId": "p", "event": "intent.analyze"})()
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.INIT, ctx={}, event=Event.INTENT_ANALYZE,
+    )
+
+    # 旧行为：action=error 但 escalated 未设（没链式 emit）
+    assert result["action"] == "error"
+    assert "escalated" not in result
+    # 状态保持 ANALYZING（cas 已推进但 escalate 未触发）
+    assert pool.rows["REQ-1"].state == ReqState.ANALYZING.value
 
 
 @pytest.mark.asyncio

--- a/orchestrator/tests/test_k8s_runner.py
+++ b/orchestrator/tests/test_k8s_runner.py
@@ -174,6 +174,112 @@ async def test_ensure_runner_raises_on_other_api_error():
         await rc.ensure_runner("REQ-1", wait_ready=False)
 
 
+# ─── M9: ensure_runner 多次 attempt ────────────────────────────────────
+
+
+def _make_controller_with_attempts(core_v1: MagicMock, attempts: int) -> RunnerController:
+    return RunnerController(
+        namespace="sisyphus-runners",
+        runner_image="img",
+        runner_sa="sa",
+        storage_class="local-path",
+        workspace_size="5Gi",
+        runner_secret_name="s",
+        image_pull_secrets=[],
+        ready_timeout_sec=1,      # 每轮 1s 超时，测试快
+        ready_attempts=attempts,
+        core_v1=core_v1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_runner_multi_attempt_succeeds_on_second(monkeypatch):
+    """第 1 次 _wait_pod_ready 抛 TimeoutError → 第 2 次 Ready → ensure_runner 返回 pod_name。"""
+    core = MagicMock()
+    core.create_namespaced_persistent_volume_claim = MagicMock(return_value=None)
+    core.create_namespaced_pod = MagicMock(return_value=None)
+    rc = _make_controller_with_attempts(core, attempts=3)
+
+    calls = {"n": 0}
+
+    async def fake_wait(pod_name, timeout_sec):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise TimeoutError(f"Pod {pod_name} not ready in {timeout_sec}s")
+        return None
+
+    monkeypatch.setattr(rc, "_wait_pod_ready", fake_wait)
+
+    pod_name = await rc.ensure_runner("REQ-1", wait_ready=True)
+    assert pod_name == "runner-req-1"
+    assert calls["n"] == 2, "should retry once then succeed"
+
+
+@pytest.mark.asyncio
+async def test_ensure_runner_multi_attempt_all_fail_raises_last_timeout(monkeypatch):
+    """所有 attempts 都超时 → 抛最后一次 TimeoutError（engine retry policy 接手）。"""
+    core = MagicMock()
+    core.create_namespaced_persistent_volume_claim = MagicMock(return_value=None)
+    core.create_namespaced_pod = MagicMock(return_value=None)
+    rc = _make_controller_with_attempts(core, attempts=3)
+
+    calls = {"n": 0}
+
+    async def fake_wait(pod_name, timeout_sec):
+        calls["n"] += 1
+        raise TimeoutError(f"Pod {pod_name} not ready (attempt {calls['n']})")
+
+    monkeypatch.setattr(rc, "_wait_pod_ready", fake_wait)
+
+    with pytest.raises(TimeoutError) as exc_info:
+        await rc.ensure_runner("REQ-1", wait_ready=True)
+    assert calls["n"] == 3
+    # 最后一次的错误 message（attempt 3）
+    assert "attempt 3" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_ensure_runner_attempts_override_via_kwarg(monkeypatch):
+    """attempts 参数可以覆盖 controller 默认值（给单次 ensure 临时延长耐心）。"""
+    core = MagicMock()
+    core.create_namespaced_persistent_volume_claim = MagicMock(return_value=None)
+    core.create_namespaced_pod = MagicMock(return_value=None)
+    rc = _make_controller_with_attempts(core, attempts=1)
+
+    calls = {"n": 0}
+
+    async def fake_wait(pod_name, timeout_sec):
+        calls["n"] += 1
+        if calls["n"] < 4:
+            raise TimeoutError("slow node")
+        return None
+
+    monkeypatch.setattr(rc, "_wait_pod_ready", fake_wait)
+
+    await rc.ensure_runner("REQ-1", wait_ready=True, attempts=5)
+    assert calls["n"] == 4
+
+
+@pytest.mark.asyncio
+async def test_ensure_runner_single_attempt_still_works_when_ready(monkeypatch):
+    """attempts=1 + 立即 Ready：不多做无谓循环。"""
+    core = MagicMock()
+    core.create_namespaced_persistent_volume_claim = MagicMock(return_value=None)
+    core.create_namespaced_pod = MagicMock(return_value=None)
+    rc = _make_controller_with_attempts(core, attempts=1)
+
+    calls = {"n": 0}
+
+    async def fake_wait(pod_name, timeout_sec):
+        calls["n"] += 1
+        return None
+
+    monkeypatch.setattr(rc, "_wait_pod_ready", fake_wait)
+
+    await rc.ensure_runner("REQ-1", wait_ready=True)
+    assert calls["n"] == 1
+
+
 # ─── pause / resume / destroy ──────────────────────────────────────────
 
 

--- a/orchestrator/tests/test_req_state.py
+++ b/orchestrator/tests/test_req_state.py
@@ -68,3 +68,52 @@ async def test_cas_failed_returns_false():
         Event.INTENT_ANALYZE, "start_analyze",
     )
     assert ok is False
+
+
+# ── M9: action_retries CRUD ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bump_action_retry_returns_new_round():
+    pool = CapturePool(ret={"new_round": 3})
+    r = await rs.bump_action_retry(pool, "REQ-1", "start_analyze")
+    assert r == 3
+    sql, args = pool.calls[0]
+    assert "action_retries" in sql
+    assert "jsonb_set" in sql
+    assert "RETURNING" in sql
+    assert args == ("REQ-1", "start_analyze")
+
+
+@pytest.mark.asyncio
+async def test_bump_action_retry_row_missing_returns_zero():
+    pool = AsyncMock()
+    pool.fetchrow = AsyncMock(return_value=None)   # row 不存在
+    r = await rs.bump_action_retry(pool, "REQ-missing", "start_analyze")
+    assert r == 0
+
+
+@pytest.mark.asyncio
+async def test_reset_action_retry_runs_subtract_sql():
+    pool = AsyncMock()
+    pool.execute = AsyncMock()
+    await rs.reset_action_retry(pool, "REQ-1", "start_analyze")
+    pool.execute.assert_awaited_once()
+    sql, *args = pool.execute.call_args.args
+    assert "action_retries" in sql
+    assert "- $2::text" in sql
+    assert args == ["REQ-1", "start_analyze"]
+
+
+@pytest.mark.asyncio
+async def test_get_action_retry_zero_when_missing():
+    pool = CapturePool(ret={"r": None})
+    r = await rs.get_action_retry(pool, "REQ-1", "create_dev")
+    assert r == 0
+
+
+@pytest.mark.asyncio
+async def test_get_action_retry_returns_int():
+    pool = CapturePool(ret={"r": 2})
+    r = await rs.get_action_retry(pool, "REQ-1", "start_analyze")
+    assert r == 2

--- a/orchestrator/tests/test_retry_policy.py
+++ b/orchestrator/tests/test_retry_policy.py
@@ -1,15 +1,21 @@
-"""retry.policy.decide 单测：每种 fail_kind × round 组合验路由。"""
+"""retry.policy.decide / decide_action_fail 单测。"""
 from __future__ import annotations
 
+import asyncio
+
+import httpx
 import pytest
+from kubernetes.client.exceptions import ApiException as K8sApiException
 
 from orchestrator.retry.policy import (
     FAIL_KIND_FLAKY,
     FAIL_KIND_PROMPT_TOO_LONG,
     FAIL_KIND_TEST,
     SURGICAL_KINDS,
+    ActionFailDecision,
     RetryDecision,
     decide,
+    decide_action_fail,
 )
 
 
@@ -124,3 +130,99 @@ def test_custom_diagnose_threshold_2():
 def test_high_max_allows_more_rounds():
     d = decide("s", "test", round=4, diagnose_threshold=3, max_rounds=10)
     assert d.action == "diagnose"   # 不 escalate，还在 diagnose 窗口
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# M9: decide_action_fail — engine action handler 异常分级
+# ═══════════════════════════════════════════════════════════════════════
+
+
+# ─── 非幂等 action：永远 escalate（无论异常类型/round） ───────────────────
+@pytest.mark.parametrize("exc", [
+    TimeoutError("pod not ready"),
+    K8sApiException(status=500, reason="server error"),
+    httpx.ConnectError("connect failed"),
+    ValueError("bad input"),
+])
+def test_non_idempotent_always_escalates(exc):
+    d = decide_action_fail("create_dev", exc=exc, round=0, idempotent=False)
+    assert d.action == "escalate"
+    assert "non-idempotent" in d.reason
+    assert d.backoff_sec == 0.0
+
+
+def test_non_idempotent_ignores_round():
+    d = decide_action_fail("fanout_specs", exc=TimeoutError(), round=10, idempotent=False)
+    assert d.action == "escalate"
+
+
+# ─── 幂等 + transient 异常 + 未超轮：retry + 递增 backoff ────────────────
+@pytest.mark.parametrize("exc_factory", [
+    lambda: TimeoutError("pod not ready in 120s"),
+    # asyncio.TimeoutError 在 3.11+ 就是 TimeoutError 别名，显式覆盖确保老代码
+    # 里用旧名字的 raise asyncio.TimeoutError 也被认成 transient
+    lambda: asyncio.TimeoutError(),  # noqa: UP041
+    lambda: K8sApiException(status=500, reason="server error"),
+    lambda: K8sApiException(status=503, reason="service unavailable"),
+    lambda: httpx.ConnectError("conn reset"),
+    lambda: httpx.TimeoutException("read timeout"),
+    lambda: ConnectionError("broken pipe"),
+])
+def test_idempotent_transient_retries(exc_factory):
+    d = decide_action_fail("start_analyze", exc=exc_factory(),
+                           round=0, idempotent=True, max_rounds=3)
+    assert d.action == "retry"
+    assert d.backoff_sec == 30.0   # round 0 → 30s
+
+
+def test_transient_backoff_grows_per_round():
+    exc = TimeoutError("x")
+    b0 = decide_action_fail("a", exc=exc, round=0, idempotent=True, max_rounds=5).backoff_sec
+    b1 = decide_action_fail("a", exc=exc, round=1, idempotent=True, max_rounds=5).backoff_sec
+    b2 = decide_action_fail("a", exc=exc, round=2, idempotent=True, max_rounds=5).backoff_sec
+    b3 = decide_action_fail("a", exc=exc, round=3, idempotent=True, max_rounds=5).backoff_sec
+    assert (b0, b1, b2, b3) == (30.0, 60.0, 90.0, 120.0)
+
+
+def test_transient_backoff_caps_at_120():
+    """round 超过 3 也不让 backoff 无限涨。"""
+    d = decide_action_fail("a", exc=TimeoutError(), round=10,
+                           idempotent=True, max_rounds=20)
+    assert d.action == "retry"
+    assert d.backoff_sec == 120.0
+
+
+# ─── 幂等 + transient + 超轮：escalate ─────────────────────────────────
+def test_idempotent_transient_exceeds_max_rounds_escalates():
+    d = decide_action_fail("start_analyze", exc=TimeoutError("pod"),
+                           round=3, idempotent=True, max_rounds=3)
+    assert d.action == "escalate"
+    assert "exceeded max_rounds" in d.reason
+
+
+def test_idempotent_transient_beyond_max_rounds_escalates():
+    d = decide_action_fail("start_analyze", exc=K8sApiException(status=500),
+                           round=5, idempotent=True, max_rounds=3)
+    assert d.action == "escalate"
+
+
+# ─── 幂等 + 非 transient 异常：直接 escalate（不重试 bug） ──────────────
+@pytest.mark.parametrize("exc", [
+    ValueError("bad ctx field"),
+    KeyError("issue_id"),
+    RuntimeError("Pod failed: CrashLoopBackOff"),
+    TypeError("NoneType has no attribute"),
+])
+def test_idempotent_non_transient_escalates(exc):
+    d = decide_action_fail("start_analyze", exc=exc,
+                           round=0, idempotent=True, max_rounds=3)
+    assert d.action == "escalate"
+    assert "non-transient" in d.reason
+    assert d.backoff_sec == 0.0
+
+
+def test_decision_is_frozen_dataclass():
+    d = decide_action_fail("a", exc=TimeoutError(), round=0, idempotent=True)
+    assert isinstance(d, ActionFailDecision)
+    with pytest.raises(AttributeError):
+        d.action = "nope"   # type: ignore[misc]


### PR DESCRIPTION
## Summary

扩展 M4 (#5) retry 覆盖 `engine.action_failed` 路径。修复 BKD issue #29 端到端测试时暴露的 gap：REQ-final-1776857112 因 `start_analyze` 抛 `Pod not ready in 120s` → 状态机卡 `analyzing` 20 min，M8 watchdog (#11) 兜底慢且只能 escalate 不能救活。

**核心改动**

- `engine.step` 异常处理：idempotent action + transient 异常（TimeoutError / k8s ApiException / httpx.HTTPError / ConnectionError）→ 按 30/60/90/120s 递增 backoff 原地重试 handler；超 `retry_action_max_rounds` 或非幂等或非 transient → emit `SESSION_FAILED` 走既有 escalate 链。
- `retry/policy.decide_action_fail`：新纯函数 + `ActionFailDecision` dataclass（不污染 M4 的 `RetryDecision`）。
- `actions.register(name, *, idempotent=...)`：加声明式幂等标记 + `ACTION_META` dict，12 个 action 按实际副作用标记（`start_analyze` / `mark_spec_reviewed_and_check` / `teardown_accept_env` / `escalate` = idempotent；`create_*` / `fanout_specs` / `open_gh_and_bugfix` / `done_archive` / `spawn_diagnose` = `False` 以防重复建 BKD issue）。
- `store/req_state`：`bump_action_retry` / `reset_action_retry` / `get_action_retry` 落 `context.action_retries`（独立于 M4 的 `context.retries`）。
- `config.py`：`retry_action_max_rounds=3` + `runner_ready_attempts=3`。
- `k8s_runner.ensure_runner`：外层 `ready_attempts` 轮 `_wait_pod_ready`，每轮 `ready_timeout_sec` 超时计一次 attempt，全超后抛 TimeoutError 让 engine retry 接手（默认 3 × 120s = 6min 总耐心）。

**Flag 状态**

`retry_enabled=False`（默认）时完全沿用老行为（action 挂即记 + 返 error，不重试）。跟 M4 共用同一 flag 一键回滚。

## Test plan

- [x] `tests/test_retry_policy.py` 覆盖 decide_action_fail 全分支：非幂等 escalate、幂等 transient retry、backoff 递增 + 120s 上限、超 max_rounds escalate、非 transient escalate
- [x] `tests/test_engine.py` 端到端：transient 异常第 2 次成功、非幂等立即 escalate 到 ESCALATED、超 max_rounds escalate、非 transient escalate、retry_enabled=False 保持老行为
- [x] `tests/test_k8s_runner.py` ensure_runner 多 attempt：第 2 次 ready 成功、全超时抛 TimeoutError、`attempts=1` 覆盖默认、立即 Ready 不多轮
- [x] 全套 303 测试通过、ruff 无警告
- [ ] 灰度：单 REQ 打开 `SISYPHUS_RETRY_ENABLED=true` 验实测 k8s 抖动能自愈（跟 #5 / #9 一样按 REQ 试点）

Refs: #5 (M4 policy), #11 (M8 watchdog), BKD issue #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)