### PR TITLE
feat(verifier): M14b verifier-agent 框架

### DIFF
--- a/orchestrator/src/orchestrator/actions/__init__.py
+++ b/orchestrator/src/orchestrator/actions/__init__.py
@@ -60,6 +60,7 @@ def register(name: str, *, idempotent: bool = False):
 
 # 触发各 handler 注册（导入即注册）
 from . import (  # noqa: E402,F401
+    _verifier,
     create_accept,
     create_dev,
     create_pr_ci_watch,

--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -1,0 +1,288 @@
+"""M14b：verifier-agent 框架
+
+每个 stage transition（success / fail）调 `invoke_verifier` 起一个 BKD verifier-agent
+issue，让它做主观判断（pass / fix / retry_checker / escalate）。verifier 完成后
+webhook.py 解析 decision JSON，映射成 Event 推状态机。
+
+本模块只管"起 issue + 挂 prompt"：同步返回 verifier_issue_id，不等决策
+（异步走 session.completed webhook）。决策 → Event 映射在 webhook.py。
+
+同时提供 action handler：
+- `apply_verify_pass`：decision=pass → 手工 CAS 回 stage_running + 链式 emit
+   对应 stage 的 done/pass 事件（走原主链 transition）
+- `apply_verify_retry_checker`：decision=retry_checker → 同手法，回 stage_running
+   + 链 emit "restart" 事件触发 checker 重跑
+- `start_fixer`：decision=fix → 起 fixer agent（dev / spec / manifest）
+- `invoke_verifier_after_fix`：fixer 完 → 再调 verifier 复查
+
+PR1（本 PR）只铺框架，verifier_enabled 默认 False；PR3 砍旧 bugfix 路径后翻 True。
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+import structlog
+
+from ..bkd import BKDClient
+from ..config import settings
+from ..prompts import render
+from ..state import Event, ReqState
+from ..store import db, req_state
+from . import register, short_title
+
+log = structlog.get_logger(__name__)
+
+
+# 支持的 stage 名（对应 prompts/verifier/{stage}_{trigger}.md.j2）
+_STAGES = {"analyze", "spec", "dev", "staging_test", "pr_ci", "accept"}
+
+# Trigger 类型
+Trigger = Literal["success", "fail"]
+
+# stage → decision=pass 时要 emit 的原主链 event + 目标 stage_running state
+# 用于 apply_verify_pass 手工把 state 从 REVIEW_RUNNING 回推到对应 stage_running，
+# 随后链式 emit 该 stage 的 done/pass 事件走原 transition。
+_PASS_ROUTING: dict[str, tuple[ReqState, Event]] = {
+    "analyze":       (ReqState.ANALYZING,            Event.ANALYZE_DONE),
+    "spec":          (ReqState.SPECS_RUNNING,        Event.SPEC_ALL_PASSED),
+    "dev":           (ReqState.DEV_RUNNING,          Event.DEV_DONE),
+    "staging_test":  (ReqState.STAGING_TEST_RUNNING, Event.STAGING_TEST_PASS),
+    "pr_ci":         (ReqState.PR_CI_RUNNING,        Event.PR_CI_PASS),
+    "accept":        (ReqState.ACCEPT_RUNNING,       Event.ACCEPT_PASS),
+}
+
+# stage → retry_checker 时回推的 state（checker 类 stage 才真有意义）
+# 对 agent 类 stage（analyze/spec/dev）本期先按"回 stage_running 重跑"兜底。
+_RETRY_TARGET_STATE: dict[str, ReqState] = {
+    "analyze":      ReqState.ANALYZING,
+    "spec":         ReqState.SPECS_RUNNING,
+    "dev":          ReqState.DEV_RUNNING,
+    "staging_test": ReqState.STAGING_TEST_RUNNING,
+    "pr_ci":        ReqState.PR_CI_RUNNING,
+    "accept":       ReqState.ACCEPT_RUNNING,
+}
+
+
+# ─── invoke_verifier：起 BKD verifier issue ──────────────────────────────
+
+async def invoke_verifier(
+    *,
+    stage: str,
+    trigger: Trigger,
+    req_id: str,
+    project_id: str,
+    artifact_paths: list[str] | None = None,
+    stderr_tail: str | None = None,
+    history: list[dict] | None = None,
+    ctx: dict | None = None,
+) -> dict:
+    """起一个 BKD verifier-agent issue，异步等 session.completed 推进状态机。
+
+    Args:
+        stage: 被审阶段名（analyze/spec/dev/staging_test/pr_ci/accept）
+        trigger: "success"=机械 checker 过 / agent 跑完；"fail"=checker 红 / agent 报错
+        req_id / project_id: 绑定 REQ
+        artifact_paths: 可选，给 prompt 提示 agent 要看哪些产物（manifest / spec / 日志）
+        stderr_tail: fail 触发时的 stderr 尾部
+        history: 可选，之前 verifier / fixer 轮次摘要
+
+    Returns:
+        {"verifier_issue_id": "<id>", "stage": stage, "trigger": trigger}
+    """
+    if stage not in _STAGES:
+        raise ValueError(f"unknown verifier stage: {stage!r}")
+    if trigger not in ("success", "fail"):
+        raise ValueError(f"trigger must be 'success' or 'fail', got {trigger!r}")
+
+    template_name = f"verifier/{stage}_{trigger}.md.j2"
+    prompt = render(
+        template_name,
+        req_id=req_id,
+        stage=stage,
+        trigger=trigger,
+        artifact_paths=artifact_paths or [],
+        stderr_tail=stderr_tail or "",
+        history=history or [],
+    )
+
+    async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+        issue = await bkd.create_issue(
+            project_id=project_id,
+            title=f"[{req_id}] [VERIFY {stage}] {trigger}{short_title(ctx)}",
+            tags=[
+                "verifier",
+                req_id,
+                f"verify:{stage}",
+                f"trigger:{trigger}",
+            ],
+            status_id="todo",
+            use_worktree=True,   # 并行 verifier 互不抢 working tree
+        )
+        await bkd.follow_up_issue(project_id=project_id, issue_id=issue.id, prompt=prompt)
+        await bkd.update_issue(project_id=project_id, issue_id=issue.id, status_id="working")
+
+    # 落 ctx 给 apply_verify_* action 后续查 stage 用
+    pool = db.get_pool()
+    await req_state.update_context(pool, req_id, {
+        "verifier_issue_id": issue.id,
+        "verifier_stage": stage,
+        "verifier_trigger": trigger,
+    })
+
+    log.info(
+        "verifier.invoked",
+        req_id=req_id, stage=stage, trigger=trigger, issue_id=issue.id,
+    )
+    return {
+        "verifier_issue_id": issue.id,
+        "stage": stage,
+        "trigger": trigger,
+    }
+
+
+# ─── action handlers ────────────────────────────────────────────────────
+
+@register("apply_verify_pass", idempotent=True)
+async def apply_verify_pass(*, body, req_id, tags, ctx):
+    """decision=pass：读 ctx.verifier_stage，手工 CAS REVIEW_RUNNING → stage_running，
+    链式 emit 该 stage 的 done/pass 事件（走原主链 transition，推进到下一 stage）。
+    """
+    stage = (ctx or {}).get("verifier_stage")
+    route = _PASS_ROUTING.get(stage) if stage else None
+    if route is None:
+        log.error("apply_verify_pass.unknown_stage", req_id=req_id, stage=stage)
+        return {"emit": Event.VERIFY_ESCALATE.value,
+                "reason": f"unknown verifier_stage: {stage!r}"}
+
+    target_state, next_event = route
+    pool = db.get_pool()
+    advanced = await req_state.cas_transition(
+        pool, req_id, ReqState.REVIEW_RUNNING, target_state,
+        Event.VERIFY_PASS, "apply_verify_pass",
+    )
+    if not advanced:
+        # 状态已被并发事件改动 → 让上层 skip，不重复 emit
+        log.warning("apply_verify_pass.cas_failed", req_id=req_id, stage=stage)
+        return {"cas_failed": True}
+
+    log.info("apply_verify_pass.done",
+             req_id=req_id, stage=stage,
+             target_state=target_state.value, emit=next_event.value)
+    return {"emit": next_event.value, "stage": stage}
+
+
+@register("apply_verify_retry_checker", idempotent=True)
+async def apply_verify_retry_checker(*, body, req_id, tags, ctx):
+    """decision=retry_checker：回到 stage_running 状态。PR3 之后由 stage action
+    自己处理"当前在 stage_running 再触发一次 checker" 的语义（或通过 ctx flag）。
+    本期先只把 state 回滚并落 ctx 标记，等真正接入时再完善。
+    """
+    stage = (ctx or {}).get("verifier_stage")
+    target = _RETRY_TARGET_STATE.get(stage) if stage else None
+    if target is None:
+        log.error("apply_verify_retry_checker.unknown_stage",
+                  req_id=req_id, stage=stage)
+        return {"emit": Event.VERIFY_ESCALATE.value,
+                "reason": f"unknown verifier_stage: {stage!r}"}
+
+    pool = db.get_pool()
+    advanced = await req_state.cas_transition(
+        pool, req_id, ReqState.REVIEW_RUNNING, target,
+        Event.VERIFY_RETRY_CHECKER, "apply_verify_retry_checker",
+    )
+    if not advanced:
+        log.warning("apply_verify_retry_checker.cas_failed",
+                    req_id=req_id, stage=stage)
+        return {"cas_failed": True}
+
+    await req_state.update_context(pool, req_id, {
+        "retry_checker_pending": True,
+        "retry_checker_stage": stage,
+    })
+    log.info("apply_verify_retry_checker.done",
+             req_id=req_id, stage=stage, target_state=target.value)
+    return {"retry_checker": True, "stage": stage}
+
+
+@register("start_fixer", idempotent=False)
+async def start_fixer(*, body, req_id, tags, ctx):
+    """decision=fix：起对应 fixer agent（dev / spec / manifest）。
+
+    ctx 里应有 verifier 之前写的 fixer / scope（webhook 解 decision 时存）。
+    本期的 prompt 先用通用 bugfix 模板兜底，PR4 / 独立 PR 再做专用 fixer prompt。
+    """
+    proj = body.projectId
+    ctx = ctx or {}
+    stage = ctx.get("verifier_stage")
+    fixer = ctx.get("verifier_fixer") or "dev"
+    scope = ctx.get("verifier_scope") or ""
+    reason = ctx.get("verifier_reason") or ""
+    branch = ctx.get("branch") or f"feat/{req_id}"
+
+    async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+        issue = await bkd.create_issue(
+            project_id=proj,
+            title=f"[{req_id}] [FIXER {fixer}] {stage}{short_title(ctx)}",
+            tags=[
+                "fixer",
+                req_id,
+                f"fixer:{fixer}",
+                f"parent-stage:{stage}",
+                f"parent-id:{ctx.get('verifier_issue_id', '')}",
+            ],
+            status_id="todo",
+            use_worktree=True,
+        )
+        # 通用 bugfix prompt 作为过渡；PR4 再做每类 fixer 专用模板。
+        prompt = render(
+            "bugfix.md.j2",
+            req_id=req_id, round_n=ctx.get("fixer_round", 1),
+            kind=f"verifier-{fixer}",
+            source_issue_id=ctx.get("verifier_issue_id", ""),
+            branch=branch,
+            workdir=f"{settings.workdir_root}/feat-{req_id}",
+        )
+        # 把 verifier 的 scope / reason 叠进 prompt 作为上下文
+        if scope or reason:
+            prompt += f"\n\n## Verifier 决策\n- fixer: {fixer}\n- scope: {scope}\n- reason: {reason}\n"
+        await bkd.follow_up_issue(project_id=proj, issue_id=issue.id, prompt=prompt)
+        await bkd.update_issue(project_id=proj, issue_id=issue.id, status_id="working")
+
+    pool = db.get_pool()
+    await req_state.update_context(pool, req_id, {
+        "fixer_issue_id": issue.id,
+        "fixer_role": fixer,
+        "fixer_scope": scope,
+    })
+
+    log.info("start_fixer.done",
+             req_id=req_id, fixer=fixer, stage=stage, issue_id=issue.id)
+    return {"fixer_issue_id": issue.id, "fixer": fixer, "stage": stage}
+
+
+@register("invoke_verifier_after_fix", idempotent=False)
+async def invoke_verifier_after_fix(*, body, req_id, tags, ctx):
+    """fixer 完 → 再跑 verifier 一次（同 stage，trigger=success：fixer 已改过代码）。"""
+    ctx = ctx or {}
+    stage = ctx.get("verifier_stage") or "dev"
+    history = [
+        *(ctx.get("verifier_history") or []),
+        {
+            "fixer": ctx.get("fixer_role"),
+            "fixer_issue_id": ctx.get("fixer_issue_id"),
+        },
+    ]
+
+    result = await invoke_verifier(
+        stage=stage,
+        trigger="success",
+        req_id=req_id,
+        project_id=body.projectId,
+        history=history,
+        ctx=ctx,
+    )
+    pool = db.get_pool()
+    await req_state.update_context(pool, req_id, {"verifier_history": history})
+    return result
+
+

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -119,6 +119,13 @@ class Settings(BaseSettings):
     # 默认 3 × 120s = 6min，覆盖 K3s 节点偶发慢启动；生产可调更高。
     runner_ready_attempts: int = 3
 
+    # ─── M14b：verifier-agent 框架 ──────────────────────────────────────
+    # True = 每个 stage transition（成功 or 失败）先起一个 verifier-agent 做主观判断
+    # （pass / fix / retry_checker / escalate），再由 webhook 路由推进状态机。
+    # 替代 M4 fail_kind 分类 + M5 diagnose 子链（PR3 砍旧逻辑后翻 true）。
+    # 默认 false：老路径完全不变，PR1 仅铺框架。
+    verifier_enabled: bool = False
+
     # ─── M8：watchdog 兜底卡死 stage ────────────────────────────────────
     # 周期扫 req_state，发现某 stage 超过阈值没 transition 且关联 BKD session
     # 不在 running → emit SESSION_FAILED 走 escalate。兜底 BKD spawn-time

--- a/orchestrator/src/orchestrator/prompts/verifier/_decision.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/_decision.md.j2
@@ -1,0 +1,32 @@
+## 输出格式（HARD CONSTRAINT）
+
+**本 issue 的 description 末尾必须追加**一块合法 JSON decision，且**只能追加一次**。
+结构如下，键和字面量严格匹配，多余字段忽略：
+
+````json
+{
+  "action":     "pass" | "fix" | "retry_checker" | "escalate",
+  "fixer":      "dev" | "spec" | "manifest" | null,
+  "scope":      "src/" | "openspec/changes/REQ-x/" | "manifest.pr.number" | null,
+  "reason":     "一句话人话：为什么做这个决定",
+  "confidence": "high" | "low"
+}
+````
+
+语义：
+- `pass`：产物可以推进到下一阶段。sisyphus 会把 REQ 主链继续往下走。
+- `fix`：需要起 fixer agent 改代码/spec/manifest。必须同时给 `fixer` 和 `scope`。
+  - `dev`：改 src/ 下业务代码 / 实现
+  - `spec`：改 openspec/changes/REQ-*/ 下的需求 / acceptance 描述
+  - `manifest`：改 /workspace/.sisyphus/manifest.yaml（比如 pr.number / sha_by_repo 错了）
+- `retry_checker`：代码没问题、纯 flaky / 环境抖动 / 刚才 checker 用错参数，重跑 checker 即可。
+- `escalate`：超出 AI 自理范围（人类决策 / 安全边界 / 不明故障）。
+
+规则：
+- `action=fix` 时 `fixer` 不能是 null；其它 action 时 `fixer` 必须是 null。
+- `confidence=low` 表示你不太确信 → sisyphus 可能让你再判一轮或直接升级人工。
+- 不要在 JSON 里写注释（会 parse 失败）。
+
+sisyphus 会在本 issue 的 tags 里找 `decision:<base64>` 或从 description 抓最后一个
+```json ... ``` 代码块。两种都可以，推荐用 update-issue 加个 `decision:<base64>` tag
+（base64 对 JSON 字符串做 URL-safe 编码）更稳。

--- a/orchestrator/src/orchestrator/prompts/verifier/_header.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/_header.md.j2
@@ -1,0 +1,24 @@
+{% include "_shared/tools_whitelist.md.j2" %}
+
+─────────
+
+{% include "_shared/self_issue_constraint.md.j2" %}
+
+─────────
+
+## VERIFIER
+AGENT_ROLE=verifier-agent
+REQ={{ req_id }}
+STAGE={{ stage }}
+TRIGGER={{ trigger }}
+{% if history %}
+HISTORY={{ history }}
+{% endif %}
+
+你是 sisyphus 的 **verifier-agent**。你的唯一任务：读代码/产物/日志，输出一个 JSON
+**decision**，让 sisyphus 推主链。**不要改任何代码**，不要跑任何业务脚本，不要
+commit/push，不要 create/cancel 其他 BKD issue。
+
+机械层能自动判的事 sisyphus 已经做过了（schema validate / checker 退出码 / JSON
+结构 / tag 存在性）。**你只判人话问题** —— 契约语义、内容质量、失败是真 bug 还是
+flaky、改动范围是 code 还是 spec 还是 manifest。

--- a/orchestrator/src/orchestrator/prompts/verifier/accept_fail.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/accept_fail.md.j2
@@ -1,0 +1,27 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（accept / fail）
+accept-agent 跑 FEATURE-A* 时有 feature 红了 / 报 bug。
+
+{% if stderr_tail %}
+### 失败尾
+```
+{{ stderr_tail }}
+```
+{% endif %}
+
+你要判：失败是**实现 bug**、**spec 描述错**、**env 起不来**，还是 **flaky**。
+
+### 关注点
+- 失败 step 是调用 API → 业务 bug → `fix` + `fixer=dev`
+- 失败是 Given fixture 起不来（数据库 / seed）→ 可能 `retry_checker`，或 env 问题 `escalate`
+- feature 里的断言本来就描述错了（spec 和 dev 各说各的）→ `fix` + `fixer=spec`
+- 明显 flaky（偶发 timeout / 外部依赖抽风）→ `retry_checker`
+
+### NOT 该做
+- 不自己跑 env-up / env-down
+- 不改 acceptance 文件
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/prompts/verifier/accept_success.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/accept_success.md.j2
@@ -1,0 +1,28 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（accept / success）
+accept-agent 跑完 acceptance（FEATURE-A*），标记全 pass，artifact 里有每条 feature
+的 step 结果。env-down 还没跑。
+
+你要判：这些 pass 是**真达标**还是**被 agent 作弊 / 假装通过**。
+
+### 关注点
+- 每条 FEATURE-A* 是否真的跑过（时间戳 / step count 合理）
+- 有没有 agent 把 acceptance 里的 assert 改弱了（`then something happens` 这种）
+- Given 用的 fixture 是不是真的加载了（不是空库 pass all）
+- 日志里有没有"skip / pending / TODO" 字样
+
+### NOT 该做
+- 不跑 env-down —— 下一个 action 会跑
+- 不自己再跑 feature
+- 不 merge PR
+
+### 典型决策
+- `pass`：真的都跑了 + 结果 assert 严格 + 覆盖到 REQ
+- `fix` + `fixer=spec`：acceptance feature 文件有被降标（需要回 spec 阶段修）
+- `fix` + `fixer=dev`：feature 暴露出实际 bug（assert 对着新 bug）
+- `escalate`：明显过不去，且看不出是哪层的锅
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/prompts/verifier/analyze_fail.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/analyze_fail.md.j2
@@ -1,0 +1,27 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（analyze / fail）
+analyze-agent 跑不下去了（session failed / 超时 / 写出来的 manifest 过不了 schema）。
+
+你要判：这是**哪一类**失败、能不能重试。
+
+{% if stderr_tail %}
+### 最近错误栈尾
+```
+{{ stderr_tail }}
+```
+{% endif %}
+
+### 关注点
+- manifest schema 报的字段错 → `fix` + `fixer=manifest`
+- analyze-agent 本身 LLM 抽风（空输出 / 格式乱）→ `retry_checker`（让主链再起一次 analyze）
+- 需求本身矛盾 / 信息不全 → `escalate`
+- sisyphus runner / K8s 环境炸 → `escalate`（sisyphus 自己的锅）
+
+### NOT 该做
+- 不跑 /opsx:propose
+- 不改任何业务代码
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/prompts/verifier/analyze_success.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/analyze_success.md.j2
@@ -1,0 +1,29 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（analyze / success）
+analyze-agent 说它已经拆完需求，写了 `/workspace/.sisyphus/manifest.yaml` + 初版
+openspec delta（`openspec/changes/{{ req_id }}/`）。
+
+你要判：这个拆解是不是**可落地**。
+
+### 关注点
+- manifest.yaml 里的 sources / integration / test_cmd 是否和本 REQ 的改动范围自洽
+  （没引错仓库、没把别的 REQ 的东西挂进来）
+- openspec delta 是否把用户的 intent 讲清楚了（acceptance 可机械 verify / 没有"改善用户体验"这种空话）
+- open_questions 里有没有"sisyphus 搞不定 / 业务方没回答 / 安全红线"的项
+  —— 有的话应该 escalate 给人类
+
+### NOT 该做
+- 不跑 manifest validate（sisyphus 已跑，tag `manifest:valid` 才会到你）
+- 不跑 /opsx:propose（agent 已跑）
+- 不去 grep 代码改动 —— analyze 阶段本来就没代码
+
+### 典型决策
+- `pass`：拆解清晰 + acceptance 可验 + 范围合理
+- `fix` + `fixer=spec`：范围或 acceptance 描述需要改写
+- `fix` + `fixer=manifest`：sources/integration 错了
+- `escalate`：open_questions 里是产品/业务层决策，agent 不该自理
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/prompts/verifier/dev_fail.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/dev_fail.md.j2
@@ -1,0 +1,25 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（dev / fail）
+dev-agent 跑不下去（session failed / 超时 / 没建出 PR / manifest 写回失败）。
+
+{% if stderr_tail %}
+### 失败栈尾
+```
+{{ stderr_tail }}
+```
+{% endif %}
+
+### 关注点
+- 编译 / build 错，改 src 能修 → `fix` + `fixer=dev`
+- spec 对不上实现（dev 卡住说"contract 这条实现不了"）→ `fix` + `fixer=spec`
+- gh CLI / ghcr / PR 创建失败（token、permission）→ `escalate`（环境层）
+- LLM 抽风空输出 → `retry_checker`（让 dev 阶段自己再起一次）
+
+### NOT 该做
+- 不帮 dev 改代码
+- 不自己建 PR
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/prompts/verifier/dev_success.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/dev_success.md.j2
@@ -1,0 +1,30 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（dev / success）
+dev-agent 说它已经写完代码 + 建 PR + 写回 manifest。机械层已经确认：
+- manifest 里 pr_by_repo / sha_by_repo 已补
+- git 分支存在、PR 链接 open
+- staging-test 还没开始
+
+你要判：dev **实现质量**对得起后面跑 staging test 吗？
+
+### 关注点
+- 代码改动**是否真的满足了 contract-spec 的 endpoint 契约**（不是空壳、不是 stub）
+- 边界场景 / 错误码有没有实现（不是只 happy path）
+- 有没有明显的 spec 对齐遗漏（比如 acceptance 提到的字段漏了）
+- 有没有**改错 scope**（改了不该改的仓库、动了 integration 配置）
+
+### NOT 该做
+- 不跑 unit / int test —— staging-test 阶段的 checker 会跑
+- 不管 CI 工具链绿不绿 —— pr-ci 阶段会跑
+- 不 merge PR
+
+### 典型决策
+- `pass`：改动覆盖契约，质量可接受，staging 继续跑
+- `fix` + `fixer=dev` + `scope=src/`：需要补逻辑 / 修实现 / 加边界
+- `fix` + `fixer=manifest`：dev 写回 manifest 的 pr.number 或 sha 错了
+- `escalate`：发现 spec 和 dev 都没错但改动根本偏离 intent（需求层 bug）
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/prompts/verifier/pr_ci_fail.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/pr_ci_fail.md.j2
@@ -1,0 +1,29 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（pr_ci / fail）
+PR 上某 GHA job 红了 / 超时。checker 把失败的 check-run 名字 + 最后几行日志
+放 artifact 里。
+
+{% if stderr_tail %}
+### 失败日志尾
+```
+{{ stderr_tail }}
+```
+{% endif %}
+
+你要判：失败是**本次 REQ 的 code 问题**、**基础设施问题**、还是 **flaky**。
+
+### 关注点
+- 失败 job 是 lint / unit / int / sonar / image-publish 哪一个？
+- 失败栈指向新改动 → `fix` + `fixer=dev`
+- 失败栈指向 CI 配置（workflow YAML、docker build 脚本）→ `escalate`
+  （sisyphus 的 fixer 本期不改 .github/ 目录）
+- 明显 flaky（网络、docker rate limit）→ `retry_checker`
+
+### NOT 该做
+- 不在本地重跑业务代码
+- 不 close PR / 不 force-push
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/prompts/verifier/pr_ci_success.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/pr_ci_success.md.j2
@@ -1,0 +1,26 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（pr_ci / success）
+pr-ci-watch checker 看到 PR 的 GHA 全套绿（lint / unit / int / sonar /
+image-publish），artifact 里有 check-runs 清单。
+
+你要判：**"全绿"是不是漏了该跑的检查**。
+
+### 关注点
+- check-runs 列表里有没有少关键项（比如漏跑了 sonar？漏跑了 image-publish？）
+- 各 job 的 duration / 产物 size 合理吗（构建 0 秒 = 缓存吃光？）
+- image tag 是否推到 ghcr 且带 REQ / sha 前缀
+
+### NOT 该做
+- 不自己再调 gh API —— checker 已拉过
+- 不动 PR 状态（merge 留给 archive 阶段）
+
+### 典型决策
+- `pass`：关键 check 全在、全绿、产物签出
+- `fix` + `fixer=manifest`：PR 模板没配全套检查（`.github/workflows/` 缺 job）
+  —— scope 其实是源仓库 CI 配置，这种 sisyphus 改不了，`escalate` 更合适
+- `escalate`：漏检查但无法自动补
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/prompts/verifier/spec_fail.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/spec_fail.md.j2
@@ -1,0 +1,27 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（spec / fail）
+contract 或 acceptance spec-agent 红了（机械 ci 红 / session failed）。
+
+你要判：是**spec 写错**还是**sisyphus 机械层 bug**。
+
+{% if stderr_tail %}
+### 失败栈尾
+```
+{{ stderr_tail }}
+```
+{% endif %}
+
+### 关注点
+- schemathesis/lint 报的结构错（OpenAPI 字段类型 / enum / required 缺失）→ `fix` + `fixer=spec`
+- acceptance Gherkin parse 错（语法 / 缺 step）→ `fix` + `fixer=spec`
+- sisyphus 自己的 ci 脚本抽风（路径 / 工具链不在）→ `retry_checker` 或 `escalate`
+- 需求本身让 spec 写不出来 → `escalate`
+
+### NOT 该做
+- 不动 source repo 业务代码
+- 不跑 dev 实现
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/prompts/verifier/spec_success.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/spec_success.md.j2
@@ -1,0 +1,29 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（spec / success）
+contract-spec + acceptance-spec 两个 agent 都报 ci-passed。机械层已经确认：
+- OpenAPI spec `schemathesis` lint 通过
+- acceptance feature 文件 parse 成功
+- 契约与 source repo 对得上（没空 endpoint）
+
+你要判：这俩 spec **内容是否真的覆盖了 REQ 的意图**。
+
+### 关注点
+- OpenAPI endpoint 有没有把 intent 里提到的所有操作覆盖（CRUD / filter / pagination）
+- acceptance 的每条 Given/When/Then 是否可机械 verify
+- 有没有漏掉错误场景 / 权限 / 边界值
+- contract 和 acceptance 是否自洽（acceptance 调的 endpoint 在 contract 里都存在）
+
+### NOT 该做
+- 不跑 schemathesis / lint —— sisyphus 已跑
+- 不改 spec 本身；有问题就 `fix` + `fixer=spec`
+- 不去看 dev 代码（dev 还没开始）
+
+### 典型决策
+- `pass`：两个 spec 覆盖到位、自洽、可机械 verify
+- `fix` + `fixer=spec` + `scope=openspec/changes/{{ req_id }}/`：需要补/改 spec
+- `escalate`：需求本身表达就矛盾，spec 怎么写都不对
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/prompts/verifier/staging_test_fail.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/staging_test_fail.md.j2
@@ -1,0 +1,29 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（staging_test / fail）
+staging-test checker 红了（exit_code != 0 或 timeout）。
+
+{% if stderr_tail %}
+### stderr 尾部
+```
+{{ stderr_tail }}
+```
+{% endif %}
+
+你要判：这失败是 **code bug / spec bug / env bug / flaky** 哪一类，以及能不能修。
+
+### 关注点
+- 失败 assert 是不是对着**新实现**（那就 `fix` + `fixer=dev`）
+- 失败 assert 是不是对着**老逻辑**但被新 spec 重新定义了（那 `fix` + `fixer=spec` 或 dev 看情况）
+- manifest 里 test_cmd 指的用例集合跟 REQ 根本不沾边 → `fix` + `fixer=manifest`
+- stderr 是 network / docker-pull / kubectl race → `retry_checker`
+- 失败栈指向 sisyphus runner 本身（kubectl permission / PVC 挂载）→ `escalate`
+
+### NOT 该做
+- 不 kubectl exec 重跑 test —— 让状态机触发 retry_checker
+- 不改代码
+- 不 cancel dev issue
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/prompts/verifier/staging_test_success.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/staging_test_success.md.j2
@@ -1,0 +1,27 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（staging_test / success）
+staging-test checker（sisyphus 自己 kubectl exec）跑完，**退出码 0**，
+unit + integration test 全绿。artifact（checker 结果、stdout_tail）存在 Postgres。
+
+你要判：这个"绿"是不是**真的绿**。
+
+### 关注点
+- **test suite 是否真的跑了该跑的用例**（偷偷 skip 了所有新测？）
+- stdout_tail 里能不能看到和 REQ 相关的用例名字
+- duration 是不是过短（0.1s 跑完 200 个用例 = 可疑）
+- integration test 是不是和 unit 全是 mock、没真调依赖
+
+### NOT 该做
+- 不跑 test —— checker 已经跑过；你就 read artifact
+- 不改 test_cmd（manifest.yaml 归 manifest fixer）
+
+### 典型决策
+- `pass`：真跑了、真绿、duration 合理、覆盖到 REQ 用例
+- `fix` + `fixer=dev`：跑了但被 skip 或某些 assert 太弱（需要 dev 补测 / 加 assert）
+- `retry_checker`：stdout 里能看到 flaky（network glitch / race condition）
+- `escalate`：看不懂为什么绿，但明显覆盖不到 REQ
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/router.py
+++ b/orchestrator/src/orchestrator/router.py
@@ -4,18 +4,116 @@
 输出：Event 枚举值 或 None（无映射，skip）
 
 只做"标签 → 事件名"的翻译。不做状态判断（state.py 干），不做 action（actions/ 干）。
+
+M14b：verifier-agent 触发后本模块负责把 decision JSON（tag 或 description 里）
+翻成 VERIFY_* 事件；decision schema 校验也在这里（非法 → VERIFY_ESCALATE）。
 """
 from __future__ import annotations
 
+import base64
+import json
 import re
 from collections.abc import Iterable
 
 from .state import Event
 
+log = __import__("structlog").get_logger(__name__)
+
 REQ_ID_RE = re.compile(r"^REQ-[\w-]+$")
 SPEC_TAGS = {"contract-spec", "acceptance-spec"}
 # v0.2 新增：stage tag 用于区分 agent role
 # staging-test / pr-ci / accept 都走 result:* tag 判 pass/fail
+
+# ─── M14b verifier decision schema 校验 + 映射 ─────────────────────────────
+_VALID_ACTIONS = {"pass", "fix", "retry_checker", "escalate"}
+_VALID_FIXERS = {"dev", "spec", "manifest", None}
+_VALID_CONFIDENCE = {"high", "low"}
+
+
+def validate_decision(decision: object) -> tuple[bool, str]:
+    """校验 verifier-agent 输出的 decision JSON 是否合规。
+
+    返回 (ok, reason)。ok=False 时 reason 写入日志 + 上层按 VERIFY_ESCALATE 走。
+    """
+    if not isinstance(decision, dict):
+        return False, "decision must be dict"
+    action = decision.get("action")
+    if action not in _VALID_ACTIONS:
+        return False, f"invalid action: {action!r}"
+    fixer = decision.get("fixer")
+    if fixer not in _VALID_FIXERS:
+        return False, f"invalid fixer: {fixer!r}"
+    if action == "fix" and fixer is None:
+        return False, "action=fix requires non-null fixer"
+    if action != "fix" and fixer is not None:
+        return False, f"action={action} must have null fixer"
+    conf = decision.get("confidence")
+    if conf not in _VALID_CONFIDENCE:
+        return False, f"invalid confidence: {conf!r}"
+    if not isinstance(decision.get("reason", ""), str):
+        return False, "reason must be string"
+    return True, ""
+
+
+def decision_to_event(decision: dict) -> Event:
+    """合规 decision → Event。调用前必须先跑 validate_decision。"""
+    action = decision["action"]
+    if action == "pass":
+        return Event.VERIFY_PASS
+    if action == "fix":
+        return Event.VERIFY_FIX_NEEDED
+    if action == "retry_checker":
+        return Event.VERIFY_RETRY_CHECKER
+    return Event.VERIFY_ESCALATE
+
+
+def derive_verifier_event(
+    description: str | None, tags: Iterable[str] | None,
+) -> tuple[Event, dict | None, str]:
+    """verifier issue session.completed → (Event, decision | None, reason)。
+
+    decision 拿不到或 schema 不合规 → 返回 (VERIFY_ESCALATE, None, reason)。
+    合规 → 返回 (VERIFY_*, decision_dict, "")。
+
+    reason 只在 escalate 时非空，供 obs / log 用。
+    """
+    decision = extract_decision_from_issue(description, tags)
+    if decision is None:
+        return Event.VERIFY_ESCALATE, None, "no decision JSON found in tag or description"
+    ok, why = validate_decision(decision)
+    if not ok:
+        return Event.VERIFY_ESCALATE, decision, f"invalid decision: {why}"
+    return decision_to_event(decision), decision, ""
+
+
+def extract_decision_from_issue(
+    description: str | None, tags: Iterable[str] | None,
+) -> dict | None:
+    """从 BKD verifier issue 提取 decision JSON。
+
+    顺序：
+    1. tags 里的 `decision:<urlsafe-base64-json>`（机器写最稳）
+    2. description 里最后一个 ```json ... ``` 代码块
+    3. 都拿不到 → None（webhook 按 VERIFY_ESCALATE 走）
+    """
+    for t in tags or []:
+        if t.startswith("decision:"):
+            raw = t.removeprefix("decision:")
+            try:
+                data = base64.urlsafe_b64decode(raw + "==").decode("utf-8")
+                return json.loads(data)
+            except Exception as e:
+                log.warning("verifier.tag_decision_parse_failed", error=str(e))
+                break   # 继续试 description
+    if not description:
+        return None
+    blocks = re.findall(r"```json\s*(\{.*?\})\s*```", description, flags=re.DOTALL)
+    for blk in reversed(blocks):
+        try:
+            return json.loads(blk)
+        except Exception:
+            continue
+    return None
 
 
 def derive_event(event_type: str, tags: Iterable[str], result_tags_only: bool = False) -> Event | None:
@@ -40,6 +138,16 @@ def derive_event(event_type: str, tags: Iterable[str], result_tags_only: bool = 
     # ─── session.completed: 按主 stage tag 分流 ───────────────────────────
     if event_type != "session.completed":
         return None  # 未知 event type
+
+    # M14b verifier-agent：优先匹配。decision 解析需要 description，router.derive_event
+    # 只能看 tag；真正解析走 webhook.py 那层的 extract_decision_from_issue。
+    # 这里返 None 让 webhook fall through 到 _derive_verifier_event。
+    if "verifier" in tagset:
+        return None
+
+    # M14b fixer-agent：fixer 完成 → FIXER_DONE
+    if "fixer" in tagset:
+        return Event.FIXER_DONE
 
     # diagnose agent（M5）：比 bugfix 先查，因为 diagnose issue 可能也带 bugfix 历史 tag
     if "diagnose" in tagset:

--- a/orchestrator/src/orchestrator/state.py
+++ b/orchestrator/src/orchestrator/state.py
@@ -40,6 +40,9 @@ class ReqState(StrEnum):
     DIAGNOSE_RUNNING = "diagnose-running"       # bugfix 反复失败 → 轻 agent 分流
     GH_INCIDENT_OPEN = "gh-incident-open"       # GitHub issue 已开，等人
     ARCHIVING = "archiving"                     # done-archive agent（合 PR 等）
+    # M14b：verifier-agent 框架
+    REVIEW_RUNNING = "review-running"           # verifier-agent 在跑（success / fail 两触发统一入口）
+    FIXER_RUNNING = "fixer-running"             # verifier decision=fix → 起对应 fixer agent（dev/spec/manifest）
     DONE = "done"                               # REQ 完成
     ESCALATED = "escalated"                     # 熔断 / session-failed / 人工止损
 
@@ -68,6 +71,12 @@ class Event(StrEnum):
     SPEC_REWORK = "spec.rework"                     # diagnose:spec-bug → escalate（spec-fix 本期不做）
     ARCHIVE_DONE = "archive.done"
     SESSION_FAILED = "session.failed"
+    # M14b：verifier-agent 决策事件（webhook.py 从 verifier issue 的 decision JSON 派发）
+    VERIFY_PASS = "verify.pass"                     # decision.action = pass → 推下一 stage
+    VERIFY_FIX_NEEDED = "verify.fix-needed"         # decision.action = fix → 起 fixer agent
+    VERIFY_RETRY_CHECKER = "verify.retry-checker"   # decision.action = retry_checker → 重跑当前 checker
+    VERIFY_ESCALATE = "verify.escalate"             # decision.action = escalate
+    FIXER_DONE = "fixer.done"                       # fixer agent 跑完 → 回对应 stage 重跑 checker
 
 
 @dataclass(frozen=True)
@@ -160,6 +169,30 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
         Transition(ReqState.ESCALATED, "escalate",
                    "diagnosis:env-bug / unknown → escalate"),
 
+    # ─── M14b verifier 子链 ─────────────────────────────────────────────
+    # verifier-agent 完成 → webhook 解 decision JSON → emit 对应事件。
+    # 注意：VERIFY_PASS 的目标 stage 由 ctx.verifier_stage 决定 —— transition 表无法静态表达
+    # next_state 随 stage 变化，所以 apply_verify_pass action 内部手工 CAS 到对应 stage_running
+    # 再链式 emit 该 stage 的 done/pass 事件（走原主链 transition）。VERIFY_RETRY_CHECKER
+    # 类似。此处 next_state 声明为 REVIEW_RUNNING（self-loop），实际目标状态由 action 改。
+    (ReqState.REVIEW_RUNNING, Event.VERIFY_PASS):
+        Transition(ReqState.REVIEW_RUNNING, "apply_verify_pass",
+                   "decision=pass → action 读 stage 手动推进"),
+    (ReqState.REVIEW_RUNNING, Event.VERIFY_FIX_NEEDED):
+        Transition(ReqState.FIXER_RUNNING, "start_fixer",
+                   "decision=fix → 起对应 fixer（dev/spec/manifest）"),
+    (ReqState.REVIEW_RUNNING, Event.VERIFY_RETRY_CHECKER):
+        Transition(ReqState.REVIEW_RUNNING, "apply_verify_retry_checker",
+                   "decision=retry_checker → 重跑当前 stage 的 checker"),
+    (ReqState.REVIEW_RUNNING, Event.VERIFY_ESCALATE):
+        Transition(ReqState.ESCALATED, "escalate",
+                   "verifier decision=escalate 或 schema invalid"),
+
+    # fixer agent 完成 → 回 REVIEW_RUNNING 让 verifier 再判一次（pass / 再 fix）
+    (ReqState.FIXER_RUNNING, Event.FIXER_DONE):
+        Transition(ReqState.REVIEW_RUNNING, "invoke_verifier_after_fix",
+                   "fixer 完 → 再跑 verifier 复查"),
+
     # ─── 终态 ───────────────────────────────────────────────────────────
     (ReqState.ARCHIVING, Event.ARCHIVE_DONE):
         Transition(ReqState.DONE, None, "REQ complete"),
@@ -173,6 +206,7 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
             ReqState.STAGING_TEST_RUNNING, ReqState.PR_CI_RUNNING,
             ReqState.ACCEPT_RUNNING, ReqState.ACCEPT_TEARING_DOWN,
             ReqState.BUGFIX_RUNNING, ReqState.DIAGNOSE_RUNNING,
+            ReqState.REVIEW_RUNNING, ReqState.FIXER_RUNNING,
             ReqState.ARCHIVING,
         ]
     },

