### PR TITLE
fix(M18): challenger 写到 tests/integration/ 对齐业务仓惯例

### DIFF
--- a/orchestrator/src/orchestrator/prompts/analyze.md.j2
+++ b/orchestrator/src/orchestrator/prompts/analyze.md.j2
@@ -29,9 +29,9 @@ session 结束 + move review 时，每个被改的 source repo 的 `feat/{{ req_
   - `specs/<capability>/contract.spec.yaml`（API 契约 / schema 等）
   - `specs/<capability>/spec.md` —— **必须用 openspec delta 格式**，示例：
 
-  > **M18 注意**：你**不写** `tests/contract/` —— 那是 challenger-agent 的活（spec_lint
+  > **M18 注意**：你**不写** `tests/integration/` —— 那是 challenger-agent 的活（spec_lint
   > 通过后 sisyphus 起 challenger 黑盒读 spec 自己写 contract test）。你只写 spec
-  > + 业务代码 + **unit test**（同包白盒测试）。tests/contract/ 留给 challenger。
+  > + 业务代码 + **unit test**（同包白盒测试）。tests/integration/ 留给 challenger。
 
     ```markdown
     ## ADDED Requirements
@@ -51,7 +51,9 @@ session 结束 + move review 时，每个被改的 source repo 的 `feat/{{ req_
     不能只写 `### [UBOX-S1]` 这种形式 —— check-scenario-refs.sh 的 `HEADING_PATTERN: ^##+ Scenario:`
     匹配不上 = 0 scenarios 定义 + 引用全失败）
 - ✅ 实际业务代码（cmd/、internal/、handlers、migrations 等）
-- ✅ unit test + integration test（`make ci-test` 在本仓 docker stack 通过）
+- ✅ unit test —— **如果业务仓有 `.claude/skills/unit-test/SKILL.md`，先读它跟模板，按仓约定写**；
+  没有则按 Go test 默认（`*_test.go` 同包）。**integration test 不是你的活**（M18 challenger 写）。
+- `make ci-test` 在本仓 docker stack 通过
 - ✅ feat 分支已 push 到 GitHub
 - ✅ PR 已开（标题、body 写清楚动机 + 测试方案）
 

--- a/orchestrator/src/orchestrator/prompts/challenger.md.j2
+++ b/orchestrator/src/orchestrator/prompts/challenger.md.j2
@@ -43,7 +43,7 @@ kubectl exec runner-{{ req_id | lower }} -- ls /workspace/source/<spec_home_repo
 - `openspec/changes/{{ req_id }}/design.md`（如有）
 - `openspec/changes/{{ req_id }}/specs/<capability>/contract.spec.yaml`
 - `openspec/changes/{{ req_id }}/specs/<capability>/spec.md`（scenarios）
-- 仓里**已有的** `tests/contract/` 现存模式（学约定）
+- 仓里**已有的** `tests/integration/` 现存模式（学约定）
 - 仓里 `Makefile` 看 ci-test 入口
 - 仓里 `tests/docker-compose.yml` 看 stack 入口
 
@@ -57,10 +57,33 @@ kubectl exec runner-{{ req_id | lower }} -- ls /workspace/source/<spec_home_repo
 
 ## Part B: 写 contract test
 
+### B.0 必读：业务仓的 integration-test skill（**先读再写**）
+
+业务仓如果有 `.claude/skills/integration-test/SKILL.md`，**必须先读它**：
+```bash
+ls /workspace/source/<repo>/.claude/skills/integration-test/ 2>/dev/null
+# 有的话:
+cat /workspace/source/<repo>/.claude/skills/integration-test/SKILL.md
+cat /workspace/source/<repo>/.claude/skills/integration-test/rules.md
+ls /workspace/source/<repo>/.claude/skills/integration-test/templates/   # 用模板
+```
+
+skill 写明这个仓的：
+- 测试组织方式（per-scenario file / per-capability file / 等）
+- docker-compose 入口 + service 拓扑
+- env 注入约定（`BASE_URL` / `BUILD_ID` 等）
+- build tag 约定（`//go:build integration`）
+- 命名 + assertion 风格
+
+**不读 skill 自己发明 = 偏离仓约定 = staging_test 必跑不通**。如果模板存在直接用模板，
+skill 已规定好一切，你只填 scenario 逻辑。
+
+如果**没有** skill（业务仓还没接入），按下面 B.1 默认约定写。
+
 ### B.1 测试位置 + 命名
 
-写在 spec home repo 的 `tests/contract/<capability>_contract_test.go`（或对应语言）。
-一个 capability 一个文件。
+写在 spec home repo 的 `tests/integration/<capability>_test.go`（一个 capability 一个文件）。
+**优先按仓 skill 的命名规则**；skill 没说时按上面默认。
 
 ### B.2 内容原则
 
@@ -73,7 +96,7 @@ kubectl exec runner-{{ req_id | lower }} -- ls /workspace/source/<spec_home_repo
 
 ### B.3 示例（Go HTTP service）
 
-`tests/contract/buildinfo_contract_test.go`：
+`tests/integration/buildinfo_contract_test.go`：
 ```go
 //go:build contract
 // +build contract
@@ -113,8 +136,8 @@ func TestBuildinfo_S2_JSONShape(t *testing.T) {
 gh repo clone phona/<spec_home_repo> ./repo
 cd ./repo
 git checkout feat/{{ req_id }}     # checkout 到 dev 已用的 feat 分支
-# 写 tests/contract/*.go
-git add tests/contract/
+# 写 tests/integration/*.go
+git add tests/integration/
 git commit -m "test(contract): add contract tests for {{ req_id }} per spec"
 git push
 ```
@@ -126,7 +149,7 @@ git push
 kubectl exec runner-{{ req_id | lower }} -- bash -c "
   cd /workspace/source/<spec_home_repo> && \
   git fetch origin feat/{{ req_id }} && git checkout feat/{{ req_id }} && \
-  go test -tags=contract ./tests/contract/... 2>&1 | tail -20
+  go test -tags=contract ./tests/integration/... 2>&1 | tail -20
 "
 ```
 

--- a/orchestrator/src/orchestrator/prompts/verifier/challenger_fail.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/challenger_fail.md.j2
@@ -3,7 +3,7 @@
 ## 职责（challenger / fail）
 
 sisyphus M18：challenger-agent 设了 `result:fail`。它的任务是**根据 spec 写黑盒 contract test**
-（`tests/contract/`），不看业务代码。设 `result:fail` 通常意味着 spec 本身有问题。
+（`tests/integration/`），不看业务代码。设 `result:fail` 通常意味着 spec 本身有问题。
 
 你要判：是 **spec 模糊/矛盾/漏定义**（spec_fixer 修），还是 challenger 自己**理解错了 spec**
 （retry_checker 重起 challenger），还是**根本没法黑盒测**（escalate 给 user）。


### PR DESCRIPTION
PR #37 merge 后小修：tests/contract/ → tests/integration/ 跟 ubox-crosser 现有 tests/integration/tunnel_test.go + make ci-integration-test 对齐。