### PR TITLE
fix: webhook dedup + verifier stage race (REQ-final7 实证 2 bug)

### DIFF
--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -149,12 +149,23 @@ async def invoke_verifier(
 
 # ─── action handlers ────────────────────────────────────────────────────
 
+def _stage_from_tags_or_ctx(tags: list[str] | None, ctx: dict | None) -> str | None:
+    """从触发本次 transition 的 issue tags 取 stage（verify:<stage>），fallback ctx。
+
+    多 verifier 并发时 ctx.verifier_stage 会被后来者覆盖，issue tag 是无歧义真相。
+    """
+    for t in (tags or []):
+        if t.startswith("verify:"):
+            return t.removeprefix("verify:")
+    return (ctx or {}).get("verifier_stage")
+
+
 @register("apply_verify_pass", idempotent=True)
 async def apply_verify_pass(*, body, req_id, tags, ctx):
-    """decision=pass：读 ctx.verifier_stage，手工 CAS REVIEW_RUNNING → stage_running，
-    链式 emit 该 stage 的 done/pass 事件（走原主链 transition，推进到下一 stage）。
+    """decision=pass：读 verifier issue 的 verify:<stage> tag，手工 CAS REVIEW_RUNNING
+    → stage_running，链式 emit 该 stage 的 done/pass 事件（走原主链 transition）。
     """
-    stage = (ctx or {}).get("verifier_stage")
+    stage = _stage_from_tags_or_ctx(tags, ctx)
     route = _PASS_ROUTING.get(stage) if stage else None
     if route is None:
         log.error("apply_verify_pass.unknown_stage", req_id=req_id, stage=stage)
@@ -184,7 +195,7 @@ async def apply_verify_retry_checker(*, body, req_id, tags, ctx):
     自己处理"当前在 stage_running 再触发一次 checker" 的语义（或通过 ctx flag）。
     本期先只把 state 回滚并落 ctx 标记，等真正接入时再完善。
     """
-    stage = (ctx or {}).get("verifier_stage")
+    stage = _stage_from_tags_or_ctx(tags, ctx)
     target = _RETRY_TARGET_STATE.get(stage) if stage else None
     if target is None:
         log.error("apply_verify_retry_checker.unknown_stage",
@@ -217,10 +228,20 @@ async def start_fixer(*, body, req_id, tags, ctx):
 
     ctx 里应有 verifier 之前写的 fixer / scope（webhook 解 decision 时存）。
     本期的 prompt 先用通用 bugfix 模板兜底，PR4 / 独立 PR 再做专用 fixer prompt。
+
+    stage 优先从当前 verifier issue 的 tags 取（`verify:<stage>`）—— 多 verifier 并发
+    时 ctx.verifier_stage 可能被后来者覆盖，从触发本次 transition 的 issue tag 直读
+    更稳。
     """
     proj = body.projectId
     ctx = ctx or {}
-    stage = ctx.get("verifier_stage")
+    stage = None
+    for t in (tags or []):
+        if t.startswith("verify:"):
+            stage = t.removeprefix("verify:")
+            break
+    if not stage:
+        stage = ctx.get("verifier_stage")
     fixer = ctx.get("verifier_fixer") or "dev"
     scope = ctx.get("verifier_scope") or ""
     reason = ctx.get("verifier_reason") or ""
@@ -270,9 +291,20 @@ async def start_fixer(*, body, req_id, tags, ctx):
 
 @register("invoke_verifier_after_fix", idempotent=False)
 async def invoke_verifier_after_fix(*, body, req_id, tags, ctx):
-    """fixer 完 → 再跑 verifier 一次（同 stage，trigger=success：fixer 已改过代码）。"""
+    """fixer 完 → 再跑 verifier 一次（同 stage，trigger=success：fixer 已改过代码）。
+
+    stage 必须从**当前 fixer issue 的 tags** 取（`parent-stage:<stage>`），不能依赖
+    ctx.verifier_stage —— 多 verifier 并发时 ctx 是最新一个的 stage，老 fixer 完成时
+    ctx 已被覆盖，会拿错 stage。fixer issue 自带 parent-stage tag 是无歧义的真相。
+    """
     ctx = ctx or {}
-    stage = ctx.get("verifier_stage") or "dev"
+    stage = None
+    for t in (tags or []):
+        if t.startswith("parent-stage:"):
+            stage = t.removeprefix("parent-stage:")
+            break
+    if not stage:
+        stage = ctx.get("verifier_stage") or "dev_cross_check"
     history = [
         *(ctx.get("verifier_history") or []),
         {

--- a/orchestrator/src/orchestrator/webhook.py
+++ b/orchestrator/src/orchestrator/webhook.py
@@ -99,10 +99,20 @@ async def webhook(request: Request) -> JSONResponse:
     pool = db.get_pool()
 
     # ─── 1. Dedup ───────────────────────────────────────────────────────────
-    eid_parts = [body.timestamp or "", body.issueId, body.event]
-    if body.executionId:
-        eid_parts.append(body.executionId)
-    eid = "|".join(eid_parts)
+    # 不要带 timestamp —— BKD 重发时 timestamp 通常变（实测 REQ-final7 同 issue 的
+    # session.completed 间隔 10min 重发了一次，timestamp 不同绕过原 dedup → 触发
+    # 已 superseded 的 verifier decision，把已推进的 REQ 反向 escalate）。
+    # 用 (issueId, event_type, executionId) 作 key —— 同一 BKD execution 只能处理一次
+    # session.completed / session.failed；issue.updated 没 executionId 用 timestamp 兜底
+    # （issue.updated 不会触发 verifier 决策，timestamp 重发危害有限）
+    if body.event in ("session.completed", "session.failed") and body.executionId:
+        eid = f"{body.issueId}|{body.event}|{body.executionId}"
+    else:
+        # issue.updated 等：用 timestamp + issueId + event 兜底
+        eid_parts = [body.timestamp or "", body.issueId, body.event]
+        if body.executionId:
+            eid_parts.append(body.executionId)
+        eid = "|".join(eid_parts)
     if not await dedup.check_and_record(pool, eid):
         log.debug("webhook.dedup.skip", event_id=eid)
         await obs.record_event("dedup.hit", issue_id=body.issueId, extras={"event_id": eid})


### PR DESCRIPTION
REQ-final7 跑通到 staging_test 后 escalate，trace 出 2 bug：(1) BKD 重发 webhook 时 timestamp 不同绕过 dedup → 反向 escalate (2) ctx.verifier_stage 被并发 verifier 覆盖。详见 commit。