### PR TITLE
feat(alerts): alerts 表 + TG 推送 + escalate reason 细分 + PVC GC + watchdog 5min warn + fixer loop detect

### DIFF
--- a/observability/queries/sisyphus/18-active-alerts.sql
+++ b/observability/queries/sisyphus/18-active-alerts.sql
@@ -1,0 +1,14 @@
+-- Q18: 未处理告警（active alerts）
+-- 实时看板：显示所有未 ack 的 alert，按时间倒序
+SELECT
+    created_at,
+    severity,
+    req_id,
+    stage,
+    reason,
+    hint,
+    suggested_action
+FROM alerts
+WHERE acknowledged_at IS NULL
+ORDER BY created_at DESC
+LIMIT 50;

--- a/observability/queries/sisyphus/19-alerts-trend.sql
+++ b/observability/queries/sisyphus/19-alerts-trend.sql
@@ -1,0 +1,9 @@
+-- Q19: 过去 24h 告警趋势（按小时 + severity）
+SELECT
+    date_trunc('hour', created_at) AS hour,
+    severity,
+    COUNT(*) AS n
+FROM alerts
+WHERE created_at > now() - INTERVAL '24 hours'
+GROUP BY 1, 2
+ORDER BY 1 DESC, 2;

--- a/observability/queries/sisyphus/20-escalate-reasons.sql
+++ b/observability/queries/sisyphus/20-escalate-reasons.sql
@@ -1,0 +1,11 @@
+-- Q20: 过去 30d escalate reason 分布（critical alert）
+-- 帮助识别哪类 reason 最频繁、哪块 prompt 最需要改进
+SELECT
+    date_trunc('day', created_at) AS day,
+    reason,
+    COUNT(*) AS n
+FROM alerts
+WHERE severity = 'critical'
+  AND created_at > now() - INTERVAL '30 days'
+GROUP BY 1, 2
+ORDER BY 1 DESC, 3 DESC;

--- a/observability/sisyphus-dashboard.md
+++ b/observability/sisyphus-dashboard.md
@@ -176,6 +176,35 @@ M7 原 5 条（Q1–Q5）基于 `artifact_checks`。M14e 追加 8 条（Q6–Q13
   - `test_changes > src_changes` 且 `test_changes ≥ 5` → fixer 改测试比改代码还多，可疑
   - `spec_changes` 持续增长 → fixer 在改 spec 迎合实现，spec-drift 告警
 
+### Q17. Dedup retry rate（重复事件比例）
+
+- **SQL**：[queries/sisyphus/17-dedup-retry-rate.sql](queries/sisyphus/17-dedup-retry-rate.sql)
+
+### Q18. Active alerts（未处理告警）
+
+- **SQL**：[queries/sisyphus/18-active-alerts.sql](queries/sisyphus/18-active-alerts.sql)
+- **Visualization**：Table（列顺序：`created_at, severity, req_id, stage, reason, hint, suggested_action`）
+- **说明**：实时看板，显示所有未 ack 的 alert。critical 行代表已 escalate 的 REQ（同时推过 TG）；warn 行代表 5min stuck 预警。
+- **人工介入阈值**：出现任意 critical 行即需人工介入；warn 行若持续超 30min 会自动升级为 critical。
+- **数据源**：`sisyphus` 主库 `alerts` 表（migration 0008）
+
+### Q19. Alerts trend（24h 告警趋势）
+
+- **SQL**：[queries/sisyphus/19-alerts-trend.sql](queries/sisyphus/19-alerts-trend.sql)
+- **Visualization**：Line chart，X = `hour`，Y = `n`，按 `severity` 分系列（critical=红 / warn=黄）
+- **说明**：观测 24h 内告警频率变化，帮助识别突发故障期。
+- **人工介入阈值**：单小时 critical ≥ 3 → 系统性问题，需立刻排查。
+
+### Q20. Escalate reason distribution（escalate 原因分布 30d）
+
+- **SQL**：[queries/sisyphus/20-escalate-reasons.sql](queries/sisyphus/20-escalate-reasons.sql)
+- **Visualization**：Table（列顺序：`day, reason, n`）或 Stacked bar chart
+- **说明**：按 reason 分桶统计 critical alert 数量，帮助识别哪类 reason 最频繁、哪块 prompt 该改。
+- **关键 reason 字面量**：`runner-pod-not-ready` / `fixer-loop-3rounds` / `watchdog-stuck-30min` / `session-failed` / `dedup-swallowed-event`
+- **人工介入阈值**：
+  - `fixer-loop-3rounds` 持续增长 → fixer prompt 老化，需专项优化
+  - `runner-pod-not-ready` 占比 > 30% → K8s 基础设施问题，检查 PVC / 节点资源
+
 ## 看板布局
 
 推荐两列布局（Metabase Dashboard，gridsize 18×? 自适应）：

--- a/openspec/changes/REQ-alerts-1777014525/proposal.md
+++ b/openspec/changes/REQ-alerts-1777014525/proposal.md
@@ -1,0 +1,61 @@
+# REQ-alerts-1777014525: feat(alerts): 三类静默失败可观测 + 两阶段 watchdog + PVC GC
+
+## 问题
+
+生产环境中存在三类静默失败，均不触发告警、难以发现：
+
+1. **PVC 慢速满盘**：runner PVC 持续写入，无监控，磁盘用尽后 pod 崩溃，escalate reason 无意义（`issue-updated`）
+2. **runner pod 启动失败**：`ensure_runner` 超时后 escalate reason 为 `issue-updated`，完全无法区分是 pod 调度失败还是代码问题
+3. **fixer 死循环**：verifier→fixer→verifier 循环 >3 轮无 net progress，无自动止损，消耗大量 token
+
+## 根因
+
+- `alerts` 表不存在，orchestrator 没有统一告警写入路径
+- `escalate.py` 直接用 `body.event` 作 reason，无 ctx 优先级
+- `apply_verify_pass` 的 `ensure_runner` 超时不记录 K8s 诊断
+- watchdog 只有 30min 硬 escalate，无早期 5min warn
+- `runner_gc` 只 GC runner pod，不管 PVC
+- `invoke_verifier_after_fix` 没有轮次上限
+
+## 方案
+
+### A. alerts 表 + store 层
+
+新建 `alerts` 表（migration 0008），severity CHECK('info','warn','critical')。
+`store/alerts.py` 提供 `insert_alert` / `mark_sent_to_tg`；`alerts/__init__.py` 暴露 `insert()`（自动取 pool）。
+
+### B. Telegram Bot push
+
+`alerts/tg.py` 实现 `send_critical(text)`，读 `settings.tg_bot_token` / `settings.tg_chat_id`，无配置时静默跳过。
+
+### C. escalate reason 精化
+
+`escalate.py`：`ctx.escalated_reason` 优先级高于 `body.event` 名。所有 escalate 写 alerts 表 + 推 TG。
+
+### D. K8s pod 诊断
+
+`k8s_runner.K8sRunnerController` 新增 `_diagnose_pod(pod_name)` 方法（读 K8s events API，识别 ImagePullBackOff / PVC pending / resource insufficient）；新增 `delete_pvc(req_id)` 方法。
+
+### E. runner 超时诊断上下文
+
+`apply_verify_pass` 捕获 `ensure_runner` 的 `TimeoutError`，调 `_diagnose_pod`，写 `ctx.escalated_reason="runner-pod-not-ready"` + `escalated_hint=<诊断结果>`，再 re-raise 走原有 SESSION_FAILED 路径。
+
+### F. watchdog 两阶段
+
+SQL 阈值降到 `_WARN_THRESHOLD_SEC=300s`（5min）抓取 stuck rows，5–30min 写 `alert(severity=warn)` + `ctx.warned_at_5min=True`；≥30min 走原 escalate path + `ctx.escalated_reason="watchdog-stuck-30min"`。
+
+### G. fixer 循环检测
+
+`invoke_verifier_after_fix` 在 append 当前轮次到 `ctx.verifier_history` 后检查 `len(history) > 3`，超过则写 `escalated_reason="fixer-loop-3rounds"` + 发 `VERIFY_ESCALATE` event，终止循环。
+
+### PVC GC
+
+`runner_gc.gc_pvcs()` 独立于 `gc_once()`：done → 立即删，escalated → 保留 24h 后删，disk>80% → 强清非 active PVC。`run_loop()` 每轮也调 `gc_pvcs()`。
+
+## 取舍
+
+- **TG 失败不阻断**：网络抖动不影响状态机，告警尽力而为
+- **fixer 阈值=3轮**：保守，允许真实多轮修复；>3 才认为循环
+- **watchdog 5min warn 不 escalate**：给人工介入时间，30min 才硬 escalate
+- **_diagnose_pod 用 K8s events API**：避免 subprocess kubectl，与现有 kubernetes asyncio 一致
+- **PVC GC 独立函数**：runner GC（pod orphan）与 PVC GC 关注点不同，分离易测试

