### PR TITLE
fix(checkers): replace 'exit $fail' to preserve orch's exit-marker

### DIFF
--- a/orchestrator/src/orchestrator/checkers/dev_cross_check.py
+++ b/orchestrator/src/orchestrator/checkers/dev_cross_check.py
@@ -41,7 +41,7 @@ def _build_cmd(req_id: str) -> str:
         "    fi; "
         "  fi; "
         "done; "
-        "exit $fail"
+        "[ $fail -eq 0 ]"
     )
 
 

--- a/orchestrator/src/orchestrator/checkers/spec_lint.py
+++ b/orchestrator/src/orchestrator/checkers/spec_lint.py
@@ -55,7 +55,7 @@ def _build_cmd(req_id: str) -> str:
         f'    echo "[skip] $name: no openspec/changes/{req_id}/"; '
         "  fi; "
         "done; "
-        "exit $fail"
+        "[ $fail -eq 0 ]"
     )
 
 

--- a/orchestrator/src/orchestrator/checkers/staging_test.py
+++ b/orchestrator/src/orchestrator/checkers/staging_test.py
@@ -61,7 +61,7 @@ def _build_cmd(req_id: str) -> str:
         '    tail -10 "/tmp/staging-test-logs/$name.log"; '
         "  fi; "
         "done; "
-        "exit $fail"
+        "[ $fail -eq 0 ]"
     )
 
 

--- a/orchestrator/tests/test_checkers_staging_test.py
+++ b/orchestrator/tests/test_checkers_staging_test.py
@@ -30,7 +30,7 @@ def _assert_for_each_repo_cmd(cmd: str) -> None:
     assert "ci-test:" in cmd  # grep Makefile target 过滤
     assert " & " in cmd  # 后台并行
     assert "wait $pid" in cmd
-    assert "exit $fail" in cmd
+    assert "[ $fail -eq 0 ]" in cmd  # 不能用 `exit $fail`：orch 包装的 exit-marker echo 不再跑
 
 
 # ── pass：验 cmd 是 for-each-repo 并行版 ─────────────────────────────────────


### PR DESCRIPTION
REQ-final9 实证 checker 实际跑过但 orch 当 fail。'exit' 杀了 marker echo。详 commit。