### PR TITLE
feat(escalated): resumable via verifier follow-up + title dedup

### DIFF
--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -96,6 +96,11 @@ stateDiagram-v2
     review_running --> fixer_running: verify.fix-needed
     review_running --> escalated: verify.escalate\n(含 flaky / 基础设施抖动)
 
+    %% escalated 不是死终态：用户 follow-up 那个 escalate 的 verifier issue → 走原 verifier 同链
+    escalated --> escalated: verify.pass\n(apply_verify_pass 内部 CAS 推下一 stage)
+    escalated --> fixer_running: verify.fix-needed
+    escalated --> escalated: verify.escalate\n(verifier 又判 escalate, 留原地)
+
     fixer_running --> review_running: fixer.done\n(invoke_verifier_after_fix)
 
     state "session.failed (any in-flight)" as anyfail
@@ -111,6 +116,12 @@ stateDiagram-v2
 
 3 路决策：**pass / fix / escalate**（retry_checker 已砍 —— 基础设施 flaky 由 verifier 判
 escalate 给人，sisyphus 不机制性兜 retry，避免假阳性 retry 死循环）。
+
+**ESCALATED 可恢复**：用户在 BKD UI follow-up 那条 escalate 的 verifier issue（webhook
+统一推 statusId="review" 让"待审查"列只剩它）→ BKD wake agent → 写新 decision → 走原
+verifier session.completed 同一套 webhook 链路，直接命中 `(ESCALATED, VERIFY_*)` transition。
+零新概念 / 零新 tag / 零新 endpoint。**注意**只可 follow-up verifier issue 续；analyze
+issue 续会重起整个 analyze 等于新 REQ，文档不推荐。
 
 `VERIFY_PASS` 在 transition 表里看起来是 self-loop（next_state 还是 `review-running`），
 但 **action 内部手工 CAS 推到目标 stage_running 再链式 emit 该 stage 的 done/pass 事件**。

--- a/orchestrator/src/orchestrator/actions/__init__.py
+++ b/orchestrator/src/orchestrator/actions/__init__.py
@@ -29,11 +29,21 @@ ACTION_META: dict[str, ActionMeta] = {}
 def short_title(ctx: dict | None, max_len: int = 50) -> str:
     """从 ctx.intent_title 取需求标题做成短后缀（` — <title>`）方便 BKD 看板辨识。
 
+    剥掉前缀的 `[...]` 括号（如 `[REQ-x]`、`[ANALYZE]`、`[E2E FOO]`）—— 上层
+    title 模板已经在外面再加 `[REQ-x] [STAGE]` 前缀，不剥的话 BKD UI 显示双倍
+    `[REQ-x] [VERIFY pr_ci] fail — [REQ-x] [E2E FOO] /buildinfo` 长得读不下去。
+
     没设 / 太长截断。返空字符串则上层不该 append。
     """
     if not ctx:
         return ""
     t = (ctx.get("intent_title") or "").strip()
+    # 反复剥前缀的 `[...]`（每次去掉一对括号 + 后续空格）
+    while t.startswith("["):
+        end = t.find("]")
+        if end == -1:
+            break
+        t = t[end + 1:].lstrip()
     if not t:
         return ""
     if len(t) > max_len:

--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -28,6 +28,7 @@ from typing import Literal
 
 import structlog
 
+from .. import k8s_runner
 from ..bkd import BKDClient
 from ..config import settings
 from ..prompts import render
@@ -163,18 +164,35 @@ async def apply_verify_pass(*, body, req_id, tags, ctx):
 
     target_state, next_event = route
     pool = db.get_pool()
-    advanced = await req_state.cas_transition(
-        pool, req_id, ReqState.REVIEW_RUNNING, target_state,
-        Event.VERIFY_PASS, "apply_verify_pass",
-    )
-    if not advanced:
-        # 状态已被并发事件改动 → 让上层 skip，不重复 emit
+    # CAS 接 REVIEW_RUNNING（正常 verifier 完成）+ ESCALATED（人续 escalate 的 verifier）
+    src_state = None
+    for src in (ReqState.REVIEW_RUNNING, ReqState.ESCALATED):
+        if await req_state.cas_transition(
+            pool, req_id, src, target_state,
+            Event.VERIFY_PASS, "apply_verify_pass",
+        ):
+            src_state = src
+            break
+    if src_state is None:
         log.warning("apply_verify_pass.cas_failed", req_id=req_id, stage=stage)
         return {"cas_failed": True}
 
