### PR TITLE
feat(runner_gc): tighter PVC retention + disk-pressure purge + runner mem 1Gi→512Mi

### DIFF
--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -40,10 +40,14 @@ class Settings(BaseSettings):
     # False = 本地调试，load_kube_config() 读 ~/.kube/config
     k8s_in_cluster: bool = True
 
-    # PVC 保留策略：escalated REQ 保留天数（过期 GC 自动清）
-    pvc_retain_on_escalate_days: int = 7
-    # GC 扫描周期
-    runner_gc_interval_sec: int = 3600   # 1h
+    # PVC 保留策略：escalated REQ 保留时长（过期 GC 自动清，给 PR #48 resume 时间窗）
+    # 默认 1 天：足够人当天 follow-up 续；超 1 天没人理就清掉
+    # （之前 7 天太宽，一次实证时 30 个 PVC 堆满磁盘；2026-04-24）
+    pvc_retain_on_escalate_days: int = 1
+    # GC 扫描周期 15 min（之前 1h 太松，REQ 频繁时 PVC 堆得快）
+    runner_gc_interval_sec: int = 900    # 15min
+    # 磁盘压力阈值：超过此比例 GC 强清所有非 active PVC（不论 retention）
+    runner_gc_disk_pressure_threshold: float = 0.8
 
     # GitHub token（烘进 runner Pod env，给 agent 用 gh CLI / docker login ghcr.io）
     # scope: repo + read:packages

--- a/orchestrator/src/orchestrator/k8s_runner.py
+++ b/orchestrator/src/orchestrator/k8s_runner.py
@@ -230,7 +230,11 @@ class RunnerController:
             # privileged: DinD 必须；fuse-overlayfs 要 /dev/fuse + CAP_SYS_ADMIN
             security_context=client.V1SecurityContext(privileged=True),
             resources=client.V1ResourceRequirements(
-                requests={"cpu": "500m", "memory": "1Gi"},
+                # 2026-04 实证：vm-node04 5991Mi 总内存，1Gi request 只能塞 1 个 runner，
+                # 多 REQ 并发时撞 FailedScheduling: Insufficient memory。
+                # 降到 512Mi/250m，能塞 2-3 个并发 runner。
+                # limit 保持 8Gi（runner 跑 docker build 高峰时需要）。
+                requests={"cpu": "250m", "memory": "512Mi"},
                 limits={"cpu": "4", "memory": "8Gi"},
             ),
             env=env_vars,
@@ -455,6 +459,28 @@ class RunnerController:
                 results.append(s)
         return results
 
