### PR TITLE
fix(runner-go): install golangci-lint (REQ-final13 dev_cross_check loop fix)

### DIFF
--- a/runner/go.Dockerfile
+++ b/runner/go.Dockerfile
@@ -41,6 +41,13 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 # REQ-997 analyze 报 "openspec: command not found"）
 RUN npm install -g @fission-ai/openspec@latest && openspec --version
 
+# ─── 2b. golangci-lint（业务仓 Makefile ci-lint target 依赖） ──────────
+# REQ-final13 实证：ubox-crosser dev-cross-check → ci-lint 调 golangci-lint，没装
+# 时 fixer 死循环试图修 Makefile 也修不好。Go runner image 装上避免 env-bug 转 fix-dev。
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
+    | sh -s -- -b /usr/local/bin v1.62.2 \
+    && golangci-lint --version
+
 # ─── 3. sisyphus 合约脚本 ──────────────────
 COPY scripts/check-scenario-refs.sh \
      scripts/check-tasks-section-ownership.sh \


### PR DESCRIPTION
REQ-final13 实证 dev_cross_check 死循环 fixer:dev 因为 golangci-lint 没装。装上。