--- a/orchestrator/src/orchestrator/webhook.py
+++ b/orchestrator/src/orchestrator/webhook.py
@@ -133,6 +133,28 @@ async def webhook(request: Request) -> JSONResponse:
 
     # ─── 3. derive event ────────────────────────────────────────────────────
     event = router_lib.derive_event(body.event, tags)
+
+    # M14b：verifier-agent session.completed → 解 decision JSON（tag 或 description）
+    # router.derive_event 对 `verifier` tag 主动返 None，交给这里 full parse。
+    decision_payload: dict | None = None
+    if (
+        event is None
+        and body.event == "session.completed"
+        and "verifier" in set(tags)
+    ):
+        description = None
+        try:
+            async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+                issue = await bkd.get_issue(body.projectId, body.issueId)
+                description = issue.description
+        except Exception as e:
+            log.warning("webhook.verifier.fetch_desc_failed",
+                        issue_id=body.issueId, error=str(e))
+        event, decision_payload, why = router_lib.derive_verifier_event(description, tags)
+        log.info("webhook.verifier.decision",
+                 issue_id=body.issueId, event=event.value,
+                 decision=decision_payload, reason=why)
+
     if event is None:
         log.debug("webhook.no_event_mapping", tags=tags, event_type=body.event)
         return {"action": "skip", "reason": "no event mapping"}