+    # 推下一 stage 前 ensure_runner（idempotent，pod 在则秒返）。
+    # 关键场景：从 ESCALATED 续 → escalate 时 runner pod 被删了；fixer 跑完续也可能没 pod。
+    # PVC 因 #40 retain，workspace 状态不丢。
+    try:
+        rc = k8s_runner.get_controller()
+    except RuntimeError:
+        log.warning("apply_verify_pass.no_runner_controller", req_id=req_id)
+    else:
+        pod = await rc.ensure_runner(req_id, wait_ready=True)
+        log.info("apply_verify_pass.runner_ready",
+                 req_id=req_id, stage=stage, pod=pod, src_state=src_state.value)
+
     log.info("apply_verify_pass.done",
              req_id=req_id, stage=stage,
-             target_state=target_state.value, emit=next_event.value)
+             src_state=src_state.value, target_state=target_state.value,
+             emit=next_event.value)
     return {"emit": next_event.value, "stage": stage}
 
 

--- a/orchestrator/src/orchestrator/engine.py
+++ b/orchestrator/src/orchestrator/engine.py
@@ -176,8 +176,12 @@ async def step(
         cur_state=cur_state, next_state=transition.next_state, event=event,
     )
 
-    # M10：转 terminal state 时立即清 runner（fire-and-forget）
-    if transition.next_state in _TERMINAL_STATES:
+    # M10：转 terminal state 时立即清 runner（fire-and-forget）。
+    # 但跳过 terminal self-loop（cur 已是 terminal）—— 出现在 ESCALATED 接 verifier 续 follow-up
+    # 的场景：engine 表面 self-loop，apply_verify_pass 内部把 state CAS 推到下游 stage_running
+    # 并 ensure_runner；这时再清 pod 会误删 resume 路径刚拉起的 pod。
+    if (transition.next_state in _TERMINAL_STATES
+            and cur_state not in _TERMINAL_STATES):
         task = asyncio.create_task(
             _cleanup_runner_on_terminal(req_id, transition.next_state)
         )

--- a/orchestrator/src/orchestrator/state.py
+++ b/orchestrator/src/orchestrator/state.py
@@ -172,6 +172,22 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
     (ReqState.ARCHIVING, Event.ARCHIVE_DONE):
         Transition(ReqState.DONE, None, "REQ complete"),
 
