### PR TITLE
fix(verifier): 拆 fail 路由为 3 个专 action（B2 修 staging-test 误路成 dev）

### DIFF
--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -42,15 +42,15 @@
 | `spec.all-passed` | 聚合事件：N/N spec 都 reviewed | create_dev |
 | `dev.done` | dev-agent session.completed | create_staging_test |
 | `staging-test.pass` | M1 checker 退码 0 | create_pr_ci_watch |
-| `staging-test.fail` | M1 checker 退码非 0 | invoke_verifier_for_fail |
+| `staging-test.fail` | M1 checker 退码非 0 | invoke_verifier_for_staging_test_fail |
 | `pr-ci.pass` | M2 checker 全绿 | create_accept |
-| `pr-ci.fail` | M2 checker 任一红 | invoke_verifier_for_fail |
+| `pr-ci.fail` | M2 checker 任一红 | invoke_verifier_for_pr_ci_fail |
 | `pr-ci.timeout` | M2 checker 超时 | escalate（PR repo 可能没配 CI） |
 | `accept-env-up.fail` | create_accept 内部 emit | escalate（lab 起不来） |
 | `accept.pass` | accept-agent 写 result:pass tag | teardown_accept_env |
 | `accept.fail` | accept-agent 写 result:fail tag | teardown_accept_env |
 | `teardown-done.pass` | 上一个是 accept.pass 的 teardown 完 | done_archive |
-| `teardown-done.fail` | 上一个是 accept.fail 的 teardown 完 | invoke_verifier_for_fail |
+| `teardown-done.fail` | 上一个是 accept.fail 的 teardown 完 | invoke_verifier_for_accept_fail |
 | `archive.done` | done_archive agent session.completed | （进入 done） |
 | `session.failed` | 任意 stage agent session 崩 / watchdog 超时 | escalate |
 | **`verify.pass`** | M14b verifier decision=pass | apply_verify_pass（手工 CAS 推进下一 stage） |

--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -14,7 +14,10 @@ webhook.py 解析 decision JSON，映射成 Event 推状态机。
    + 链 emit "restart" 事件触发 checker 重跑
 - `start_fixer`：decision=fix → 起 fixer agent（dev / spec）
 - `invoke_verifier_after_fix`：fixer 完 → 再调 verifier 复查
