### PR TITLE
fix(prompt): expose aissh-tao MCP usage so agent uses it for kubectl

### DIFF
--- a/orchestrator/src/orchestrator/actions/start_analyze.py
+++ b/orchestrator/src/orchestrator/actions/start_analyze.py
@@ -49,7 +49,14 @@ async def start_analyze(*, body, req_id, tags, ctx):
             title=f"[{req_id}] [ANALYZE]{short_title(ctx)}",
             tags=["analyze", req_id],
         )
-        prompt = render("analyze.md.j2", req_id=req_id, aissh_server_id=settings.aissh_server_id)
+        prompt = render(
+            "analyze.md.j2",
+            req_id=req_id,
+            aissh_server_id=settings.aissh_server_id,
+            project_id=proj,
+            project_alias=proj,   # BKD REST 接 id 也接 alias，二者等价
+            issue_id=issue_id,
+        )
         await bkd.follow_up_issue(project_id=proj, issue_id=issue_id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue_id, status_id="working")
 

--- a/orchestrator/src/orchestrator/actions/start_analyze.py
+++ b/orchestrator/src/orchestrator/actions/start_analyze.py
@@ -49,7 +49,7 @@ async def start_analyze(*, body, req_id, tags, ctx):
             title=f"[{req_id}] [ANALYZE]{short_title(ctx)}",
             tags=["analyze", req_id],
         )
-        prompt = render("analyze.md.j2", req_id=req_id)
+        prompt = render("analyze.md.j2", req_id=req_id, aissh_server_id=settings.aissh_server_id)
         await bkd.follow_up_issue(project_id=proj, issue_id=issue_id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue_id, status_id="working")
 

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -114,6 +114,12 @@ class Settings(BaseSettings):
     # analyze fan out 的 sub-issue model 由 analyze prompt 自己控（见 analyze.md.j2）。
     agent_model: str | None = None
 
+    # ─── aissh-tao MCP server id (vm-node04) ─────────────────────────────
+    # BKD agent 跑在 Coder workspace 没装 kubectl，所有 vm-node04 上的 kubectl 命令
+    # 必须经 aissh-tao MCP 跨 SSH 跑。prompt 模板里需要这个 server_id 告诉 agent。
+    # vm-node04 默认 id 见 runner_container.md.j2 的 fallback。helm values 可覆盖。
+    aissh_server_id: str = "5b25f0cd-4fef-4a1f-a4c0-14ecf1395d84"
+
     # ─── M14b/M14c：verifier-agent 框架 ─────────────────────────────────
     # 每个 stage transition（成功 or 失败）先起一个 verifier-agent 做主观判断
     # （pass / fix / retry_checker / escalate），再由 webhook 路由推进状态机。

--- a/orchestrator/src/orchestrator/prompts/_shared/runner_container.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/runner_container.md.j2
@@ -9,25 +9,28 @@ dev 启动前把 Pod 拉起好，你**不用**建 Pod，直接 `kubectl exec` �
 - PVC 生命周期：同 Pod；中途 Pod 重启（OOM / node 迁移）PVC 不动
 - 工具链：Go 1.23 + docker DinD + helm + kubectl + gh + openspec + /opt/sisyphus/scripts/
 
-### 所有命令都包成 kubectl exec
+### 所有 kubectl 命令必须通过 mcp__aissh-tao__exec_run（**关键**）
+
+⚠️ **你 (BKD agent) 跑在 Coder workspace，没装 kubectl，没 KUBECONFIG**。直接 `Bash kubectl ...` = `command not found`。
+
+vm-node04 上的所有 `kubectl` 命令**必须**经 aissh-tao MCP 跨过 SSH 跑：
+
+```
+mcp__aissh-tao__exec_run(
+  server_id="{{ aissh_server_id or '5b25f0cd-4fef-4a1f-a4c0-14ecf1395d84' }}",   # vm-node04
+  command="kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c 'YOUR_COMMAND'"
+)
+```
+
+把 `YOUR_COMMAND` 想成"你在 runner pod 里要跑的 shell"，包成 `kubectl exec runner -- bash -c '...'`，再交给 aissh-tao。
+
+下面所有出现 `kubectl -n $NS exec $POD ...` 的例子都是这个意思 —— **不要用 Bash 工具裸跑 kubectl**。
 
 ```bash
+# 假名变量（仅 reference，不要 Bash 跑）
 POD=runner-{{ req_id | lower }}
 NS=sisyphus-runners
-
-# 替代 "cd $WORKDIR && cmd"
-kubectl -n $NS exec $POD -- bash -c "cmd"
-
-# 传环境变量
-kubectl -n $NS exec $POD -- env FOO=bar bash -c "cmd"
 ```