--- a/openspec/changes/REQ-alerts-1777014525/specs/alerts-observability/contract.spec.yaml
+++ b/openspec/changes/REQ-alerts-1777014525/specs/alerts-observability/contract.spec.yaml
@@ -1,0 +1,132 @@
+capability: alerts-observability
+version: "1.0"
+description: |
+  三类静默失败可观测：alerts 表 + TG push + escalate reason 精化 +
+  watchdog 两阶段（5min warn / 30min escalate）+ PVC GC + fixer 循环检测。
+
+db_schema_changes:
+  - table: alerts
+    migration: "0008_create_alerts"
+    columns:
+      - name: id
+        type: BIGSERIAL
+        nullable: false
+        comment: "PK"
+      - name: severity
+        type: TEXT
+        nullable: false
+        constraint: "CHECK (severity IN ('info', 'warn', 'critical'))"
+      - name: req_id
+        type: TEXT
+        nullable: true
+      - name: stage
+        type: TEXT
+        nullable: true
+      - name: reason
+        type: TEXT
+        nullable: false
+      - name: hint
+        type: TEXT
+        nullable: true
+      - name: suggested_action
+        type: TEXT
+        nullable: true
+      - name: created_at
+        type: TIMESTAMPTZ
+        nullable: false
+        default: "NOW()"
+      - name: acknowledged_at
+        type: TIMESTAMPTZ
+        nullable: true
+      - name: sent_to_tg
+        type: BOOLEAN
+        nullable: false
+        default: "FALSE"
+    indexes:
+      - name: idx_alerts_unack
+        columns: ["created_at DESC"]
+        partial: "WHERE acknowledged_at IS NULL"
+        comment: "dashboard 查活跃告警用"
+
+functions:
+  store.alerts.insert_alert:
+    module: orchestrator.store.alerts
+    signature: "async (pool, *, severity: str, reason: str, hint: str | None = None, suggested_action: str | None = None, req_id: str | None = None, stage: str | None = None) -> int"
+    semantics: "INSERT INTO alerts ... RETURNING id"
+
+  store.alerts.mark_sent_to_tg:
+    module: orchestrator.store.alerts
+    signature: "async (pool, alert_id: int) -> None"
+    semantics: "UPDATE alerts SET sent_to_tg = TRUE WHERE id = $1"
+
+  alerts.insert:
+    module: orchestrator.alerts
+    signature: "async (*, severity, reason, hint=None, suggested_action=None, req_id=None, stage=None) -> int"
+    semantics: "convenience wrapper, auto-gets pool via db.get_pool()"
+
+  alerts.tg.send_critical:
+    module: orchestrator.alerts.tg
+    signature: "async (text: str) -> bool"
+    semantics: "POST to telegram Bot API; returns False silently if not configured or on error"
+    must_not_raise: true
+
+  k8s_runner.K8sRunnerController._diagnose_pod:
+    module: orchestrator.k8s_runner
+    signature: "async (pod_name: str) -> str"
+    semantics: "reads K8s events for pod, returns human-readable diagnosis"
+    must_not_raise: true
+
+  k8s_runner.K8sRunnerController.delete_pvc:
+    module: orchestrator.k8s_runner
+    signature: "async (req_id: str) -> bool"
+    semantics: "deletes PVC named runner-<req_id> in runners namespace"
+
+  runner_gc.gc_pvcs:
+    module: orchestrator.runner_gc
+    signature: "async () -> dict"
+    semantics: |
+      done → immediate delete_pvc;
+      escalated → retain _PVC_ESCALATED_RETAIN_H hours then delete;
+      disk>80% → force purge non-active PVCs;
+      active req_ids never deleted.
+    returns: "{'pvc_deleted': [str]}"
+
+  runner_gc._disk_pressure:
+    module: orchestrator.runner_gc
+    signature: "async () -> float"
+    semantics: "shutil.disk_usage('/') used/total, returns 0.0–1.0"
+
+constants:
+  _WARN_THRESHOLD_SEC: 300
+  _ESCALATE_THRESHOLD_SEC: 1800
+  _PVC_ESCALATED_RETAIN_H: 24
+
+ctx_fields_added:
+  - field: escalated_reason
+    set_by: [escalate, watchdog, _verifier, apply_verify_pass]
+    read_by: [escalate]
+    comment: "takes priority over body.event name in escalate action"
+  - field: escalated_hint
+    set_by: [apply_verify_pass, _verifier]
+    read_by: [escalate]
+  - field: warned_at_5min
+    set_by: [watchdog]
+    semantics: "True → skip duplicate 5min warn"
+  - field: verifier_history
+    set_by: [invoke_verifier_after_fix]
+    semantics: "list of {fixer, fixer_issue_id} per round; len > 3 → VERIFY_ESCALATE"
+
+config_settings_added:
+  - name: tg_bot_token
+    type: "str | None"
+    default: null
+    env: "TG_BOT_TOKEN"
+  - name: tg_chat_id
+    type: "str | None"
+    default: null
+    env: "TG_CHAT_ID"
+
+observability_queries:
+  Q18: "observability/queries/sisyphus/18-active-alerts.sql"
+  Q19: "observability/queries/sisyphus/19-alerts-trend.sql"
+  Q20: "observability/queries/sisyphus/20-escalate-reasons.sql"

--- a/openspec/changes/REQ-alerts-1777014525/specs/alerts-observability/spec.md
+++ b/openspec/changes/REQ-alerts-1777014525/specs/alerts-observability/spec.md
@@ -1,0 +1,157 @@
+## ADDED Requirements
+
+### Requirement: alerts 表 + 统一告警写入路径
+
+The system SHALL create an `alerts` PostgreSQL table with columns: id (BIGSERIAL PK), severity (TEXT NOT NULL CHECK IN ('info','warn','critical')), req_id (TEXT), stage (TEXT), reason (TEXT NOT NULL), hint (TEXT), suggested_action (TEXT), created_at (TIMESTAMPTZ DEFAULT NOW()), acknowledged_at (TIMESTAMPTZ), sent_to_tg (BOOLEAN DEFAULT FALSE). The system MUST enforce the severity constraint at the database level. A partial index on `(created_at DESC) WHERE acknowledged_at IS NULL` MUST exist for dashboard queries.
+
+The system SHALL provide `store/alerts.insert_alert(pool, *, severity, reason, ...)` returning the inserted row id, and `alerts.insert(*, severity, reason, ...)` as a convenience wrapper that auto-obtains the pool via `db.get_pool()`.
+
+#### Scenario: ALERTS-S1 insert_alert 插入返回 id
+
+- **GIVEN** pool 可用，severity='critical', reason='watchdog-stuck-30min'
+- **WHEN** 调用 `insert_alert(pool, severity='critical', reason='watchdog-stuck-30min', req_id='REQ-1')`
+- **THEN** 返回 int id > 0，alerts 表中新增一行
+
+#### Scenario: ALERTS-S2 severity CHECK 约束拒绝非法值
+
+- **GIVEN** severity='invalid'
+- **WHEN** 调用 `insert_alert(pool, severity='invalid', reason='x')`
+- **THEN** 抛出 IntegrityConstraintViolationError（PostgreSQL CHECK constraint）
+
+### Requirement: Telegram Bot 静默推送
+
+The system SHALL implement `alerts.tg.send_critical(text: str) -> bool` that sends a message via Telegram Bot API using `settings.tg_bot_token` and `settings.tg_chat_id`. The function MUST return False without raising an exception if either setting is missing or if the HTTP request fails.
+
+#### Scenario: ALERTS-S3 无 TG 配置时静默返回 False
+
+- **GIVEN** `settings.tg_bot_token` 为 None
+- **WHEN** 调用 `send_critical("test")`
+- **THEN** 返回 False，不发起 HTTP 请求，不抛异常
+
+#### Scenario: ALERTS-S4 HTTP 200 时返回 True
+
+- **GIVEN** settings 配置了有效 token/chat_id，HTTP mock 返回 200
+- **WHEN** 调用 `send_critical("test message")`
+- **THEN** 返回 True
+
+#### Scenario: ALERTS-S5 网络异常时静默返回 False
+
+- **GIVEN** HTTP 请求抛出 ConnectError
+- **WHEN** 调用 `send_critical("test")`
+- **THEN** 返回 False，不抛异常
+
+### Requirement: escalate reason 精化与告警写入
+
+The system SHALL update `escalate.py` so that `ctx.escalated_reason` takes priority over the event name when determining the escalation reason. The escalation action MUST write a record to the `alerts` table with severity='critical' and MUST attempt to send a Telegram notification via `tg.send_critical`.
+
+#### Scenario: ALERTS-S6 ctx.escalated_reason 优先于 body.event
+
+- **GIVEN** ctx 含 `escalated_reason="runner-pod-not-ready"`, body.event="SESSION_FAILED"
+- **WHEN** `escalate` action 执行
+- **THEN** alerts 表中 reason="runner-pod-not-ready"，而非 "session-failed"
+
+#### Scenario: ALERTS-S7 escalate 写 alert + 推 TG
+
+- **GIVEN** 正常 escalate 触发
+- **WHEN** `escalate` action 执行
+- **THEN** `alerts.insert` 被调用一次，`tg.send_critical` 被调用一次
+
+### Requirement: K8s pod 启动诊断
+
+The system SHALL add `_diagnose_pod(pod_name: str) -> str` to `K8sRunnerController` that queries the K8s events API for the given pod and returns a human-readable diagnosis string. The method MUST identify at least: ImagePullBackOff/ErrImagePull → "image pull failed"; WaitForFirstConsumer/WaitForPodScheduled → "PVC pending (likely disk pressure or scheduler can't fit)"; Insufficient resources → "node resource insufficient". On API failure the method MUST return "diagnostic failed" without raising.
+
+The system SHALL add `delete_pvc(req_id: str) -> bool` method that deletes the PVC named `runner-<req_id>` in the runners namespace.
+
+#### Scenario: ALERTS-S8 ImagePullBackOff → "image pull failed"
+
+- **GIVEN** K8s events 包含 reason=ImagePullBackOff
+- **WHEN** `_diagnose_pod("pod-x")` 被调用
+- **THEN** 返回 "image pull failed"
+
+#### Scenario: ALERTS-S9 WaitForFirstConsumer → PVC pending
+
+- **GIVEN** K8s events 包含 message 含 "WaitForFirstConsumer"
+- **WHEN** `_diagnose_pod("pod-x")` 被调用
+- **THEN** 返回 "PVC pending (likely disk pressure or scheduler can't fit)"
+
+#### Scenario: ALERTS-S10 API 失败 → "diagnostic failed"
+
+- **GIVEN** `core_v1.list_namespaced_event` 抛出异常
+- **WHEN** `_diagnose_pod("pod-x")` 被调用
+- **THEN** 返回 "diagnostic failed"，不抛异常
+
+### Requirement: runner 超时时写入诊断上下文
+
+The system SHALL modify `apply_verify_pass` to catch `TimeoutError` from `ensure_runner`, call `_diagnose_pod`, update `ctx.escalated_reason="runner-pod-not-ready"` and `ctx.escalated_hint=<diagnosis>` via `req_state.update_context`, then re-raise the exception so the engine handles it via the SESSION_FAILED path.
+
+### Requirement: watchdog 两阶段告警
+
+The system SHALL use `_WARN_THRESHOLD_SEC = 300` (5 min) as the SQL fetch threshold. For rows stuck 5–30 minutes that have not yet been warned, the system MUST insert an `alert(severity='warn', reason='stuck-5min')` and set `ctx.warned_at_5min=True`. For rows stuck ≥30 minutes, the system MUST escalate via `engine.step` with `ctx.escalated_reason="watchdog-stuck-30min"`. The `_tick()` function MUST return `{"checked": N, "escalated": N, "warned": N}`.
+
+#### Scenario: ALERTS-S11 5min warn 写 alert + ctx，不 escalate
+
+- **GIVEN** stuck_sec=600（5–30min 区间），warned_at_5min 未设
+- **WHEN** `_tick()` 运行
+- **THEN** result["warned"]=1, result["escalated"]=0; alerts 写了 severity='warn', reason='stuck-5min'; ctx.warned_at_5min=True
+
+#### Scenario: ALERTS-S12 warned_at_5min 已设 → 不重复告警
+
+- **GIVEN** stuck_sec=700，ctx.warned_at_5min=True
+- **WHEN** `_tick()` 运行
+- **THEN** result["warned"]=0，alert_calls=[]
+
+#### Scenario: ALERTS-S13 30min escalate 写 ctx.escalated_reason
+
+- **GIVEN** stuck_sec=2000（≥30min）
+- **WHEN** `_tick()` 运行
+- **THEN** result["escalated"]=1; ctx.escalated_reason="watchdog-stuck-30min"
+
+### Requirement: fixer 循环检测
+
+The system SHALL detect fixer loops in `invoke_verifier_after_fix`. After appending the current fixer round to `ctx.verifier_history`, if `len(history) > 3` the system MUST write `ctx.escalated_reason="fixer-loop-3rounds"` and return `{"emit": Event.VERIFY_ESCALATE.value}` instead of launching another verifier. An `alert(severity='critical', reason='fixer-loop-3rounds')` MUST also be inserted.
+
+#### Scenario: ALERTS-S14 3+1 轮 → VERIFY_ESCALATE
+
+- **GIVEN** `ctx.verifier_history` 已有 3 条记录，当前为第 4 次
+- **WHEN** `invoke_verifier_after_fix` 执行
+- **THEN** 返回 `{"emit": "VERIFY_ESCALATE", ...}`，alert 写了 reason='fixer-loop-3rounds'
+
+#### Scenario: ALERTS-S15 2+1=3 轮 → 正常启动 verifier
+
+- **GIVEN** `ctx.verifier_history` 已有 2 条记录，当前为第 3 次
+- **WHEN** `invoke_verifier_after_fix` 执行
+- **THEN** 启动 verifier（不返回 VERIFY_ESCALATE）
+
+### Requirement: PVC GC
+
+The system SHALL provide `runner_gc.gc_pvcs() -> dict` that independently manages PVC lifecycle: done→immediate delete; escalated→retain 24h then delete; disk usage >80%→force purge non-active PVCs. Active req_ids MUST NOT have their PVCs deleted even under disk pressure. The `_disk_pressure()` helper MUST use `shutil.disk_usage('/')` returning a float 0.0–1.0.
+
+#### Scenario: ALERTS-S16 state=done → 立即删 PVC
+
+- **GIVEN** state='done'，updated_at=now
+- **WHEN** `gc_pvcs()` 运行
+- **THEN** `delete_pvc("REQ-D1")` 被调用一次
+
+#### Scenario: ALERTS-S17 state=escalated < 24h → 不删
+
+- **GIVEN** state='escalated'，updated_at=12h 前
+- **WHEN** `gc_pvcs()` 运行
+- **THEN** `delete_pvc` 未被调用
+
+#### Scenario: ALERTS-S18 state=escalated > 24h → 删
+
+- **GIVEN** state='escalated'，updated_at=25h 前
+- **WHEN** `gc_pvcs()` 运行
+- **THEN** `delete_pvc` 被调用
+
+#### Scenario: ALERTS-S19 disk pressure > 80% 强清非 active
+
+- **GIVEN** disk usage=85%，escalated PVC 未过 24h 但 req 非 active
+- **WHEN** `gc_pvcs()` 运行
+- **THEN** `delete_pvc` 被调用
+
+#### Scenario: ALERTS-S20 disk pressure > 80% 但 req active → 不删
+
+- **GIVEN** disk usage=90%，escalated PVC 的 req 仍 active（in-flight）
+- **WHEN** `gc_pvcs()` 运行
+- **THEN** `delete_pvc` 未被调用

