### PR TITLE
feat(bkd): create_issue 默认 useWorktree=true

### DIFF
--- a/orchestrator/src/orchestrator/bkd_mcp.py
+++ b/orchestrator/src/orchestrator/bkd_mcp.py
@@ -101,7 +101,7 @@ class BKDMcpClient:
         title: str,
         tags: list[str],
         status_id: str = "todo",
-        use_worktree: bool = False,
+        use_worktree: bool = True,
     ) -> Issue:
         data = await self.call("create-issue", {
             "projectId": project_id,

--- a/orchestrator/src/orchestrator/bkd_rest.py
+++ b/orchestrator/src/orchestrator/bkd_rest.py
@@ -52,7 +52,7 @@ class BKDRestClient:
         title: str,
         tags: list[str],
         status_id: str = "todo",
-        use_worktree: bool = False,
+        use_worktree: bool = True,
         engine_type: str | None = None,
         model: str | None = None,
     ) -> Issue:

--- a/orchestrator/tests/test_bkd_rest.py
+++ b/orchestrator/tests/test_bkd_rest.py
@@ -68,7 +68,7 @@ async def test_create_issue_payload_shape(monkeypatch):
     assert captured["json"] == {
         "title": "Add /version",
         "statusId": "todo",
-        "useWorktree": False,
+        "useWorktree": True,
         "tags": ["intent:analyze", "REQ-1"],
     }
     assert issue.id == "new-1"


### PR DESCRIPTION
## Summary
- `bkd_rest.py` + `bkd_mcp.py` 中 `create_issue(use_worktree=...)` 默认值由 `False` 翻为 `True`。
- 让 sisyphus 派的 BKD agent 默认跑独立 worktree，避免并行 fanout / 多 stage 时共享 main worktree 互踩 `git checkout` 抹未提交工作。
- 现有 actions 全部走 default（不显式传参，符合 M14a 要求保持代码简洁）；保留 `use_worktree` 参数可显式 `False`。

## Test plan
- [x] `pytest -q` 全过（323 passed）
- [x] `ruff check src tests` clean
- [x] `test_bkd_rest::test_create_issue_payload_shape` 默认 payload 断言更新到 `"useWorktree": True`
- [x] `test_create_issue_with_engine_and_model` 不影响（不检 useWorktree）

🤖 Generated with [Claude Code](https://claude.com/claude-code)