### PR TITLE
feat(M18): challenger stage — 黑盒契约测试 + dev/test 对抗式 TDD

### DIFF
--- a/orchestrator/src/orchestrator/actions/__init__.py
+++ b/orchestrator/src/orchestrator/actions/__init__.py
@@ -68,5 +68,6 @@ from . import (  # noqa: E402,F401
     done_archive,
     escalate,
     start_analyze,
+    start_challenger,
     teardown_accept_env,
 )

--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -39,7 +39,7 @@ log = structlog.get_logger(__name__)
 
 # 支持的 stage 名（对应 prompts/verifier/{stage}_{trigger}.md.j2）
 # 包括 agent stage（analyze）和 checker stage（spec_lint / dev_cross_check / staging_test / pr_ci）
-_STAGES = {"analyze", "spec_lint", "dev_cross_check", "staging_test", "pr_ci", "accept"}
+_STAGES = {"analyze", "spec_lint", "challenger", "dev_cross_check", "staging_test", "pr_ci", "accept"}
 
 # Trigger 类型
 Trigger = Literal["success", "fail"]
@@ -50,6 +50,7 @@ Trigger = Literal["success", "fail"]
 _PASS_ROUTING: dict[str, tuple[ReqState, Event]] = {
     "analyze":           (ReqState.ANALYZING,                Event.ANALYZE_DONE),
     "spec_lint":         (ReqState.SPEC_LINT_RUNNING,        Event.SPEC_LINT_PASS),
+    "challenger":        (ReqState.CHALLENGER_RUNNING,       Event.CHALLENGER_PASS),
     "dev_cross_check":   (ReqState.DEV_CROSS_CHECK_RUNNING,  Event.DEV_CROSS_CHECK_PASS),
     "staging_test":      (ReqState.STAGING_TEST_RUNNING,     Event.STAGING_TEST_PASS),
     "pr_ci":             (ReqState.PR_CI_RUNNING,            Event.PR_CI_PASS),
@@ -60,6 +61,7 @@ _PASS_ROUTING: dict[str, tuple[ReqState, Event]] = {
 _RETRY_TARGET_STATE: dict[str, ReqState] = {
     "analyze":          ReqState.ANALYZING,
     "spec_lint":        ReqState.SPEC_LINT_RUNNING,
+    "challenger":       ReqState.CHALLENGER_RUNNING,
     "dev_cross_check":  ReqState.DEV_CROSS_CHECK_RUNNING,
     "staging_test":     ReqState.STAGING_TEST_RUNNING,
     "pr_ci":            ReqState.PR_CI_RUNNING,
@@ -345,4 +347,16 @@ async def invoke_verifier_for_dev_cross_check_fail(*, body, req_id, tags, ctx):
     """DEV_CROSS_CHECK_FAIL → 起 verifier-agent(stage=dev_cross_check, trigger=fail)。"""
     return await _invoke_verifier_fail(
         stage="dev_cross_check", body=body, req_id=req_id, ctx=ctx,
+    )
+
+
+@register("invoke_verifier_for_challenger_fail", idempotent=False)
+async def invoke_verifier_for_challenger_fail(*, body, req_id, tags, ctx):
+    """CHALLENGER_FAIL (M18) → 起 verifier-agent(stage=challenger, trigger=fail)。
+
+    challenger 拒写 contract test 通常意味着 spec 自相矛盾 / 缺关键定义 —— verifier
+    判要不要回头让 spec_fixer 修 spec 还是 escalate 给 user。
+    """
+    return await _invoke_verifier_fail(
+        stage="challenger", body=body, req_id=req_id, ctx=ctx,
     )

--- a/orchestrator/src/orchestrator/actions/start_challenger.py
+++ b/orchestrator/src/orchestrator/actions/start_challenger.py
@@ -1,0 +1,65 @@
+"""start_challenger (M18)：spec lint pass → 起 challenger-agent 写 contract test。
+
+理念：
+- challenger 是黑盒挑战者：**只**读 openspec/changes/<REQ>/specs/*/contract.spec.yaml + spec.md，
+  **不**看 cmd/ internal/ handlers/ 等业务代码（white-box 是 dev 的活）。
+- 输出：tests/contract/*_contract_test.go（或对应语言的 contract test）—— 黑盒断言契约。
+- challenger 写完 push 同一 feat/<REQ> 分支，set tag result:pass。
+- 后续 staging_test 跑 dev 的 unit + challenger 的 contract，任一红 → fixer 修
+  （fix 域路径白名单：dev_fixer 不能改 tests/contract/，spec_fixer 不能改 cmd/）。
+
+跟 dev 的对抗约束：
+- challenger 不见 dev 代码（path scope 排除 cmd/internal/handlers/migrations/...）
+- dev 不能改 challenger 写的 tests/contract/ —— 不能"偷偷改测试让它绿"
+- 真冲突时 verifier 4-路判：code bug / contract test bug / spec 模糊 / spec 漏写
+
+行为：
+1. update-issue 自己 sub-issue（spec lint 上游）—— 不复用 intent issue（让 challenger 干净）
+   实际：sisyphus 创新 BKD issue，prompt 里说明 REQ context
+2. follow-up-issue 发 challenger prompt
+3. update-issue statusId=working 触发
+"""
+from __future__ import annotations
+
+import structlog
+
+from ..bkd import BKDClient
+from ..config import settings
+from ..prompts import render
+from ..state import Event
+from . import register, short_title
+from ._skip import skip_if_enabled
+
+log = structlog.get_logger(__name__)
+
+
+@register("start_challenger", idempotent=False)
+async def start_challenger(*, body, req_id, tags, ctx):
+    if rv := skip_if_enabled("challenger", Event.CHALLENGER_PASS, req_id=req_id):
+        return rv
+
+    proj = body.projectId
+    source_issue_id = body.issueId   # spec_lint 没 BKD agent issue，用上游 intent issue
+
+    async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+        issue = await bkd.create_issue(
+            project_id=proj,
+            title=f"[{req_id}] [CHALLENGER]{short_title(ctx)}",
+            tags=["challenger", req_id, f"parent-id:{source_issue_id}"],
+            status_id="todo",
+            use_worktree=True,   # 黑盒，不污染主 worktree
+            model=settings.agent_model,
+        )
+        prompt = render(
+            "challenger.md.j2",
+            req_id=req_id,
+            aissh_server_id=settings.aissh_server_id,
+            project_id=proj,
+            project_alias=proj,
+            issue_id=issue.id,
+        )
+        await bkd.follow_up_issue(project_id=proj, issue_id=issue.id, prompt=prompt)
+        await bkd.update_issue(project_id=proj, issue_id=issue.id, status_id="working")
+
+    log.info("start_challenger.done", req_id=req_id, issue_id=issue.id)
+    return {"challenger_issue_id": issue.id, "req_id": req_id}

--- a/orchestrator/src/orchestrator/prompts/analyze.md.j2
+++ b/orchestrator/src/orchestrator/prompts/analyze.md.j2
@@ -29,6 +29,10 @@ session 结束 + move review 时，每个被改的 source repo 的 `feat/{{ req_
   - `specs/<capability>/contract.spec.yaml`（API 契约 / schema 等）
   - `specs/<capability>/spec.md` —— **必须用 openspec delta 格式**，示例：
 
+  > **M18 注意**：你**不写** `tests/contract/` —— 那是 challenger-agent 的活（spec_lint
+  > 通过后 sisyphus 起 challenger 黑盒读 spec 自己写 contract test）。你只写 spec
+  > + 业务代码 + **unit test**（同包白盒测试）。tests/contract/ 留给 challenger。
+
     ```markdown
     ## ADDED Requirements
 

--- a/orchestrator/src/orchestrator/prompts/challenger.md.j2
+++ b/orchestrator/src/orchestrator/prompts/challenger.md.j2
@@ -1,0 +1,161 @@
+{% include "_shared/tools_whitelist.md.j2" %}
+
+─────────
+
+{% include "_shared/self_issue_constraint.md.j2" %}
+
+─────────
+
+{% include "_shared/runner_container.md.j2" %}
+
+─────────
+
+## 挑战者 (CHALLENGER, M18)
+AGENT_ROLE=challenger-agent
+REQ={{ req_id }}
+
+你是 sisyphus 的 **黑盒挑战者**。任务：根据 spec 写 contract test，**不**看 dev 代码。
+
+> 这是对抗式 TDD 的关键一环：你定下契约边界，dev 必须满足。dev 不能改你写的 test
+> 让它绿（违反就是 dev 偷懒）。如果你的 test 真错了 → 升级 spec_fixer 重写，不允许
+> 改 dev 代码绕过契约。
+
+---
+
+## Part A: 设置 + 读 spec
+
+### A.1 进 runner pod 准备工作树（用 mcp__aissh-tao）
+
+按 runner_container.md.j2 段。所有 kubectl 包成 `mcp__aissh-tao__exec_run` 跨 SSH。
+
+### A.2 找 spec home repo（spec 在哪个仓）
+
+读 BKD intent issue 的 description 取 "spec home repo"（一般跟 BKD project 同 repo）。
+```bash
+# 在 runner pod
+kubectl exec runner-{{ req_id | lower }} -- ls /workspace/source/<spec_home_repo>/openspec/changes/{{ req_id }}/specs/
+```
+
+### A.3 读 spec —— **只**读 spec，**不**读业务代码
+
+允许读：
+- `openspec/changes/{{ req_id }}/proposal.md`
+- `openspec/changes/{{ req_id }}/design.md`（如有）
+- `openspec/changes/{{ req_id }}/specs/<capability>/contract.spec.yaml`
+- `openspec/changes/{{ req_id }}/specs/<capability>/spec.md`（scenarios）
+- 仓里**已有的** `tests/contract/` 现存模式（学约定）
+- 仓里 `Makefile` 看 ci-test 入口
+- 仓里 `tests/docker-compose.yml` 看 stack 入口
+
+**禁止读**：
+- `cmd/` `internal/` `handlers/` `pkg/` `migrations/` 等业务代码目录
+- `*_test.go`（dev 写的 unit test，避免你抄它思路）
+
+如果不小心打开了，立即关闭，不要把内容用进 contract test 设计。
+
+---
+
+## Part B: 写 contract test
+
+### B.1 测试位置 + 命名
+
+写在 spec home repo 的 `tests/contract/<capability>_contract_test.go`（或对应语言）。
+一个 capability 一个文件。
+
+### B.2 内容原则
+
+- **黑盒断言**：起服务（docker-compose / docker run），HTTP/gRPC/CLI 等真实接口调用，
+  断言响应符合 spec
+- **覆盖 spec.md 里的所有 `#### Scenario:`** —— 每条 scenario 至少 1 个 test func
+- **不假设实现细节** —— 不要测内部类型、私有函数、数据库 schema（除非 spec 明确要求）
+- **要 RED 不要 GREEN** —— 你写完 test 后跑一次，**预期失败**（dev 还没实现），
+  这是 TDD 的 RED 阶段。如果你写完意外 GREEN，说明已有实现满足或测试太弱。
+
+### B.3 示例（Go HTTP service）
+
+`tests/contract/buildinfo_contract_test.go`：
+```go
+//go:build contract
+// +build contract
+
+package contract
+
+import (
+    "encoding/json"
+    "net/http"
+    "testing"
+)
+
+// Scenario: UBOX-S1 Returns 200 OK
+func TestBuildinfo_S1_Returns200(t *testing.T) {
+    r, err := http.Get(serviceURL() + "/buildinfo")
+    if err != nil { t.Fatal(err) }
+    if r.StatusCode != 200 { t.Errorf("want 200, got %d", r.StatusCode) }
+}
+
+// Scenario: UBOX-S2 Response is valid JSON + has 3 fields
+func TestBuildinfo_S2_JSONShape(t *testing.T) {
+    r, _ := http.Get(serviceURL() + "/buildinfo")
+    var d map[string]any
+    if err := json.NewDecoder(r.Body).Decode(&d); err != nil { t.Fatal(err) }
+    for _, k := range []string{"git_sha","build_id","go_version"} {
+        if _, ok := d[k]; !ok { t.Errorf("missing field %s", k) }
+    }
+}
+
+// ... S3 ~ Sn
+```
+
+### B.4 push commit
+
+在你自己 cwd（不是 runner pod，runner 只读）：
+```bash
+gh repo clone phona/<spec_home_repo> ./repo
+cd ./repo
+git checkout feat/{{ req_id }}     # checkout 到 dev 已用的 feat 分支
+# 写 tests/contract/*.go
+git add tests/contract/
+git commit -m "test(contract): add contract tests for {{ req_id }} per spec"
+git push
+```
+
+### B.5 验证 RED 状态（可选但建议）
+
+在 runner pod 跑你的 test 一次，确认它能编译 + 现在确实失败（dev 没实现）：
+```bash
+kubectl exec runner-{{ req_id | lower }} -- bash -c "
+  cd /workspace/source/<spec_home_repo> && \
+  git fetch origin feat/{{ req_id }} && git checkout feat/{{ req_id }} && \
+  go test -tags=contract ./tests/contract/... 2>&1 | tail -20
+"
+```
+
+预期：编译通过 + 所有 test fail（because no impl）。
+
+---
+
+## Part C: 失败路径 —— spec 自相矛盾
+
+如果你读 spec 后发现：
+- spec 自相矛盾（S1 说返 200 但 S5 说返 401）
+- spec 漏了关键定义（"返 JSON" 但没说 schema）
+- 不可能 black-box 测（要内部 hook）
+
+**不要硬写 test**。直接：
+1. update-issue tags 加 `result:fail`
+2. 自己 issue description（用 follow-up）写明：哪段 spec 有问题 + 你判断
+3. move review
+
+sisyphus 会起 verifier 判（多半 escalate spec_fixer 重写 spec）。
+
+---
+
+## 完成时
+
+- contract test 文件已 push 到 feat/{{ req_id }} 分支
+- update-issue tags **加** `result:pass`（保留原有 `challenger`、REQ-id）
+- statusId='review'
+- （如失败）tags 加 `result:fail` + 在 chat 写明原因
+
+sisyphus 看到 result:pass → 推进 dev_cross_check stage（dev 的代码 + 你的 contract test
+一起跑 staging_test 验证）。

--- a/orchestrator/src/orchestrator/prompts/verifier/challenger_fail.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/challenger_fail.md.j2
@@ -1,0 +1,37 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（challenger / fail）
+
+sisyphus M18：challenger-agent 设了 `result:fail`。它的任务是**根据 spec 写黑盒 contract test**
+（`tests/contract/`），不看业务代码。设 `result:fail` 通常意味着 spec 本身有问题。
+
+你要判：是 **spec 模糊/矛盾/漏定义**（spec_fixer 修），还是 challenger 自己**理解错了 spec**
+（retry_checker 重起 challenger），还是**根本没法黑盒测**（escalate 给 user）。
+
+{% if stderr_tail %}
+### 失败栈尾 / agent 留言
+```
+{{ stderr_tail }}
+```
+{% endif %}
+
+### 关注点
+- challenger 在 BKD chat 写"spec 自相矛盾" → `fix` + `fixer=spec` + `target_repo=<spec home repo>` + scope 指 spec.md / contract.spec.yaml 的具体段落
+- challenger 写"spec 漏关键字段"（比如说"返 JSON" 但没说 schema）→ `fix` + `fixer=spec`
+- challenger 写"无法黑盒测"（要内部 hook / 时序敏感 / 需要 mock 不可能）→ `escalate`
+  说明这条 spec 不可被外部观察验证，需要 user 改需求或加可观测点
+- challenger 看错了 spec，把 hint 当强约束 → `retry_checker`，重起 challenger 让它再读
+- 极少数 sisyphus / 工具链问题（runner pod 起不来 / contract 目录权限）→ `retry_checker`
+
+### NOT 该做
+- 不亲自写 contract test（那是 challenger 的职责）
+- 不动 dev 业务代码 / unit test
+- 不直接改 spec（你只判 fixer 谁来改）
+
+### 多仓识别
+
+如果 spec 跨仓（producer 在 repo-A，consumer 在 repo-B），挑**包含矛盾段落的仓**填 `target_repo`。
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/prompts/verifier/challenger_success.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/challenger_success.md.j2
@@ -1,0 +1,32 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（challenger / success）
+
+sisyphus M18：challenger-agent 设 `result:pass`，已 push contract test 到 feat/{{ req_id }}。
+
+你要判：contract test 是否**忠实反映 spec**，还是**水或越界**。pass 后 sisyphus 会推 dev_cross_check
+（dev 写代码满足这些 contract）。如果 contract test 本身错了，dev 会无辜挨炸。
+
+### 关注点（黑盒 + scope）
+- 每个 spec 里的 `#### Scenario:` 是否有对应 test func（看 commit diff）
+- test 是不是真的 black-box：通过公开 HTTP/CLI/RPC 调用，**不**导入业务包，**不**测内部 struct
+- test 不应该假设实现细节（比如断言"用了 Goroutine"、"用了 Postgres" —— 除非 spec 明确）
+- 命名 / build tag 是否符合仓约定（一般 `//go:build contract`）
+
+### 关注点（覆盖度）
+- spec 写了 N 条 scenarios，contract test 是不是有 N 个 test func
+- 漏了任意一条 → `fix` + `fixer=spec`（让 challenger 补上，scope 指漏了的 scenario id）
+- 测试逻辑跟 scenario 描述对得上吗（GIVEN/WHEN/THEN 跟 test 步骤同步）
+
+### 关注点（不应做的）
+- challenger 改了业务代码 / unit test（违反路径白名单）→ `fix` + `fixer=spec` + scope 指被违规改的文件
+- challenger 跳过 push（feat 分支没新 commit）→ `retry_checker`
+
+### 通常路径
+- contract test 完整 + 黑盒 + 覆盖每条 scenario → `pass`，dev_cross_check 接手
+- 漏 / 错 / 越界 → `fix` + `fixer=spec`
+- 完全跑偏（比如只写了一个空文件）→ `escalate` 或 `retry_checker`
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/router.py
+++ b/orchestrator/src/orchestrator/router.py
@@ -150,6 +150,14 @@ def derive_event(event_type: str, tags: Iterable[str], result_tags_only: bool = 
     if "fixer" in tagset:
         return Event.FIXER_DONE
 
+    # M18：challenger-agent 写完 contract test → result:pass / result:fail
+    if "challenger" in tagset:
+        if "result:pass" in tagset:
+            return Event.CHALLENGER_PASS
+        if "result:fail" in tagset:
+            return Event.CHALLENGER_FAIL
+        return None
+
     # v0.2：staging-test agent 在调试环境跑 unit+int，结果带 result:pass/fail
     if "staging-test" in tagset:
         if "result:pass" in tagset:

--- a/orchestrator/src/orchestrator/state.py
+++ b/orchestrator/src/orchestrator/state.py
@@ -26,6 +26,7 @@ class ReqState(StrEnum):
     INIT = "init"                               # 还没 analyze / 待初始化
     ANALYZING = "analyzing"                     # analyze-agent 在跑
     SPEC_LINT_RUNNING = "spec-lint-running"     # openspec validate 检查（sisyphus 下发 runner 任务）
+    CHALLENGER_RUNNING = "challenger-running"   # M18：challenger-agent 读 spec 写 contract test（黑盒，不看 dev 代码）
     DEV_CROSS_CHECK_RUNNING = "dev-cross-check-running"  # 开发交叉验证（sisyphus 下发 runner 任务）
     STAGING_TEST_RUNNING = "staging-test-running"  # 调试环境 build + unit + int test
     PR_CI_RUNNING = "pr-ci-running"             # PR 已开，等 GHA 全套绿
@@ -45,6 +46,8 @@ class Event(StrEnum):
     ANALYZE_DONE = "analyze.done"                   # analyze-agent 完成
     SPEC_LINT_PASS = "spec-lint.pass"               # openspec validate 通过
     SPEC_LINT_FAIL = "spec-lint.fail"               # openspec validate 失败 → verifier
+    CHALLENGER_PASS = "challenger.pass"             # M18：challenger 写完 contract test 推 feat 分支
+    CHALLENGER_FAIL = "challenger.fail"             # M18：challenger 写失败 / 拒绝（spec 自相矛盾等）→ verifier
     DEV_CROSS_CHECK_PASS = "dev-cross-check.pass"   # 开发交叉验证通过
     DEV_CROSS_CHECK_FAIL = "dev-cross-check.fail"   # 开发交叉验证失败 → verifier
     STAGING_TEST_PASS = "staging-test.pass"         # 调试环境测试全绿
@@ -86,12 +89,20 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
         Transition(ReqState.SPEC_LINT_RUNNING, "create_spec_lint", "下发 openspec validate 任务"),
 
     (ReqState.SPEC_LINT_RUNNING, Event.SPEC_LINT_PASS):
-        Transition(ReqState.DEV_CROSS_CHECK_RUNNING, "create_dev_cross_check",
-                   "spec lint 通过 → 开发交叉验证"),
+        Transition(ReqState.CHALLENGER_RUNNING, "start_challenger",
+                   "spec lint 通过 → 起 challenger 写 contract test (M18)"),
 
     (ReqState.SPEC_LINT_RUNNING, Event.SPEC_LINT_FAIL):
         Transition(ReqState.REVIEW_RUNNING, "invoke_verifier_for_spec_lint_fail",
                    "spec lint 失败 → verifier"),
+
+    (ReqState.CHALLENGER_RUNNING, Event.CHALLENGER_PASS):
+        Transition(ReqState.DEV_CROSS_CHECK_RUNNING, "create_dev_cross_check",
+                   "challenger 写完 contract test → 开发交叉验证"),
+
+    (ReqState.CHALLENGER_RUNNING, Event.CHALLENGER_FAIL):
+        Transition(ReqState.REVIEW_RUNNING, "invoke_verifier_for_challenger_fail",
+                   "challenger 失败（spec 自相矛盾 / 写不出 test 等）→ verifier 判"),
 
     (ReqState.DEV_CROSS_CHECK_RUNNING, Event.DEV_CROSS_CHECK_PASS):
         Transition(ReqState.STAGING_TEST_RUNNING, "create_staging_test",
@@ -168,7 +179,8 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
     **{
         (st, Event.SESSION_FAILED): Transition(ReqState.ESCALATED, "escalate", "agent session crashed")
         for st in [
-            ReqState.ANALYZING, ReqState.SPEC_LINT_RUNNING, ReqState.DEV_CROSS_CHECK_RUNNING,
+            ReqState.ANALYZING, ReqState.SPEC_LINT_RUNNING, ReqState.CHALLENGER_RUNNING,
+            ReqState.DEV_CROSS_CHECK_RUNNING,
             ReqState.STAGING_TEST_RUNNING, ReqState.PR_CI_RUNNING,
             ReqState.ACCEPT_RUNNING, ReqState.ACCEPT_TEARING_DOWN,
             ReqState.REVIEW_RUNNING, ReqState.FIXER_RUNNING,

--- a/orchestrator/tests/test_engine.py
+++ b/orchestrator/tests/test_engine.py
@@ -97,14 +97,14 @@ def stub_actions(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_chain_emit_spec_lint_pass(stub_actions):
-    """spec-lint.pass 事件直接触发 create_dev_cross_check 链式推进。"""
+    """spec-lint.pass 触发 start_challenger（M18：spec_lint → challenger → dev_cross_check）。"""
     calls, reg = stub_actions
 
-    async def create_dev_cross_check(*, body, req_id, tags, ctx):
-        calls.append(("create_dev_cross_check", {"req_id": req_id}))
-        return {"passed": True}
+    async def start_challenger(*, body, req_id, tags, ctx):
+        calls.append(("start_challenger", {"req_id": req_id}))
+        return {"challenger_issue_id": "ch-1"}
 
-    reg["create_dev_cross_check"] = create_dev_cross_check
+    reg["start_challenger"] = start_challenger
 
     pool = FakePool({"REQ-1": FakeReq(state=ReqState.SPEC_LINT_RUNNING.value)})
 
@@ -115,7 +115,32 @@ async def test_chain_emit_spec_lint_pass(stub_actions):
         ctx={}, event=Event.SPEC_LINT_PASS,
     )
 
-    # create_dev_cross_check 被调用（spec-lint.pass → dev-cross-check 转移）
+    # start_challenger 被调用（M18 spec-lint.pass → CHALLENGER_RUNNING）
+    assert [n for n, _ in calls] == ["start_challenger"]
+    assert pool.rows["REQ-1"].state == ReqState.CHALLENGER_RUNNING.value
+    assert result["action"] == "start_challenger"
+
+
+@pytest.mark.asyncio
+async def test_chain_emit_challenger_pass(stub_actions):
+    """challenger.pass → create_dev_cross_check（M18：challenger 写完 contract 后接 dev_cross_check）。"""
+    calls, reg = stub_actions
+
+    async def create_dev_cross_check(*, body, req_id, tags, ctx):
+        calls.append(("create_dev_cross_check", {"req_id": req_id}))
+        return {"passed": True}
+
+    reg["create_dev_cross_check"] = create_dev_cross_check
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.CHALLENGER_RUNNING.value)})
+    body = type("B", (), {"issueId": "ch-1", "projectId": "p", "event": "session.completed"})()
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["challenger", "REQ-1", "result:pass"],
+        cur_state=ReqState.CHALLENGER_RUNNING,
+        ctx={}, event=Event.CHALLENGER_PASS,
+    )
+
     assert [n for n, _ in calls] == ["create_dev_cross_check"]
     assert pool.rows["REQ-1"].state == ReqState.DEV_CROSS_CHECK_RUNNING.value
     assert result["action"] == "create_dev_cross_check"
@@ -322,13 +347,13 @@ async def test_recursion_depth_guard(stub_actions, monkeypatch):
         return {"emit": Event.SPEC_LINT_PASS.value}
 
     reg["create_spec_lint"] = loopy
-    reg["create_dev_cross_check"] = loopy
-    # 让 DEV_CROSS_CHECK_RUNNING + SPEC_LINT_PASS 也能走 create_dev_cross_check（模拟死循环）
+    reg["start_challenger"] = loopy
+    # 让 CHALLENGER_RUNNING + SPEC_LINT_PASS 也能走 start_challenger（模拟死循环）
     from orchestrator import state as state_mod
     monkeypatch.setitem(
         state_mod.TRANSITIONS,
-        (ReqState.DEV_CROSS_CHECK_RUNNING, Event.SPEC_LINT_PASS),
-        state_mod.Transition(ReqState.DEV_CROSS_CHECK_RUNNING, "create_dev_cross_check"),
+        (ReqState.CHALLENGER_RUNNING, Event.SPEC_LINT_PASS),
+        state_mod.Transition(ReqState.CHALLENGER_RUNNING, "start_challenger"),
     )
 
     pool = FakePool({"REQ-1": FakeReq(state=ReqState.SPEC_LINT_RUNNING.value)})

--- a/orchestrator/tests/test_state.py
+++ b/orchestrator/tests/test_state.py
@@ -10,8 +10,11 @@ EXPECTED = [
     # state, event, next_state, action
     (ReqState.INIT,                 Event.INTENT_ANALYZE,      ReqState.ANALYZING,           "start_analyze"),
     (ReqState.ANALYZING,            Event.ANALYZE_DONE,        ReqState.SPEC_LINT_RUNNING,   "create_spec_lint"),
-    (ReqState.SPEC_LINT_RUNNING,    Event.SPEC_LINT_PASS,      ReqState.DEV_CROSS_CHECK_RUNNING, "create_dev_cross_check"),
+    (ReqState.SPEC_LINT_RUNNING,    Event.SPEC_LINT_PASS,      ReqState.CHALLENGER_RUNNING,  "start_challenger"),
     (ReqState.SPEC_LINT_RUNNING,    Event.SPEC_LINT_FAIL,      ReqState.REVIEW_RUNNING,      "invoke_verifier_for_spec_lint_fail"),
+    # M18: challenger between spec_lint and dev_cross_check
+    (ReqState.CHALLENGER_RUNNING,   Event.CHALLENGER_PASS,     ReqState.DEV_CROSS_CHECK_RUNNING, "create_dev_cross_check"),
+    (ReqState.CHALLENGER_RUNNING,   Event.CHALLENGER_FAIL,     ReqState.REVIEW_RUNNING,      "invoke_verifier_for_challenger_fail"),
     (ReqState.DEV_CROSS_CHECK_RUNNING, Event.DEV_CROSS_CHECK_PASS, ReqState.STAGING_TEST_RUNNING, "create_staging_test"),
     (ReqState.DEV_CROSS_CHECK_RUNNING, Event.DEV_CROSS_CHECK_FAIL, ReqState.REVIEW_RUNNING, "invoke_verifier_for_dev_cross_check_fail"),
     (ReqState.STAGING_TEST_RUNNING, Event.STAGING_TEST_PASS,   ReqState.PR_CI_RUNNING,       "create_pr_ci_watch"),
@@ -86,8 +89,13 @@ def test_new_checker_events_and_states():
     assert "spec-lint-running" in states
     assert "dev-cross-check-running" in states
 
-    # SPEC_LINT_PASS 推进到 dev-cross-check
+    # M18: SPEC_LINT_PASS 推进到 challenger（再 challenger.pass → dev-cross-check）
     t = decide(ReqState.SPEC_LINT_RUNNING, Event.SPEC_LINT_PASS)
+    assert t is not None
+    assert t.next_state == ReqState.CHALLENGER_RUNNING
+    assert t.action == "start_challenger"
+
+    t = decide(ReqState.CHALLENGER_RUNNING, Event.CHALLENGER_PASS)
     assert t is not None
     assert t.next_state == ReqState.DEV_CROSS_CHECK_RUNNING
     assert t.action == "create_dev_cross_check"


### PR DESCRIPTION
## Why

恢复 ef1a8b8 那条 \"dev⇄测试 battle\" 设计的精神，落到当前 M15+M17 状态机里。

dev 写代码 + 白盒 unit test，challenger 黑盒读 spec 写 contract test —— **互为对抗**：
- challenger 不看代码，凭 spec 定契约
- dev 不能改 challenger 写的测试让它绿
- 真冲突时 verifier 4-路判 code/contract-test/spec 模糊/spec 漏

## What

最小改动落地一个新 stage（150 行 python + 3 个 prompt）：

\`\`\`
INIT → ANALYZING → SPEC_LINT_RUNNING → CHALLENGER_RUNNING (新)
                                     ↓                   ↓
                               (fail) verifier      (pass) DEV_CROSS_CHECK_RUNNING → ...
\`\`\`

详见 commit 描述。

## Verification

- pytest: 258/258 pass（test_engine + test_state 加了 challenger transitions）
- jinja: challenger.md.j2 + 2 个 verifier 模板都能渲染

## Out of scope

- fixer 路径白名单（dev/spec 各自能改的目录边界）
- staging_test 跑 contract test 的 -tags=contract 编译指令（业务 repo Makefile 配合）

下一轮 e2e 跑通后真测验对抗效果。