--- a/openspec/changes/REQ-alerts-1777014525/tasks.md
+++ b/openspec/changes/REQ-alerts-1777014525/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: REQ-alerts-1777014525
+
+## Stage: migration
+
+- [x] 创建 `orchestrator/migrations/0008_create_alerts.sql`（CREATE TABLE alerts + partial index）
+- [x] 创建 `orchestrator/migrations/0008_create_alerts.rollback.sql`（DROP TABLE alerts）
+
+## Stage: implementation
+
+- [x] 创建 `orchestrator/src/orchestrator/store/alerts.py`（insert_alert / mark_sent_to_tg）
+- [x] 创建 `orchestrator/src/orchestrator/alerts/__init__.py`（insert wrapper，自动取 pool）
+- [x] 创建 `orchestrator/src/orchestrator/alerts/tg.py`（send_critical，无配置静默跳过）
+- [x] 修改 `orchestrator/src/orchestrator/config.py`（tg_bot_token / tg_chat_id）
+- [x] 改写 `orchestrator/src/orchestrator/actions/escalate.py`（ctx reason 优先级 + alerts + TG）
+- [x] 修改 `orchestrator/src/orchestrator/k8s_runner.py`（_diagnose_pod + delete_pvc）
+- [x] 修改 `orchestrator/src/orchestrator/actions/_verifier.py`（apply_verify_pass timeout 诊断 + invoke_verifier_after_fix 循环检测）
+- [x] 改写 `orchestrator/src/orchestrator/watchdog.py`（5min warn 两阶段 + _WARN_THRESHOLD_SEC）
+- [x] 改写 `orchestrator/src/orchestrator/runner_gc.py`（gc_pvcs + _disk_pressure）
+
+## Stage: observability
+
+- [x] 创建 `observability/queries/sisyphus/18-active-alerts.sql`（Q18 未 ack 活跃告警）
+- [x] 创建 `observability/queries/sisyphus/19-alerts-trend.sql`（Q19 24h 趋势按小时/severity）
+- [x] 创建 `observability/queries/sisyphus/20-escalate-reasons.sql`（Q20 30d critical reason 分布）
+- [x] 修改 `observability/sisyphus-dashboard.md`（添加 Q17–Q20 条目）
+
+## Stage: tests
+
+- [x] 创建 `orchestrator/tests/test_alerts.py`（alerts insert/tg/escalate/diagnose/fixer-loop 共 14+ 用例）
+- [x] 修改 `orchestrator/tests/test_watchdog.py`（两阶段 warn/escalate 测试 + _WARN_THRESHOLD_SEC 验证）
+- [x] 修改 `orchestrator/tests/test_runner_gc.py`（gc_pvcs 5 个用例 + disk pressure）
+- [x] 修改 `orchestrator/tests/test_migrate.py`（0008 forward/rollback 验证）
+
+## Stage: spec
+
+- [x] `openspec/changes/REQ-alerts-1777014525/proposal.md`
+- [x] `openspec/changes/REQ-alerts-1777014525/tasks.md`
+- [x] `openspec/changes/REQ-alerts-1777014525/specs/alerts-observability/spec.md`
+- [x] `openspec/changes/REQ-alerts-1777014525/specs/alerts-observability/contract.spec.yaml`
+
+## Stage: PR
+
+- [x] git push feat/REQ-alerts-1777014525
+- [x] gh pr create（PR #53）

--- a/orchestrator/migrations/0008_create_alerts.rollback.sql
+++ b/orchestrator/migrations/0008_create_alerts.rollback.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS alerts;

--- a/orchestrator/migrations/0008_create_alerts.sql
+++ b/orchestrator/migrations/0008_create_alerts.sql
@@ -1,0 +1,15 @@
+-- 0008: alerts 表，持久化 warn / critical 告警，对接 Telegram 推送。
+CREATE TABLE IF NOT EXISTS alerts (
+    id               BIGSERIAL PRIMARY KEY,
+    severity         TEXT NOT NULL CHECK (severity IN ('info', 'warn', 'critical')),
+    req_id           TEXT,
+    stage            TEXT,
+    reason           TEXT NOT NULL,
+    hint             TEXT,
+    suggested_action TEXT,
+    created_at       TIMESTAMPTZ DEFAULT NOW(),
+    acknowledged_at  TIMESTAMPTZ,
+    sent_to_tg       BOOLEAN DEFAULT FALSE
+);
+
+CREATE INDEX idx_alerts_unack ON alerts(created_at DESC) WHERE acknowledged_at IS NULL;

--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -28,7 +28,7 @@ from typing import Literal
 
 import structlog
 
-from .. import k8s_runner
+from .. import alerts, k8s_runner
 from ..bkd import BKDClient
 from ..config import settings
 from ..prompts import render
@@ -185,9 +185,21 @@ async def apply_verify_pass(*, body, req_id, tags, ctx):
     except RuntimeError:
         log.warning("apply_verify_pass.no_runner_controller", req_id=req_id)
     else:
