### PR TITLE
fix(webhook): 改 log.info kwargs 名避免跟 event 位置参数冲突 (B1)

### DIFF
--- a/orchestrator/src/orchestrator/webhook.py
+++ b/orchestrator/src/orchestrator/webhook.py
@@ -152,7 +152,7 @@ async def webhook(request: Request) -> JSONResponse:
                         issue_id=body.issueId, error=str(e))
         event, decision_payload, why = router_lib.derive_verifier_event(description, tags)
         log.info("webhook.verifier.decision",
-                 issue_id=body.issueId, event=event.value,
+                 issue_id=body.issueId, verifier_event=event.value,
                  decision=decision_payload, reason=why)
 
     if event is None:


### PR DESCRIPTION
## Summary
- 现象：verifier-agent `session.completed` 回 webhook 时 crash：
  ```
  File "orchestrator/webhook.py", line 154, in webhook
      log.info("webhook.verifier.decision", ...)
  TypeError: meth() got multiple values for argument 'event'
  ```
- 根因：`structlog` 的 `log.info(event, **kw)` 第一个位置参数已经叫 `event`。下面再传 `event=event.value` kwarg → 同名冲突，整条 verifier decision 分支 100% crash。
- 修法：把 kwarg 重命名为 `verifier_event=event.value`（语义也更准：这里记的是 verifier 解析出的下游事件，不是日志主 event）。

## 关联
- e2e issue: REQ-e2e-M15-1776921738（verifier decision webhook 挂掉）
- M14b 引入，M15 主线合并时未触发

## 改动
- `orchestrator/src/orchestrator/webhook.py` L155：`event=event.value` → `verifier_event=event.value`
- 1 file changed, 1 insertion(+), 1 deletion(-)

## Test plan
- [x] `ruff check src` 全过
- [x] `pytest -q` 265 passed
- [ ] e2e 再跑一次验证 verifier decision 分支不再 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)