-
-{% if aissh_server_id %}
-sisyphus 通过 aissh-tao MCP 给你运行 kubectl（vm-node04 上）：
-```
-mcp__aissh-tao__exec_run(server_id="{{ aissh_server_id }}", command="kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c '...'")
-```
-{% endif %}
 
 ### workspace 约定结构（**sisyphus 强约定**）
 

--- a/orchestrator/src/orchestrator/prompts/_shared/self_issue_constraint.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/self_issue_constraint.md.j2
@@ -1,13 +1,15 @@
 ## 只改本 issue (HARD CONSTRAINT — 第二优先级)
 
 prompt 里可能带上游参考变量 (REQ / BRANCH / SRC_ISSUE / ACCEPT_ISSUE / PARENT_ISSUE 等)。
-**它们只用来读**，任何 mcp__bkd__update-issue / mcp__bkd__follow-up-issue 的 issueId
+**它们只用来读**，任何 PATCH（update-issue）/ POST follow-up 的 issueId
 **必须是你自己 session 所在的 issue**，不是上面任何参考变量。
 
 ### tags 覆盖语义
-BKD update-issue 会**替换**整个 tags 数组。每次 update 前必须：
-1. `mcp__bkd__get-issue` 取当前 tags；
-2. merge：保留所有非本阶段管理的 tag + 追加本阶段要写入的 tag；
-3. 再 update-issue。
+
+BKD `PATCH /issues/{id}` 的 tags 字段会**整数组替换**。每次 PATCH 前必须：
+
+1. `curl GET /api/projects/{alias}/issues/{id}` 取当前 tags
+2. merge：保留所有非本阶段管理的 tag + 追加本阶段要写入的 tag
+3. 再 `curl PATCH ... -d '{"tags":[...]}'`
 
 不要只传新 tag 导致原 REQ-xxx / 阶段 tag 被抹掉。

--- a/orchestrator/src/orchestrator/prompts/_shared/tools_whitelist.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/tools_whitelist.md.j2
@@ -1,9 +1,57 @@
 ## 工具白名单 (HARD CONSTRAINT — 第一优先级)
-**仅允许**调用以下 MCP 工具：
-- mcp__bkd__* (管 BKD issue 状态/tags/follow-up/get-issue)
-- mcp__aissh-tao__* (在 vm-node04 exec_run 命令、file_deploy)
+
+**仅允许**调用以下工具：
+
+- `mcp__aissh-tao__*` —— vm-node04 上 exec_run 命令、file_deploy 文件
+- `Bash` —— 跑 curl 调 BKD REST API（见下方）、跑本地 git/gh CLI 命令、跑本地 openspec 等
+- `Read` / `Write` / `Edit` / `Glob` / `Grep` —— agent 自己 cwd 的文件操作
 
 **绝对禁止**调用：
-- mcp__vibe_kanban__* / mcp__erpnext__* / Task / Agent / 其他未列出 MCP
+- `mcp__bkd__*` —— **BKD ≥0.0.65 没 MCP 端点**，全走 REST。调了必失败。
+- `mcp__vibe_kanban__*` / `mcp__erpnext__*` / `Task` / `Agent` / 其他未列出 MCP
 
 违反即视为任务失败。BKD session 日志会记录工具调用，审计会拦截越权调用。
