### PR TITLE
fix(checkers): checkout feat/<REQ> before validating per-repo

### DIFF
--- a/orchestrator/src/orchestrator/checkers/dev_cross_check.py
+++ b/orchestrator/src/orchestrator/checkers/dev_cross_check.py
@@ -20,13 +20,20 @@ _TAIL = 2048
 
 
 def _build_cmd(req_id: str) -> str:
-    """遍历 /workspace/source/*/，对含 Makefile 的仓跑 make dev-cross-check。"""
+    """遍历 /workspace/source/*/，先切到 feat/<REQ>，对含 Makefile 的仓跑 make dev-cross-check。
+
+    fetch + checkout feat/<REQ> 失败 → 该仓 not involved，跳过不算 fail。
+    """
     return (
         "set -o pipefail; "
         "fail=0; "
         "for repo in /workspace/source/*/; do "
-        '  if [ -d "$repo" ] && [ -f "$repo/Makefile" ]; then '
-        '    name=$(basename "$repo"); '
+        '  name=$(basename "$repo"); '
+        f'  if ! (cd "$repo" && git fetch origin "feat/{req_id}" 2>/dev/null && git checkout -B "feat/{req_id}" "origin/feat/{req_id}" 2>/dev/null); then '
+        '    echo "[skip] $name: no feat branch / not involved"; '
+        "    continue; "
+        "  fi; "
+        '  if [ -f "$repo/Makefile" ]; then '
         '    echo "=== dev_cross_check: $name ==="; '
         '    if ! (cd "$repo" && make dev-cross-check); then '
         '      echo "=== FAIL: $name ===" >&2; '

--- a/orchestrator/src/orchestrator/checkers/spec_lint.py
+++ b/orchestrator/src/orchestrator/checkers/spec_lint.py
@@ -22,20 +22,26 @@ _TAIL = 2048
 
 
 def _build_cmd(req_id: str) -> str:
-    """遍历 /workspace/source/*/，对含 openspec/changes/<REQ>/ 的仓跑两项检查。
+    """遍历 /workspace/source/*/，先切到 feat/<REQ>，对含 openspec/changes/<REQ>/ 的仓跑两项检查。
 
-    1. openspec validate openspec/changes/<REQ>
-    2. check-scenario-refs.sh --specs-search-path /workspace/source .
+    1. git fetch origin feat/<REQ> + git checkout -B feat/<REQ> origin/feat/<REQ>
+       —— spec/dev 文件由 agent 推到 feat/<REQ> 分支，runner pod 默认在 main。
+       fetch 失败 / 没有该 branch → 该仓视为 not involved（agent 没改它），跳过不算 fail。
+    2. openspec validate openspec/changes/<REQ>
+    3. check-scenario-refs.sh --specs-search-path /workspace/source .
 
-    任一仓任一检查失败 → exit 1。check-scenario-refs.sh 的
-    --specs-search-path flag 支持跨仓 scenario 引用（Agent B 实现）。
+    任一仓任一检查失败 → exit 1。
     """
     return (
         "set -o pipefail; "
         "fail=0; "
         "for repo in /workspace/source/*/; do "
+        '  name=$(basename "$repo"); '
+        f'  if ! (cd "$repo" && git fetch origin "feat/{req_id}" 2>/dev/null && git checkout -B "feat/{req_id}" "origin/feat/{req_id}" 2>/dev/null); then '
+        '    echo "[skip] $name: no feat branch / not involved"; '
+        "    continue; "
+        "  fi; "
         f'  if [ -d "$repo/openspec/changes/{req_id}" ]; then '
-        '    name=$(basename "$repo"); '
         '    echo "=== spec_lint: $name ==="; '
         f'    if ! (cd "$repo" && openspec validate "openspec/changes/{req_id}"); then '
         '      echo "=== FAIL: $name ===" >&2; '
@@ -45,6 +51,8 @@ def _build_cmd(req_id: str) -> str:
         '      echo "=== FAIL scenario-refs: $name ===" >&2; '
         "      fail=1; "
         "    fi; "
+        "  else "
+        f'    echo "[skip] $name: no openspec/changes/{req_id}/"; '
         "  fi; "
         "done; "
         "exit $fail"

--- a/orchestrator/src/orchestrator/checkers/staging_test.py
+++ b/orchestrator/src/orchestrator/checkers/staging_test.py
@@ -24,9 +24,10 @@ _TAIL = 2048
 _DEFAULT_TIMEOUT = 1800
 
 
-def _build_cmd() -> str:
+def _build_cmd(req_id: str) -> str:
     """对含 ci-test target 的每个 source repo 并行跑 make ci-test。
 
+    每仓先切到 feat/<REQ>（agent 推到的分支）；fetch/checkout 失败 → not involved 跳过。
     pids 列表存 `pid:name`，结尾按 pid 依次 wait；失败 tail 最后 50 行到 stderr。
     """
     return (
@@ -35,8 +36,12 @@ def _build_cmd() -> str:
         "mkdir -p /tmp/staging-test-logs; "
         'pids=""; '
         "for repo in /workspace/source/*/; do "
+        '  name=$(basename "$repo"); '
+        f'  if ! (cd "$repo" && git fetch origin "feat/{req_id}" 2>/dev/null && git checkout -B "feat/{req_id}" "origin/feat/{req_id}" 2>/dev/null); then '
+        '    echo "[skip] $name: no feat branch / not involved"; '
+        "    continue; "
+        "  fi; "
         '  if [ -f "$repo/Makefile" ] && grep -q \'^ci-test:\' "$repo/Makefile"; then '
-        '    name=$(basename "$repo"); '
         "    ( "
         '      echo "=== staging_test: $name ==="; '
         '      cd "$repo" && make ci-test '
@@ -62,7 +67,7 @@ def _build_cmd() -> str:
 
 async def run_staging_test(req_id: str) -> CheckResult:
     """在 runner pod 并行对每个 source repo 跑 make ci-test，收退出码决定 pass/fail。"""
-    cmd = _build_cmd()
+    cmd = _build_cmd(req_id)
     timeout_sec = _DEFAULT_TIMEOUT
 
     rc = k8s_runner.get_controller()


### PR DESCRIPTION
## Why

E2E REQ-final 暴露：spec/dev/staging-test checker 都默认在 runner pod 的 master 分支跑，但 agent 把改动推到 `feat/<REQ>`。runner 没切分支 → checker 找不到 `openspec/changes/<REQ>/` → 永远立即 fail → escalate。

这是 pre-existing bug，跟 #31 同一类隐式契约（agent 推到的分支 / runner 期望的 cwd 状态）。

## What

3 个 checker shell 在 cd 进每个 repo 后**先**：

```bash
git fetch origin feat/<REQ> 2>/dev/null && git checkout -B feat/<REQ> origin/feat/<REQ>
```

- fetch/checkout 任一失败 → 该仓 not involved（agent 没改它），跳过不算 fail
- 这天然支持多仓 REQ（agent 只改子集仓）

## How verified
- `pytest tests/`: 19/19 affected pass
- `py_compile` 三个 checker 通过

## Out of scope
- 跨仓拓扑序的 checkout（producer 先于 consumer）—— 当前并行 fetch，单仓不影响