-        pod = await rc.ensure_runner(req_id, wait_ready=True)
-        log.info("apply_verify_pass.runner_ready",
-                 req_id=req_id, stage=stage, pod=pod, src_state=src_state.value)
+        try:
+            pod = await rc.ensure_runner(req_id, wait_ready=True)
+            log.info("apply_verify_pass.runner_ready",
+                     req_id=req_id, stage=stage, pod=pod, src_state=src_state.value)
+        except TimeoutError:
+            pod_name = rc.pod_name(req_id)
+            hint = await rc._diagnose_pod(pod_name)
+            pool = db.get_pool()
+            await req_state.update_context(pool, req_id, {
+                "escalated_reason": "runner-pod-not-ready",
+                "escalated_stage": "runner-startup",
+                "escalated_hint": hint,
+                "escalated_action": "kubectl describe pvc + delete stale PVCs",
+            })
+            raise
 
     log.info("apply_verify_pass.done",
              req_id=req_id, stage=stage,
@@ -270,6 +282,8 @@ async def invoke_verifier_after_fix(*, body, req_id, tags, ctx):
     stage 必须从**当前 fixer issue 的 tags** 取（`parent-stage:<stage>`），不能依赖
     ctx.verifier_stage —— 多 verifier 并发时 ctx 是最新一个的 stage，老 fixer 完成时
     ctx 已被覆盖，会拿错 stage。fixer issue 自带 parent-stage tag 是无歧义的真相。
+
+    fixer loop detection：history 已有 3 条 → 直接 emit VERIFY_ESCALATE 不再跑 verifier。
     """
     ctx = ctx or {}
     stage = None
@@ -286,6 +300,30 @@ async def invoke_verifier_after_fix(*, body, req_id, tags, ctx):
             "fixer_issue_id": ctx.get("fixer_issue_id"),
         },
     ]
+
+    # fixer loop detection：超过 3 轮直接 escalate，不再起新 verifier
+    fixer_rounds = len(history)
+    if fixer_rounds > 3:
+        escalate_hint = "fixer 跑 3 轮无 net progress; 多半 fixer prompt 老化或 bug 不可修"
+        pool = db.get_pool()
+        await req_state.update_context(pool, req_id, {
+            "verifier_history": history,
+            "escalated_reason": "fixer-loop-3rounds",
+            "escalated_hint": escalate_hint,
+        })
+        try:
+            await alerts.insert(
+                severity="critical",
+                req_id=req_id,
+                stage=stage,
+                reason="fixer-loop-3rounds",
+                hint=escalate_hint,
+            )
+        except Exception as e:
+            log.warning("invoke_verifier_after_fix.alert_failed", req_id=req_id, error=str(e))
+        log.warning("invoke_verifier_after_fix.loop_detected",
+                    req_id=req_id, stage=stage, rounds=fixer_rounds)
+        return {"emit": Event.VERIFY_ESCALATE.value, "reason": "fixer loop"}
 
     result = await invoke_verifier(
         stage=stage,

--- a/orchestrator/src/orchestrator/actions/escalate.py
+++ b/orchestrator/src/orchestrator/actions/escalate.py
@@ -1,8 +1,11 @@
 """escalate: 终态卡住兜底。
 
 只做两件事：
-1. 在 intent issue 上加 `escalated` + `reason:<event>` tag（人工告警入口）
+1. 在 intent issue 上加 `escalated` + `reason:<reason>` tag（人工告警入口）
 2. 落 ctx 标记 escalated_reason
+3. 写 alerts 表 + 推 Telegram critical（新）
+
+reason 优先读 ctx.escalated_reason（caller 已细分），fallback 到 body.event 名。
 
 不开新 issue（避免污染列表）；不 cancel 当前 issue（让人工有现场）。
 """
@@ -10,6 +13,8 @@ from __future__ import annotations
 
 import structlog
 
+from .. import alerts
+from ..alerts import tg
 from ..bkd import BKDClient
 from ..config import settings
 from ..store import db, req_state
@@ -22,7 +27,11 @@ log = structlog.get_logger(__name__)
 async def escalate(*, body, req_id, tags, ctx):
     proj = body.projectId
     intent_issue_id = (ctx or {}).get("intent_issue_id") or body.issueId
-    reason = (body.event or "unknown").replace(".", "-")[:40]
+    ctx = ctx or {}
+
+    # 优先用 caller 细分的 reason；fallback 到 event 名
+    reason = ctx.get("escalated_reason") or (body.event or "unknown").replace(".", "-")[:40]
+    hint = ctx.get("escalated_hint")
 
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         try:
@@ -38,6 +47,28 @@ async def escalate(*, body, req_id, tags, ctx):
         "escalated_reason": reason,
         "escalated_source_issue_id": body.issueId,
     })
+
+    # 写 alerts 表
+    try:
+        await alerts.insert(
+            severity="critical",
+            req_id=req_id,
+            stage=ctx.get("escalated_stage"),
+            reason=reason,
+            hint=hint,
+            suggested_action=ctx.get("escalated_action"),
+        )
+    except Exception as e:
+        log.warning("escalate.alert_insert_failed", req_id=req_id, error=str(e))
+
+    # Telegram 推送
+    try:
+        text = f"\U0001f6a8 *sisyphus alert*\n`{req_id}` escalated\nreason: `{reason}`"
+        if hint:
+            text += f"\nhint: {hint}"
+        await tg.send_critical(text)
+    except Exception as e:
+        log.warning("escalate.tg_failed", req_id=req_id, error=str(e))
 
     log.warning("escalate.done", req_id=req_id, reason=reason, issue_id=intent_issue_id)
     return {"escalated": True, "reason": reason}

--- a/orchestrator/src/orchestrator/alerts/__init__.py
+++ b/orchestrator/src/orchestrator/alerts/__init__.py
@@ -1,0 +1,34 @@
+"""alerts 包：DB 持久化 + Telegram 推送。
+
+用法：
+    from orchestrator import alerts
+    from orchestrator.alerts import tg
+
+    alert_id = await alerts.insert(severity="critical", reason="...", ...)
+    await tg.send_critical("🚨 *sisyphus alert*\n...")
+"""
+from __future__ import annotations
+
+from ..store import alerts as _store, db
+
+
+async def insert(
+    *,
+    severity: str,
+    reason: str,
+    hint: str | None = None,
+    suggested_action: str | None = None,
+    req_id: str | None = None,
+    stage: str | None = None,
+) -> int:
+    """写一条 alert，返回 id。"""
+    pool = db.get_pool()
+    return await _store.insert_alert(
+        pool,
+        severity=severity,
+        reason=reason,
+        hint=hint,
+        suggested_action=suggested_action,
+        req_id=req_id,
+        stage=stage,
+    )

--- a/orchestrator/src/orchestrator/alerts/tg.py
+++ b/orchestrator/src/orchestrator/alerts/tg.py
@@ -1,0 +1,24 @@
+"""Telegram 推送：critical alert 才推，失败只 log 不阻塞主流程。"""
+from __future__ import annotations
+
+import structlog
+import httpx
+
+from ..config import settings
+
+log = structlog.get_logger(__name__)
+
+
+async def send_critical(text: str) -> bool:
+    """严重 alert 推 TG。失败只 log warning，不阻塞主流程。"""
+    if not settings.tg_bot_token or not settings.tg_chat_id:
+        return False
+    url = f"https://api.telegram.org/bot{settings.tg_bot_token}/sendMessage"
+    payload = {"chat_id": settings.tg_chat_id, "text": text, "parse_mode": "Markdown"}
+    try:
+        async with httpx.AsyncClient(timeout=5) as c:
+            r = await c.post(url, json=payload)
+            return r.status_code == 200
+    except Exception as e:
+        log.warning("tg.send_failed", error=str(e))
+        return False

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -114,6 +114,12 @@ class Settings(BaseSettings):
     # analyze fan out 的 sub-issue model 由 analyze prompt 自己控（见 analyze.md.j2）。
     agent_model: str | None = None
 
+    # ─── Telegram 告警推送 ────────────────────────────────────────────────
+    # critical severity 的 alert 推送到 TG。不配则跳过（不抛错）。
+    # 申请 bot token 步骤见用户文档；sisyphus 不管 bot 部署。
+    tg_bot_token: str | None = None
+    tg_chat_id: str | None = None
+
     # ─── aissh-tao MCP server id (vm-node04) ─────────────────────────────
     # BKD agent 跑在 Coder workspace 没装 kubectl，所有 vm-node04 上的 kubectl 命令
     # 必须经 aissh-tao MCP 跨 SSH 跑。prompt 模板里需要这个 server_id 告诉 agent。

--- a/orchestrator/src/orchestrator/k8s_runner.py
+++ b/orchestrator/src/orchestrator/k8s_runner.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 import structlog
 from kubernetes import client, config
@@ -482,6 +483,48 @@ class RunnerController:
         if cleaned:
             log.info("runner.gc.cleaned", count=len(cleaned), reqs=cleaned)
         return cleaned
+
+    # ── diagnostics ─────────────────────────────────────────────────────
+
+    async def _diagnose_pod(self, pod_name: str) -> str:
+        """从 K8s events 抠关键失败原因（用于 escalate hint）。"""
+        try:
+            event_list = await asyncio.to_thread(
+                self.core_v1.list_namespaced_event,
+                self.namespace,
+                field_selector=f"involvedObject.name={pod_name}",
+            )
+            events_text = " ".join(
+                f"{e.reason or ''}: {e.message or ''}"
+                for e in sorted(
+                    event_list.items or [],
+                    key=lambda e: (e.last_timestamp or datetime.min.replace(tzinfo=timezone.utc)),
+                )
+            )
+        except Exception:
+            return "diagnostic failed"
+
+        if "ImagePullBackOff" in events_text or "ErrImagePull" in events_text:
+            return "image pull failed"
+        if "WaitForFirstConsumer" in events_text or "WaitForPodScheduled" in events_text:
+            return "PVC pending (likely disk pressure or scheduler can't fit)"
+        if "Insufficient" in events_text:
+            return "node resource insufficient"
+        return f"unknown (events tail: {events_text[-200:]})"
+
+    async def delete_pvc(self, req_id: str) -> bool:
+        """直接删 PVC（不删 Pod）。幂等。"""
+        try:
+            await asyncio.to_thread(
+                self.core_v1.delete_namespaced_persistent_volume_claim,
+                self.pvc_name(req_id), self.namespace,
+            )
+            log.info("runner.pvc.deleted", req_id=req_id)
+            return True
+        except ApiException as e:
+            if e.status != 404:
+                raise
+            return False
 
     # ── exec ────────────────────────────────────────────────────────────
 

--- a/orchestrator/src/orchestrator/k8s_runner.py
+++ b/orchestrator/src/orchestrator/k8s_runner.py
@@ -231,7 +231,7 @@ class RunnerController:
             # privileged: DinD 必须；fuse-overlayfs 要 /dev/fuse + CAP_SYS_ADMIN
             security_context=client.V1SecurityContext(privileged=True),
             resources=client.V1ResourceRequirements(
-                requests={"cpu": "500m", "memory": "1Gi"},
+                requests={"cpu": "500m", "memory": "512Mi"},
                 limits={"cpu": "4", "memory": "8Gi"},
             ),
             env=env_vars,

--- a/orchestrator/src/orchestrator/runner_gc.py
+++ b/orchestrator/src/orchestrator/runner_gc.py
@@ -5,11 +5,17 @@
 - state=escalated 且 escalated_at > retention 天的：也销
 - 完全找不到 req_state 的 runner（孤儿：orchestrator 丢数据 / 手动清了 PG）：也销
 
+PVC GC 补丁（gc_pvcs）：
+- terminal=done 立即删 PVC
+- terminal=escalated 保留 24h
+- disk pressure > 80% 时强清所有非 active REQ 的 PVC
+
 不会销正在跑的 REQ 资源（in-flight state）。
 """
 from __future__ import annotations
 
 import asyncio
+import shutil
 from datetime import UTC, datetime, timedelta
 
 import structlog
@@ -23,6 +29,9 @@ log = structlog.get_logger(__name__)
 
 # 状态机里"终态"和"进行中"的区分
 _TERMINAL_STATES = {"done", "escalated"}
+
+# escalated PVC 保留 24h 给人翻 workspace（独立于 pvc_retain_on_escalate_days 的 Pod GC 保留期）
+_PVC_ESCALATED_RETAIN_H = 24
 
 
 async def _active_req_ids() -> set[str]:
@@ -50,6 +59,72 @@ async def _active_req_ids() -> set[str]:
     return active
 
 
+async def _disk_pressure() -> float:
+    """返回根文件系统磁盘使用率（0.0–1.0）。"""
+    usage = await asyncio.to_thread(shutil.disk_usage, "/")
+    return usage.used / usage.total
+
+
+async def gc_pvcs() -> dict:
+    """PVC 专项 GC：
+
+    - done REQ → 立即删 PVC
+    - escalated REQ → 超 24h 删 PVC
+    - disk pressure > 80% → 强清所有非 active REQ 的 PVC
+    """
+    try:
+        rc = k8s_runner.get_controller()
+    except RuntimeError:
+        return {"skipped": "no runner controller"}
+
+    pool = db.get_pool()
+    rows = await pool.fetch(
+        "SELECT req_id, state, updated_at FROM req_state "
+        "WHERE state IN ('done', 'escalated')",
+    )
+
+    pressure = await _disk_pressure()
+    now = datetime.now(UTC)
+    deleted: list[str] = []
+
+    # 先算 active req ids（用于 disk pressure 强清）
+    active_rows = await pool.fetch("SELECT req_id FROM req_state WHERE state <> ALL($1::text[])",
+                                   list(_TERMINAL_STATES))
+    active_req_ids = {r["req_id"].lower() for r in active_rows}
+
+    for r in rows:
+        req_id = r["req_id"]
+        state = r["state"]
+        updated_at = r["updated_at"]
+
+        should_delete = False
+        if state == "done":
+            should_delete = True
+        elif state == "escalated" and updated_at:
+            age_h = (now - updated_at).total_seconds() / 3600
+            if age_h > _PVC_ESCALATED_RETAIN_H:
+                should_delete = True
+
+        # disk pressure 强清：所有非 active 的 PVC
+        if not should_delete and pressure > 0.8:
+            if req_id.lower() not in active_req_ids:
+                should_delete = True
+
+        if should_delete:
+            try:
+                ok = await rc.delete_pvc(req_id)
+                if ok:
+                    deleted.append(req_id)
+            except Exception as e:
+                log.warning("runner_gc.pvc_delete_failed", req_id=req_id, error=str(e))
+
+    if pressure > 0.8:
+        log.warning("runner_gc.disk_pressure_purge",
+                    usage_pct=f"{pressure:.0%}", deleted=deleted)
+
+    return {"pvc_deleted": deleted, "disk_pressure": round(pressure, 3)}
+
+
 async def gc_once() -> dict:
     """单次 GC pass。返回 {cleaned: [...]}。"""
     try:
@@ -74,6 +149,10 @@ async def run_loop() -> None:
                 log.warning("runner_gc.swept", cleaned=result["cleaned"])
             else:
                 log.debug("runner_gc.tick", result=result)
+
+            pvc_result = await gc_pvcs()
+            if pvc_result.get("pvc_deleted"):
+                log.warning("runner_gc.pvcs_swept", **pvc_result)
         except asyncio.CancelledError:
             log.info("runner_gc.loop.stopped")
             raise

--- a/orchestrator/src/orchestrator/store/alerts.py
+++ b/orchestrator/src/orchestrator/store/alerts.py
@@ -1,0 +1,32 @@
+"""alerts 表写入 helper。"""
+from __future__ import annotations
+
+import asyncpg
+
+
+async def insert_alert(
+    pool: asyncpg.Pool,
+    *,
+    severity: str,
+    reason: str,
+    hint: str | None = None,
+    suggested_action: str | None = None,
+    req_id: str | None = None,
+    stage: str | None = None,
+) -> int:
+    """写一条 alert 行。返回 id。"""
+    row = await pool.fetchrow(
+        """
+        INSERT INTO alerts(severity, req_id, stage, reason, hint, suggested_action)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        RETURNING id
+        """,
+        severity, req_id, stage, reason, hint, suggested_action,
+    )
+    return row["id"]
+
+
+async def mark_sent_to_tg(pool: asyncpg.Pool, alert_id: int) -> None:
+    await pool.execute(
+        "UPDATE alerts SET sent_to_tg = TRUE WHERE id = $1", alert_id,
+    )

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -6,10 +6,11 @@ M4 retry policy 假设"失败事件总会到"被打破 — watchdog 作为独立
 
 每 N 秒扫一次 req_state，发现某 REQ：
 1. state 在 in-flight（非 done / 非 escalated / 非 init）
-2. updated_at 距今超过 watchdog_stuck_threshold_sec
-3. 关联 BKD issue 的 session_status 不在 'running' 状态
+2. updated_at 距今超过 _WARN_THRESHOLD_SEC（5min）
 
-→ 写一条 artifact_checks 记录 + 通过 engine.step 发 SESSION_FAILED 走 escalate。
+→ 5min–30min：插 alert(warn) + 在 ctx 标 warned_at_5min（只告一次）
+→ 超过 watchdog_stuck_threshold_sec（30min）且 BKD session 不在 running：
+  写 artifact_checks 记录 + 通过 engine.step 发 SESSION_FAILED 走 escalate。
 
 不 restart agent（restart 归 M4 retry policy 管），只 escalate。
 """
@@ -21,14 +22,17 @@ from dataclasses import dataclass
 
 import structlog
 
-from . import engine
+from . import alerts, engine
 from .bkd import BKDClient
 from .checkers._types import CheckResult
 from .config import settings
 from .state import Event, ReqState
-from .store import artifact_checks, db
+from .store import artifact_checks, db, req_state
 
 log = structlog.get_logger(__name__)
+
+# 5min warn 阈值（固定，不做配置）
+_WARN_THRESHOLD_SEC = 300
 
 
 # state → ctx 里追踪该 stage 当前 agent issue 的 key
@@ -64,10 +68,9 @@ class _SyntheticBody:
 
 
 async def _tick() -> dict:
-    """单次扫描 + escalate 卡死 REQ。返回 {checked, escalated}。"""
+    """单次扫描：warn 5min stuck + escalate 30min stuck。返回 {checked, escalated, warned}。"""
     pool = db.get_pool()
-    threshold = settings.watchdog_stuck_threshold_sec
-    # psql 语法：INTERVAL '1 second' * N 把 int 参数转成 interval
+    # 扫所有 stuck > 5min 的（含 5-30min warn 区间 + 30min+ escalate 区间）
     rows = await pool.fetch(
         """
         SELECT req_id, project_id, state, context,
@@ -76,17 +79,21 @@ async def _tick() -> dict:
          WHERE state <> ALL($1::text[])
            AND updated_at < NOW() - INTERVAL '1 second' * $2
         """,
-        list(_SKIP_STATES), threshold,
+        list(_SKIP_STATES), _WARN_THRESHOLD_SEC,
     )
     escalated = 0
+    warned = 0
     for row in rows:
-        if await _check_and_escalate(row):
+        outcome = await _check_and_maybe_alert(row)
+        if outcome == "escalated":
             escalated += 1
-    return {"checked": len(rows), "escalated": escalated}
+        elif outcome == "warned":
+            warned += 1
+    return {"checked": len(rows), "escalated": escalated, "warned": warned}
 
 
-async def _check_and_escalate(row) -> bool:
-    """检查一条 stuck row：session 仍 running 就 skip，否则 escalate。返 True = 真 escalate。"""
+async def _check_and_maybe_alert(row) -> str:
+    """检查一条 stuck row。返回 'escalated' / 'warned' / 'skip'。"""
     req_id = row["req_id"]
     project_id = row["project_id"]
     state_str = row["state"]
@@ -99,8 +106,43 @@ async def _check_and_escalate(row) -> bool:
         state = ReqState(state_str)
     except ValueError:
         log.warning("watchdog.unknown_state", req_id=req_id, state=state_str)
-        return False
+        return "skip"
 
+    # 5-30min：warn path（BKD session 仍 running 就跳过）
+    if stuck_sec < settings.watchdog_stuck_threshold_sec:
+        if ctx.get("warned_at_5min"):
+            return "skip"  # 已经告过，不重复
+
+        # 简单 check：有 issue_id 才查 BKD（避免无意义 warn）
+        issue_key = _STATE_ISSUE_KEY.get(state)
+        issue_id = ctx.get(issue_key) if issue_key else None
+        if issue_id:
+            try:
+                async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+                    issue = await bkd.get_issue(project_id, issue_id)
+                if issue.session_status == "running":
+                    return "skip"
+            except Exception as e:
+                log.warning("watchdog.bkd_check_warn_failed",
+                            req_id=req_id, issue_id=issue_id, error=str(e))
+
+        try:
+            await alerts.insert(
+                severity="warn",
+                req_id=req_id,
+                stage=state.value,
+                reason="stuck-5min",
+                hint=f"REQ has not advanced for {stuck_sec}s",
+            )
+        except Exception as e:
+            log.warning("watchdog.warn_insert_failed", req_id=req_id, error=str(e))
+
+        pool = db.get_pool()
+        await req_state.update_context(pool, req_id, {"warned_at_5min": True})
+        log.warning("watchdog.warn_5min", req_id=req_id, state=state_str, stuck_sec=stuck_sec)
+        return "warned"
+
+    # >=30min：escalate path（原逻辑 + escalated_reason 细分）
     issue_key = _STATE_ISSUE_KEY.get(state)
     issue_id: str | None = None
     if issue_key:
@@ -128,7 +170,7 @@ async def _check_and_escalate(row) -> bool:
             )
 
     if still_running:
-        return False
+        return "skip"
 
     # 2. 写 artifact_checks 记一笔，给 dashboard M7 04-fail-kind-distribution 抓
     pool = db.get_pool()
@@ -149,6 +191,12 @@ async def _check_and_escalate(row) -> bool:
         log.warning("watchdog.artifact_insert_failed", req_id=req_id, error=str(e))
 
     # 3. 通过 engine.step 发 SESSION_FAILED → 走 escalate transition
+    # 填 escalated_reason 给 escalate action 用
+    await req_state.update_context(pool, req_id, {
+        "escalated_reason": "watchdog-stuck-30min",
+        "escalated_hint": f"stuck for {stuck_sec}s in state {state_str}",
+    })
+
     body = _SyntheticBody(
         projectId=project_id,
         issueId=issue_id or ctx.get("intent_issue_id") or "",
@@ -171,8 +219,8 @@ async def _check_and_escalate(row) -> bool:
         )
     except Exception as e:
         log.exception("watchdog.engine_step_failed", req_id=req_id, error=str(e))
-        return False
-    return True
+        return "skip"
+    return "escalated"
 
 
 async def run_loop() -> None:
@@ -185,11 +233,12 @@ async def run_loop() -> None:
         "watchdog.loop.started",
         interval_sec=interval,
         stuck_threshold_sec=settings.watchdog_stuck_threshold_sec,
+        warn_threshold_sec=_WARN_THRESHOLD_SEC,
     )
     while True:
         try:
             result = await _tick()
-            if result.get("escalated"):
+            if result.get("escalated") or result.get("warned"):
                 log.warning("watchdog.swept", **result)
             else:
                 log.debug("watchdog.tick", **result)

--- a/orchestrator/tests/test_alerts.py
+++ b/orchestrator/tests/test_alerts.py
@@ -1,0 +1,469 @@
+"""alerts 模块测试（store + TG + escalate 集成）。"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ─── Fake pool ──────────────────────────────────────────────────────────────
+@dataclass
+class FakePool:
+    inserted: list = field(default_factory=list)
+    updated: list = field(default_factory=list)
+    _next_id: int = 1
+
+    async def fetchrow(self, sql, *args):
+        self.inserted.append({"sql": sql, "args": args})
+        result = {"id": self._next_id}
+        self._next_id += 1
+        return result
+
+    async def execute(self, sql, *args):
+        self.updated.append({"sql": sql, "args": args})
+        return None
+
+    async def fetch(self, sql, *args):
+        return []
+
+
+# ─── test_alerts_insert_and_query ───────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_alerts_insert_and_query():
+    """store.alerts.insert_alert 写入 + 返回 id。"""
+    from orchestrator.store import alerts as store_alerts
+
+    pool = FakePool()
+    alert_id = await store_alerts.insert_alert(
+        pool,
+        severity="critical",
+        reason="runner-pod-not-ready",
+        hint="image pull failed",
+        suggested_action="kubectl describe pod",
+        req_id="REQ-1",
+        stage="runner-startup",
+    )
+    assert alert_id == 1
+    assert len(pool.inserted) == 1
+    args = pool.inserted[0]["args"]
+    # severity, req_id, stage, reason, hint, suggested_action
+    assert args[0] == "critical"
+    assert args[1] == "REQ-1"
+    assert args[2] == "runner-startup"
+    assert args[3] == "runner-pod-not-ready"
+    assert args[4] == "image pull failed"
+    assert args[5] == "kubectl describe pod"
+
+
+@pytest.mark.asyncio
+async def test_alerts_mark_sent_to_tg():
+    """store.alerts.mark_sent_to_tg 更新 sent_to_tg=TRUE。"""
+    from orchestrator.store import alerts as store_alerts
+
+    pool = FakePool()
+    await store_alerts.mark_sent_to_tg(pool, 42)
+    assert len(pool.updated) == 1
+    assert "42" in str(pool.updated[0]["args"])
+
+
+# ─── test_alerts_severity_check_constraint ──────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_alerts_severity_check_constraint():
+    """非法 severity 值应被 DB CHECK 约束拒绝（模拟 asyncpg 抛 IntegrityError）。"""
+    import asyncpg
+    from orchestrator.store import alerts as store_alerts
+
+    class _ConstraintPool:
+        async def fetchrow(self, sql, *args):
+            raise asyncpg.IntegrityConstraintViolationError(
+                "ERROR: new row violates check constraint"
+            )
+
+    with pytest.raises(asyncpg.IntegrityConstraintViolationError):
+        await store_alerts.insert_alert(
+            _ConstraintPool(),
+            severity="invalid",
+            reason="test",
+        )
+
+
+# ─── test_tg_send_critical_no_config ────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_tg_send_critical_no_config(monkeypatch):
+    """settings 没有 token → return False，不抛异常。"""
+    from orchestrator.alerts import tg
+
+    monkeypatch.setattr("orchestrator.alerts.tg.settings.tg_bot_token", None)
+    monkeypatch.setattr("orchestrator.alerts.tg.settings.tg_chat_id", None)
+
+    result = await tg.send_critical("test message")
+    assert result is False
+
+
+# ─── test_tg_send_critical_mock_success ─────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_tg_send_critical_mock_success(monkeypatch):
+    """mock httpx → 200 OK → return True。"""
+    from orchestrator.alerts import tg
+
+    monkeypatch.setattr("orchestrator.alerts.tg.settings.tg_bot_token", "fake-token")
+    monkeypatch.setattr("orchestrator.alerts.tg.settings.tg_chat_id", "-123456789")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    with patch("orchestrator.alerts.tg.httpx.AsyncClient", return_value=mock_client):
+        result = await tg.send_critical("🚨 test alert")
+
+    assert result is True
+    mock_client.post.assert_called_once()
+    call_kwargs = mock_client.post.call_args
+    # verify payload
+    payload = call_kwargs[1]["json"] if call_kwargs[1] else call_kwargs[0][1]
+    assert payload["parse_mode"] == "Markdown"
+
+
+@pytest.mark.asyncio
+async def test_tg_send_critical_network_error_returns_false(monkeypatch):
+    """httpx 抛网络异常 → return False，不向上传播。"""
+    from orchestrator.alerts import tg
+
+    monkeypatch.setattr("orchestrator.alerts.tg.settings.tg_bot_token", "fake-token")
+    monkeypatch.setattr("orchestrator.alerts.tg.settings.tg_chat_id", "-123456789")
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(side_effect=Exception("connection refused"))
+
+    with patch("orchestrator.alerts.tg.httpx.AsyncClient", return_value=mock_client):
+        result = await tg.send_critical("test")
+
+    assert result is False
+
+
+# ─── test_escalate_with_ctx_reason ──────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_escalate_with_ctx_reason(monkeypatch):
+    """ctx.escalated_reason 优先于 body.event。"""
+    from orchestrator.actions import escalate as escalate_mod
+
+    @dataclass
+    class _Body:
+        projectId: str = "proj-1"
+        issueId: str = "issue-1"
+        event: str = "session.failed"
+
+    reasons_used: list = []
+
+    # mock BKD merge_tags_and_update
+    class _FakeBKD:
+        def __init__(self, *a, **kw): pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            pass
+        async def merge_tags_and_update(self, proj, iid, add):
+            reasons_used.extend([t for t in add if t.startswith("reason:")])
+
+    monkeypatch.setattr("orchestrator.actions.escalate.BKDClient", _FakeBKD)
+
+    updates: list = []
+    async def fake_update_context(pool, req_id, patch):
+        updates.append(patch)
+    monkeypatch.setattr("orchestrator.actions.escalate.req_state.update_context", fake_update_context)
+    monkeypatch.setattr("orchestrator.actions.escalate.db.get_pool", lambda: object())
+
+    alert_inserts: list = []
+    async def fake_alert_insert(**kw):
+        alert_inserts.append(kw)
+        return 1
+    monkeypatch.setattr("orchestrator.actions.escalate.alerts.insert", fake_alert_insert)
+    monkeypatch.setattr("orchestrator.actions.escalate.tg.send_critical", AsyncMock(return_value=False))
+
+    result = await escalate_mod.escalate(
+        body=_Body(),
+        req_id="REQ-1",
+        tags=[],
+        ctx={"escalated_reason": "runner-pod-not-ready", "intent_issue_id": "intent-1"},
+    )
+
+    assert result["reason"] == "runner-pod-not-ready"
+    assert any("reason:runner-pod-not-ready" in r for r in reasons_used)
+
+
+# ─── test_escalate_writes_alert_and_tg ──────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_escalate_writes_alert_and_tg(monkeypatch):
+    """escalate action: alerts.insert 和 tg.send_critical 都被调用。"""
+    from orchestrator.actions import escalate as escalate_mod
+
+    @dataclass
+    class _Body:
+        projectId: str = "proj-1"
+        issueId: str = "issue-1"
+        event: str = "session.failed"
+
+    class _FakeBKD:
+        def __init__(self, *a, **kw): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): pass
+        async def merge_tags_and_update(self, *a, **kw): pass
+
+    monkeypatch.setattr("orchestrator.actions.escalate.BKDClient", _FakeBKD)
+    monkeypatch.setattr("orchestrator.actions.escalate.req_state.update_context", AsyncMock())
+    monkeypatch.setattr("orchestrator.actions.escalate.db.get_pool", lambda: object())
+
+    alert_calls: list = []
+    async def fake_insert(**kw):
+        alert_calls.append(kw)
+        return 1
+    monkeypatch.setattr("orchestrator.actions.escalate.alerts.insert", fake_insert)
+
+    tg_calls: list = []
+    async def fake_tg(text):
+        tg_calls.append(text)
+        return True
+    monkeypatch.setattr("orchestrator.actions.escalate.tg.send_critical", fake_tg)
+
+    await escalate_mod.escalate(
+        body=_Body(),
+        req_id="REQ-2",
+        tags=[],
+        ctx={"escalated_reason": "watchdog-stuck-30min"},
+    )
+
+    assert len(alert_calls) == 1
+    assert alert_calls[0]["severity"] == "critical"
+    assert alert_calls[0]["reason"] == "watchdog-stuck-30min"
+    assert len(tg_calls) == 1
+    assert "REQ-2" in tg_calls[0]
+
+
+# ─── test_diagnose_pod_pull_failed ──────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_diagnose_pod_pull_failed():
+    """events 含 ImagePullBackOff → 返回 'image pull failed'。"""
+    from orchestrator.k8s_runner import RunnerController
+
+    mock_core_v1 = MagicMock()
+
+    # 构造 fake event
+    fake_event = MagicMock()
+    fake_event.reason = "BackOff"
+    fake_event.message = "Back-off pulling image: ImagePullBackOff"
+    fake_event.last_timestamp = None
+
+    mock_event_list = MagicMock()
+    mock_event_list.items = [fake_event]
+    mock_core_v1.list_namespaced_event.return_value = mock_event_list
+
+    rc = RunnerController(
+        namespace="sisyphus-runners",
+        runner_image="test-image",
+        runner_sa="sa",
+        storage_class="local-path",
+        workspace_size="10Gi",
+        runner_secret_name="secret",
+        core_v1=mock_core_v1,
+    )
+
+    result = await rc._diagnose_pod("test-pod")
+    assert result == "image pull failed"
+
+
+@pytest.mark.asyncio
+async def test_diagnose_pod_pvc_pending():
+    """events 含 WaitForFirstConsumer → 返回 PVC pending 字符串。"""
+    from orchestrator.k8s_runner import RunnerController
+
+    mock_core_v1 = MagicMock()
+
+    fake_event = MagicMock()
+    fake_event.reason = "FailedScheduling"
+    fake_event.message = "WaitForFirstConsumer: no consumer yet"
+    fake_event.last_timestamp = None
+
+    mock_event_list = MagicMock()
+    mock_event_list.items = [fake_event]
+    mock_core_v1.list_namespaced_event.return_value = mock_event_list
+
+    rc = RunnerController(
+        namespace="sisyphus-runners",
+        runner_image="test-image",
+        runner_sa="sa",
+        storage_class="local-path",
+        workspace_size="10Gi",
+        runner_secret_name="secret",
+        core_v1=mock_core_v1,
+    )
+
+    result = await rc._diagnose_pod("test-pod")
+    assert "PVC pending" in result
+
+
+@pytest.mark.asyncio
+async def test_diagnose_pod_api_failure_returns_diagnostic_failed():
+    """K8s API 抛异常 → 返回 'diagnostic failed'（不向上传播）。"""
+    from orchestrator.k8s_runner import RunnerController
+
+    mock_core_v1 = MagicMock()
+    mock_core_v1.list_namespaced_event.side_effect = Exception("API error")
+
+    rc = RunnerController(
+        namespace="sisyphus-runners",
+        runner_image="test-image",
+        runner_sa="sa",
+        storage_class="local-path",
+        workspace_size="10Gi",
+        runner_secret_name="secret",
+        core_v1=mock_core_v1,
+    )
+
+    result = await rc._diagnose_pod("test-pod")
+    assert result == "diagnostic failed"
+
+
+# ─── test_migrate_0008 ──────────────────────────────────────────────────────
+
+def test_migrate_0008_forward_creates_alerts_table():
+    """migration 0008 forward SQL 含 CREATE TABLE alerts。"""
+    from orchestrator.migrate import _DEFAULT_MIGRATIONS_DIR
+
+    fwd = Path(_DEFAULT_MIGRATIONS_DIR) / "0008_create_alerts.sql"
+    assert fwd.is_file(), "migration 0008 not found"
+    body = fwd.read_text()
+    assert "CREATE TABLE" in body.upper()
+    assert "alerts" in body.lower()
+    assert "severity" in body
+    assert "reason" in body
+    assert "sent_to_tg" in body
+
+
+def test_migrate_0008_rollback_drops_alerts():
+    """migration 0008 rollback SQL 含 DROP TABLE alerts。"""
+    from orchestrator.migrate import _DEFAULT_MIGRATIONS_DIR
+
+    rb = Path(_DEFAULT_MIGRATIONS_DIR) / "0008_create_alerts.rollback.sql"
+    assert rb.is_file(), "migration 0008 rollback not found"
+    body = rb.read_text()
+    assert "DROP TABLE" in body.upper()
+    assert "alerts" in body.lower()
+
+
+# ─── test_invoke_verifier_after_fix_loop_detect ─────────────────────────────
+
+@pytest.mark.asyncio
+async def test_invoke_verifier_after_fix_loop_detect(monkeypatch):
+    """verifier_history 已有 3 条 → 直接 emit VERIFY_ESCALATE，不起新 verifier。"""
+    from orchestrator.actions._verifier import invoke_verifier_after_fix
+    from orchestrator.state import Event
+
+    # mock db
+    ctx_patches: list = []
+    async def fake_update_context(pool, req_id, patch):
+        ctx_patches.append(patch)
+
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update_context)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: object())
+
+    invoke_calls: list = []
+    async def fake_invoke_verifier(**kw):
+        invoke_calls.append(kw)
+        return {"verifier_issue_id": "v-1"}
+
+    monkeypatch.setattr("orchestrator.actions._verifier.invoke_verifier", fake_invoke_verifier)
+
+    alert_calls: list = []
+    async def fake_alert_insert(**kw):
+        alert_calls.append(kw)
+        return 1
+    monkeypatch.setattr("orchestrator.actions._verifier.alerts.insert", fake_alert_insert)
+
+    @dataclass
+    class _Body:
+        projectId: str = "proj-1"
+
+    result = await invoke_verifier_after_fix(
+        body=_Body(),
+        req_id="REQ-X",
+        tags=["parent-stage:dev_cross_check"],
+        ctx={
+            "verifier_history": [
+                {"fixer": "dev", "fixer_issue_id": "f-1"},
+                {"fixer": "dev", "fixer_issue_id": "f-2"},
+                {"fixer": "dev", "fixer_issue_id": "f-3"},
+            ],
+            "fixer_role": "dev",
+            "fixer_issue_id": "f-4",
+        },
+    )
+
+    # 4 rounds total (3 existing + 1 current) → loop detected
+    assert result["emit"] == Event.VERIFY_ESCALATE.value
+    assert result["reason"] == "fixer loop"
+    # invoke_verifier NOT called
+    assert invoke_calls == []
+    # alert written
+    assert len(alert_calls) == 1
+    assert alert_calls[0]["reason"] == "fixer-loop-3rounds"
+    # ctx patched with escalated_reason
+    merged_patch = {}
+    for p in ctx_patches:
+        merged_patch.update(p)
+    assert merged_patch["escalated_reason"] == "fixer-loop-3rounds"
+
+
+@pytest.mark.asyncio
+async def test_invoke_verifier_after_fix_no_loop(monkeypatch):
+    """verifier_history 有 2 条（+本次=3）→ 正常起 verifier，不触发 loop detect。"""
+    from orchestrator.actions._verifier import invoke_verifier_after_fix
+
+    async def fake_update_context(pool, req_id, patch):
+        pass
+
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update_context)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: object())
+
+    invoke_calls: list = []
+    async def fake_invoke_verifier(**kw):
+        invoke_calls.append(kw)
+        return {"verifier_issue_id": "v-1", "stage": "dev_cross_check", "trigger": "success"}
+
+    monkeypatch.setattr("orchestrator.actions._verifier.invoke_verifier", fake_invoke_verifier)
+    monkeypatch.setattr("orchestrator.actions._verifier.alerts.insert", AsyncMock(return_value=1))
+
+    @dataclass
+    class _Body:
+        projectId: str = "proj-1"
+
+    result = await invoke_verifier_after_fix(
+        body=_Body(),
+        req_id="REQ-Y",
+        tags=["parent-stage:staging_test"],
+        ctx={
+            "verifier_history": [
+                {"fixer": "dev", "fixer_issue_id": "f-1"},
+                {"fixer": "dev", "fixer_issue_id": "f-2"},
+            ],
+            "fixer_role": "dev",
+            "fixer_issue_id": "f-3",
+        },
+    )
+
+    # 3 rounds total → boundary, NOT loop (loop triggers at > 3)
+    assert "emit" not in result or result.get("emit") != "verify.escalate"
+    assert len(invoke_calls) == 1

