### PR TITLE
fix(intake/escalate): race bug + ctx key mismatch + poisoning (3-in-1)

### DIFF
--- a/orchestrator/src/orchestrator/actions/escalate.py
+++ b/orchestrator/src/orchestrator/actions/escalate.py
@@ -42,9 +42,19 @@ def _is_transient(body_event: str | None, reason: str) -> bool:
         return False  # verifier 主观判，不重试
     if body_event == "session.failed":
         return True
+    if body_event == "watchdog.stuck":
+        return True  # watchdog 兜底永远值得续一次（BKD 漏发 webhook / process 卡住等）
     if reason in _TRANSIENT_REASONS:
         return True
+    if reason.startswith("action-error:"):
+        # engine _emit_escalate 注的：action handler 抛异常多半是基础设施 flaky
+        # （pod 没起、K3s 慢、BKD 临时 5xx）。续一次合理；真 bug 第二次还会同样异常
+        # 走 retry 用完 → 真 escalate。
+        return True
     return False
+
+
+_CANONICAL_SIGNALS = {"session.failed", "watchdog.stuck"}
 
 
 @register("escalate", idempotent=True)
@@ -52,10 +62,17 @@ async def escalate(*, body, req_id, tags, ctx):
     proj = body.projectId
     intent_issue_id = (ctx or {}).get("intent_issue_id") or body.issueId
     failed_issue_id = body.issueId  # 这次崩的具体 BKD issue
-    # ctx.escalated_reason 优先（caller 已细分），fallback 到 event 名
-    reason = (ctx or {}).get("escalated_reason") or (
-        (body.event or "unknown").replace(".", "-")[:40]
-    )
+    # reason 优先级：
+    #   1. body.event 是 canonical 失败信号（session.failed / watchdog.stuck）
+    #      → 用 body.event（最新一手信号；避免被前轮 ctx.escalated_reason 毒化）
+    #   2. ctx.escalated_reason 已被 caller 细分（engine action-error 等）
+    #   3. fallback：body.event 转 slug
+    if body.event in _CANONICAL_SIGNALS:
+        reason = body.event.replace(".", "-")[:40]
+    else:
+        reason = (ctx or {}).get("escalated_reason") or (
+            (body.event or "unknown").replace(".", "-")[:40]
+        )
     retry_count = (ctx or {}).get("auto_retry_count", 0)
 
     # ─── 1. transient + retry < 2 → auto-resume ────────────────────────────

--- a/orchestrator/src/orchestrator/bkd_rest.py
+++ b/orchestrator/src/orchestrator/bkd_rest.py
@@ -136,6 +136,34 @@ class BKDRestClient:
                     return c
         return None
 
