### PR TITLE
feat(checker): M11 checkers 从 manifest 读 test_cmd / pr_repo

### DIFF
--- a/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
@@ -1,19 +1,19 @@
-"""create_pr_ci_watch（v0.2 + M2 checker）：staging-test pass → 等 PR CI 全套绿。
+"""create_pr_ci_watch（v0.2 + M2 checker + M11 manifest-driven）：
+staging-test pass → 等 PR CI 全套绿。
 
 feature flag checker_pr_ci_watch_enabled:
   False（默认）: 创建 BKD agent issue（老路，agent 用 gh CLI 轮询，报 tag）
   True: sisyphus 自己调 GitHub REST API 轮询 check-runs，emit PR_CI_PASS/FAIL/TIMEOUT
 
-ctx 输入（checker 模式）：
-  pr_repo: "owner/name" 例 "phona/ubox-crosser"
-  pr_number: int
-M3 会改成统一从 manifest.yaml 读，M2 先硬编码 ctx 字段（dev/staging-test agent 写入）。
+M11：pr_repo / pr_number 不再从 ctx 读，checker 自己从 PVC manifest.yaml 的
+`pr` 段读。上游（dev / staging-test agent）开 PR 后要回写 manifest 填 pr.number。
 """
 from __future__ import annotations
 
 import structlog
 
 from ..bkd import BKDClient
+from ..checkers import manifest_io
 from ..checkers import pr_ci_watch as checker
 from ..config import settings
 from ..prompts import render
@@ -39,28 +39,21 @@ async def create_pr_ci_watch(*, body, req_id, tags, ctx):
 # ── 新路：sisyphus 自检 ────────────────────────────────────────────────────
 
 async def _run_checker(*, req_id: str, ctx: dict) -> dict:
-    pr_repo = ctx.get("pr_repo")
-    pr_number = ctx.get("pr_number")
-    if not pr_repo or not pr_number:
-        # ctx 缺字段：emit fail 进 bugfix（按 PR_CI_FAIL 路径走，跟老路报 pr-ci:fail tag 等价）
-        log.error("create_pr_ci_watch.checker_missing_ctx",
-                  req_id=req_id, pr_repo=pr_repo, pr_number=pr_number)
-        return {
-            "emit": Event.PR_CI_FAIL.value,
-            "reason": "missing pr_repo / pr_number in ctx",
-            "exit_code": -1,
-        }
-
-    log.info("create_pr_ci_watch.checker_path",
-             req_id=req_id, repo=pr_repo, pr=pr_number)
+    log.info("create_pr_ci_watch.checker_path", req_id=req_id)
 
     try:
         result = await checker.watch_pr_ci(
-            repo=pr_repo,
-            pr_number=int(pr_number),
+            req_id,
             poll_interval_sec=settings.pr_ci_watch_poll_interval_sec,
             timeout_sec=settings.pr_ci_watch_timeout_sec,
         )
+    except manifest_io.ManifestReadError as e:
+        log.error("create_pr_ci_watch.manifest_read_failed", req_id=req_id, error=str(e))
+        return {
+            "emit": Event.PR_CI_FAIL.value,
+            "reason": f"manifest read failed: {e}"[:200],
+            "exit_code": -1,
+        }
     except Exception as e:
         log.exception("create_pr_ci_watch.checker_error", req_id=req_id, error=str(e))
         return {

--- a/orchestrator/src/orchestrator/actions/create_staging_test.py
+++ b/orchestrator/src/orchestrator/actions/create_staging_test.py
@@ -1,4 +1,5 @@
-"""create_staging_test（v0.2 + M1 checker + M4 retry）：dev.done 后验 staging 测试。
+"""create_staging_test（v0.2 + M1 checker + M4 retry + M11 manifest-driven）：
+dev.done 后验 staging 测试。
 
 feature flag checker_staging_test_enabled:
   False（默认）: 创建 BKD agent issue（老路，保证老行为不破）
@@ -8,12 +9,15 @@ feature flag retry_enabled（仅 checker 路径生效）:
   False（默认）: checker fail 直 emit STAGING_TEST_FAIL（老行为，进 bugfix 链）
   True: checker fail 走 retry.executor 分级决策；follow_up/diagnose 不 emit fail，
         状态留在 STAGING_TEST_RUNNING 等 dev agent 修完再触发重跑
+
+M11：test_cmd / cwd / timeout 不再硬编码，checker 自己从 PVC manifest.yaml 读。
 """
 from __future__ import annotations
 
 import structlog
 
 from ..bkd import BKDClient
+from ..checkers import manifest_io
 from ..checkers import staging_test as checker
 from ..config import settings
 from ..prompts import render
@@ -26,7 +30,6 @@ from ._skip import skip_if_enabled
 
 log = structlog.get_logger(__name__)
 
-_TEST_CMD = "make test"   # M1 硬编码；M3 改成读 PVC manifest.yaml
 _STAGE = "staging-test"
 
 
@@ -44,23 +47,31 @@ async def create_staging_test(*, body, req_id, tags, ctx):
 # ── 新路：sisyphus 自检 ────────────────────────────────────────────────────
 
 async def _run_checker(*, body, req_id: str, ctx: dict) -> dict:
-    log.info("create_staging_test.checker_path", req_id=req_id, cmd=_TEST_CMD)
+    log.info("create_staging_test.checker_path", req_id=req_id)
 
     try:
-        result = await checker.run_staging_test(req_id, _TEST_CMD)
+        result = await checker.run_staging_test(req_id)
     except TimeoutError:
         log.error("create_staging_test.checker_timeout", req_id=req_id)
         return await _handle_fail(
             body=body, req_id=req_id, ctx=ctx,
             fail_kind="flaky",   # timeout 归 flaky；不烦 agent，sisyphus 自己重跑
-            details={"reason": "timeout", "exit_code": -1, "cmd": _TEST_CMD},
+            details={"reason": "timeout", "exit_code": -1},
+        )
+    except manifest_io.ManifestReadError as e:
+        # 读 manifest 失败（PVC 挂了 / yaml 坏 / 缺字段）→ infra/flaky，给 retry 重跑一次
+        log.error("create_staging_test.manifest_read_failed", req_id=req_id, error=str(e))
+        return await _handle_fail(
+            body=body, req_id=req_id, ctx=ctx,
+            fail_kind="flaky",
+            details={"reason": f"manifest read failed: {e}"[:200], "exit_code": -1},
         )
     except Exception as e:
         log.exception("create_staging_test.checker_error", req_id=req_id, error=str(e))
         return await _handle_fail(
             body=body, req_id=req_id, ctx=ctx,
             fail_kind="test",
-            details={"reason": str(e)[:200], "exit_code": -1, "cmd": _TEST_CMD},
+            details={"reason": str(e)[:200], "exit_code": -1},
         )
 
     pool = db.get_pool()