@@ -170,6 +192,17 @@ async def webhook(request: Request) -> JSONResponse:
             return {"action": "error", "reason": "init failed"}
     cur_state = row.state
     ctx = row.context
+
+    # ─── 5.5 verifier decision payload 落 ctx（start_fixer 等 action 读）──
+    if decision_payload is not None:
+        patch = {
+            "verifier_fixer": decision_payload.get("fixer"),
+            "verifier_scope": decision_payload.get("scope"),
+            "verifier_reason": decision_payload.get("reason"),
+            "verifier_confidence": decision_payload.get("confidence"),
+        }
+        await req_state.update_context(pool, req_id, patch)
+        ctx = {**ctx, **patch}
 
     # ─── 6. 推进状态机（engine 内部循环 emit）─────────────────────────────
     return await engine.step(

--- a/orchestrator/tests/test_router.py
+++ b/orchestrator/tests/test_router.py
@@ -43,6 +43,11 @@ CASES: list[tuple[str, list[str], Event | None]] = [
     ("session.completed", ["diagnose", "REQ-1"],                             Event.BUGFIX_ENV_BUG),
     ("session.completed", ["done-archive", "REQ-1"],                         Event.ARCHIVE_DONE),
 
+    # M14b verifier-agent：由 router 主动返 None，交 webhook.derive_verifier_event 解 JSON
+    ("session.completed", ["verifier", "REQ-1", "verify:dev", "trigger:success"], None),
+    # M14b fixer-agent：完成后 FIXER_DONE
+    ("session.completed", ["fixer", "REQ-1", "fixer:dev"],                    Event.FIXER_DONE),
+
     # 没结果 tag → None（agent 没正常完成）
     ("session.completed", ["staging-test", "REQ-1"],                         None),
     ("session.completed", ["pr-ci", "REQ-1"],                                None),

--- a/orchestrator/tests/test_state.py
+++ b/orchestrator/tests/test_state.py
@@ -33,6 +33,12 @@ EXPECTED = [
     (ReqState.DIAGNOSE_RUNNING,     Event.SPEC_REWORK,         ReqState.ESCALATED,           "escalate"),
     (ReqState.DIAGNOSE_RUNNING,     Event.BUGFIX_ENV_BUG,      ReqState.ESCALATED,           "escalate"),
     (ReqState.ARCHIVING,            Event.ARCHIVE_DONE,        ReqState.DONE,                None),
+    # M14b verifier 子链
+    (ReqState.REVIEW_RUNNING,       Event.VERIFY_PASS,         ReqState.REVIEW_RUNNING,      "apply_verify_pass"),
+    (ReqState.REVIEW_RUNNING,       Event.VERIFY_FIX_NEEDED,   ReqState.FIXER_RUNNING,       "start_fixer"),
+    (ReqState.REVIEW_RUNNING,       Event.VERIFY_RETRY_CHECKER, ReqState.REVIEW_RUNNING,     "apply_verify_retry_checker"),
+    (ReqState.REVIEW_RUNNING,       Event.VERIFY_ESCALATE,     ReqState.ESCALATED,           "escalate"),
+    (ReqState.FIXER_RUNNING,        Event.FIXER_DONE,          ReqState.REVIEW_RUNNING,      "invoke_verifier_after_fix"),
 ]
 
 
@@ -50,11 +56,30 @@ def test_session_failed_escalates_all_running_states():
         ReqState.STAGING_TEST_RUNNING, ReqState.PR_CI_RUNNING,
         ReqState.ACCEPT_RUNNING, ReqState.ACCEPT_TEARING_DOWN,
         ReqState.BUGFIX_RUNNING, ReqState.DIAGNOSE_RUNNING,
+        # M14b：verifier / fixer running state 也必须 escalate
+        ReqState.REVIEW_RUNNING, ReqState.FIXER_RUNNING,
         ReqState.ARCHIVING,
     ]
     for st in running:
         t = decide(st, Event.SESSION_FAILED)
         assert t is not None and t.next_state == ReqState.ESCALATED, st
+
+
+def test_m14b_verifier_states_present():
+    """M14b：新引入的 REVIEW_RUNNING / FIXER_RUNNING 应出现在 ReqState 枚举。"""
+    values = {s.value for s in ReqState}
+    assert "review-running" in values
+    assert "fixer-running" in values
+
+
+def test_m14b_verifier_events_present():
+    """M14b：新 events 全部定义。"""
+    values = {e.value for e in Event}
+    for ev in [
+        "verify.pass", "verify.fix-needed", "verify.retry-checker",
+        "verify.escalate", "fixer.done",
+    ]:
+        assert ev in values, f"M14b 缺 event: {ev}"
 
 
 def test_terminal_states_have_no_outgoing():

--- a/orchestrator/tests/test_verifier.py
+++ b/orchestrator/tests/test_verifier.py
@@ -1,0 +1,486 @@
+"""M14b：verifier-agent 框架 单测。
+
+覆盖：
+1. decision schema 校验 + Event 映射（router.validate_decision / decision_to_event）
+2. decision 提取（tag base64 / description ```json```）
+3. derive_verifier_event 整合：合规 / 非法 / 缺失 → 正确事件
+4. invoke_verifier：prompt 渲染 + BKD issue 创建 + ctx 落字段
+5. action handler：apply_verify_pass / apply_verify_retry_checker / start_fixer /
+   invoke_verifier_after_fix 的行为
+6. 12 个 stage_trigger prompt 模板都能渲染出来
+"""
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from unittest.mock import AsyncMock
+
+import pytest
+
+from orchestrator.router import (
+    decision_to_event,
+    derive_verifier_event,
+    extract_decision_from_issue,
+    validate_decision,
+)
+from orchestrator.state import Event
+
+# ─── 1. validate_decision ────────────────────────────────────────────────
+
+@pytest.mark.parametrize("decision,ok", [
+    ({"action": "pass", "fixer": None, "scope": None, "reason": "ok", "confidence": "high"}, True),
+    ({"action": "fix", "fixer": "dev", "scope": "src/", "reason": "bug", "confidence": "high"}, True),
+    ({"action": "fix", "fixer": "spec", "scope": "openspec/changes/REQ-1/", "reason": "x", "confidence": "low"}, True),
+    ({"action": "fix", "fixer": "manifest", "scope": "manifest.pr.number", "reason": "y", "confidence": "high"}, True),
+    ({"action": "retry_checker", "fixer": None, "scope": None, "reason": "flaky", "confidence": "low"}, True),
+    ({"action": "escalate", "fixer": None, "scope": None, "reason": "need human", "confidence": "high"}, True),
+    # invalid action
+    ({"action": "nope", "fixer": None, "scope": None, "reason": "", "confidence": "high"}, False),
+    # missing fixer for fix
+    ({"action": "fix", "fixer": None, "scope": "src/", "reason": "", "confidence": "high"}, False),
+    # fixer set when not fix
+    ({"action": "pass", "fixer": "dev", "scope": "src/", "reason": "", "confidence": "high"}, False),
+    # invalid fixer
+    ({"action": "fix", "fixer": "wizard", "scope": "src/", "reason": "", "confidence": "high"}, False),
+    # invalid confidence
+    ({"action": "pass", "fixer": None, "scope": None, "reason": "", "confidence": "medium"}, False),
+    # not a dict
+    ("not a dict", False),
+    (None, False),
+])
+def test_validate_decision(decision, ok):
+    got_ok, _ = validate_decision(decision)
+    assert got_ok == ok
+
+
+def test_decision_to_event_mapping():
+    assert decision_to_event({"action": "pass"}) == Event.VERIFY_PASS
+    assert decision_to_event({"action": "fix"}) == Event.VERIFY_FIX_NEEDED
+    assert decision_to_event({"action": "retry_checker"}) == Event.VERIFY_RETRY_CHECKER
+    assert decision_to_event({"action": "escalate"}) == Event.VERIFY_ESCALATE
+
+
+# ─── 2. extract_decision_from_issue ──────────────────────────────────────
+
+def test_extract_from_tag_base64():
+    d = {"action": "pass", "fixer": None, "scope": None, "reason": "ok", "confidence": "high"}
+    b64 = base64.urlsafe_b64encode(json.dumps(d).encode()).decode().rstrip("=")
+    tags = ["verifier", "REQ-1", f"decision:{b64}"]
+    got = extract_decision_from_issue(None, tags)
+    assert got == d
+
+
+def test_extract_from_description_json_block():
+    d = {"action": "fix", "fixer": "dev", "scope": "src/", "reason": "need fix", "confidence": "high"}
+    desc = f"some text\n```json\n{json.dumps(d)}\n```\nfooter"
+    got = extract_decision_from_issue(desc, [])
+    assert got == d
+
+
+def test_extract_prefers_last_json_block():
+    d1 = {"action": "pass", "fixer": None}
+    d2 = {"action": "escalate", "fixer": None}
+    desc = f"```json\n{json.dumps(d1)}\n```\n```json\n{json.dumps(d2)}\n```"
+    got = extract_decision_from_issue(desc, [])
+    assert got == d2
+
+
+def test_extract_tag_beats_description_when_valid():
+    d_tag = {"action": "pass", "fixer": None}
+    d_desc = {"action": "escalate", "fixer": None}
+    b64 = base64.urlsafe_b64encode(json.dumps(d_tag).encode()).decode().rstrip("=")
+    desc = f"```json\n{json.dumps(d_desc)}\n```"
+    got = extract_decision_from_issue(desc, [f"decision:{b64}"])
+    assert got == d_tag
+
+
+def test_extract_bad_tag_falls_back_to_description():
+    d_desc = {"action": "pass", "fixer": None}
+    desc = f"```json\n{json.dumps(d_desc)}\n```"
+    got = extract_decision_from_issue(desc, ["decision:!!!not-base64!!!"])
+    assert got == d_desc
+
+
+def test_extract_none_when_empty():
+    assert extract_decision_from_issue(None, []) is None
+    assert extract_decision_from_issue("", []) is None
+    assert extract_decision_from_issue("no json here", []) is None
+
+
+# ─── 3. derive_verifier_event 整合 ───────────────────────────────────────
+
+def test_derive_verifier_event_pass():
+    d = {"action": "pass", "fixer": None, "scope": None, "reason": "ok", "confidence": "high"}
+    b64 = base64.urlsafe_b64encode(json.dumps(d).encode()).decode().rstrip("=")
+    ev, decision, why = derive_verifier_event(None, [f"decision:{b64}"])
+    assert ev == Event.VERIFY_PASS
+    assert decision == d
+    assert why == ""
+
+
+def test_derive_verifier_event_fix():
+    d = {"action": "fix", "fixer": "dev", "scope": "src/", "reason": "bug", "confidence": "high"}
+    b64 = base64.urlsafe_b64encode(json.dumps(d).encode()).decode().rstrip("=")
+    ev, got_decision, _ = derive_verifier_event(None, [f"decision:{b64}"])
+    assert ev == Event.VERIFY_FIX_NEEDED
+    assert got_decision == d
+
+
+def test_derive_verifier_event_retry_checker():
+    d = {"action": "retry_checker", "fixer": None, "scope": None, "reason": "flaky", "confidence": "low"}
+    desc = f"```json\n{json.dumps(d)}\n```"
+    ev, _decision, _ = derive_verifier_event(desc, [])
+    assert ev == Event.VERIFY_RETRY_CHECKER
+
+
+def test_derive_verifier_event_invalid_decision_escalates():
+    d = {"action": "nope"}  # invalid
+    desc = f"```json\n{json.dumps(d)}\n```"
+    ev, decision, why = derive_verifier_event(desc, [])
+    assert ev == Event.VERIFY_ESCALATE
+    assert decision == d
+    assert "invalid" in why.lower()
+
+
+def test_derive_verifier_event_no_decision_escalates():
+    ev, decision, why = derive_verifier_event("no json here", [])
+    assert ev == Event.VERIFY_ESCALATE
+    assert decision is None
+    assert "no decision" in why.lower()
+
+
+# ─── 4. invoke_verifier ─────────────────────────────────────────────────
+
+@dataclass
+class FakeIssue:
+    id: str
+    project_id: str = "p"
+    issue_number: int = 0
+    title: str = ""
+    status_id: str = "todo"
+    tags: list = None
+    session_status: str | None = None
+    description: str | None = None
+
+    def __post_init__(self):
+        if self.tags is None:
+            self.tags = []
+
+
+def make_fake_bkd():
+    bkd = AsyncMock()
+    bkd.create_issue = AsyncMock(return_value=FakeIssue(id="vfy-1"))
+    bkd.update_issue = AsyncMock(return_value=FakeIssue(id="vfy-1"))
+    bkd.follow_up_issue = AsyncMock(return_value={})
+    return bkd
+
+
+def patch_bkd(monkeypatch, fake):
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _ctx(*a, **kw):
+        yield fake
+    monkeypatch.setattr("orchestrator.actions._verifier.BKDClient", _ctx)
+
+
+def patch_db(monkeypatch):
+    writes: list = []
+
+    class P:
+        async def execute(self, sql, *args):
+            writes.append((sql.strip()[:40], args))
+        async def fetchrow(self, sql, *args):
+            return None
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: P())
+    return writes
+
+
+@pytest.mark.asyncio
+async def test_invoke_verifier_creates_issue_with_right_tags(monkeypatch):
+    from orchestrator.actions import _verifier as v
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, fake)
+    patch_db(monkeypatch)
+
+    out = await v.invoke_verifier(
+        stage="staging_test",
+        trigger="fail",
+        req_id="REQ-9",
+        project_id="proj-1",
+        stderr_tail="oops",
+        ctx={"intent_title": "加登录"},
+    )
+    assert out["verifier_issue_id"] == "vfy-1"
+    assert out["stage"] == "staging_test"
+    assert out["trigger"] == "fail"
+
+    _args, kwargs = fake.create_issue.await_args
+    assert kwargs["project_id"] == "proj-1"
+    assert "verifier" in kwargs["tags"]
+    assert "REQ-9" in kwargs["tags"]
+    assert "verify:staging_test" in kwargs["tags"]
+    assert "trigger:fail" in kwargs["tags"]
+    assert kwargs["use_worktree"] is True
+    assert "[VERIFY staging_test] fail" in kwargs["title"]
+    assert "加登录" in kwargs["title"]
+
+    fake.follow_up_issue.assert_awaited_once()
+    # update_issue 被调 1 次（→working）
+    fake.update_issue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_invoke_verifier_renders_template(monkeypatch):
+    """验 prompt 渲染结果带 stderr_tail + stage hint。"""
+    from orchestrator.actions import _verifier as v
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, fake)
+    patch_db(monkeypatch)
+
+    await v.invoke_verifier(
+        stage="dev", trigger="fail",
+        req_id="REQ-7", project_id="p",
+        stderr_tail="TypeError: whoopsie",
+    )
+    _, kwargs = fake.follow_up_issue.await_args
+    prompt = kwargs["prompt"]
+    assert "verifier-agent" in prompt
+    assert "REQ-7" in prompt
+    assert "TypeError: whoopsie" in prompt
+    # decision schema 指示必须在
+    assert '"action":' in prompt
+    assert "pass" in prompt and "fix" in prompt and "retry_checker" in prompt and "escalate" in prompt
+
+
+@pytest.mark.asyncio
+async def test_invoke_verifier_rejects_unknown_stage():
+    from orchestrator.actions import _verifier as v
+    with pytest.raises(ValueError):
+        await v.invoke_verifier(
+            stage="nonsense", trigger="success",
+            req_id="R", project_id="p",
+        )
+
+
+@pytest.mark.asyncio
+async def test_invoke_verifier_rejects_unknown_trigger():
+    from orchestrator.actions import _verifier as v
+    with pytest.raises(ValueError):
+        await v.invoke_verifier(
+            stage="dev", trigger="maybe",
+            req_id="R", project_id="p",
+        )
+
+
+# ─── 5. 所有 12 个 prompt 模板都能渲染 ─────────────────────────────────────
+
+@pytest.mark.parametrize("stage", [
+    "analyze", "spec", "dev", "staging_test", "pr_ci", "accept",
+])
+@pytest.mark.parametrize("trigger", ["success", "fail"])
+def test_all_verifier_prompts_render(stage, trigger):
+    from orchestrator.prompts import render
+    out = render(
+        f"verifier/{stage}_{trigger}.md.j2",
+        req_id="REQ-42",
+        stage=stage,
+        trigger=trigger,
+        stderr_tail="boom",
+        history=[],
+        artifact_paths=[],
+    )
+    assert "REQ-42" in out
+    assert "verifier-agent" in out
+    # decision schema 文本必须在 —— 强校验 agent 输出格式
+    assert '"action":' in out
+    assert "pass" in out and "escalate" in out
+
+
+# ─── 6. action handlers ─────────────────────────────────────────────────
+
+def make_body(issue_id="src-1", project_id="p", event="session.completed"):
+    return type("B", (), {
+        "issueId": issue_id, "projectId": project_id,
+        "event": event, "title": "", "tags": [], "issueNumber": None,
+    })()
+
+
+@pytest.mark.asyncio
+async def test_apply_verify_pass_chains_staging_test_pass(monkeypatch):
+    """verifier_stage=staging_test + VERIFY_PASS → CAS REVIEW_RUNNING→STAGING_TEST_RUNNING
+    + emit STAGING_TEST_PASS（走原主链）。"""
+    from orchestrator.actions import _verifier as v
+
+    cas_calls: list = []
+
+    async def fake_cas(pool, req_id, expected, nxt, event, action, context_patch=None):
+        cas_calls.append((req_id, expected, nxt, event, action))
+        return True
+
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.cas_transition", fake_cas)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+
+    out = await v.apply_verify_pass(
+        body=make_body(), req_id="REQ-9", tags=[],
+        ctx={"verifier_stage": "staging_test"},
+    )
+    assert out["emit"] == Event.STAGING_TEST_PASS.value
+    assert out["stage"] == "staging_test"
+    assert len(cas_calls) == 1
+    (_, expected, nxt, event, _) = cas_calls[0]
+    assert expected.value == "review-running"
+    assert nxt.value == "staging-test-running"
+    assert event == Event.VERIFY_PASS
+
+
+@pytest.mark.asyncio
+async def test_apply_verify_pass_unknown_stage_escalates(monkeypatch):
+    from orchestrator.actions import _verifier as v
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+    out = await v.apply_verify_pass(
+        body=make_body(), req_id="REQ-9", tags=[],
+        ctx={"verifier_stage": None},
+    )
+    assert out["emit"] == Event.VERIFY_ESCALATE.value
+
+
+@pytest.mark.asyncio
+async def test_apply_verify_pass_cas_fail_returns_skip(monkeypatch):
+    """并发导致 REVIEW_RUNNING 已被别的事件改走 → action 不抛，返 cas_failed。"""
+    from orchestrator.actions import _verifier as v
+
+    async def fake_cas(*a, **kw):
+        return False
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.cas_transition", fake_cas)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+
+    out = await v.apply_verify_pass(
+        body=make_body(), req_id="REQ-9", tags=[],
+        ctx={"verifier_stage": "dev"},
+    )
+    assert out == {"cas_failed": True}
+
+
+@pytest.mark.asyncio
+async def test_apply_verify_retry_checker(monkeypatch):
+    from orchestrator.actions import _verifier as v
+
+    cas_calls: list = []
+
+    async def fake_cas(pool, req_id, expected, nxt, event, action, context_patch=None):
+        cas_calls.append((expected.value, nxt.value, event))
+        return True
+
+    update_patches: list = []
+
+    async def fake_update(pool, req_id, patch):
+        update_patches.append(patch)
+
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.cas_transition", fake_cas)
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+
+    out = await v.apply_verify_retry_checker(
+        body=make_body(), req_id="REQ-9", tags=[],
+        ctx={"verifier_stage": "pr_ci"},
+    )
+    assert out["retry_checker"] is True
+    assert out["stage"] == "pr_ci"
+    # CAS 回 pr-ci-running
+    assert cas_calls == [("review-running", "pr-ci-running", Event.VERIFY_RETRY_CHECKER)]
+    # ctx 标 retry_checker_pending
+    assert update_patches[0]["retry_checker_pending"] is True
+
+
+@pytest.mark.asyncio
+async def test_start_fixer_creates_issue_with_fixer_tags(monkeypatch):
+    from orchestrator.actions import _verifier as v
+    fake = make_fake_bkd()
+    fake.create_issue.return_value = FakeIssue(id="fix-1")
+    patch_bkd(monkeypatch, fake)
+
+    async def fake_update(pool, req_id, patch):
+        pass
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+
+    out = await v.start_fixer(
+        body=make_body(project_id="proj-x"), req_id="REQ-9", tags=[],
+        ctx={
+            "verifier_stage": "staging_test",
+            "verifier_fixer": "spec",
+            "verifier_scope": "openspec/changes/REQ-9/",
+            "verifier_reason": "spec contract 漏字段",
+            "verifier_issue_id": "vfy-old",
+        },
+    )
+    assert out["fixer_issue_id"] == "fix-1"
+    assert out["fixer"] == "spec"
+    assert out["stage"] == "staging_test"
+
+    _, kwargs = fake.create_issue.await_args
+    assert "fixer" in kwargs["tags"]
+    assert "REQ-9" in kwargs["tags"]
+    assert "fixer:spec" in kwargs["tags"]
+    assert "parent-stage:staging_test" in kwargs["tags"]
+    assert kwargs["use_worktree"] is True
+
+    # follow-up prompt 里 scope + reason 带入
+    _, fu = fake.follow_up_issue.await_args
+    assert "openspec/changes/REQ-9/" in fu["prompt"]
+    assert "spec contract 漏字段" in fu["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_start_fixer_defaults_to_dev(monkeypatch):
+    """ctx 里没 verifier_fixer 时兜底 dev。"""
+    from orchestrator.actions import _verifier as v
+    fake = make_fake_bkd()
+    fake.create_issue.return_value = FakeIssue(id="fix-2")
+    patch_bkd(monkeypatch, fake)
+
+    async def fake_update(pool, req_id, patch):
+        pass
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+
+    out = await v.start_fixer(
+        body=make_body(), req_id="REQ-9", tags=[],
+        ctx={"verifier_stage": "dev"},
+    )
+    assert out["fixer"] == "dev"
+
+
+@pytest.mark.asyncio
+async def test_invoke_verifier_after_fix_passes_history(monkeypatch):
+    from orchestrator.actions import _verifier as v
+    fake = make_fake_bkd()
+    fake.create_issue.return_value = FakeIssue(id="vfy-2")
+    patch_bkd(monkeypatch, fake)
+
+    history_updates: list = []
+
+    async def fake_update(pool, req_id, patch):
+        history_updates.append(patch)
+
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+
+    out = await v.invoke_verifier_after_fix(
+        body=make_body(project_id="p"), req_id="REQ-9", tags=[],
+        ctx={
+            "verifier_stage": "staging_test",
+            "fixer_role": "dev",
+            "fixer_issue_id": "fix-1",
+            "verifier_history": [{"round": 1}],
+        },
+    )
+    assert out["verifier_issue_id"] == "vfy-2"
+    # 至少一次 update 带有累积的 history
+    hist_writes = [p for p in history_updates if "verifier_history" in p]
+    assert hist_writes, "should persist verifier_history"
+    hist = hist_writes[-1]["verifier_history"]
+    assert len(hist) == 2
+    assert hist[-1] == {"fixer": "dev", "fixer_issue_id": "fix-1"}


### PR DESCRIPTION
M14 重设计第二部分：每 stage transition 召 verifier-agent 决定 pass/fix/retry/escalate，sisyphus 不抢 AI 决定权。

## 改动
- _verifier.py 统一调度 + 12 个 stage prompt 模板
- state.py / router.py / webhook.py 接新 decision 事件
- config.py verifier_enabled 灰度
- 380 tests pass

## 依赖
独立可合，但 M14c (砍旧分流 PR3) 依赖本 PR

## Test plan
- [ ] CI 全绿
- [ ] PR3/PR4 派 agent 拉新分支基于本 PR