--- a/orchestrator/tests/test_migrate.py
+++ b/orchestrator/tests/test_migrate.py
@@ -56,3 +56,25 @@ def test_0006_rollback_drops_audit_column():
     body = rb.read_text()
     assert "audit" in body.lower()
     assert "DROP COLUMN" in body.upper()
+
+
+def test_0008_forward_creates_alerts_table():
+    """0008 forward：CREATE TABLE alerts + 关键列名。"""
+    fwd = Path(_DEFAULT_MIGRATIONS_DIR) / "0008_create_alerts.sql"
+    assert fwd.is_file(), "migration 0008 not found"
+    body = fwd.read_text()
+    assert "CREATE TABLE" in body.upper()
+    assert "alerts" in body.lower()
+    assert "severity" in body
+    assert "reason" in body
+    assert "sent_to_tg" in body
+    assert "acknowledged_at" in body
+
+
+def test_0008_rollback_drops_alerts():
+    """0008 rollback：DROP TABLE alerts。"""
+    rb = Path(_DEFAULT_MIGRATIONS_DIR) / "0008_create_alerts.rollback.sql"
+    assert rb.is_file(), "migration 0008 rollback not found"
+    body = rb.read_text()
+    assert "DROP TABLE" in body.upper()
+    assert "alerts" in body.lower()