+    async def get_all_assistant_messages_concat(
+        self,
+        project_id: str,
+        issue_id: str,
+    ) -> str | None:
+        """拼所有 assistant-messages 文本，给 extractor 在大字符串里找 JSON 用。
+
+        intake-agent 不像 verifier 那样严格："finalized JSON 必须放最后一条"。
+        它常先贴 JSON 再发短消息（"PATCH 加 result:pass"）再 PATCH 触发 webhook，
+        此刻 last assistant-message 没 JSON。get_last_assistant_message 漏掉。
+        """
+        try:
+            data = await self._get(
+                f"/projects/{project_id}/issues/{issue_id}/logs?limit=200"
+            )
+        except Exception as e:
+            log.warning("bkd.get_logs_failed", issue_id=issue_id, error=str(e))
+            return None
+        if not isinstance(data, dict):
+            return None
+        logs = data.get("logs") or []
+        msgs = [
+            e.get("content") for e in logs
+            if e.get("entryType") == "assistant-message"
+            and isinstance(e.get("content"), str)
+        ]
+        return "\n\n---\n\n".join(msgs) if msgs else None
+
     async def merge_tags_and_update(
         self,
         project_id: str,

--- a/orchestrator/src/orchestrator/engine.py
+++ b/orchestrator/src/orchestrator/engine.py
@@ -332,10 +332,11 @@ async def _emit_escalate(
     new_row = await req_state.get(pool, req_id)
     cur_state = new_row.state if new_row else fallback_state
     cur_ctx = new_row.context if new_row else {}
-    # 把失败原因暴露给 escalate action（ctx + body.event）— escalate 读 body.event 打 tag
-    # 这里不改 body.event（signature 限制）；仅保留 ctx 里的诊断信息
+    # 把失败原因暴露给 escalate action 当 reason —— key 必须是 escalated_reason
+    # （原来写 action_escalate_reason，escalate.py 读 escalated_reason，永远读不到，
+    # fallback 到 body.event 拿到 "issue.updated" 之类无意义值）。
     await req_state.update_context(pool, req_id, {
-        "action_escalate_reason": error_reason[:200],
+        "escalated_reason": f"action-error:{error_reason[:160]}",
     })
     return await step(
         pool,

--- a/orchestrator/src/orchestrator/webhook.py
+++ b/orchestrator/src/orchestrator/webhook.py
@@ -184,14 +184,19 @@ async def webhook(request: Request) -> JSONResponse:
                  issue_id=body.issueId, verifier_event=event.value,
                  decision=decision_payload, reason=why)
 
-    # INTAKE_PASS：从 intake-agent 最后一条 message 解 finalized intent JSON
+    # INTAKE_PASS：扫所有 assistant-messages 找 finalized intent JSON
+    # （不像 verifier 严要求 "JSON 必须放最后一条"，intake-agent 常先贴 JSON 再发短消息）
     # 解不到 → 降级为 INTAKE_FAIL 触发 escalate
     intake_finalized_intent: dict | None = None
     if event == Event.INTAKE_PASS:
         intake_text = None
         try:
             async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
-                if hasattr(bkd, "get_last_assistant_message"):
+                if hasattr(bkd, "get_all_assistant_messages_concat"):
+                    intake_text = await bkd.get_all_assistant_messages_concat(
+                        body.projectId, body.issueId,
+                    )
+                elif hasattr(bkd, "get_last_assistant_message"):
                     intake_text = await bkd.get_last_assistant_message(
                         body.projectId, body.issueId,
                     )

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -210,6 +210,53 @@ async def test_escalate_non_transient_immediate(monkeypatch):
     fake.merge_tags_and_update.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_escalate_canonical_signal_overrides_stale_ctx(monkeypatch):
+    """body.event=watchdog.stuck 应覆盖前一轮残留的 ctx.escalated_reason，
+    避免 ctx 毒化（实证 sis #27：第一次 escalate 写了垃圾 reason，第二次
+    watchdog 读 ctx 仍拿垃圾 → 不 transient → 永远不 auto-resume）。
+    """
+    from orchestrator.actions import escalate as mod
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, "escalate", fake)
+    patch_db(monkeypatch, "escalate")
+    body = make_body(issue_id="src-1", event="watchdog.stuck")
+    out = await mod.escalate(
+        body=body, req_id="REQ-9", tags=["watchdog:intaking"],
+        ctx={
+            "intent_issue_id": "intent-1",
+            "escalated_reason": "issue-updated",  # ← 上一轮写的垃圾值
+        },
+    )
+    # body.event canonical 优先 → reason=watchdog-stuck → transient → auto-resume
+    assert out["auto_resumed"] is True
+    assert out["reason"] == "watchdog-stuck"
+    fake.follow_up_issue.assert_awaited_once()
+    fake.merge_tags_and_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_escalate_action_error_is_transient(monkeypatch):
+    """engine _emit_escalate 注的 ctx.escalated_reason='action-error:...' 应被识别为
+    transient（基础设施 flaky）→ auto-resume 一次，给环境恢复机会。
+    """
+    from orchestrator.actions import escalate as mod
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, "escalate", fake)
+    patch_db(monkeypatch, "escalate")
+    body = make_body(issue_id="src-1", event="issue.updated")
+    out = await mod.escalate(
+        body=body, req_id="REQ-9", tags=["intent:intake"],
+        ctx={
+            "intent_issue_id": "intent-1",
+            "escalated_reason": "action-error:RuntimeError: pod not ready in 120s after 3 attempts",
+        },
+    )
+    assert out["auto_resumed"] is True
+    assert "action-error" in out["reason"]
+    fake.follow_up_issue.assert_awaited_once()
+
+
 # ─── done_archive ─────────────────────────────────────────────────────────
 @pytest.mark.asyncio
 async def test_done_archive(monkeypatch):

--- a/orchestrator/tests/test_bkd_rest.py
+++ b/orchestrator/tests/test_bkd_rest.py
@@ -164,6 +164,89 @@ async def test_cancel_issue_posts_to_cancel_endpoint():
     assert out["status"] == "cancelled"
 
 
