### PR TITLE
fix(pr_ci_watch): per-REQ multi-repo support (verifier #11 root-cause)

### DIFF
--- a/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
@@ -41,12 +41,18 @@ async def _run_checker(*, req_id: str, ctx: dict) -> dict:
     log.info("create_pr_ci_watch.checker_path", req_id=req_id)
     branch = ctx.get("branch") or f"feat/{req_id}"
 
+    # per-REQ involved_repos 优先（intake-agent 写的 finalized intent 里有），
+    # checker fallback 到全局 SISYPHUS_BUSINESS_REPO 兼容老 REQ
+    finalized = ctx.get("intake_finalized_intent") or {}
+    repos = finalized.get("involved_repos") or ctx.get("involved_repos")
+
     try:
         result = await checker.watch_pr_ci(
             req_id,
             branch=branch,
             poll_interval_sec=settings.pr_ci_watch_poll_interval_sec,
             timeout_sec=settings.pr_ci_watch_timeout_sec,
+            repos=repos,
         )
     except ValueError as e:
         log.error("create_pr_ci_watch.config_error", req_id=req_id, error=str(e))

--- a/orchestrator/src/orchestrator/checkers/pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/checkers/pr_ci_watch.py
@@ -1,17 +1,25 @@
 """pr-ci-watch 自检（M2）：sisyphus 直接调 GitHub REST API 轮询 PR check-runs。
 
 M15：repo / pr_number 用 gh api 实时查，不读 manifest。
-repo 从环境变量 SISYPHUS_BUSINESS_REPO 拿，branch 从参数传入。
+repos 列表优先来自 caller（per-REQ involved_repos），fallback 到全局环境变量
+SISYPHUS_BUSINESS_REPO（兼容旧单仓 REQ）。
+
 dev agent 只需 push branch + 创 PR，不用回写任何东西。
+
+多仓 REQ 行为：
+- 任一 repo 的 PR check-runs 红 → 整体 fail
+- 任一 repo 上找不到 open PR → fail（说明 dev agent 没 push 完）
+- 所有 repo 全绿 → pass
+- 还有 pending → 等
 
 GH API:
 - GET /repos/{owner}/{repo}/pulls?head={owner}:{branch}&state=open  → PR list（含 number + head.sha）
 - GET /repos/{owner}/{repo}/commits/{sha}/check-runs                 → check_runs[]
 
 退出码：
-- 0   = 全绿（所有 check-run completed 且 conclusion 友好）
-- 1   = 至少一个失败（completed + conclusion 红）
-- 124 = 超时（到 timeout_sec 还有 check-run 没 completed）
+- 0   = 全绿（所有 repo 的 check-run completed 且 conclusion 友好）
+- 1   = 至少一个失败
+- 124 = 超时
 """
 from __future__ import annotations
 
@@ -39,11 +47,19 @@ async def watch_pr_ci(
     branch: str,
     poll_interval_sec: int = 30,
     timeout_sec: int = 1800,
+    repos: list[str] | None = None,
 ) -> CheckResult:
-    """轮询 PR check-runs → 全绿 / 任一失败 / 超时返 CheckResult。"""
-    repo = os.getenv("SISYPHUS_BUSINESS_REPO")
-    if not repo:
-        raise ValueError("SISYPHUS_BUSINESS_REPO env var not set")
+    """轮询所有 repos 的 PR check-runs → 全绿 / 任一失败 / 超时返 CheckResult。
+
+    repos 优先于 SISYPHUS_BUSINESS_REPO 环境变量（per-REQ involved_repos 优先于全局）。
+    """
+    repo_list = repos or ([os.getenv("SISYPHUS_BUSINESS_REPO")] if os.getenv("SISYPHUS_BUSINESS_REPO") else [])
+    repo_list = [r for r in repo_list if r]
+    if not repo_list:
+        raise ValueError(
+            "no repos provided to watch_pr_ci (caller didn't pass repos and "
+            "SISYPHUS_BUSINESS_REPO env var not set)"
+        )
 
     headers = {
         "Accept": "application/vnd.github+json",
@@ -52,62 +68,97 @@ async def watch_pr_ci(
     if settings.github_token:
         headers["Authorization"] = f"Bearer {settings.github_token}"
 
-    log.info("checker.pr_ci_watch.start", repo=repo, branch=branch,
+    log.info("checker.pr_ci_watch.start", repos=repo_list, branch=branch,
              poll=poll_interval_sec, timeout=timeout_sec)
 
     start = time.monotonic()
     async with httpx.AsyncClient(base_url=_GH_API, headers=headers, timeout=30.0) as client:
-        # 1. 用 REST API 查 PR number + head.sha（替代 gh CLI，避免同步阻塞事件循环）
-        try:
-            pr_number, sha = await _get_pr_info(client, repo, branch)
-        except httpx.HTTPError as e:
-            log.exception("checker.pr_ci_watch.pr_lookup_failed", repo=repo, branch=branch)
-            return CheckResult(
-                passed=False, exit_code=1,
-                stdout_tail="", stderr_tail=f"PR lookup failed: {e}"[:_TAIL],
-                duration_sec=time.monotonic() - start, cmd=f"watch-pr-ci {repo}@{branch}",
-            )
+        # 1. 查每个 repo 的 PR number + head.sha
+        pr_infos: list[tuple[str, int, str]] = []  # [(repo, pr_number, sha)]
+        for repo in repo_list:
+            try:
+                pr_number, sha = await _get_pr_info(client, repo, branch)
+                pr_infos.append((repo, pr_number, sha))
+            except httpx.HTTPError as e:
+                log.exception("checker.pr_ci_watch.pr_lookup_failed",
+                              repo=repo, branch=branch)
+                return CheckResult(
+                    passed=False, exit_code=1,
+                    stdout_tail="", stderr_tail=f"PR lookup failed for {repo}: {e}"[:_TAIL],
+                    duration_sec=time.monotonic() - start,
+                    cmd=f"watch-pr-ci {repo}@{branch}",
+                )
+            except ValueError as e:
+                # No open PR found
+                return CheckResult(
+                    passed=False, exit_code=1,
+                    stdout_tail="", stderr_tail=str(e)[:_TAIL],
+                    duration_sec=time.monotonic() - start,
+                    cmd=f"watch-pr-ci {repo}@{branch}",
+                )
 
-        cmd_label = f"watch-pr-ci {repo}#{pr_number}@{sha[:8]}"
+        cmd_label = "watch-pr-ci " + " ".join(f"{r}#{n}@{s[:8]}" for r, n, s in pr_infos)
         deadline = start + timeout_sec
-        last_runs: list[dict] = []
+        per_repo_runs: dict[str, list[dict]] = {}
 
         while True:
-            try:
-                last_runs = await _get_check_runs(client, repo, sha)
-            except httpx.HTTPError as e:
-                log.warning("checker.pr_ci_watch.api_error", repo=repo, sha=sha[:8], error=str(e))
-                if time.monotonic() >= deadline:
-                    return CheckResult(
-                        passed=False, exit_code=124,
-                        stdout_tail="", stderr_tail=f"API error at deadline: {e}"[:_TAIL],
-                        duration_sec=time.monotonic() - start, cmd=cmd_label,
-                    )
+            api_error = None
+            for repo, _, sha in pr_infos:
+                try:
+                    per_repo_runs[repo] = await _get_check_runs(client, repo, sha)
+                except httpx.HTTPError as e:
+                    api_error = (repo, e)
+                    log.warning("checker.pr_ci_watch.api_error",
+                                repo=repo, sha=sha[:8], error=str(e))
+
+            if api_error and time.monotonic() >= deadline:
+                repo, e = api_error
+                return CheckResult(
+                    passed=False, exit_code=124,
+                    stdout_tail="",
+                    stderr_tail=f"API error at deadline for {repo}: {e}"[:_TAIL],
+                    duration_sec=time.monotonic() - start, cmd=cmd_label,
+                )
+            if api_error:
                 await asyncio.sleep(poll_interval_sec)
                 continue
 
-            verdict = _classify(last_runs)
-            log.info("checker.pr_ci_watch.poll", repo=repo, sha=sha[:8],
-                     verdict=verdict, run_count=len(last_runs))
+            # 聚合判 verdict：任一 fail → fail；全部 pass → pass；否则 pending
+            verdicts = {repo: _classify(runs) for repo, runs in per_repo_runs.items()}
+            log.info("checker.pr_ci_watch.poll",
+                     verdicts=verdicts,
+                     run_counts={r: len(rs) for r, rs in per_repo_runs.items()})
 
-            if verdict == "pass":
-                return CheckResult(
-                    passed=True, exit_code=0,
-                    stdout_tail=_summarize(last_runs)[:_TAIL], stderr_tail="",
-                    duration_sec=time.monotonic() - start, cmd=cmd_label,
-                )
-            if verdict == "fail":
+            if any(v == "fail" for v in verdicts.values()):
+                summary_parts = [
+                    f"{repo}: {_summarize(runs, failed_only=True)}"
+                    for repo, runs in per_repo_runs.items()
+                    if verdicts[repo] == "fail"
+                ]
                 return CheckResult(
                     passed=False, exit_code=1,
-                    stdout_tail=_summarize(last_runs, failed_only=True)[:_TAIL],
-                    stderr_tail="",
-                    duration_sec=time.monotonic() - start, cmd=cmd_label,
+                    stdout_tail=" | ".join(summary_parts)[:_TAIL],
+                    stderr_tail="", duration_sec=time.monotonic() - start, cmd=cmd_label,
+                )
+            if all(v == "pass" for v in verdicts.values()):
+                summary_parts = [
+                    f"{repo}: {_summarize(runs)}"
+                    for repo, runs in per_repo_runs.items()
+                ]
+                return CheckResult(
+                    passed=True, exit_code=0,
+                    stdout_tail=" | ".join(summary_parts)[:_TAIL],
+                    stderr_tail="", duration_sec=time.monotonic() - start, cmd=cmd_label,
                 )
 
             if time.monotonic() + poll_interval_sec >= deadline:
+                summary_parts = [
+                    f"{repo}: {_summarize(runs)}"
+                    for repo, runs in per_repo_runs.items()
+                ]
                 return CheckResult(
                     passed=False, exit_code=124,
-                    stdout_tail=_summarize(last_runs)[:_TAIL],
+                    stdout_tail=" | ".join(summary_parts)[:_TAIL],
                     stderr_tail=f"timeout after {timeout_sec}s, still pending",
                     duration_sec=time.monotonic() - start, cmd=cmd_label,
                 )

--- a/orchestrator/tests/test_checkers_pr_ci_watch.py
+++ b/orchestrator/tests/test_checkers_pr_ci_watch.py
@@ -206,24 +206,104 @@ async def test_watch_pr_ci_empty_runs_times_out(httpx_mock, monkeypatch):
 # ── env / branch 不全 → 抛 ValueError ────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_watch_pr_ci_raises_when_env_missing(monkeypatch):
-    """SISYPHUS_BUSINESS_REPO 没设 → 直接 ValueError。"""
+async def test_watch_pr_ci_raises_when_no_repos(monkeypatch):
+    """没传 repos 参数 + SISYPHUS_BUSINESS_REPO 没设 → 直接 ValueError。"""
     monkeypatch.delenv("SISYPHUS_BUSINESS_REPO", raising=False)
-    with pytest.raises(ValueError, match="SISYPHUS_BUSINESS_REPO"):
+    with pytest.raises(ValueError, match="no repos provided"):
         await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9")
 
 
 @pytest.mark.asyncio
-async def test_watch_pr_ci_raises_when_no_pr(monkeypatch):
-    """_get_pr_info 找不到对应 PR → ValueError。"""
+async def test_watch_pr_ci_returns_fail_when_no_pr(monkeypatch):
+    """找不到对应 PR → 返 fail CheckResult（exit=1），不再抛 ValueError 让 caller 处理。"""
     monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/ubox-crosser")
 
     async def fake_lookup_none(client, _repo: str, _branch: str) -> tuple[int, str]:
         raise ValueError("No open PR found for branch")
     monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup_none)
 
-    with pytest.raises(ValueError, match="No open PR found"):
-        await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9")
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9")
+    assert result.passed is False
+    assert result.exit_code == 1
+    assert "No open PR found" in result.stderr_tail
+
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_per_req_repos_override_env(monkeypatch):
+    """传入 repos 参数应覆盖 SISYPHUS_BUSINESS_REPO env var（per-REQ 覆盖全局）。"""
+    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/wrong-repo")
+
+    looked_up: list[str] = []
+
+    async def fake_lookup(client, repo: str, _branch: str):
+        looked_up.append(repo)
+        return (101, "abc1234567890def")
+
+    async def fake_check_runs(client, _repo: str, _sha: str):
+        return [_run("CI", conclusion="success")]
+
+    monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
+    monkeypatch.setattr(pr_ci_watch, "_get_check_runs", fake_check_runs)
+
+    result = await pr_ci_watch.watch_pr_ci(
+        "REQ-9", "feat/REQ-9",
+        poll_interval_sec=0, timeout_sec=10,
+        repos=["ZonEaseTech/ttpos-server-go"],
+    )
+    assert result.passed
+    # env var 完全没被用到，只用 caller 给的 repo
+    assert looked_up == ["ZonEaseTech/ttpos-server-go"]
+
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_multi_repo_all_green(monkeypatch):
+    """多 repo REQ：所有 repo 都绿 → pass，cmd label 含全部 repo+sha。"""
+    looked_up: list[str] = []
+
+    async def fake_lookup(client, repo: str, _branch: str):
+        looked_up.append(repo)
+        return (1, f"sha-{repo[:4]}aaaa")
+
+    async def fake_check_runs(client, _repo: str, _sha: str):
+        return [_run("CI", conclusion="success")]
+
+    monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
+    monkeypatch.setattr(pr_ci_watch, "_get_check_runs", fake_check_runs)
+
+    result = await pr_ci_watch.watch_pr_ci(
+        "REQ-9", "feat/REQ-9",
+        poll_interval_sec=0, timeout_sec=10,
+        repos=["a/repo-x", "b/repo-y"],
+    )
+    assert result.passed
+    assert "a/repo-x" in result.cmd
+    assert "b/repo-y" in result.cmd
+
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_multi_repo_one_fails(monkeypatch):
+    """多 repo REQ：任一 repo CI 红 → 整体 fail，stdout 标出哪个 repo 红。"""
+    async def fake_lookup(client, repo: str, _branch: str):
+        return (1, f"sha-{repo[:4]}aaaa")
+
+    async def fake_check_runs(client, repo: str, _sha: str):
+        if repo == "b/repo-y":
+            return [_run("CI", conclusion="failure")]
+        return [_run("CI", conclusion="success")]
+
+    monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
+    monkeypatch.setattr(pr_ci_watch, "_get_check_runs", fake_check_runs)
+
+    result = await pr_ci_watch.watch_pr_ci(
+        "REQ-9", "feat/REQ-9",
+        poll_interval_sec=0, timeout_sec=10,
+        repos=["a/repo-x", "b/repo-y"],
+    )
+    assert not result.passed
+    assert result.exit_code == 1
+    # 只输出失败的 repo 摘要
+    assert "b/repo-y" in result.stdout_tail
+    assert "failure" in result.stdout_tail
 
 
 # ── _classify 单测 ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

verifier #11 (REQ-pr-quantity-check pr_ci) 实测找到的 sisyphus bug：

> SISYPHUS_BUSINESS_REPO=phona/ubox-crosser (orchestrator global config) is wrong
> for this REQ — actual involved repo is ZonEaseTech/ttpos-server-go, which is
> inaccessible via the runner GH_TOKEN; pr_ci checker fired fail via config error
> (no PR found), both fixers abandoned unable to push; all checker stages passed
> as false positives (workspace/source/ empty, loop never executed).
> Needs human: ... fix SISYPHUS_BUSINESS_REPO per-REQ routing.

## 改造

| 改 | 文件 |
|---|---|
| `watch_pr_ci()` 加 `repos: list[str]` 参数，per-REQ 优先 + env fallback | `checkers/pr_ci_watch.py` |
| 多 repo 聚合判：任一 fail → 整体 fail；全绿 → pass | 同上 |
| `create_pr_ci_watch` 从 `ctx.intake_finalized_intent.involved_repos` 读 repos | `actions/create_pr_ci_watch.py` |
| 找不到 PR 不抛 ValueError，返 fail CheckResult | 同 `checkers/pr_ci_watch.py` |

## Test plan

- [x] `pytest` 382 / 382 ✅（含 4 个新 case：per-REQ 覆盖、多 repo 全绿、多 repo 一红 fail、no-pr 返 fail）
- [ ] merge + helm upgrade，重发 REQ-pr-quantity-check（ZonEaseTech/ttpos-server-go），看 pr_ci checker 真打到对的 repo

## 跟 PR #61 关系

PR #61 修 intake/escalate 三件套（race + key mismatch + ctx 毒化）。
本 PR 修 pr_ci_watch repo routing。两个独立，可分别 merge。

🤖 Generated with [Claude Code](https://claude.com/claude-code)