+    async def node_disk_usage_ratio(self) -> float:
+        """节点磁盘使用率 0.0~1.0。用于 GC 判断磁盘压力。
+
+        通过节点 ephemeral-storage allocatable / capacity 推算（local-path PVC 占 ephemeral）。
+        失败时抛异常，让 caller fallback 到正常 retention 模式。
+        """
+        nodes = await asyncio.to_thread(self.core_v1.list_node)
+        # 取第一个 ready node（sisyphus 单节点 K3s 场景）
+        for node in nodes.items:
+            cap = node.status.capacity or {}
+            alloc = node.status.allocatable or {}
+            cap_eph = cap.get("ephemeral-storage")
+            alloc_eph = alloc.get("ephemeral-storage")
+            if cap_eph and alloc_eph:
+                # K8s 单位 like "50644856Ki"，统一转 KiB
+                cap_ki = _parse_k8s_quantity(cap_eph)
+                alloc_ki = _parse_k8s_quantity(alloc_eph)
+                if cap_ki > 0:
+                    used_ratio = 1.0 - (alloc_ki / cap_ki)
+                    return max(0.0, min(1.0, used_ratio))
+        raise RuntimeError("no node with ephemeral-storage info")
+
     async def gc_orphans(self, keep_req_ids: set[str]) -> list[str]:
         """删除 keep_req_ids 之外的所有 runner（pod + pvc）。
 
@@ -575,3 +601,32 @@ def _strip_exit_marker(stdout: str) -> str:
     while lines and lines[-1].strip().startswith(_EXIT_MARKER):
         lines.pop()
     return "".join(lines)
+
+
+_K8S_UNITS = {
+    "Ki": 1024, "Mi": 1024**2, "Gi": 1024**3, "Ti": 1024**4,
+    "K": 1000, "M": 1000**2, "G": 1000**3, "T": 1000**4,
+    "k": 1000, "m": 0.001,
+}
+
+
+def _parse_k8s_quantity(q: str) -> int:
+    """K8s 资源数量字符串解析为 KiB。e.g. "50644856Ki" → 50644856；"5Gi" → 5*1024*1024。
+
+    简化版，只支持常见后缀。无后缀按字节算。失败返 0。
+    """
+    if not q:
+        return 0
+    q = q.strip()
+    for unit in sorted(_K8S_UNITS.keys(), key=len, reverse=True):
+        if q.endswith(unit):
+            try:
+                num = float(q[:-len(unit)])
+                bytes_val = num * _K8S_UNITS[unit]
+                return int(bytes_val / 1024)  # 统一返 KiB
+            except ValueError:
+                return 0
+    try:
+        return int(int(q) / 1024)
+    except ValueError:
+        return 0

--- a/orchestrator/src/orchestrator/runner_gc.py
+++ b/orchestrator/src/orchestrator/runner_gc.py
@@ -25,9 +25,11 @@ log = structlog.get_logger(__name__)
 _TERMINAL_STATES = {"done", "escalated"}
 
 
-async def _active_req_ids() -> set[str]:
-    """列出所有 non-terminal REQ 的 req_id（大写）；
-    或 terminal 但还在保留期内的也算 active（先不清）。"""
+async def _active_req_ids(*, ignore_retention: bool = False) -> set[str]:
+    """列出所有 non-terminal REQ 的 req_id；或 terminal 但仍在保留期内的也算 active。
+
+    ignore_retention=True：磁盘压力下，escalated 也不留 retention，全清。
+    """
     pool = db.get_pool()
     rows = await pool.fetch(
         "SELECT req_id, state, updated_at, context FROM req_state",
@@ -42,8 +44,8 @@ async def _active_req_ids() -> set[str]:
             continue
         if state == "done":
             continue   # done 的 runner 立即销
-        # escalated：看是否还在保留期
-        if state == "escalated":
+        # escalated：看是否还在保留期（磁盘压力时跳过 retention 直接清）
+        if state == "escalated" and not ignore_retention:
             updated_at = r["updated_at"]
             if updated_at and (now - updated_at) < retention:
                 active.add(r["req_id"])
@@ -51,16 +53,35 @@ async def _active_req_ids() -> set[str]:
 
 
 async def gc_once() -> dict:
-    """单次 GC pass。返回 {cleaned: [...]}。"""
+    """单次 GC pass。返回 {cleaned: [...]}。
+
+    磁盘压力 (> threshold) 时：忽略 escalated retention，全清 non-active PVC（紧急疏散）。
+    """
     try:
         rc = k8s_runner.get_controller()
     except RuntimeError:
         # dev 环境没 K8s，跳过
         return {"skipped": "no runner controller"}
 
-    active = await _active_req_ids()
+    # 检查磁盘压力。压时 escalated PVC 也立即清（不留 retention）。
+    disk_pressure = False
+    try:
+        ratio = await rc.node_disk_usage_ratio()
+        if ratio > settings.runner_gc_disk_pressure_threshold:
+            log.warning("runner_gc.disk_pressure", ratio=round(ratio, 2),
+                        threshold=settings.runner_gc_disk_pressure_threshold)
+            disk_pressure = True
+    except Exception as e:
+        # 取不到磁盘指标 → 退回正常 retention 模式
+        log.debug("runner_gc.disk_check_failed", error=str(e))
+
+    active = await _active_req_ids(ignore_retention=disk_pressure)
     cleaned = await rc.gc_orphans(active)
-    return {"cleaned": cleaned, "active_kept": len(active)}
+    return {
+        "cleaned": cleaned,
+        "active_kept": len(active),
+        "disk_pressure": disk_pressure,
+    }
 
 
 async def run_loop() -> None:

--- a/orchestrator/tests/test_runner_gc.py
+++ b/orchestrator/tests/test_runner_gc.py
@@ -65,9 +65,27 @@ async def test_done_state_not_active(monkeypatch, mock_controller):
 
 
 @pytest.mark.asyncio
+async def test_escalated_within_retention_purged_on_disk_pressure(monkeypatch, mock_controller):
+    """disk > threshold → escalated 也强清（不留 retention）。"""
+    from unittest.mock import AsyncMock
+    recent = datetime.now(UTC) - timedelta(hours=2)
+    pool = _FakePool([
+        _row("REQ-1", "escalated", updated_at=recent),
+    ])
+    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
+    # 模拟磁盘 90% 用了
+    mock_controller.node_disk_usage_ratio = AsyncMock(return_value=0.9)
+
+    result = await runner_gc.gc_once()
+    assert result["disk_pressure"] is True
+    called_with = mock_controller.gc_orphans.await_args.args[0]
+    assert called_with == set()  # 紧急模式，escalated 不再 keep
+
+
+@pytest.mark.asyncio
 async def test_escalated_within_retention_kept(monkeypatch, mock_controller):
-    """escalated 但还在保留期内（默认 7 天）→ 仍 active（PVC 留给人翻）。"""
-    recent = datetime.now(UTC) - timedelta(days=1)
+    """escalated 但还在保留期内（默认 1 天）→ 仍 active（PVC 留给人 PR #48 resume）。"""
+    recent = datetime.now(UTC) - timedelta(hours=2)  # < 1 day default retention
     pool = _FakePool([
         _row("REQ-1", "escalated", updated_at=recent),
     ])


### PR DESCRIPTION
## Why

今晚撞 30 个 PVC 堆满磁盘 (75%) → provisioner 拒新卷 → REQ runner pod stuck → escalate。

根因：retention 7 天 + GC 1h 间隔 + 没磁盘兜底 + runner mem 1Gi 节点只塞 1 个。

## What

- config: retention 7→1 天、GC 间隔 1h→15min、加 disk_pressure_threshold (0.8)
- runner_gc: 磁盘 > 80% 时 escalated 也强清，不留 retention
- k8s_runner: runner pod request 1Gi→512Mi（节点能塞 2-3 个并发 runner）
- 加 node_disk_usage_ratio + _parse_k8s_quantity helper

## Tests

378 passed.