+@pytest.mark.asyncio
+async def test_get_all_assistant_messages_concat_finds_json_in_earlier_message():
+    """Race bug 回归：intake-agent 把 finalized JSON 放早期 assistant-message，
+    后面又发短消息 → 旧 get_last_assistant_message 漏；新 helper 拼全部找得到。
+    """
+    captured_url = {}
+
+    class FakeHttp:
+        async def get(self, url, headers=None):
+            captured_url["url"] = url
+            payload = {
+                "success": True,
+                "data": {
+                    "logs": [
+                        {"entryType": "user-message", "content": "hi"},
+                        {"entryType": "assistant-message",
+                         "content": '完整 finalized intent:\n```json\n{"involved_repos":["x"],"business_behavior":"b","data_constraints":"c","edge_cases":"e","do_not_touch":"d","acceptance":"a"}\n```'},
+                        {"entryType": "tool-use", "content": "curl GET ..."},
+                        {"entryType": "tool-result", "content": "{...}"},
+                        {"entryType": "assistant-message",
+                         "content": "现在 PATCH 加 result:pass"},
+                        {"entryType": "tool-use", "content": "curl PATCH ..."},
+                    ]
+                },
+            }
+            return httpx.Response(200, text=json.dumps(payload))
+
+        async def aclose(self):
+            pass
+
+    client = BKDRestClient("https://bkd.example/api", "tok")
+    client._http = FakeHttp()  # type: ignore[assignment]
+
+    text = await client.get_all_assistant_messages_concat("p", "issue-1")
+    assert text is not None
+    # JSON 必须出现在拼接结果里（race bug 触发场景）
+    assert "involved_repos" in text
+    assert "business_behavior" in text
+    # 同时尾部短消息也要在
+    assert "PATCH 加 result:pass" in text
+    # URL 用了 logs?limit=200
+    assert "/projects/p/issues/issue-1/logs?limit=200" in captured_url["url"]
+
+
+@pytest.mark.asyncio
+async def test_get_all_assistant_messages_concat_returns_none_when_empty():
+    class FakeHttp:
+        async def get(self, url, headers=None):
+            return httpx.Response(200, text='{"success":true,"data":{"logs":[]}}')
+
+        async def aclose(self):
+            pass
+
+    client = BKDRestClient("https://bkd.example/api", "tok")
+    client._http = FakeHttp()  # type: ignore[assignment]
+    assert await client.get_all_assistant_messages_concat("p", "i") is None
+
+
+@pytest.mark.asyncio
+async def test_get_last_assistant_message_unchanged_only_returns_last():
+    """旧 helper 行为不变（verifier 路径还在用 it）—— regression"""
+    class FakeHttp:
+        async def get(self, url, headers=None):
+            payload = {
+                "success": True,
+                "data": {
+                    "logs": [
+                        {"entryType": "assistant-message", "content": "first"},
+                        {"entryType": "tool-use", "content": "..."},
+                        {"entryType": "assistant-message", "content": "last"},
+                    ]
+                },
+            }
+            return httpx.Response(200, text=json.dumps(payload))
+
+        async def aclose(self):
+            pass
+
+    client = BKDRestClient("https://bkd.example/api", "tok")
+    client._http = FakeHttp()  # type: ignore[assignment]
+    assert await client.get_last_assistant_message("p", "i") == "last"
+
+
 def test_factory_picks_rest_by_default(monkeypatch):
     """BKDClient(...) 默认应返回 REST 实例（settings.bkd_transport 默认 'rest'）。"""
     from orchestrator.bkd import BKDClient


### PR DESCRIPTION
## Summary

3 个相关 bug 一起修，从今晚 sis #27 / sis #28 实证倒推：

| # | 现象 | Root cause | Fix |
|---|---|---|---|
| **1** | intake-agent 提交了完整 finalized JSON 但 sisyphus 报 `webhook.intake.no_finalized_intent` → INTAKE_FAIL → escalate | `get_last_assistant_message` 只看尾巴一条，agent 在 PATCH 前发了短消息 → JSON 在更早消息被漏 | 加 `get_all_assistant_messages_concat`，拼所有 assistant-message 给 extractor。verifier 路径继续用旧 helper（严要求 JSON 放最后） |
| **2** | escalate tag 永远写 `reason:issue-updated`，跟实际 action 错误对不上 | `engine._emit_escalate` 写 `ctx.action_escalate_reason`，`escalate.py` 读 `ctx.escalated_reason` —— **不同 key** | 统一 key 为 `escalated_reason`，前缀 `action-error:` |
| **3** | watchdog 30 分钟兜底 escalate 永远不 auto-resume | escalate 第一次写的旧 ctx 值毒化第二次：`body.event=watchdog.stuck` 被 stale ctx 覆盖 → 不在 transient 集 → 直接终态 | reason 优先级：canonical signals (`session.failed`/`watchdog.stuck`) > ctx > body.event fallback；`watchdog.stuck` + `action-error:*` 加进 transient |

## 实证

**sis #27 (REQ-runner-gh-token)**：
```
15:57:09 INTENT_INTAKE → start_intake action
15:57~16:03 runner pod 拉 3 次都没 ready (vm-node04 K3s 拥挤)
16:03:13 start_intake 抛 → engine _emit_escalate
         → ctx.action_escalate_reason set （但 escalate.py 不读这个 key）
         → escalate.py fallback to body.event "issue.updated"
         → tag reason:issue-updated（含义错）
         → state 留 INTAKING（is_session_failed_path=False）
16:33:42 watchdog 30 分钟兜底 SESSION_FAILED w/ event=watchdog.stuck
         → escalate.py 读 ctx.escalated_reason 拿到上一轮旧 "issue-updated"
         → 不 transient → 永远不 auto-resume → 强 escalate 终态
```

**sis #28 (REQ-fixer-env-fail)**：
```
17:09:37 intake-agent: PATCH result:pass → BKD webhook
         此刻 last assistant-message = "现在 PATCH 加 result:pass" (no JSON)
         → extractor 0 块 → INTAKE_FAIL → escalate
17:09:55 agent 之后才贴 "Finalized intent 已写入 ```json{...}```"，太晚
```

## Test plan
- [x] `pytest` 384/384 ✅（含 5 个新 case）
- [ ] merge + helm upgrade，重发一个 intake REQ 验证 race bug 不再触发
- [ ] 触发一个 ensure_runner 失败场景，验证 auto-resume 真起作用

REQ: REQ-sisyphus-intake-race-1777051375

🤖 Generated with [Claude Code](https://claude.com/claude-code)