### PR TITLE
feat: per-task agent_model config + fix runner-image.yml paths

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -4,18 +4,14 @@ on:
   pull_request:
     paths:
       - 'runner/**'
-      - 'scripts/check-scenario-refs.sh'
-      - 'scripts/check-tasks-section-ownership.sh'
-      - 'scripts/pre-commit-acl.sh'
+      - 'scripts/**'    # 任意 helper 改动都重 build runner image
       - '.github/workflows/runner-image.yml'
   push:
     branches: [main]
     tags: ['runner-v*']
     paths:
       - 'runner/**'
-      - 'scripts/check-scenario-refs.sh'
-      - 'scripts/check-tasks-section-ownership.sh'
-      - 'scripts/pre-commit-acl.sh'
+      - 'scripts/**'
       - '.github/workflows/runner-image.yml'
 
 env:

--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -121,6 +121,7 @@ async def invoke_verifier(
             ],
             status_id="todo",
             use_worktree=True,   # 并行 verifier 互不抢 working tree
+            model=settings.agent_model,
         )
         await bkd.follow_up_issue(project_id=project_id, issue_id=issue.id, prompt=prompt)
         await bkd.update_issue(project_id=project_id, issue_id=issue.id, status_id="working")
@@ -236,6 +237,7 @@ async def start_fixer(*, body, req_id, tags, ctx):
             ],
             status_id="todo",
             use_worktree=True,
+            model=settings.agent_model,
         )
         # 通用 bugfix prompt 作为过渡；PR4 再做每类 fixer 专用模板。
         prompt = render(

--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -107,6 +107,7 @@ async def create_accept(*, body, req_id, tags, ctx):
             title=f"[{req_id}] [ACCEPT] AI-QA{short_title(ctx)}",
             tags=["accept", req_id, f"parent-id:{source_issue_id}"],
             status_id="todo",
+            model=settings.agent_model,
         )
         prompt = render(
             "accept.md.j2",

--- a/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
@@ -98,6 +98,7 @@ async def _dispatch_bkd_agent(*, body, req_id: str, ctx: dict) -> dict:
             title=f"[{req_id}] [pr-ci-watch]{short_title(ctx)}",
             tags=["pr-ci", req_id, f"parent-id:{source_issue_id}"],
             status_id="todo",
+            model=settings.agent_model,
         )
         prompt = render(
             "pr_ci_watch.md.j2",

--- a/orchestrator/src/orchestrator/actions/create_staging_test.py
+++ b/orchestrator/src/orchestrator/actions/create_staging_test.py
@@ -99,6 +99,7 @@ async def _dispatch_bkd_agent(*, body, req_id: str, ctx: dict) -> dict:
             title=f"[{req_id}] [staging-test]{short_title(ctx)}",
             tags=["staging-test", req_id, f"parent-id:{source_issue_id}"],
             status_id="todo",
+            model=settings.agent_model,
         )
         prompt = render(
             "staging_test.md.j2",

--- a/orchestrator/src/orchestrator/actions/done_archive.py
+++ b/orchestrator/src/orchestrator/actions/done_archive.py
@@ -29,6 +29,7 @@ async def done_archive(*, body, req_id, tags, ctx):
             title=f"[{req_id}] [DONE] archive & PR{short_title(ctx)}",
             tags=["done-archive", req_id, f"parent-id:{accept_issue_id}"],
             status_id="todo",
+            model=settings.agent_model,
         )
         prompt = render(
             "done_archive.md.j2",

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -106,6 +106,14 @@ class Settings(BaseSettings):
     # 默认 3 × 120s = 6min，覆盖 K3s 节点偶发慢启动；生产可调更高。
     runner_ready_attempts: int = 3
 
+    # ─── agent model 控制 ─────────────────────────────────────────────────
+    # sisyphus 起的 agent 用哪个模型（verifier / fixer / accept / pr_ci_watch /
+    # done_archive / staging_test）。None = 用 BKD per-engine 默认。
+    # 生产 None 走 BKD 默认（opus）；测试 helm values 覆盖成 'claude-haiku-4-5'。
+    # 注意：analyze agent 的 model 是 user 创 intent issue 时定的，sisyphus 不控；
+    # analyze fan out 的 sub-issue model 由 analyze prompt 自己控（见 analyze.md.j2）。
+    agent_model: str | None = None
+
     # ─── M14b/M14c：verifier-agent 框架 ─────────────────────────────────
     # 每个 stage transition（成功 or 失败）先起一个 verifier-agent 做主观判断
     # （pass / fix / retry_checker / escalate），再由 webhook 路由推进状态机。


### PR DESCRIPTION
## Why

1. **agent_model 不可控** — sisyphus 起的 verifier/fixer/accept/etc agent 都用 BKD 全局默认 (opus)。dev/test 时想用 haiku 加速但全局切换会影响生产。
2. **runner-image.yml paths 漏了** — PR #33 加的 `scripts/sisyphus-clone-repos.sh` 不在 trigger paths 白名单，runner image 没 rebuild → REQ-final3 跑老 helper 还是 spec_lint fail。

## What

### agent_model config
- 加 `settings.agent_model`，6 个 `bkd.create_issue` 调用点串入
- helm values 覆盖：dev 用 haiku，prod None 走 BKD 默认 (opus)
- analyze 不受影响 (user 创 intent 时定 model)；analyze fan out 的 sub-agent 自管

### runner-image.yml paths
- `scripts/check-scenario-refs.sh / check-tasks-section-ownership.sh / pre-commit-acl.sh` → `scripts/**`
- 任何 helper 改动都重 build runner image

## Verification
- `pytest tests/`: 255/255 pass

## Refs
- e2e bug REQ-final3-1776951645