-- `invoke_verifier_for_fail`：M14c — staging-test / pr-ci / accept fail 全部入口
+- `invoke_verifier_for_staging_test_fail` / `_pr_ci_fail` / `_accept_fail`：
+   机械 checker / accept fail 的 3 个专门入口。stage 由 transition table 写死，
+   不再从 webhook tags sniff（机械 checker 没 issue，tags 来自上游 dev issue，
+   以前按 tag 推会把 staging-test fail 误路成 dev）。
 
 M14c：verifier_enabled 默认 True，旧 fail_kind / bugfix 子链已砍。
 """
@@ -61,17 +64,6 @@ _RETRY_TARGET_STATE: dict[str, ReqState] = {
     "staging_test": ReqState.STAGING_TEST_RUNNING,
     "pr_ci":        ReqState.PR_CI_RUNNING,
     "accept":       ReqState.ACCEPT_RUNNING,
-}
-
-# M14c：fail event tag → verifier stage（invoke_verifier_for_fail 用）
-# tag 来自 BKD webhook 的 issue tags（agent role）。teardown 是内部 emit，
-# 复用上游 accept tag。
-# M15：加 "dev" tag → dev stage（dev issue 失败时）
-_FAIL_TAG_TO_STAGE: dict[str, str] = {
-    "dev":          "dev",
-    "staging-test": "staging_test",
-    "pr-ci":        "pr_ci",
-    "accept":       "accept",
 }
 
 
@@ -298,43 +290,43 @@ async def invoke_verifier_after_fix(*, body, req_id, tags, ctx):
     return result
 
 
-def _infer_fail_stage(tags: list[str] | None, ctx: dict | None) -> str | None:
-    """M14c：从 webhook tags / ctx 推 verifier 用的 stage 名。
-
-    顺序：
-    1. ctx.verifier_stage（fix 二次回流时上一次写的）
-    2. tags 里的 agent role 标签（staging-test / pr-ci / accept）
-    3. None（上层按 escalate 走）
-    """
-    if ctx and ctx.get("verifier_stage") in _STAGES:
-        return ctx["verifier_stage"]
-    for t in tags or []:
-        stage = _FAIL_TAG_TO_STAGE.get(t)
-        if stage:
-            return stage
-    return None
-
-
-@register("invoke_verifier_for_fail", idempotent=False)
-async def invoke_verifier_for_fail(*, body, req_id, tags, ctx):
-    """M14c：staging-test / pr-ci / accept fail → 起 verifier-agent (trigger=fail)。
-
-    替代旧 open_gh_and_bugfix 路径。stage 从 webhook tags 或 ctx 推断；
-    推不到时 emit VERIFY_ESCALATE 让状态机走人工兜底。
-    """
-    stage = _infer_fail_stage(tags, ctx)
-    if stage is None:
-        log.error("invoke_verifier_for_fail.unknown_stage",
-                  req_id=req_id, tags=tags)
-        return {"emit": Event.VERIFY_ESCALATE.value,
-                "reason": f"cannot infer verifier stage from tags={tags}"}
-
+async def _invoke_verifier_fail(*, stage: str, body, req_id, ctx):
+    """统一跑 invoke_verifier(trigger=fail)。stage 由调用方写死。"""
     return await invoke_verifier(
         stage=stage,
         trigger="fail",
         req_id=req_id,
         project_id=body.projectId,
         ctx=ctx,
+    )
+
+
+@register("invoke_verifier_for_staging_test_fail", idempotent=False)
+async def invoke_verifier_for_staging_test_fail(*, body, req_id, tags, ctx):
+    """STAGING_TEST_FAIL → 起 verifier-agent(stage=staging_test, trigger=fail)。
+
+    stage 来自 transition table，不从 tags 推。
+    （机械 checker 没自己的 BKD issue，webhook tags 来自上游 dev issue，
+    以前 sniff tag 会把 staging-test fail 误路成 dev。）
+    """
+    return await _invoke_verifier_fail(
+        stage="staging_test", body=body, req_id=req_id, ctx=ctx,
+    )
+
+
+@register("invoke_verifier_for_pr_ci_fail", idempotent=False)
+async def invoke_verifier_for_pr_ci_fail(*, body, req_id, tags, ctx):
+    """PR_CI_FAIL → 起 verifier-agent(stage=pr_ci, trigger=fail)。"""
+    return await _invoke_verifier_fail(
+        stage="pr_ci", body=body, req_id=req_id, ctx=ctx,
+    )
+
+
+@register("invoke_verifier_for_accept_fail", idempotent=False)
+async def invoke_verifier_for_accept_fail(*, body, req_id, tags, ctx):
+    """TEARDOWN_DONE_FAIL → 起 verifier-agent(stage=accept, trigger=fail)。"""
+    return await _invoke_verifier_fail(
+        stage="accept", body=body, req_id=req_id, ctx=ctx,
     )
 
 

--- a/orchestrator/src/orchestrator/state.py
+++ b/orchestrator/src/orchestrator/state.py
@@ -108,14 +108,18 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
         Transition(ReqState.PR_CI_RUNNING, "create_pr_ci_watch", "staging 绿 → 开 PR 等 CI"),
 
     # M14c：fail 全部走 verifier，trigger=fail
+    # 每类 fail 都有专门 action —— stage 由 transition 写死，不从 webhook tags sniff
+    # （机械 checker 没自己 issue，tags 来自上游 dev issue，sniff 会错路）
     (ReqState.STAGING_TEST_RUNNING, Event.STAGING_TEST_FAIL):
-        Transition(ReqState.REVIEW_RUNNING, "invoke_verifier_for_fail", "staging fail → verifier"),
+        Transition(ReqState.REVIEW_RUNNING, "invoke_verifier_for_staging_test_fail",
+                   "staging fail → verifier"),
 
     (ReqState.PR_CI_RUNNING, Event.PR_CI_PASS):
         Transition(ReqState.ACCEPT_RUNNING, "create_accept", "CI 全绿 → 转测"),
 
     (ReqState.PR_CI_RUNNING, Event.PR_CI_FAIL):
-        Transition(ReqState.REVIEW_RUNNING, "invoke_verifier_for_fail", "pr-ci fail → verifier"),
+        Transition(ReqState.REVIEW_RUNNING, "invoke_verifier_for_pr_ci_fail",
+                   "pr-ci fail → verifier"),
 
     (ReqState.PR_CI_RUNNING, Event.PR_CI_TIMEOUT):
         Transition(ReqState.ESCALATED, "escalate", "PR CI 未触发（repo 可能没配模板）"),
@@ -137,7 +141,7 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
         Transition(ReqState.ARCHIVING, "done_archive", "teardown 完 → 归档"),
 
     (ReqState.ACCEPT_TEARING_DOWN, Event.TEARDOWN_DONE_FAIL):
-        Transition(ReqState.REVIEW_RUNNING, "invoke_verifier_for_fail",
+        Transition(ReqState.REVIEW_RUNNING, "invoke_verifier_for_accept_fail",
                    "accept fail + teardown 完 → verifier"),
 
     # ─── M14b verifier 子链 ─────────────────────────────────────────────

--- a/orchestrator/tests/test_state.py
+++ b/orchestrator/tests/test_state.py
@@ -16,16 +16,16 @@ EXPECTED = [
     (ReqState.DEV_RUNNING,          Event.DEV_DONE,            ReqState.DEV_RUNNING,          "mark_dev_reviewed_and_check"),
     (ReqState.DEV_RUNNING,          Event.DEV_ALL_PASSED,      ReqState.STAGING_TEST_RUNNING, "create_staging_test"),
     (ReqState.STAGING_TEST_RUNNING, Event.STAGING_TEST_PASS,   ReqState.PR_CI_RUNNING,       "create_pr_ci_watch"),
-    # M14c：fail 全部走 verifier
-    (ReqState.STAGING_TEST_RUNNING, Event.STAGING_TEST_FAIL,   ReqState.REVIEW_RUNNING,      "invoke_verifier_for_fail"),
+    # M14c：fail 全部走 verifier（B2：3 个专门 action 替代旧统一路由）
+    (ReqState.STAGING_TEST_RUNNING, Event.STAGING_TEST_FAIL,   ReqState.REVIEW_RUNNING,      "invoke_verifier_for_staging_test_fail"),
     (ReqState.PR_CI_RUNNING,        Event.PR_CI_PASS,          ReqState.ACCEPT_RUNNING,      "create_accept"),
-    (ReqState.PR_CI_RUNNING,        Event.PR_CI_FAIL,          ReqState.REVIEW_RUNNING,      "invoke_verifier_for_fail"),
+    (ReqState.PR_CI_RUNNING,        Event.PR_CI_FAIL,          ReqState.REVIEW_RUNNING,      "invoke_verifier_for_pr_ci_fail"),
     (ReqState.PR_CI_RUNNING,        Event.PR_CI_TIMEOUT,       ReqState.ESCALATED,           "escalate"),
     (ReqState.ACCEPT_RUNNING,       Event.ACCEPT_ENV_UP_FAIL,  ReqState.ESCALATED,           "escalate"),
     (ReqState.ACCEPT_RUNNING,       Event.ACCEPT_PASS,         ReqState.ACCEPT_TEARING_DOWN, "teardown_accept_env"),
     (ReqState.ACCEPT_RUNNING,       Event.ACCEPT_FAIL,         ReqState.ACCEPT_TEARING_DOWN, "teardown_accept_env"),
     (ReqState.ACCEPT_TEARING_DOWN,  Event.TEARDOWN_DONE_PASS,  ReqState.ARCHIVING,           "done_archive"),
-    (ReqState.ACCEPT_TEARING_DOWN,  Event.TEARDOWN_DONE_FAIL,  ReqState.REVIEW_RUNNING,      "invoke_verifier_for_fail"),
+    (ReqState.ACCEPT_TEARING_DOWN,  Event.TEARDOWN_DONE_FAIL,  ReqState.REVIEW_RUNNING,      "invoke_verifier_for_accept_fail"),
     (ReqState.ARCHIVING,            Event.ARCHIVE_DONE,        ReqState.DONE,                None),
     # M14b verifier 子链
     (ReqState.REVIEW_RUNNING,       Event.VERIFY_PASS,         ReqState.REVIEW_RUNNING,      "apply_verify_pass"),

--- a/orchestrator/tests/test_verifier.py
+++ b/orchestrator/tests/test_verifier.py
@@ -455,8 +455,12 @@ async def test_start_fixer_defaults_to_dev(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_invoke_verifier_for_fail_infers_stage_from_tags(monkeypatch):
-    """M14c：staging-test fail webhook tag → verifier stage=staging_test。"""
+async def test_invoke_verifier_for_staging_test_fail(monkeypatch):
+    """B2：专门 handler 写死 stage=staging_test，不再从 tags sniff。
+
+    用上游 dev issue 的 tags 调（机械 checker 没自己 issue，webhook tags
+    就是 dev）—— 旧实现会按 tag 误路成 dev，新实现应稳定落 staging_test。
+    """
     from orchestrator.actions import _verifier as v
     fake = make_fake_bkd()
     fake.create_issue.return_value = FakeIssue(id="vfy-3")
@@ -467,10 +471,10 @@ async def test_invoke_verifier_for_fail_infers_stage_from_tags(monkeypatch):
     monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update)
     monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
 
-    out = await v.invoke_verifier_for_fail(
+    out = await v.invoke_verifier_for_staging_test_fail(
         body=make_body(project_id="proj-x"),
         req_id="REQ-9",
-        tags=["staging-test", "REQ-9", "result:fail"],
+        tags=["dev", "REQ-9"],
         ctx={},
     )
     assert out["stage"] == "staging_test"
@@ -482,11 +486,10 @@ async def test_invoke_verifier_for_fail_infers_stage_from_tags(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_invoke_verifier_for_fail_uses_ctx_stage(monkeypatch):
-    """M14c：teardown 等无 agent role tag 的场景 → ctx.verifier_stage 兜底。"""
+async def test_invoke_verifier_for_pr_ci_fail(monkeypatch):
     from orchestrator.actions import _verifier as v
     fake = make_fake_bkd()
-    fake.create_issue.return_value = FakeIssue(id="vfy-4")
+    fake.create_issue.return_value = FakeIssue(id="vfy-pr")
     patch_bkd(monkeypatch, fake)
 
     async def fake_update(pool, req_id, patch):
@@ -494,27 +497,42 @@ async def test_invoke_verifier_for_fail_uses_ctx_stage(monkeypatch):
     monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update)
     monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
 
-    out = await v.invoke_verifier_for_fail(
-        body=make_body(),
+    out = await v.invoke_verifier_for_pr_ci_fail(
+        body=make_body(project_id="proj-x"),
+        req_id="REQ-9",
+        tags=["dev", "REQ-9"],
+        ctx={},
+    )
+    assert out["stage"] == "pr_ci"
+    assert out["trigger"] == "fail"
+
+    _, kwargs = fake.create_issue.await_args
+    assert "verify:pr_ci" in kwargs["tags"]
+
+
+@pytest.mark.asyncio
+async def test_invoke_verifier_for_accept_fail(monkeypatch):
+    from orchestrator.actions import _verifier as v
+    fake = make_fake_bkd()
+    fake.create_issue.return_value = FakeIssue(id="vfy-ac")
+    patch_bkd(monkeypatch, fake)
+
+    async def fake_update(pool, req_id, patch):
+        pass
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+
+    out = await v.invoke_verifier_for_accept_fail(
+        body=make_body(project_id="proj-x"),
         req_id="REQ-9",
         tags=["watchdog:accept-tearing-down"],
-        ctx={"verifier_stage": "accept"},
+        ctx={},
     )
     assert out["stage"] == "accept"
     assert out["trigger"] == "fail"
 
-
-@pytest.mark.asyncio
-async def test_invoke_verifier_for_fail_unknown_stage_emits_escalate(monkeypatch):
-    """M14c：tag/ctx 都推不出 stage → emit VERIFY_ESCALATE。"""
-    from orchestrator.actions import _verifier as v
-    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
-
-    out = await v.invoke_verifier_for_fail(
-        body=make_body(), req_id="REQ-9", tags=["unrelated"], ctx={},
-    )
-    assert out["emit"] == Event.VERIFY_ESCALATE.value
-    assert "cannot infer" in out["reason"]
+    _, kwargs = fake.create_issue.await_args
+    assert "verify:accept" in kwargs["tags"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 现象

e2e issue REQ-e2e-M15-1776921738：staging-test fail 触发 verifier，verifier 跑的是 `dev_fail.md.j2`（stage="dev"），而不是应该跑的 `staging_test_fail.md.j2`（stage="staging_test"）。

## 根因

`actions/_verifier.py` 的 `_infer_fail_stage` 从 webhook tags sniff verifier stage。但机械 checker（staging-test / pr-ci）**没自己的 BKD issue**，触发它的 source issue 是上游 dev issue，tags = `["dev", "REQ-xxx"]`。

M15 commit 10dc69d 给 `_FAIL_TAG_TO_STAGE` 加了 `"dev" → "dev"` 映射（目的是兜 dev issue 本身失败时的路由），结果 `_infer_fail_stage` 按 tag 顺序匹配时，"dev" 先命中，把 staging-test fail / pr-ci fail 全都错路成 dev stage。

核心问题：**action handler 根本不应该从 tags 推 stage** —— 机械 checker 没 issue，tags 根本不是自己的。stage 应当由 transition table 静态提供。

## 修法

按 M15 原 plan 第 7 步，拆 `invoke_verifier_for_fail` 为 3 个专门 action handler：

- `invoke_verifier_for_staging_test_fail` → stage=`"staging_test"`
- `invoke_verifier_for_pr_ci_fail`        → stage=`"pr_ci"`
- `invoke_verifier_for_accept_fail`       → stage=`"accept"`

每个写死 stage 调底层 `invoke_verifier(stage=..., trigger="fail")`。

`state.py` 的 3 个 fail transition 的 action 名相应更新：
- `(STAGING_TEST_RUNNING, STAGING_TEST_FAIL)` → `invoke_verifier_for_staging_test_fail`
- `(PR_CI_RUNNING, PR_CI_FAIL)`              → `invoke_verifier_for_pr_ci_fail`
- `(ACCEPT_TEARING_DOWN, TEARDOWN_DONE_FAIL)` → `invoke_verifier_for_accept_fail`

**删除**：`_infer_fail_stage` / `_FAIL_TAG_TO_STAGE` / 旧 `invoke_verifier_for_fail`（已无 caller）。

## 测试

- `test_verifier.py`：旧 3 个 infer 测试替换为 3 个新 action 的行为测试。新测试里用上游 dev issue 的 tags（`["dev", "REQ-9"]`）验证 staging_test / pr_ci fail 稳定落到正确 stage。
- `test_state.py`：EXPECTED 表 action 名对齐。
- `docs/state-machine.md`：event 表里 3 处 action 名更新。
- 跑 `ruff check src && ruff check tests && pytest -q`：全绿，**265 passed**。

## 关联

- e2e issue: REQ-e2e-M15-1776921738
- 不动 webhook.py（B1 正在并行修）

## Test plan

- [x] 本地 `ruff check src && ruff check tests`：All checks passed
- [x] 本地 `pytest -q`：265 passed
- [ ] merge 后重跑 REQ-e2e-M15 验 staging-test fail 正确起 `verifier/staging_test_fail.md.j2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)