@@ -108,8 +119,9 @@ async def _handle_fail(*, body, req_id: str, ctx: dict, fail_kind: str, details:
             "emit": Event.STAGING_TEST_FAIL.value,
             "passed": False,
             "exit_code": details.get("exit_code", -1),
-            "cmd": details.get("cmd", _TEST_CMD),
         }
+        if "cmd" in details:
+            out["cmd"] = details["cmd"]
         if "reason" in details:
             out["reason"] = details["reason"]
         return out

--- a/orchestrator/src/orchestrator/checkers/manifest_io.py
+++ b/orchestrator/src/orchestrator/checkers/manifest_io.py
@@ -1,0 +1,63 @@
+"""manifest_io：从 runner PVC 读 /workspace/.sisyphus/manifest.yaml。
+
+M11 引入：staging-test / pr-ci-watch checker 需要 analyze agent 写的配置
+（test.cmd / pr.repo 等），不再硬编码。admission 已强制 schema 带 test/pr
+必填字段，所以 checker 阶段能读到就一定有这俩 key。
+
+分两步：
+- kubectl exec cat → bytes
+- yaml.safe_load → dict
+
+失败一律 raise ManifestReadError，让 checker 决定怎么收（通常转 flaky 退
+回 retry.executor）。
+"""
+from __future__ import annotations
+
+import asyncio
+
+import structlog
+import yaml
+
+from .. import k8s_runner
+
+log = structlog.get_logger(__name__)
+
+MANIFEST_PATH = "/workspace/.sisyphus/manifest.yaml"
+_READ_CMD = f"cat {MANIFEST_PATH}"
+
+
+class ManifestReadError(RuntimeError):
+    """读 manifest 任何一步失败都抛这个。"""
+
+
+async def read_manifest(req_id: str, *, timeout_sec: int = 30) -> dict:
+    """kubectl exec runner cat manifest.yaml → parse YAML → dict。
+
+    任一环节失败（pod 不可达 / cat 非 0 / yaml 坏）抛 ManifestReadError。
+    """
+    rc = k8s_runner.get_controller()
+
+    try:
+        exec_result = await asyncio.wait_for(
+            rc.exec_in_runner(req_id, _READ_CMD, timeout_sec=timeout_sec),
+            timeout=timeout_sec + 10,
+        )
+    except TimeoutError as e:
+        raise ManifestReadError(f"read manifest timeout after {timeout_sec}s") from e
+
+    if exec_result.exit_code != 0:
+        raise ManifestReadError(
+            f"cat {MANIFEST_PATH} exit {exec_result.exit_code}: "
+            f"{(exec_result.stderr or '').strip()[:200]}"
+        )
+
+    try:
+        data = yaml.safe_load(exec_result.stdout)
+    except yaml.YAMLError as e:
+        raise ManifestReadError(f"yaml parse failed: {e}") from e
+
+    if not isinstance(data, dict):
+        raise ManifestReadError(f"manifest root must be object, got {type(data).__name__}")
+
+    log.debug("checker.manifest_io.read_ok", req_id=req_id, keys=sorted(data.keys()))
+    return data

--- a/orchestrator/src/orchestrator/checkers/pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/checkers/pr_ci_watch.py
@@ -1,5 +1,9 @@
-"""pr-ci-watch 自检（M2）：sisyphus 直接调 GitHub REST API 轮询 PR check-runs，
+"""pr-ci-watch 自检（M2 + M11）：sisyphus 直接调 GitHub REST API 轮询 PR check-runs，
 不再起 BKD agent 让它跑 `gh pr checks` 然后报 tag。
+
+M11：repo / pr_number 从 /workspace/.sisyphus/manifest.yaml 的 `pr` 段读。
+admission 强制 `pr.repo` 必填；`pr.number` 由 dev / staging-test agent
+开 PR 后回写 manifest — pr-ci-watch 跑到这里时必须已有 number，否则直接抛。
 
 GH API:
 - GET /repos/{owner}/{repo}/pulls/{pr_number}        → head.sha
@@ -19,6 +23,7 @@ import httpx
 import structlog
 
 from ..config import settings
+from . import manifest_io
 from ._types import CheckResult
 
 log = structlog.get_logger(__name__)