--- a/orchestrator/tests/test_runner_gc.py
+++ b/orchestrator/tests/test_runner_gc.py
@@ -1,4 +1,4 @@
-"""runner_gc.gc_once 单测：mock PG pool + k8s_runner controller。"""
+"""runner_gc.gc_once / gc_pvcs 单测：mock PG pool + k8s_runner controller。"""
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
@@ -10,10 +10,17 @@ from orchestrator import k8s_runner, runner_gc
 
 
 class _FakePool:
-    def __init__(self, rows):
+    def __init__(self, rows, terminal_rows=None):
         self._rows = rows
+        self._terminal_rows = terminal_rows or []
 
     async def fetch(self, sql, *args):
+        # 区分不同的 SQL 查询
+        if "state IN ('done', 'escalated')" in sql:
+            return self._terminal_rows
+        if "state <> ALL" in sql:
+            # 返回非 terminal rows（空列表，表示没有非 terminal）
+            return []
         return self._rows
 
 
@@ -98,3 +105,101 @@ async def test_skips_when_no_controller(monkeypatch):
     k8s_runner.set_controller(None)
     result = await runner_gc.gc_once()
     assert "skipped" in result
+
+
+# ─── gc_pvcs 单测 ─────────────────────────────────────────────────────────
+
+@pytest.fixture
+def mock_controller_with_pvc(monkeypatch):
+    """注入 fake controller，记录 delete_pvc 调用。"""
+    fake = MagicMock()
+    fake.delete_pvc = AsyncMock(return_value=True)
+    k8s_runner.set_controller(fake)
+    yield fake
+    k8s_runner.set_controller(None)
+
+
+@pytest.mark.asyncio
+async def test_runner_gc_pvc_done_immediate(monkeypatch, mock_controller_with_pvc):
+    """state=done 的 PVC 立即被 GC 调用 delete_pvc。"""
+    now = datetime.now(UTC)
+    terminal_rows = [_row("REQ-D1", "done", updated_at=now)]
+    pool = _FakePool(rows=[], terminal_rows=terminal_rows)
+    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
+    monkeypatch.setattr("orchestrator.runner_gc._disk_pressure", AsyncMock(return_value=0.5))
+
+    result = await runner_gc.gc_pvcs()
+
+    mock_controller_with_pvc.delete_pvc.assert_called_once_with("REQ-D1")
+    assert "REQ-D1" in result["pvc_deleted"]
+
+
+@pytest.mark.asyncio
+async def test_runner_gc_pvc_escalated_under_24h_kept(monkeypatch, mock_controller_with_pvc):
+    """state=escalated 但 < 24h → 不删 PVC。"""
+    recent = datetime.now(UTC) - timedelta(hours=12)
+    terminal_rows = [_row("REQ-E1", "escalated", updated_at=recent)]
+    pool = _FakePool(rows=[], terminal_rows=terminal_rows)
+    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
+    monkeypatch.setattr("orchestrator.runner_gc._disk_pressure", AsyncMock(return_value=0.5))
+
+    result = await runner_gc.gc_pvcs()
+
+    mock_controller_with_pvc.delete_pvc.assert_not_called()
+    assert result["pvc_deleted"] == []
+
+
+@pytest.mark.asyncio
+async def test_runner_gc_pvc_escalated_over_24h_deleted(monkeypatch, mock_controller_with_pvc):
+    """state=escalated 超 24h → 删 PVC。"""
+    old = datetime.now(UTC) - timedelta(hours=25)
+    terminal_rows = [_row("REQ-E2", "escalated", updated_at=old)]
+    pool = _FakePool(rows=[], terminal_rows=terminal_rows)
+    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
+    monkeypatch.setattr("orchestrator.runner_gc._disk_pressure", AsyncMock(return_value=0.5))
+
+    result = await runner_gc.gc_pvcs()
+
+    mock_controller_with_pvc.delete_pvc.assert_called_once_with("REQ-E2")
+    assert "REQ-E2" in result["pvc_deleted"]
+
+
+@pytest.mark.asyncio
+async def test_runner_gc_pvc_disk_pressure_purge(monkeypatch, mock_controller_with_pvc):
+    """disk pressure > 80% → 强清 non-active PVC（含未过期 escalated）。"""
+    recent = datetime.now(UTC) - timedelta(hours=1)
+    terminal_rows = [_row("REQ-P1", "escalated", updated_at=recent)]
+    pool = _FakePool(rows=[], terminal_rows=terminal_rows)
+    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
+    # 模拟 disk > 80%
+    monkeypatch.setattr("orchestrator.runner_gc._disk_pressure", AsyncMock(return_value=0.85))
+
+    result = await runner_gc.gc_pvcs()
+
+    mock_controller_with_pvc.delete_pvc.assert_called_once_with("REQ-P1")
+    assert "REQ-P1" in result["pvc_deleted"]
+
+
+@pytest.mark.asyncio
+async def test_runner_gc_pvc_skips_active_on_disk_pressure(monkeypatch, mock_controller_with_pvc):
+    """disk pressure > 80% 时 active REQ 的 PVC 不删。"""
+    recent = datetime.now(UTC) - timedelta(hours=1)
+    terminal_rows = [_row("REQ-A1", "escalated", updated_at=recent)]
+
+    class _ActivePool:
+        async def fetch(self, sql, *args):
+            if "state IN ('done', 'escalated')" in sql:
+                return terminal_rows
+            if "state <> ALL" in sql:
+                # REQ-A1 is active (in-flight)
+                return [{"req_id": "REQ-A1"}]
+            return []
+
+    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: _ActivePool())
+    monkeypatch.setattr("orchestrator.runner_gc._disk_pressure", AsyncMock(return_value=0.9))
+
+    result = await runner_gc.gc_pvcs()
+
+    # REQ-A1 is active → not deleted despite disk pressure
+    mock_controller_with_pvc.delete_pvc.assert_not_called()
+    assert result["pvc_deleted"] == []