+
+### 你的 BKD 上下文（已知，直接用）
+
+- **PROJECT** = `{{ project_alias or 'workflowtest' }}` （也可用 projectId `{{ project_id or 'illwkr1k' }}` 替代，二者等价）
+- **MY_ISSUE_ID** = `{{ issue_id or '<from-cwd>' }}`
+  - 如果上面是 `<from-cwd>`，从你 cwd 取：cwd 是 `/workspace/worktrees/<projectId>/<issueId>/`，basename 即 issueId
+
+> **REQ id ≠ BKD issue id**。
+> - REQ id（workflow 标识，比如 `REQ-final5-1776...`）= BKD issue 的一个 tag
+> - BKD issue id（数据库行 id，比如 `7m6atxpr`）= REST endpoint `/issues/{id}` 的 id
+> - PATCH / follow-up 接 `MY_ISSUE_ID`（BKD 行 id），不是 REQ id
+
+### BKD REST API 速查（用 Bash + curl）
+
+BKD 在 agent 所在 host 的 `localhost:3000`。**不用 token**（localhost 绕过 Coder 网关）。
+
+```bash
+PROJECT={{ project_alias or 'workflowtest' }}
+MY={{ issue_id or '$(basename $PWD)' }}    # 你自己 issue 的 BKD 行 id
+
+# 取 issue（看 tags / status / prompt）
+curl -sS http://localhost:3000/api/projects/$PROJECT/issues/$MY
+
+# 列 issues
+curl -sS "http://localhost:3000/api/projects/$PROJECT/issues?limit=50"
+
+# 创 sub-issue（fan out 用）
+curl -sS -X POST http://localhost:3000/api/projects/$PROJECT/issues \
+  -H 'content-type: application/json' \
+  -d '{"title":"...", "tags":[...], "statusId":"todo", "useWorktree":true, "engineType":"claude-code"}'
+
+# follow-up（追加 prompt 给 sub-agent，target_id 不是 $MY 而是 sub-issue 的 id）
+curl -sS -X POST http://localhost:3000/api/projects/$PROJECT/issues/<sub_issue_id>/follow-up \
+  -H 'content-type: application/json' -d '{"prompt":"..."}'
+
+# update 自己 issue（改 tags / status / title）—— **tags 是替换不是追加**
+curl -sS -X PATCH http://localhost:3000/api/projects/$PROJECT/issues/$MY \
+  -H 'content-type: application/json' \
+  -d '{"tags":["a","b","c"], "statusId":"review"}'
+
+# cancel session（force=true 才真停）
+curl -sS -X POST http://localhost:3000/api/projects/$PROJECT/issues/<id>/cancel \
+  -H 'content-type: application/json' -d '{"force":true}'
+```

--- a/orchestrator/src/orchestrator/prompts/analyze.md.j2
+++ b/orchestrator/src/orchestrator/prompts/analyze.md.j2
@@ -112,7 +112,8 @@ git push origin master
 
 - ✋ 不拆：单仓 + 总改动 < 100 LOC + 无明显并行边界 → solo 自己写完
 - ✂️ 拆：多仓 / 多 capability / 测试可并行写 / 串行总耗时 > 20 min →
-  自己用 `mcp__bkd__create-issue`（或 BKD REST `POST /api/projects/{alias}/issues`）开 sub-issue
+  自己用 BKD REST `POST /api/projects/{alias}/issues` 开 sub-issue
+  （BKD 0.0.65 没 MCP 端点，必须 Bash + curl，详见 tools_whitelist.md.j2）
 
 #### 拆出去时的约定（轻）
 
@@ -120,7 +121,7 @@ git push origin master
 - 加 tag `parent:{{ req_id }}` 方便人追
 - **sisyphus 不会 track 这些 sub-issue**（router 没匹配 tag）—— 它们对 sisyphus 是黑盒
 - BKD 会在 sub-issue session 完成时给你 follow-up（如果有依赖关系），你也可以主动
-  `mcp__bkd__get-issue` 轮询；BKD 自己处理 sub-issue 等回的机制
+  `curl GET /api/projects/{alias}/issues/{id}` 轮询；BKD 自己处理 sub-issue 等回的机制
 
 ### B.3 实际写产物
 


### PR DESCRIPTION
## Why

E2E REQ-final4-1776953521 BKD session log shows haiku agent literally tried:

```
[tool-use] kubectl -n $NS exec $POD -- /opt/sisyphus/scripts/sisyphus-clone-repos.sh phona/ubox-crosser
[output] /bin/bash: line 12: kubectl: command not found
[thinking] 'Hmm, kubectl is not in my current environment. ... let me work directly in the current working directory.'
```

Agent **跑在 Coder workspace 没装 kubectl**。所以裸 `kubectl ...` 必失败，只能 fallback 写自己 cwd → runner pod 永远空。

## Root cause

`runner_container.md.j2:25` 'use aissh-tao MCP for kubectl' 段被 `{% if aissh_server_id %}` 包着，但 `start_analyze.py:52` 渲染没传 `aissh_server_id` → 条件永 false → agent 看不到这段 → 当本地命令跑。

## Fix

1. `config.py`: 加 `aissh_server_id` 默认 vm-node04
2. `start_analyze.py`: render 传 aissh_server_id
3. `runner_container.md.j2`: 拆掉 conditional + fallback hardcode + 明确警示+指令

## Verification
- pytest 255/255 pass
- 渲染输出确认'aissh-tao MCP 段落'始终出现

## Refs
- e2e bug REQ-final4-1776953521