@@ -33,21 +38,47 @@ _FAIL_CONCLUSIONS = {"failure", "cancelled", "timed_out", "action_required", "st
 
 
 async def watch_pr_ci(
-    repo: str,
-    pr_number: int,
+    req_id: str,
     poll_interval_sec: int = 30,
     timeout_sec: int = 1800,
 ) -> CheckResult:
-    """轮询 PR 的 check-runs，全绿 / 任一失败 / 超时返 CheckResult。
+    """读 manifest.pr → 轮询 check-runs → 全绿 / 任一失败 / 超时返 CheckResult。
 
-    Args:
-        repo: "owner/name" 形如 "phona/ubox-crosser"
-        pr_number: PR 编号
-        poll_interval_sec: 每轮轮询间隔
-        timeout_sec: 总超时；过期返 exit_code=124，passed=False
-
-    通过 settings.github_token 认证。
+    Raises:
+        manifest_io.ManifestReadError: 读 manifest 失败或 pr 段缺字段
+          （包括 pr.number 缺失 —— admission 不强制，但 pr-ci 阶段必须已由
+          上游 agent 写入，缺了按 infra fail 走 retry）。
     """
+    manifest = await manifest_io.read_manifest(req_id)
+
+    pr = manifest.get("pr")
+    if not isinstance(pr, dict):
+        raise manifest_io.ManifestReadError("manifest 缺 pr 段（admission 应已挡）")
+
+    repo = pr.get("repo")
+    pr_number = pr.get("number")
+    if not repo:
+        raise manifest_io.ManifestReadError(f"manifest.pr.repo 缺失：{pr!r}")
+    if not pr_number:
+        raise manifest_io.ManifestReadError(
+            "manifest.pr.number 缺失 —— 上游应在开 PR 后回写 manifest"
+        )
+
+    return await _watch_pr_ci_inner(
+        repo=repo,
+        pr_number=int(pr_number),
+        poll_interval_sec=poll_interval_sec,
+        timeout_sec=timeout_sec,
+    )
+
+
+async def _watch_pr_ci_inner(
+    *,
+    repo: str,
+    pr_number: int,
+    poll_interval_sec: int,
+    timeout_sec: int,
+) -> CheckResult:
     cmd_label = f"watch-pr-ci {repo}#{pr_number}"
     start = time.monotonic()
 

--- a/orchestrator/src/orchestrator/checkers/staging_test.py
+++ b/orchestrator/src/orchestrator/checkers/staging_test.py
@@ -1,6 +1,9 @@
-"""staging-test 自检（M1）：sisyphus 在 runner pod 直接跑测试命令，收退出码决定 pass/fail。
+"""staging-test 自检（M1 + M11）：sisyphus 在 runner pod 直接跑测试命令，收退出码决定 pass/fail。
 
 不起 BKD agent，不靠 result:pass tag，sisyphus 是唯一裁判。
+
+M11：test_cmd / cwd / timeout 从 /workspace/.sisyphus/manifest.yaml 的 `test` 段读，
+不再硬编码。admission 已强制 manifest 带 test 段，checker 跑到这里一定能读到。
 """
 from __future__ import annotations
 
@@ -9,6 +12,7 @@ import asyncio
 import structlog
 
 from .. import k8s_runner
+from . import manifest_io
 from ._types import CheckResult
 
 __all__ = ["CheckResult", "run_staging_test"]
@@ -16,22 +20,40 @@ __all__ = ["CheckResult", "run_staging_test"]
 log = structlog.get_logger(__name__)
 
 _TAIL = 2048  # stdout/stderr 各截尾 2KB，防 OOM
+_DEFAULT_TIMEOUT = 600
 
 
-async def run_staging_test(
-    req_id: str,
-    test_cmd: str,
-    timeout_sec: int = 600,
-) -> CheckResult:
-    """在 runner pod 里执行 test_cmd，收集结果。
+async def run_staging_test(req_id: str) -> CheckResult:
+    """读 manifest → 拼 `cd <cwd> && <cmd>` → 在 runner pod 里执行 → 收集结果。
 
-    timeout_sec 超时时抛 asyncio.TimeoutError（由 create_staging_test action 捕获）。
+    Raises:
+        manifest_io.ManifestReadError: 读 manifest 失败（PVC 挂了 / yaml 坏 / 缺字段）
+        TimeoutError: 测试超过 timeout_sec
     """
+    manifest = await manifest_io.read_manifest(req_id)
+
+    test = manifest.get("test")
+    if not isinstance(test, dict):
+        raise manifest_io.ManifestReadError("manifest 缺 test 段（admission 应已挡）")
+
+    cmd = test.get("cmd")
+    cwd = test.get("cwd")
+    if not cmd or not cwd:
+        raise manifest_io.ManifestReadError(
+            f"manifest.test 缺字段：cmd={cmd!r} cwd={cwd!r}"
+        )
+
+    timeout_sec = int(test.get("timeout_sec", _DEFAULT_TIMEOUT))
+    final_cmd = f"cd /workspace/{cwd} && {cmd}"
+
     rc = k8s_runner.get_controller()
-    log.info("checker.staging_test.start", req_id=req_id, cmd=test_cmd, timeout=timeout_sec)
+    log.info(
+        "checker.staging_test.start",
+        req_id=req_id, cmd=final_cmd, timeout=timeout_sec,
+    )
 
     result = await asyncio.wait_for(
-        rc.exec_in_runner(req_id, test_cmd, timeout_sec=timeout_sec),
+        rc.exec_in_runner(req_id, final_cmd, timeout_sec=timeout_sec),
         timeout=timeout_sec + 10,  # 比内部 deadline 多 10s，确保内部先超时返 -1
     )
 
@@ -48,5 +70,5 @@ async def run_staging_test(
         stdout_tail=result.stdout[-_TAIL:],
         stderr_tail=result.stderr[-_TAIL:],
         duration_sec=result.duration_sec,
-        cmd=test_cmd,
+        cmd=final_cmd,
     )

--- a/orchestrator/src/orchestrator/prompts/analyze.md.j2
+++ b/orchestrator/src/orchestrator/prompts/analyze.md.j2
@@ -86,9 +86,31 @@ integration:
 open_questions: []            # 需求里还没敲定的歧义点；**非空直接 hold REQ 等人答**
 assumptions: []               # 你为了能继续推进所做的假设（给人事后审）
 out_of_scope: []              # 主动划出的边界，避免 scope creep
+
+# ↓ M11 staging-test checker 配置（必填，schema validator 会强制）
+test:
+  cmd: "make ci-unit-test ci-integration-test"   # sisyphus 在 runner pod 里执行的测试命令
+  cwd: "source/ubox-crosser"                     # 相对 /workspace 的工作目录（通常 = leader source 的 path）
+  timeout_sec: 1800                              # 可选，默认 600，范围 30..3600
+
+# ↓ M11 pr-ci-watch checker 配置（repo 必填，number 由 dev agent 开 PR 后回写）
+pr:
+  repo: "phona/ubox-crosser"                     # leader source 的 GitHub 仓库
+  # number: 123                                   # 开 PR 后由 dev/staging-test agent 填回
 ```
 
 如果没 integration（纯 source repo REQ），省略整个 `integration:` 段。
+
+#### Step A4.0: `test` / `pr` 字段怎么填
+
+- **`test.cmd`**：看 leader source repo 的 Makefile / package.json / justfile 挑 CI 级别测试 target
+  （别写 `make test` 之类的通用别名，要写真实 target 比如 `make ci-unit-test`、
+  `npm run test:ci`、`pytest tests/`）。
+- **`test.cwd`**：一般是 `source/<leader-repo>`；若 leader 仓里测试脚本挂在子目录
+  （monorepo），写该子目录路径。
+- **`pr.repo`**：leader source 的 `<owner>/<name>`，跟 `sources[0].repo` 对齐。
+- **`pr.number`**：analyze 阶段还没 PR，**留空**即可；dev agent 开 PR 后
+  会回写 manifest 填上。
 
 #### Step A4.1: ambiguity admission（硬要求，不写三段 validator 会拒）
 

--- a/orchestrator/src/orchestrator/schemas/manifest.json
+++ b/orchestrator/src/orchestrator/schemas/manifest.json
@@ -9,7 +9,9 @@
     "sources",
     "open_questions",
     "assumptions",
-    "out_of_scope"
+    "out_of_scope",
+    "test",
+    "pr"
   ],
   "additionalProperties": true,
   "properties": {
@@ -53,7 +55,44 @@
     "sha_by_repo": {"type": "object"},
     "pr_by_repo": {"type": "object"},
     "image_tags": {"type": "object"},
-    "merge_order": {"type": "array"}
+    "merge_order": {"type": "array"},
+    "test": {
+      "type": "object",
+      "description": "staging-test checker 用：runner pod 里跑什么命令验 staging 测试通过",
+      "required": ["cmd", "cwd"],
+      "additionalProperties": true,
+      "properties": {
+        "cmd": {
+          "type": "string",
+          "minLength": 1,
+          "description": "测试命令，如 'make ci-unit-test ci-integration-test'"
+        },
+        "cwd": {
+          "type": "string",
+          "minLength": 1,
+          "description": "相对 /workspace 的工作目录，如 'source/ubox-crosser'"
+        },
+        "timeout_sec": {
+          "type": "integer",
+          "minimum": 30,
+          "maximum": 3600,
+          "default": 600
+        }
+      }
+    },
+    "pr": {
+      "type": "object",
+      "description": "pr-ci-watch checker 用：轮询哪个 repo 的哪个 PR 的 check-runs",
+      "required": ["repo"],
+      "additionalProperties": true,
+      "properties": {
+        "repo": {"$ref": "#/definitions/repo_id"},
+        "number": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    }
   },
   "definitions": {
     "repo_id": {

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -419,9 +419,9 @@ async def test_create_staging_test_checker_pass(monkeypatch):
     monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.skip_staging_test", False)
     monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.test_mode", False)
 
-    fake_result = CheckResult(passed=True, exit_code=0, stdout_tail="ok\n", stderr_tail="", duration_sec=4.2, cmd="make test")
+    fake_result = CheckResult(passed=True, exit_code=0, stdout_tail="ok\n", stderr_tail="", duration_sec=4.2, cmd="cd /workspace/source/foo && make ci-unit-test")
 
-    async def fake_run(req_id, test_cmd, timeout_sec=600):
+    async def fake_run(req_id):
         return fake_result
 
     monkeypatch.setattr("orchestrator.actions.create_staging_test.checker.run_staging_test", fake_run)
@@ -453,9 +453,9 @@ async def test_create_staging_test_checker_fail(monkeypatch):
     monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.skip_staging_test", False)
     monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.test_mode", False)
 
-    fake_result = CheckResult(passed=False, exit_code=1, stdout_tail="FAIL\n", stderr_tail="panic\n", duration_sec=2.0, cmd="make test")
+    fake_result = CheckResult(passed=False, exit_code=1, stdout_tail="FAIL\n", stderr_tail="panic\n", duration_sec=2.0, cmd="cd /workspace/source/foo && make ci-unit-test")
 
-    async def fake_run(req_id, test_cmd, timeout_sec=600):
+    async def fake_run(req_id):
         return fake_result
 
     monkeypatch.setattr("orchestrator.actions.create_staging_test.checker.run_staging_test", fake_run)
@@ -484,9 +484,9 @@ async def test_create_staging_test_checker_fail_retry_enabled(monkeypatch):
     monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.skip_staging_test", False)
     monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.test_mode", False)
 
-    fake_result = CheckResult(passed=False, exit_code=1, stdout_tail="FAIL\n", stderr_tail="panic\n", duration_sec=2.0, cmd="make test")
+    fake_result = CheckResult(passed=False, exit_code=1, stdout_tail="FAIL\n", stderr_tail="panic\n", duration_sec=2.0, cmd="cd /workspace/source/foo && make ci-unit-test")
 
-    async def fake_run_check(req_id, test_cmd, timeout_sec=600):
+    async def fake_run_check(req_id):
         return fake_result
 
     monkeypatch.setattr("orchestrator.actions.create_staging_test.checker.run_staging_test", fake_run_check)
@@ -532,9 +532,9 @@ async def test_create_staging_test_checker_pass_retry_enabled_resets_round(monke
     monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.skip_staging_test", False)
     monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.test_mode", False)
 
-    fake_result = CheckResult(passed=True, exit_code=0, stdout_tail="ok\n", stderr_tail="", duration_sec=3.0, cmd="make test")
+    fake_result = CheckResult(passed=True, exit_code=0, stdout_tail="ok\n", stderr_tail="", duration_sec=3.0, cmd="cd /workspace/source/foo && make ci-unit-test")
 
-    async def fake_run_check(req_id, test_cmd, timeout_sec=600):
+    async def fake_run_check(req_id):
         return fake_result
 
     monkeypatch.setattr("orchestrator.actions.create_staging_test.checker.run_staging_test", fake_run_check)
@@ -569,7 +569,7 @@ async def test_create_staging_test_checker_timeout_retry_enabled_flaky(monkeypat
     monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.skip_staging_test", False)
     monkeypatch.setattr("orchestrator.actions.create_staging_test.settings.test_mode", False)
 
-    async def fake_run_check(req_id, test_cmd, timeout_sec=600):
+    async def fake_run_check(req_id):
         raise TimeoutError()
 
     monkeypatch.setattr("orchestrator.actions.create_staging_test.checker.run_staging_test", fake_run_check)

--- a/orchestrator/tests/test_checkers_manifest_io.py
+++ b/orchestrator/tests/test_checkers_manifest_io.py
@@ -1,0 +1,118 @@
+"""checkers/manifest_io.py 单测：mock RunnerController.exec_in_runner，验返 dict / 失败抛。"""
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from orchestrator.checkers import manifest_io
+from orchestrator.k8s_runner import ExecResult
+
+
+def _fake_controller(exit_code: int, stdout: str = "", stderr: str = "", duration: float = 0.1):
+    class FakeRC:
+        async def exec_in_runner(self, req_id, command, **kw):
+            return ExecResult(
+                exit_code=exit_code, stdout=stdout, stderr=stderr, duration_sec=duration,
+            )
+    return FakeRC()
+
+
+# ── happy path ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_read_manifest_returns_dict(monkeypatch):
+    yaml_body = textwrap.dedent(
+        """\
+        schema_version: 1
+        req_id: REQ-9
+        test:
+          cmd: "make ci-unit-test"
+          cwd: "source/foo"
+          timeout_sec: 1200
+        pr:
+          repo: "phona/foo"
+          number: 42
+        """
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_io.k8s_runner.get_controller",
+        lambda: _fake_controller(0, yaml_body),
+    )
+    data = await manifest_io.read_manifest("REQ-9")
+    assert isinstance(data, dict)
+    assert data["test"]["cmd"] == "make ci-unit-test"
+    assert data["test"]["cwd"] == "source/foo"
+    assert data["pr"]["repo"] == "phona/foo"
+    assert data["pr"]["number"] == 42
+
+
+# ── exec fail ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_read_manifest_raises_on_cat_nonzero(monkeypatch):
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_io.k8s_runner.get_controller",
+        lambda: _fake_controller(2, stdout="", stderr="cat: No such file"),
+    )
+    with pytest.raises(manifest_io.ManifestReadError) as exc:
+        await manifest_io.read_manifest("REQ-9")
+    assert "exit 2" in str(exc.value)
+    assert "No such file" in str(exc.value)
+
+
+# ── yaml bad ─────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_read_manifest_raises_on_bad_yaml(monkeypatch):
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_io.k8s_runner.get_controller",
+        lambda: _fake_controller(0, stdout="::: not valid yaml :::\n  - ["),
+    )
+    with pytest.raises(manifest_io.ManifestReadError) as exc:
+        await manifest_io.read_manifest("REQ-9")
+    assert "yaml parse failed" in str(exc.value)
+
+
+# ── yaml root 不是 dict ─────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_read_manifest_raises_on_non_dict_root(monkeypatch):
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_io.k8s_runner.get_controller",
+        lambda: _fake_controller(0, stdout="- item1\n- item2\n"),  # YAML list not dict
+    )
+    with pytest.raises(manifest_io.ManifestReadError) as exc:
+        await manifest_io.read_manifest("REQ-9")
+    assert "must be object" in str(exc.value)
+
+
+# ── exec 超时 ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_read_manifest_raises_on_timeout(monkeypatch):
+    import asyncio
+
+    class SlowRC:
+        async def exec_in_runner(self, req_id, command, **kw):
+            await asyncio.sleep(9999)
+            return ExecResult(0, "", "", 0)
+
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_io.k8s_runner.get_controller",
+        lambda: SlowRC(),
+    )
+
+    async def fast_wait_for(coro, timeout):
+        task = asyncio.ensure_future(coro)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            raise TimeoutError() from None
+
+    monkeypatch.setattr("orchestrator.checkers.manifest_io.asyncio.wait_for", fast_wait_for)
+
+    with pytest.raises(manifest_io.ManifestReadError) as exc:
+        await manifest_io.read_manifest("REQ-9", timeout_sec=1)
+    assert "timeout" in str(exc.value).lower()

--- a/orchestrator/tests/test_checkers_manifest_validate.py
+++ b/orchestrator/tests/test_checkers_manifest_validate.py
@@ -34,6 +34,11 @@ def _yaml_min(open_questions_line: str = "open_questions: []") -> str:
         """\
         assumptions: []
         out_of_scope: []
+        test:
+          cmd: "make ci-unit-test"
+          cwd: "source/foo"
+        pr:
+          repo: "phona/foo"
         """
     )
     return base + open_questions_line.rstrip() + "\n" + tail
@@ -240,3 +245,137 @@ async def test_yaml_parse_failure_keeps_reason_none(monkeypatch):
     assert result.passed is False
     assert result.reason is None
     assert result.exit_code == 2
+
+
+# ── M11：test / pr 必填字段 ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_missing_test_section_is_schema_fail(monkeypatch):
+    """M11：manifest 缺 test 段 → admission 拒（exit 1）。"""
+    yaml_body = textwrap.dedent(
+        """\
+        schema_version: 1
+        req_id: REQ-9
+        sources:
+          - repo: phona/foo
+            path: source/foo
+            role: leader
+            branch: stage/REQ-9-dev
+        open_questions: []
+        assumptions: []
+        out_of_scope: []
+        pr:
+          repo: "phona/foo"
+        """
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.k8s_runner.get_controller",
+        lambda: _fake_controller(0, yaml_body),
+    )
+    result = await manifest_validate.run_manifest_validate("REQ-9")
+    assert result.passed is False
+    assert result.reason is None
+    assert result.exit_code == 1
+    assert "test" in result.stderr_tail
+
+
+@pytest.mark.asyncio
+async def test_missing_pr_section_is_schema_fail(monkeypatch):
+    yaml_body = textwrap.dedent(
+        """\
+        schema_version: 1
+        req_id: REQ-9
+        sources:
+          - repo: phona/foo
+            path: source/foo
+            role: leader
+            branch: stage/REQ-9-dev
+        open_questions: []
+        assumptions: []
+        out_of_scope: []
+        test:
+          cmd: "make ci-unit-test"
+          cwd: "source/foo"
+        """
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.k8s_runner.get_controller",
+        lambda: _fake_controller(0, yaml_body),
+    )
+    result = await manifest_validate.run_manifest_validate("REQ-9")
+    assert result.passed is False
+    assert result.reason is None
+    assert "pr" in result.stderr_tail
+
+
+@pytest.mark.asyncio
+async def test_test_section_missing_cmd_is_schema_fail(monkeypatch):
+    """test 段在但 cmd 缺失也拒。"""
+    yaml_body = textwrap.dedent(
+        """\
+        schema_version: 1
+        req_id: REQ-9
+        sources:
+          - repo: phona/foo
+            path: source/foo
+            role: leader
+            branch: stage/REQ-9-dev
+        open_questions: []
+        assumptions: []
+        out_of_scope: []
+        test:
+          cwd: "source/foo"
+        pr:
+          repo: "phona/foo"
+        """
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.k8s_runner.get_controller",
+        lambda: _fake_controller(0, yaml_body),
+    )
+    result = await manifest_validate.run_manifest_validate("REQ-9")
+    assert result.passed is False
+    assert "cmd" in result.stderr_tail
+
+
+@pytest.mark.asyncio
+async def test_pr_section_missing_repo_is_schema_fail(monkeypatch):
+    yaml_body = textwrap.dedent(
+        """\
+        schema_version: 1
+        req_id: REQ-9
+        sources:
+          - repo: phona/foo
+            path: source/foo
+            role: leader
+            branch: stage/REQ-9-dev
+        open_questions: []
+        assumptions: []
+        out_of_scope: []
+        test:
+          cmd: "make ci-unit-test"
+          cwd: "source/foo"
+        pr:
+          number: 42
+        """
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.k8s_runner.get_controller",
+        lambda: _fake_controller(0, yaml_body),
+    )
+    result = await manifest_validate.run_manifest_validate("REQ-9")
+    assert result.passed is False
+    assert "repo" in result.stderr_tail
+
+
+@pytest.mark.asyncio
+async def test_pr_number_optional_at_analyze_time(monkeypatch):
+    """pr.number 在 analyze 阶段可空（dev agent 开 PR 后回写）。"""
+    # 使用 _yaml_min 的 pr: 只带 repo，正是 analyze 阶段的常态
+    monkeypatch.setattr(
+        "orchestrator.checkers.manifest_validate.k8s_runner.get_controller",
+        lambda: _fake_controller(0, _yaml_min()),
+    )
+    result = await manifest_validate.run_manifest_validate("REQ-9")
+    assert result.passed is True
+    assert result.reason is None

--- a/orchestrator/tests/test_checkers_pr_ci_watch.py
+++ b/orchestrator/tests/test_checkers_pr_ci_watch.py
@@ -1,9 +1,12 @@
-"""checkers/pr_ci_watch.py 单测：mock GitHub API，验全绿/任一失败/全失败/超时。"""
+"""checkers/pr_ci_watch.py 单测：mock manifest + GitHub API，验全绿/任一失败/全失败/超时。
+
+M11：watch_pr_ci 签名改 req_id-first，repo / pr_number 从 manifest.yaml 读。
+"""
 from __future__ import annotations
 
 import pytest
 
-from orchestrator.checkers import pr_ci_watch
+from orchestrator.checkers import manifest_io, pr_ci_watch
 from orchestrator.checkers._types import CheckResult
 
 
@@ -19,11 +22,22 @@ def _run(name: str, status: str = "completed", conclusion: str | None = "success
     return {"name": name, "status": status, "conclusion": conclusion}
 
 
+def patch_manifest(monkeypatch, pr: dict):
+    """让 manifest_io.read_manifest 返 {"pr": pr}。"""
+    async def fake_read(req_id, timeout_sec=30):
+        return {"pr": pr}
+    monkeypatch.setattr(
+        "orchestrator.checkers.pr_ci_watch.manifest_io.read_manifest",
+        fake_read,
+    )
+
+
 # ── 单轮直绿 ──────────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
 async def test_watch_pr_ci_all_green(httpx_mock, monkeypatch):
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+    patch_manifest(monkeypatch, {"repo": "phona/ubox-crosser", "number": 42})
 
     httpx_mock.add_response(
         url="https://api.github.com/repos/phona/ubox-crosser/pulls/42",
@@ -34,7 +48,7 @@ async def test_watch_pr_ci_all_green(httpx_mock, monkeypatch):
         json=_runs_payload(_run("lint"), _run("unit"), _run("integration")),
     )
 
-    result = await pr_ci_watch.watch_pr_ci("phona/ubox-crosser", 42, poll_interval_sec=1, timeout_sec=60)
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", poll_interval_sec=1, timeout_sec=60)
 
     assert isinstance(result, CheckResult)
     assert result.passed is True
@@ -49,6 +63,7 @@ async def test_watch_pr_ci_all_green(httpx_mock, monkeypatch):
 @pytest.mark.asyncio
 async def test_watch_pr_ci_any_failed(httpx_mock, monkeypatch):
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+    patch_manifest(monkeypatch, {"repo": "phona/ubox-crosser", "number": 42})
 
     httpx_mock.add_response(
         url="https://api.github.com/repos/phona/ubox-crosser/pulls/42",
@@ -63,7 +78,7 @@ async def test_watch_pr_ci_any_failed(httpx_mock, monkeypatch):
         ),
     )
 
-    result = await pr_ci_watch.watch_pr_ci("phona/ubox-crosser", 42, poll_interval_sec=1, timeout_sec=60)
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", poll_interval_sec=1, timeout_sec=60)
 
     assert result.passed is False
     assert result.exit_code == 1
@@ -77,6 +92,7 @@ async def test_watch_pr_ci_any_failed(httpx_mock, monkeypatch):
 @pytest.mark.asyncio
 async def test_watch_pr_ci_all_failed(httpx_mock, monkeypatch):
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+    patch_manifest(monkeypatch, {"repo": "phona/ubox-crosser", "number": 42})
 
     httpx_mock.add_response(
         url="https://api.github.com/repos/phona/ubox-crosser/pulls/42",
@@ -90,7 +106,7 @@ async def test_watch_pr_ci_all_failed(httpx_mock, monkeypatch):
         ),
     )
 
-    result = await pr_ci_watch.watch_pr_ci("phona/ubox-crosser", 42, poll_interval_sec=1, timeout_sec=60)
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", poll_interval_sec=1, timeout_sec=60)
 
     assert result.passed is False
     assert result.exit_code == 1
@@ -104,6 +120,7 @@ async def test_watch_pr_ci_all_failed(httpx_mock, monkeypatch):
 async def test_watch_pr_ci_timeout(httpx_mock, monkeypatch):
     """所有 check-run 都还 in_progress，到 timeout 返 124。"""
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+    patch_manifest(monkeypatch, {"repo": "phona/ubox-crosser", "number": 42})
 
     # 让 sleep 立即返回，避免真等
     async def fast_sleep(_):
@@ -121,9 +138,7 @@ async def test_watch_pr_ci_timeout(httpx_mock, monkeypatch):
         is_reusable=True,
     )
 
-    result = await pr_ci_watch.watch_pr_ci(
-        "phona/ubox-crosser", 42, poll_interval_sec=0, timeout_sec=0,
-    )
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", poll_interval_sec=0, timeout_sec=0)
 
     assert result.passed is False
     assert result.exit_code == 124
@@ -137,6 +152,7 @@ async def test_watch_pr_ci_timeout(httpx_mock, monkeypatch):
 async def test_watch_pr_ci_pending_then_pass(httpx_mock, monkeypatch):
     """前一轮 pending，后一轮全绿。"""
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+    patch_manifest(monkeypatch, {"repo": "phona/ubox-crosser", "number": 42})
 
     async def fast_sleep(_):
         return None
@@ -157,7 +173,7 @@ async def test_watch_pr_ci_pending_then_pass(httpx_mock, monkeypatch):
         json=_runs_payload(_run("lint")),
     )
 
-    result = await pr_ci_watch.watch_pr_ci("phona/ubox-crosser", 42, poll_interval_sec=1, timeout_sec=60)
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", poll_interval_sec=1, timeout_sec=60)
 
     assert result.passed is True
     assert result.exit_code == 0
@@ -168,6 +184,7 @@ async def test_watch_pr_ci_pending_then_pass(httpx_mock, monkeypatch):
 @pytest.mark.asyncio
 async def test_watch_pr_ci_pr_not_found(httpx_mock, monkeypatch):
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+    patch_manifest(monkeypatch, {"repo": "phona/ubox-crosser", "number": 999})
 
     httpx_mock.add_response(
         url="https://api.github.com/repos/phona/ubox-crosser/pulls/999",
@@ -175,9 +192,7 @@ async def test_watch_pr_ci_pr_not_found(httpx_mock, monkeypatch):
         json={"message": "Not Found"},
     )
 
-    result = await pr_ci_watch.watch_pr_ci(
-        "phona/ubox-crosser", 999, poll_interval_sec=1, timeout_sec=60,
-    )
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", poll_interval_sec=1, timeout_sec=60)
 
     assert result.passed is False
     assert result.exit_code == 1
@@ -190,6 +205,7 @@ async def test_watch_pr_ci_pr_not_found(httpx_mock, monkeypatch):
 async def test_watch_pr_ci_empty_runs_times_out(httpx_mock, monkeypatch):
     """PR 刚开 GHA 还没触发，check-runs 为空 → pending → 超时。"""
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+    patch_manifest(monkeypatch, {"repo": "phona/ubox-crosser", "number": 42})
 
     async def fast_sleep(_):
         return None
@@ -205,10 +221,39 @@ async def test_watch_pr_ci_empty_runs_times_out(httpx_mock, monkeypatch):
         is_reusable=True,
     )
 
-    result = await pr_ci_watch.watch_pr_ci(
-        "phona/ubox-crosser", 42, poll_interval_sec=0, timeout_sec=0,
-    )
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", poll_interval_sec=0, timeout_sec=0)
     assert result.exit_code == 124
+
+
+# ── manifest 缺 pr 段 / 缺字段 → 抛 ManifestReadError ───────────────────
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_raises_when_manifest_missing_pr(monkeypatch):
+    async def fake_read(req_id, timeout_sec=30):
+        return {"schema_version": 1}
+    monkeypatch.setattr(
+        "orchestrator.checkers.pr_ci_watch.manifest_io.read_manifest",
+        fake_read,
+    )
+    with pytest.raises(manifest_io.ManifestReadError) as exc:
+        await pr_ci_watch.watch_pr_ci("REQ-9")
+    assert "pr" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_raises_when_pr_missing_number(monkeypatch):
+    patch_manifest(monkeypatch, {"repo": "phona/ubox-crosser"})   # 缺 number
+    with pytest.raises(manifest_io.ManifestReadError) as exc:
+        await pr_ci_watch.watch_pr_ci("REQ-9")
+    assert "number" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_raises_when_pr_missing_repo(monkeypatch):
+    patch_manifest(monkeypatch, {"number": 42})
+    with pytest.raises(manifest_io.ManifestReadError) as exc:
+        await pr_ci_watch.watch_pr_ci("REQ-9")
+    assert "repo" in str(exc.value)
 
 
 # ── _classify 单测 ───────────────────────────────────────────────────────

--- a/orchestrator/tests/test_checkers_staging_test.py
+++ b/orchestrator/tests/test_checkers_staging_test.py
@@ -1,10 +1,14 @@
-"""checkers/staging_test.py 单测：mock RunnerController，验 CheckResult 字段。"""
+"""checkers/staging_test.py 单测：mock manifest_io + RunnerController，验 CheckResult 字段。
+
+M11：run_staging_test 不再收 test_cmd 参数，自己从 manifest.yaml 读 test.cmd / cwd / timeout。
+"""
 from __future__ import annotations
 
 import asyncio
 
 import pytest
 
+from orchestrator.checkers import manifest_io
 from orchestrator.checkers._types import CheckResult
 from orchestrator.checkers.staging_test import run_staging_test
 from orchestrator.k8s_runner import ExecResult
@@ -13,19 +17,35 @@ from orchestrator.k8s_runner import ExecResult
 def make_fake_controller(exit_code: int, stdout: str = "", stderr: str = "", duration: float = 1.0):
     class FakeRC:
         async def exec_in_runner(self, req_id, command, **kw):
+            # 记下真正跑的命令，单测拿这个 assert
+            FakeRC.last_cmd = command
             return ExecResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration_sec=duration)
-    return FakeRC()
+    FakeRC.last_cmd = ""
+    return FakeRC
 
 
-# ── pass ──────────────────────────────────────────────────────────────────
+def patch_manifest(monkeypatch, manifest: dict):
+    async def fake_read(req_id, timeout_sec=30):
+        return manifest
+    monkeypatch.setattr(
+        "orchestrator.checkers.staging_test.manifest_io.read_manifest",
+        fake_read,
+    )
+
+
+# ── pass：验 final_cmd 正确拼出 cd + cmd ──────────────────────────────────
 
 @pytest.mark.asyncio
 async def test_run_staging_test_pass(monkeypatch):
+    patch_manifest(monkeypatch, {
+        "test": {"cmd": "make ci-unit-test", "cwd": "source/foo", "timeout_sec": 1200},
+    })
+    FakeRC = make_fake_controller(exit_code=0, stdout="ok\n", stderr="", duration=3.5)
     monkeypatch.setattr(
         "orchestrator.checkers.staging_test.k8s_runner.get_controller",
-        lambda: make_fake_controller(exit_code=0, stdout="ok\n", stderr="", duration=3.5),
+        lambda: FakeRC(),
     )
-    result = await run_staging_test("REQ-1", "make test")
+    result = await run_staging_test("REQ-1")
 
     assert isinstance(result, CheckResult)
     assert result.passed is True
@@ -33,18 +53,23 @@ async def test_run_staging_test_pass(monkeypatch):
     assert result.stdout_tail == "ok\n"
     assert result.stderr_tail == ""
     assert result.duration_sec == 3.5
-    assert result.cmd == "make test"
+    assert result.cmd == "cd /workspace/source/foo && make ci-unit-test"
+    assert FakeRC.last_cmd == "cd /workspace/source/foo && make ci-unit-test"
 
 
 # ── fail ──────────────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
 async def test_run_staging_test_fail(monkeypatch):
+    patch_manifest(monkeypatch, {
+        "test": {"cmd": "make ci-unit-test", "cwd": "source/foo"},
+    })
+    FakeRC = make_fake_controller(exit_code=1, stdout="FAIL\n", stderr="panic: nil ptr\n", duration=2.0)
     monkeypatch.setattr(
         "orchestrator.checkers.staging_test.k8s_runner.get_controller",
-        lambda: make_fake_controller(exit_code=1, stdout="FAIL\n", stderr="panic: nil ptr\n", duration=2.0),
+        lambda: FakeRC(),
     )
-    result = await run_staging_test("REQ-2", "make test")
+    result = await run_staging_test("REQ-2")
 
     assert result.passed is False
     assert result.exit_code == 1
@@ -56,13 +81,17 @@ async def test_run_staging_test_fail(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_run_staging_test_truncates_tails(monkeypatch):
+    patch_manifest(monkeypatch, {
+        "test": {"cmd": "make ci-unit-test", "cwd": "source/foo"},
+    })
     big_out = "x" * 5000
     big_err = "e" * 4000
+    FakeRC = make_fake_controller(exit_code=0, stdout=big_out, stderr=big_err)
     monkeypatch.setattr(
         "orchestrator.checkers.staging_test.k8s_runner.get_controller",
-        lambda: make_fake_controller(exit_code=0, stdout=big_out, stderr=big_err),
+        lambda: FakeRC(),
     )
-    result = await run_staging_test("REQ-3", "make test")
+    result = await run_staging_test("REQ-3")
 
     assert len(result.stdout_tail) == 2048
     assert len(result.stderr_tail) == 2048
@@ -74,24 +103,55 @@ async def test_run_staging_test_truncates_tails(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_run_staging_test_timeout(monkeypatch):
+    patch_manifest(monkeypatch, {
+        "test": {"cmd": "make ci-unit-test", "cwd": "source/foo", "timeout_sec": 30},
+    })
+
     class SlowRC:
         async def exec_in_runner(self, req_id, command, **kw):
-            await asyncio.sleep(9999)  # 永远不返回
+            await asyncio.sleep(9999)
             return ExecResult(exit_code=0, stdout="", stderr="", duration_sec=0)
 
     monkeypatch.setattr(
         "orchestrator.checkers.staging_test.k8s_runner.get_controller",
         lambda: SlowRC(),
     )
-    with pytest.raises(TimeoutError):
-        # 为让测试不卡，patch asyncio.wait_for 直接模拟超时
-        async def fast_wait_for(coro, timeout):
-            task = asyncio.ensure_future(coro)
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                raise TimeoutError() from None
 
-        monkeypatch.setattr("orchestrator.checkers.staging_test.asyncio.wait_for", fast_wait_for)
-        await run_staging_test("REQ-4", "make test", timeout_sec=1)
+    async def fast_wait_for(coro, timeout):
+        task = asyncio.ensure_future(coro)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            raise TimeoutError() from None
+
+    monkeypatch.setattr("orchestrator.checkers.staging_test.asyncio.wait_for", fast_wait_for)
+
+    with pytest.raises(TimeoutError):
+        await run_staging_test("REQ-4")
+
+
+# ── manifest 缺 test 段 → 抛 ManifestReadError ──────────────────────────
+
+@pytest.mark.asyncio
+async def test_run_staging_test_raises_when_manifest_missing_test(monkeypatch):
+    patch_manifest(monkeypatch, {"schema_version": 1})
+    with pytest.raises(manifest_io.ManifestReadError) as exc:
+        await run_staging_test("REQ-5")
+    assert "test" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_run_staging_test_raises_when_test_missing_cmd(monkeypatch):
+    patch_manifest(monkeypatch, {"test": {"cwd": "source/foo"}})
+    with pytest.raises(manifest_io.ManifestReadError) as exc:
+        await run_staging_test("REQ-6")
+    assert "cmd" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_run_staging_test_raises_when_test_missing_cwd(monkeypatch):
+    patch_manifest(monkeypatch, {"test": {"cmd": "make ci-unit-test"}})
+    with pytest.raises(manifest_io.ManifestReadError) as exc:
+        await run_staging_test("REQ-7")
+    assert "cwd" in str(exc.value)

--- a/orchestrator/uv.lock
+++ b/orchestrator/uv.lock
@@ -78,6 +78,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -311,6 +320,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -808,6 +844,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -833,6 +883,87 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
 ]
 
 [[package]]
@@ -869,10 +1000,12 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "jsonschema" },
     { name = "kubernetes" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyyaml" },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "yoyo-migrations" },
@@ -893,6 +1026,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jinja2", specifier = ">=3.1" },
+    { name = "jsonschema", specifier = ">=4.0" },
     { name = "kubernetes", specifier = ">=31.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
     { name = "psycopg2-binary", specifier = ">=2.9" },
@@ -901,6 +1035,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.32" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7" },
     { name = "structlog", specifier = ">=24.4" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },


### PR DESCRIPTION
今天端到端测 REQ-clean-1776863811 暴露：M1 staging-test checker 硬编码 `make test` 跟 ubox-crosser 实际命名（`make ci-unit-test ci-integration-test`）不匹配 — `No rule to make target 'test'`。

M1 PR #3 + M2 PR #6 注释里就 TODO 说 "M3 改成读 manifest"，M3 PR #7 漏了。M11 补上。

## 改动
- manifest schema 加 test/pr 必填字段
- checkers/manifest_io.py 抽 read helper
- staging_test/pr_ci_watch checker 读 manifest
- analyze prompt 加示例
- 13 files +777/-98，328 tests pass

## Test plan
- [ ] CI 全绿
- [ ] 部署后跑真 REQ，看 staging-test 真在 ubox-crosser 跑 ci-unit-test