### PR TITLE
fix(prompts/bugfix): Step 0 env-bug short-circuit (no more 191 tool-call thrashing)

### DIFF
--- a/orchestrator/src/orchestrator/prompts/bugfix.md.j2
+++ b/orchestrator/src/orchestrator/prompts/bugfix.md.j2
@@ -36,6 +36,26 @@ BRANCH={{ branch }}
 
 ## 步骤
 
+### ⚠️ Step 0 — 环境短路检测（必跑，3 个 tool call 内完成）
+
+跑代码诊断前先快速摸 runner 环境健康度。**任一症状 → 立即停手不绕路**，按 ENV BUG
+路径走（tag `diagnosis:env-bug` + move review 给运维）：
+
+| 症状 | 检测 | 触发条件 |
+|---|---|---|
+| 1. kubectl exec 401 / Pod 不存在 | `kubectl -n sisyphus-runners exec runner-{{ req_id \| lower }} -- echo ok` | 非 0 退码 / `Unauthorized` / `not found` |
+| 2. git clone 401 / 404 | runner 内 `git ls-remote https://github.com/<org>/<repo>.git HEAD` | `Authentication failed` / `repository not found` / 403/404 |
+| 3. 工具链缺 | runner 内 `go version && make --version && which kubectl` | `command not found` |
+| 4. 磁盘满 / OOM | runner 内 `df -h /workspace \| awk 'NR==2{print $5}'` 或上轮 SOURCE_ISSUE 退码=137 | usage > 90% 或 OOMKilled |
+
+任一红 → 不再 tool_use，直接：
+1. BKD chat 一句：`🚫 env-bug: <症状>。runner 环境不对，escalate 给运维。`
+2. `update-issue` tags 加 `diagnosis:env-bug`
+3. `update-issue` statusId=review
+
+**禁止**：自装 Go / 自配 git token / kubectl cp 代码绕过 / 超过 3 个 tool_use 死磕环境。
+环境是 sisyphus 自己的事，绕过会掩盖运维问题；CODE / SPEC bug 才走 Step 1+。
+
 Step 1 进 runner pod，切到 feat 分支:
 ```bash
 kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c \

--- a/orchestrator/src/orchestrator/prompts/bugfix.md.j2
+++ b/orchestrator/src/orchestrator/prompts/bugfix.md.j2
@@ -43,10 +43,10 @@ BRANCH={{ branch }}
 
 | 症状 | 检测 | 触发条件 |
 |---|---|---|
-| 1. kubectl exec 401 / Pod 不存在 | `kubectl -n sisyphus-runners exec runner-{{ req_id \| lower }} -- echo ok` | 非 0 退码 / `Unauthorized` / `not found` |
-| 2. git clone 401 / 404 | runner 内 `git ls-remote https://github.com/<org>/<repo>.git HEAD` | `Authentication failed` / `repository not found` / 403/404 |
-| 3. 工具链缺 | runner 内 `go version && make --version && which kubectl` | `command not found` |
-| 4. 磁盘满 / OOM | runner 内 `df -h /workspace \| awk 'NR==2{print $5}'` 或上轮 SOURCE_ISSUE 退码=137 | usage > 90% 或 OOMKilled |
+- **kubectl exec 401 / Pod 不存在**：`kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- echo ok` 非 0 退码 / `Unauthorized` / `not found`
+- **git clone 401 / 404**：runner 内 `git ls-remote https://github.com/<org>/<repo>.git HEAD` 出 `Authentication failed` / `repository not found` / 403 / 404
+- **工具链缺**：runner 内 `go version && make --version && which kubectl` 出 `command not found`
+- **磁盘满 / OOM**：runner 内 `df -h /workspace` usage > 90%，或上轮 SOURCE_ISSUE 退码=137 (OOMKilled)
 
 任一红 → 不再 tool_use，直接：
 1. BKD chat 一句：`🚫 env-bug: <症状>。runner 环境不对，escalate 给运维。`


### PR DESCRIPTION
## Summary
- 在 `bugfix.md.j2` 的 `## 步骤` 顶部插入 `Step 0 — 环境短路检测`
- 4 类环境症状（kubectl exec 401 / git 401 / 工具链缺 / 磁盘满 OOM）→ 立即 `diagnosis:env-bug` + move review
- 硬限：3 个 tool_use 内完成，禁自装绕过

## 背景

REQ-pr-quantity-check fixer #9 跑的时候 runner pod 没法访问 ZonEaseTech 仓
（GH_TOKEN scope 不够）+ Go 没装，fixer agent **没识别为环境问题**，开始循环
191 个 tool call 试图绕过（自己 git clone 试 token、自己 go install 等），
最终拖死整个 chain。

根因：`bugfix.md.j2` 原本只在 `## 职责` 段被动列了 ENV BUG 类型，但**没明确
"先检测后修"的硬流程**。agent 默认认为是自己代码不对要继续修。

## 修法

加 Step 0 上来先扫 4 个简单命令，红了直接 escalate；硬规则禁止 "AI 觉得能绕过就尝试"。

## Test plan
- [x] `pytest tests/test_contract_fixer_audit_v2.py` 49/49 过
- [ ] 真起一个 ENV BUG 触发场景的 fixer REQ，看 fixer 是否 ≤3 tool call 内
      tag `diagnosis:env-bug` 而不是 191 个

REQ: REQ-fixer-env-fail-1777050473

🤖 Generated with [Claude Code](https://claude.com/claude-code)