+    # ─── 人工恢复（escalate ≠ 死终态）─────────────────────────────────────
+    # 用户在 BKD UI follow-up 那个 escalate 的 verifier issue → BKD wake agent →
+    # 写新 decision JSON → session.completed 走原来 verifier 同一套链路 → 命中下面 3 条。
+    # 复用 apply_verify_pass / start_fixer，它们的 CAS source 同时接 REVIEW_RUNNING + ESCALATED。
+    # 配套：webhook.py 把 verifier-decision=escalate 的 issue PATCH 到 BKD statusId="review"
+    # （而非 done），用户在 BKD 看板"待审查"列就能定位到该 follow-up 哪条。
+    (ReqState.ESCALATED, Event.VERIFY_PASS):
+        Transition(ReqState.ESCALATED, "apply_verify_pass",
+                   "用户续 escalate 的 verifier issue → 新 decision=pass → action 推下一 stage"),
+    (ReqState.ESCALATED, Event.VERIFY_FIX_NEEDED):
+        Transition(ReqState.FIXER_RUNNING, "start_fixer",
+                   "用户续 escalate 的 verifier issue → 新 decision=fix → 起 fixer"),
+    (ReqState.ESCALATED, Event.VERIFY_ESCALATE):
+        Transition(ReqState.ESCALATED, None,
+                   "用户续了但 verifier 还是判 escalate → 留原地等下一次 follow-up"),
+
     # ─── 通用错误 ───────────────────────────────────────────────────────
     # session crash 在任何 running state 都直接 escalate
     **{

--- a/orchestrator/src/orchestrator/webhook.py
+++ b/orchestrator/src/orchestrator/webhook.py
@@ -19,7 +19,7 @@ from . import observability as obs
 from . import router as router_lib
 from .bkd import BKDClient
 from .config import settings
-from .state import ReqState
+from .state import Event, ReqState
 from .store import db, dedup, req_state, verifier_decisions
 
 log = structlog.get_logger(__name__)
@@ -60,19 +60,24 @@ class WebhookBody(BaseModel):
     changes: dict[str, Any] | None = None  # issue.updated 携带
 
 
-async def _push_upstream_done(project_id: str, issue_id: str) -> None:
-    """把刚收到 session.completed 的 BKD issue 状态推到 done。
+async def _push_upstream_status(project_id: str, issue_id: str, status_id: str) -> None:
+    """把刚收到 session.completed 的 BKD issue 状态推到目标 statusId。
 
-    幂等（重推 done 是 no-op）。失败只记 warning，不阻塞状态机。
+    statusId 取值：
+    - "done" —— 默认收尾，issue 进 BKD 看板"完成"列
+    - "review" —— verifier 判 escalate 时用，issue 进"待审查"列让用户能定位 follow-up
+      （resume 路径：用户在该 issue chat 续聊 → BKD wake agent → 新 decision → 主链继续）
+
+    幂等。失败只记 warning，不阻塞状态机。
     """
     try:
         async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
             await bkd.update_issue(
-                project_id=project_id, issue_id=issue_id, status_id="done",
+                project_id=project_id, issue_id=issue_id, status_id=status_id,
             )
     except Exception as e:
-        log.warning("webhook.upstream_done_failed",
-                    issue_id=issue_id, error=str(e))
+        log.warning("webhook.upstream_status_failed",
+                    issue_id=issue_id, status_id=status_id, error=str(e))
 
 
 @api.get("/bkd-events")
@@ -178,13 +183,19 @@ async def webhook(request: Request) -> JSONResponse:
         log.debug("webhook.no_event_mapping", tags=tags, event_type=body.event)
         return {"action": "skip", "reason": "no event mapping"}
 
-    # ─── 3.5 把上游 BKD issue 推 done（webhook 已识别为有效完工信号）──────
-    # 不修的话 dev/ci-unit/ci-int/accept/done-archive 等 issue 永远卡 review，
-    # BKD UI 一片乱，agent_quality.review_count 也失真。
-    # fanout_specs / mark_spec_reviewed_and_check 也会推自己负责的 issue done，
-    # 重推幂等不冲突。session.failed 不推（保留人工排查）。
+    # ─── 3.5 把上游 BKD issue 推目标 statusId（webhook 已识别为有效完工信号）──────
+    # 默认 "done"。**verifier 判 escalate 例外** → "review"，让 BKD 看板"待审查"列只剩
+    # 用户可 follow-up 续作业的 issue（resume 路径）。其他 (analyze/challenger/fixer/checker
+    # 完成) 全推 done，UI 干净。session.failed 不推（保留人工排查）。
     if body.event == "session.completed":
-        await _push_upstream_done(body.projectId, body.issueId)
+        is_verifier_escalate = (
+            "verifier" in (tags or [])
+            and event == Event.VERIFY_ESCALATE
+        )
+        await _push_upstream_status(
+            body.projectId, body.issueId,
+            "review" if is_verifier_escalate else "done",
+        )
 
     # ─── 4. resolve req_id ─────────────────────────────────────────────────
     req_id = router_lib.extract_req_id(tags, body.issueNumber)

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -122,6 +122,23 @@ def test_short_title_helper():
     assert len(out) < 30
 
 
+def test_short_title_strips_leading_brackets():
+    """[REQ-x] [E2E FOO] /buildinfo → /buildinfo（剥前缀避免 verifier title 双倍 [REQ-x]）"""
+    from orchestrator.actions import short_title
+    # 单层
+    assert short_title({"intent_title": "[REQ-x] hello"}) == " — hello"
+    # 双层 (REQ + E2E label)
+    assert short_title(
+        {"intent_title": "[REQ-final15-1776989948] [E2E FINAL15] /buildinfo (post-#45)"}
+    ) == " — /buildinfo (post-#45)"
+    # 不闭合的 [ —— 无法解析，原样保留（不破坏数据）
+    assert short_title({"intent_title": "[unclosed bracket"}) == " — [unclosed bracket"
+    # 全是括号无内容
+    assert short_title({"intent_title": "[A] [B] [C]"}) == ""
+    # 嵌套不剥（只剥前缀）
+    assert short_title({"intent_title": "code [in middle]"}) == " — code [in middle]"
+
+
 # ─── escalate ────────────────────────────────────────────────────────────
 @pytest.mark.asyncio
 async def test_escalate(monkeypatch):

--- a/orchestrator/tests/test_state.py
+++ b/orchestrator/tests/test_state.py
@@ -106,11 +106,24 @@ def test_new_checker_events_and_states():
     assert t.action == "create_staging_test"
 
 
-def test_terminal_states_have_no_outgoing():
-    """DONE / ESCALATED 不应再被任何 event 推动。"""
-    for st in (ReqState.DONE, ReqState.ESCALATED):
-        for ev in Event:
-            assert decide(st, ev) is None, f"terminal {st.value} should not move on {ev.value}"
+def test_done_terminal_has_no_outgoing():
+    """DONE 是死终态。"""
+    for ev in Event:
+        assert decide(ReqState.DONE, ev) is None, f"DONE should not move on {ev.value}"
+
+
+def test_escalated_resumable_via_verifier_followup():
+    """ESCALATED 不是死终态：用户续 verifier issue → BKD 新 decision → 走原 verifier 同链。
+
+    其他 event（非 verifier 类）仍然没出口 —— escalated 只通过"人续 verifier issue"复活。
+    """
+    resumable = {Event.VERIFY_PASS, Event.VERIFY_FIX_NEEDED, Event.VERIFY_ESCALATE}
+    for ev in Event:
+        t = decide(ReqState.ESCALATED, ev)
+        if ev in resumable:
+            assert t is not None, f"{ev.value} should be resumable from ESCALATED"
+        else:
+            assert t is None, f"{ev.value} should NOT move ESCALATED (non-resume path)"
 
 
 def test_m5_dropped_test_fix_reviewer_states():

--- a/orchestrator/tests/test_verifier.py
+++ b/orchestrator/tests/test_verifier.py
@@ -368,6 +368,32 @@ async def test_apply_verify_pass_cas_fail_returns_skip(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_apply_verify_pass_resumes_from_escalated(monkeypatch):
+    """resume 路径：用户 follow-up escalate 的 verifier issue → 新 decision=pass →
+    apply_verify_pass 第一次 CAS REVIEW_RUNNING 失败（state 是 ESCALATED），
+    第二次 CAS ESCALATED → STAGE_RUNNING 成功 + chain emit 上游 pass event。"""
+    from orchestrator.actions import _verifier as v
+
+    cas_calls: list = []
+
+    async def fake_cas(pool, req_id, expected, nxt, event, action, context_patch=None):
+        cas_calls.append(expected.value)
+        # 模拟"REQ 当前在 ESCALATED"——CAS REVIEW_RUNNING 失败，CAS ESCALATED 成功
+        return expected.value == "escalated"
+
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.cas_transition", fake_cas)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+
+    out = await v.apply_verify_pass(
+        body=make_body(), req_id="REQ-9", tags=[],
+        ctx={"verifier_stage": "pr_ci"},
+    )
+    assert cas_calls == ["review-running", "escalated"]
+    assert out["emit"] == Event.PR_CI_PASS.value
+    assert out["stage"] == "pr_ci"
+
+
+@pytest.mark.asyncio
 async def test_start_fixer_creates_issue_with_fixer_tags(monkeypatch):
     from orchestrator.actions import _verifier as v
     fake = make_fake_bkd()

--- a/orchestrator/tests/test_webhook_upstream_done.py
+++ b/orchestrator/tests/test_webhook_upstream_done.py
@@ -1,6 +1,7 @@
-"""webhook 收到 session.completed 时把上游 BKD issue 自动推到 done。
+"""webhook 收到 session.completed 时把上游 BKD issue 推目标 statusId。
 
-防 dev / ci-unit / ci-int / accept / done-archive issue 永远卡 review 状态。
+默认 done（防 dev / ci-unit / ci-int / accept / done-archive issue 永远卡 review）。
+verifier 判 escalate 例外 → review（resume 路径：用户可在 BKD 看板"待审查"列定位 follow-up）。
 """
 from __future__ import annotations
 
@@ -38,9 +39,21 @@ async def test_pushes_done_for_session_completed(monkeypatch):
     _FakeBKD.raise_on_update = False
     monkeypatch.setattr(webhook, "BKDClient", _FakeBKD)
 
-    await webhook._push_upstream_done("proj-1", "issue-abc")
+    await webhook._push_upstream_status("proj-1", "issue-abc", "done")
 
     assert _FakeBKD.captured == [("proj-1", "issue-abc", "done")]
+
+
+@pytest.mark.asyncio
+async def test_pushes_review_for_verifier_escalate(monkeypatch):
+    """verifier-decision=escalate → 推 review 让用户在"待审查"列 follow-up 续作业。"""
+    _FakeBKD.captured = []
+    _FakeBKD.raise_on_update = False
+    monkeypatch.setattr(webhook, "BKDClient", _FakeBKD)
+
+    await webhook._push_upstream_status("proj-1", "verifier-issue", "review")
+
+    assert _FakeBKD.captured == [("proj-1", "verifier-issue", "review")]
 
 
 @pytest.mark.asyncio
@@ -51,4 +64,4 @@ async def test_swallows_bkd_errors(monkeypatch):
     monkeypatch.setattr(webhook, "BKDClient", _FakeBKD)
 
     # 不抛 = 通过
-    await webhook._push_upstream_done("proj-1", "issue-abc")
+    await webhook._push_upstream_status("proj-1", "issue-abc", "done")


### PR DESCRIPTION
## Summary

- **escalated 不再是死终态**：用户 follow-up 那条 escalate 的 verifier issue → 走原 webhook 链路 → 主链继续
- **BKD UI 区分**：verifier-escalate 推 statusId="review"（待审查列），其他推 "done"
- **title dedup**：`short_title` 剥前缀 `[...]`，verifier title 不再出现双倍 `[REQ-x]`

## Why

REQ-final15 实证：pr_ci 撞 SonarQube 503 → verifier 判 escalate（PR #47 验证过的清晰 reason）。
但 SonarQube 修好后没法续，整条 REQ 报废。这次补"resume"路径：

> 用户：作为用户，我肯定是接着失败的 issue 继续作业呀

零新概念实现：

- 用 BKD 已有"continue chat"机制（follow-up）= 让 verifier 重新决策
- 用 BKD 已有 statusId（review/done）= 区分"待人续"vs"完工"
- 用 sisyphus 已有 verifier session.completed 链路 = 收到新 decision 自动推

唯一 sisyphus 改动：3 条新 transition + 一处 CAS 接双源 + ensure_runner。

## 用户操作

```
1. 看 BKD 看板，"待审查"列只剩 escalate 的 verifier issue
2. 修 infra（SonarQube / GHA / 网络）
3. 在该 issue 输入框打：「fixed, re-check」
4. agent 自动重跑 → 写新 decision JSON
5. orch 接到 → 主链继续 / fixer / 留原地（看 decision 是 pass/fix/escalate）
```

## 不动的

- watchdog-stuck / session.failed crash 的 escalate（没 verifier issue 可续）→ 维持现状，
  文档写明这种情况"重新创 REQ"。MVP 不覆盖。
- 不加 retry-count / 不加新 tag / 不加新 endpoint
- BKD 那侧零改

## Test plan

- [x] 260 个 pytest 通过
- [x] ruff 通过
- [ ] REQ-final15 实证：在 BKD UI follow-up issue #139 → verifier 重判 → orch 接力
- [ ] 验证 BKD 看板上 verifier issue 的 statusId="review"

🤖 Generated with [Claude Code](https://claude.com/claude-code)