--- a/orchestrator/tests/test_watchdog.py
+++ b/orchestrator/tests/test_watchdog.py
@@ -1,5 +1,8 @@
 """watchdog 单测：mock PG fetch + BKD get_issue + engine.step，
-验不同 stuck row 的分流（escalate / skip / session-running）。"""
+验不同 stuck row 的分流（escalate / skip / session-running）。
+
+v2：5-min warn + 30-min escalate 两阶段。
+"""
 from __future__ import annotations
 
 import json
@@ -11,6 +14,7 @@ import pytest
 
 from orchestrator import watchdog
 from orchestrator.state import Event, ReqState
+from orchestrator.watchdog import _WARN_THRESHOLD_SEC
 
 
 # ─── Fake pool（只实现 fetch + execute，watchdog 用到这两）──────────────────
@@ -98,6 +102,27 @@ def _patch_artifact(monkeypatch):
     return calls
 
 
+def _patch_alerts(monkeypatch):
+    calls: list = []
+
+    async def fake_insert(**kw):
+        calls.append(kw)
+        return 1
+
+    monkeypatch.setattr("orchestrator.watchdog.alerts.insert", fake_insert)
+    return calls
+
+
+def _patch_req_state_update(monkeypatch):
+    calls: list = []
+
+    async def fake_update(pool, req_id, patch):
+        calls.append({"req_id": req_id, "patch": patch})
+
+    monkeypatch.setattr("orchestrator.watchdog.req_state.update_context", fake_update)
+    return calls
+
+
 # ─── Case 1：session=failed → escalate（写 artifact + engine.step SESSION_FAILED）
 @pytest.mark.asyncio
 async def test_stuck_with_failed_session_escalates(monkeypatch):
@@ -109,10 +134,13 @@ async def test_stuck_with_failed_session_escalates(monkeypatch):
     _patch_bkd(monkeypatch, FakeIssue(session_status="failed", id="st-1"))
     step_calls = _patch_engine(monkeypatch)
     art_calls = _patch_artifact(monkeypatch)
+    _patch_req_state_update(monkeypatch)
 
     result = await watchdog._tick()
 
-    assert result == {"checked": 1, "escalated": 1}
+    assert result["checked"] == 1
+    assert result["escalated"] == 1
+    assert result["warned"] == 0
     # engine 被调且是 SESSION_FAILED
     assert len(step_calls) == 1
     assert step_calls[0]["event"] == Event.SESSION_FAILED
@@ -137,10 +165,12 @@ async def test_stuck_but_session_running_skips(monkeypatch):
     _patch_bkd(monkeypatch, FakeIssue(session_status="running", id="st-2"))
     step_calls = _patch_engine(monkeypatch)
     art_calls = _patch_artifact(monkeypatch)
+    _patch_req_state_update(monkeypatch)
 
     result = await watchdog._tick()
 
-    assert result == {"checked": 1, "escalated": 0}
+    assert result["checked"] == 1
+    assert result["escalated"] == 0
     assert step_calls == []
     assert art_calls == []
 
@@ -156,10 +186,11 @@ async def test_stuck_bkd_lookup_fails_escalates(monkeypatch):
     _patch_bkd(monkeypatch, None, side_effect=RuntimeError("404 not found"))
     step_calls = _patch_engine(monkeypatch)
     _patch_artifact(monkeypatch)
+    _patch_req_state_update(monkeypatch)
 
     result = await watchdog._tick()
 
-    assert result == {"checked": 1, "escalated": 1}
+    assert result["escalated"] == 1
     assert len(step_calls) == 1
     assert step_calls[0]["event"] == Event.SESSION_FAILED
 
@@ -176,10 +207,11 @@ async def test_spec_lint_escalates_without_bkd_lookup(monkeypatch):
     fake_bkd = _patch_bkd(monkeypatch, FakeIssue(session_status="running"))
     step_calls = _patch_engine(monkeypatch)
     _patch_artifact(monkeypatch)
+    _patch_req_state_update(monkeypatch)
 
     result = await watchdog._tick()
 
-    assert result == {"checked": 1, "escalated": 1}
+    assert result["escalated"] == 1
     # spec-lint 无 issue_key → 不查 BKD
     fake_bkd.get_issue.assert_not_called()
     assert len(step_calls) == 1
@@ -198,10 +230,11 @@ async def test_missing_issue_id_in_ctx_escalates(monkeypatch):
     fake_bkd = _patch_bkd(monkeypatch, FakeIssue(session_status="running"))
     step_calls = _patch_engine(monkeypatch)
     _patch_artifact(monkeypatch)
+    _patch_req_state_update(monkeypatch)
 
     result = await watchdog._tick()
 
-    assert result == {"checked": 1, "escalated": 1}
+    assert result["escalated"] == 1
     # 无 issue_id 不查
     fake_bkd.get_issue.assert_not_called()
     assert len(step_calls) == 1
@@ -215,17 +248,18 @@ async def test_no_stuck_rows_does_nothing(monkeypatch):
     _patch_bkd(monkeypatch, FakeIssue())
     step_calls = _patch_engine(monkeypatch)
     art_calls = _patch_artifact(monkeypatch)
+    _patch_req_state_update(monkeypatch)
 
     result = await watchdog._tick()
 
-    assert result == {"checked": 0, "escalated": 0}
+    assert result == {"checked": 0, "escalated": 0, "warned": 0}
     assert step_calls == []
     assert art_calls == []
 
 
-# ─── Case 7：SQL 参数正确下发（_SKIP_STATES 含终态 + init）────
+# ─── Case 7：SQL 参数正确下发（_SKIP_STATES 含终态 + init，阈值=_WARN_THRESHOLD_SEC）────
 @pytest.mark.asyncio
-async def test_tick_passes_skip_states_and_threshold_to_sql(monkeypatch):
+async def test_tick_passes_skip_states_and_warn_threshold_to_sql(monkeypatch):
     captured: dict = {}
 
     class _CapturingPool:
@@ -235,14 +269,12 @@ async def test_tick_passes_skip_states_and_threshold_to_sql(monkeypatch):
             return []
 
     _patch_pool(monkeypatch, _CapturingPool())
-    monkeypatch.setattr(
-        "orchestrator.watchdog.settings.watchdog_stuck_threshold_sec", 1800,
-    )
 
     await watchdog._tick()
 
     skip_arr, threshold = captured["args"]
-    assert threshold == 1800
+    # SQL 现在用 _WARN_THRESHOLD_SEC（300s）而非 escalate threshold（1800s）
+    assert threshold == _WARN_THRESHOLD_SEC
     assert "done" in skip_arr
     assert "escalated" in skip_arr
     assert "init" in skip_arr
@@ -263,12 +295,14 @@ async def test_loop_disabled_returns_immediately(monkeypatch):
 async def test_engine_step_failure_isolated(monkeypatch):
     """engine.step 对某行抛异常不阻塞后续行处理（fault isolation）。"""
     pool = FakePool(rows=[
-        _row("REQ-A", ReqState.STAGING_TEST_RUNNING.value, ctx={"staging_test_issue_id": "st-a"}),
-        _row("REQ-B", ReqState.STAGING_TEST_RUNNING.value, ctx={"staging_test_issue_id": "st-b"}),
+        _row("REQ-A", ReqState.STAGING_TEST_RUNNING.value, ctx={"staging_test_issue_id": "st-a"}, stuck_sec=2000),
+        _row("REQ-B", ReqState.STAGING_TEST_RUNNING.value, ctx={"staging_test_issue_id": "st-b"}, stuck_sec=2000),
     ])
     _patch_pool(monkeypatch, pool)
     _patch_bkd(monkeypatch, FakeIssue(session_status="failed"))
     _patch_artifact(monkeypatch)
+    _patch_alerts(monkeypatch)
+    _patch_req_state_update(monkeypatch)
 
     calls: list = []
 
@@ -282,7 +316,88 @@ async def test_engine_step_failure_isolated(monkeypatch):
 
     result = await watchdog._tick()
 
-    # 两行都被处理，但只有 REQ-B 成功 escalate（REQ-A engine.step 抛异常返 False）
+    # 两行都被处理，但只有 REQ-B 成功 escalate（REQ-A engine.step 抛异常返 skip）
     assert result["checked"] == 2
     assert result["escalated"] == 1
     assert calls == ["REQ-A", "REQ-B"]
+
+
+# ─── Case 10：5min warn → alert(warn) + ctx.warned_at_5min + 不 escalate ────
+@pytest.mark.asyncio
+async def test_watchdog_5min_warn(monkeypatch):
+    """stuck_sec=600（5-30min 区间）→ 插 alert(severity=warn)，不走 escalate。"""
+    pool = FakePool(rows=[
+        _row("REQ-W1", ReqState.STAGING_TEST_RUNNING.value,
+             ctx={"staging_test_issue_id": "st-w1"}, stuck_sec=600),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, FakeIssue(session_status="failed", id="st-w1"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+    alert_calls = _patch_alerts(monkeypatch)
+    ctx_updates = _patch_req_state_update(monkeypatch)
+
+    result = await watchdog._tick()
+
+    # 告警了但没 escalate
+    assert result["escalated"] == 0
+    assert result["warned"] == 1
+    assert step_calls == []
+
+    # alert 写了 severity=warn
+    assert len(alert_calls) == 1
+    assert alert_calls[0]["severity"] == "warn"
+    assert alert_calls[0]["reason"] == "stuck-5min"
+    assert alert_calls[0]["req_id"] == "REQ-W1"
+
+    # ctx 写了 warned_at_5min=True
+    all_patches = {k: v for d in [u["patch"] for u in ctx_updates] for k, v in d.items()}
+    assert all_patches.get("warned_at_5min") is True
+
+
+@pytest.mark.asyncio
+async def test_watchdog_5min_warn_skips_if_already_warned(monkeypatch):
+    """warned_at_5min 已设 → 不重复告警。"""
+    pool = FakePool(rows=[
+        _row("REQ-W2", ReqState.STAGING_TEST_RUNNING.value,
+             ctx={"staging_test_issue_id": "st-w2", "warned_at_5min": True}, stuck_sec=700),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, FakeIssue(session_status="failed"))
+    _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+    alert_calls = _patch_alerts(monkeypatch)
+    _patch_req_state_update(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result["warned"] == 0
+    assert result["escalated"] == 0
+    assert alert_calls == []
+
+
+# ─── Case 11：30min escalate → escalated_reason="watchdog-stuck-30min" ───────
+@pytest.mark.asyncio
+async def test_watchdog_30min_escalate_reason(monkeypatch):
+    """stuck_sec=2000 → emit escalate + ctx.escalated_reason=watchdog-stuck-30min。"""
+    pool = FakePool(rows=[
+        _row("REQ-E1", ReqState.STAGING_TEST_RUNNING.value,
+             ctx={"staging_test_issue_id": "st-e1"}, stuck_sec=2000),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, FakeIssue(session_status="failed", id="st-e1"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+    _patch_alerts(monkeypatch)
+    ctx_updates = _patch_req_state_update(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result["escalated"] == 1
+    assert result["warned"] == 0
+    assert len(step_calls) == 1
+    assert step_calls[0]["event"] == Event.SESSION_FAILED
+
+    # ctx 写了 escalated_reason
+    all_patches = {k: v for d in [u["patch"] for u in ctx_updates] for k, v in d.items()}
+    assert all_patches.get("escalated_reason") == "watchdog-stuck-30min"


### PR DESCRIPTION
## 背景

本 PR 解决 3 个今晚撞到的**沉默失败**场景，让 sisyphus 主动把问题推到用户眼前：

1. **PVC 慢慢堆满磁盘无任何告警**
2. **runner pod 起不来，escalate reason 写「issue-updated」完全看不懂**
3. **fixer 死循环 > 3 轮，系统无法自动止损**

## 变更清单

### A. alerts 表 + DB 持久化
- `migration/0008_create_alerts.sql`：alerts 表（severity / req_id / stage / reason / hint / suggested_action / sent_to_tg）
- `store/alerts.py`：`insert_alert` / `mark_sent_to_tg`
- `alerts/__init__.py`：`insert()` 便捷包装（自取 pool）

### B. Telegram 推送（critical 才推）
- `alerts/tg.py`：`send_critical(text)` — 无 token 静默跳过，失败只 log warning
- `config.py`：新增 `tg_bot_token` / `tg_chat_id`（`str | None`，默认 None）

### C. escalate reason 细分
- `escalate.py`：优先读 `ctx.escalated_reason`（caller 细分），fallback 才用 body.event 名；写 alerts 表 + 推 TG
- 统一 reason 字面量：`runner-pod-not-ready` / `fixer-loop-3rounds` / `watchdog-stuck-30min` / `session-failed`

### D. _diagnose_pod() 助手
- `k8s_runner.py`：`_diagnose_pod(pod_name)` — 查 K8s events 诊断 ImagePullBackOff / PVC pending / resource insufficient
- `apply_verify_pass` 捕获 `ensure_runner` TimeoutError → 填 `ctx.escalated_reason/hint/action` → re-raise

### E. PVC 自动 GC
- `runner_gc.py`：新增 `gc_pvcs()` — done 立即删 / escalated 保留 24h / disk > 80% 强清
- `runner_gc.py`：`_disk_pressure()` 基于 `shutil.disk_usage('/')`
- `k8s_runner.py`：新增 `delete_pvc(req_id)` 方法

### F. watchdog 早期 stuck warn
- `watchdog.py`：SQL 阈值从 30min 改为 5min；两阶段：
  - 5–30min → `alert(severity=warn)` + ctx 标 `warned_at_5min`（只告一次）
  - ≥30min → 原 escalate 路径 + `ctx.escalated_reason = "watchdog-stuck-30min"`

### G. fixer loop detection
- `_verifier.py`：`invoke_verifier_after_fix`：`history > 3` → 直接 emit `VERIFY_ESCALATE`，不再起新 verifier

### 观测看板
- `observability/queries/sisyphus/18-active-alerts.sql`（Q18）
- `observability/queries/sisyphus/19-alerts-trend.sql`（Q19）
- `observability/queries/sisyphus/20-escalate-reasons.sql`（Q20）
- `sisyphus-dashboard.md`：新增 Q17–Q20 条目

## 测试方案

- [x] `uv run pytest` 387 通过（排除预先存在的 `httpx_mock` 缺失问题）
- [x] `test_alerts.py`：20 个新测试（insert/query/severity-check/TG-mock/escalate-ctx/diagnose-pod/migrate-0008/loop-detect）
- [x] `test_watchdog.py`：3 个新测试（5min-warn / already-warned-skip / 30min-escalated-reason）
- [x] `test_runner_gc.py`：5 个新测试（done-immediate / escalated-24h / disk-pressure-purge / active-skipped）
- [x] `test_migrate.py`：0008 forward + rollback 验证

🤖 Generated with [Claude Code](https://claude.ai/claude-code)