### PR TITLE
fix(webhook): set escalated_reason='verifier-decision' when VERIFY_ESCALATE fires

### DIFF
--- a/openspec/changes/REQ-escalate-reason-verifier-1777076876/proposal.md
+++ b/openspec/changes/REQ-escalate-reason-verifier-1777076876/proposal.md
@@ -1,0 +1,26 @@
+# REQ-escalate-reason-verifier-1777076876: fix escalated_reason for verifier decisions
+
+## Problem
+
+When a verifier agent returns `action=escalate`, the webhook handler invokes `engine.step`
+with `event=VERIFY_ESCALATE` but never sets `ctx.escalated_reason` beforehand. The `escalate`
+action reads `ctx.escalated_reason` to pick the termination reason; without it, the action
+falls back to `body.event.replace(".", "-")` = `"session-completed"`, which is semantically
+meaningless and was not guarded by `_is_transient` as an explicit non-retryable reason.
+
+## Solution
+
+In `webhook.py`, after processing the verifier decision payload (section 5.6) and before
+calling `engine.step`, check `if event == Event.VERIFY_ESCALATE` and patch ctx with
+`escalated_reason = "verifier-decision"`. Update `_is_transient` in `escalate.py` to use
+`"verifier-decision"` (matching the new canonical value).
+
+## Scope
+
+Single repo: `phona/sisyphus` (orchestrator only).
+
+## Risks
+
+Low. The fix is additive: adds one context key. Existing `_is_transient` already returns
+`False` for `"verifier-decision"` via the fallthrough path; updating the explicit check is
+a cosmetic consistency fix.

--- a/openspec/changes/REQ-escalate-reason-verifier-1777076876/specs/escalate-reason/contract.spec.yaml
+++ b/openspec/changes/REQ-escalate-reason-verifier-1777076876/specs/escalate-reason/contract.spec.yaml
@@ -1,0 +1,22 @@
+openspec: "1.0"
+id: escalate-reason
+title: escalated_reason for verifier decisions
+scenarios:
+  - id: ERV-S1
+    title: verifier escalate sets reason verifier-decision in context
+    given:
+      - verifier agent session.completed with action=escalate decision
+    when:
+      - webhook processes event and derives VERIFY_ESCALATE
+    then:
+      - ctx.escalated_reason == "verifier-decision"
+      - escalate action returns reason == "verifier-decision"
+  - id: ERV-S2
+    title: verifier-decision is not treated as transient
+    given:
+      - ctx.escalated_reason = "verifier-decision"
+    when:
+      - escalate action evaluates _is_transient
+    then:
+      - _is_transient returns False
+      - real escalate performed, no auto-resume

--- a/openspec/changes/REQ-escalate-reason-verifier-1777076876/specs/escalate-reason/spec.md
+++ b/openspec/changes/REQ-escalate-reason-verifier-1777076876/specs/escalate-reason/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: webhook sets escalated_reason when verifier decides to escalate
+
+When a verifier agent session completes with `action=escalate`, the webhook handler MUST
+set `ctx.escalated_reason = "verifier-decision"` before calling `engine.step`. The `escalate`
+action SHALL use this value as the termination reason, ensuring downstream log entries and
+BKD tags carry a meaningful reason string rather than falling back to `"session-completed"`.
+
+#### Scenario: ERV-S1 verifier escalate sets reason verifier-decision in context
+
+- **GIVEN** a verifier agent session.completed with action=escalate decision
+- **WHEN** webhook processes the event and derives VERIFY_ESCALATE
+- **THEN** ctx.escalated_reason is set to "verifier-decision" before engine.step is called
+- **AND** the escalate action returns reason="verifier-decision"
+
+#### Scenario: ERV-S2 verifier-decision is not treated as transient
+
+- **GIVEN** ctx.escalated_reason = "verifier-decision"
+- **WHEN** escalate action evaluates _is_transient
+- **THEN** _is_transient returns False
+- **AND** the action performs real escalate without auto-resume follow-up

--- a/openspec/changes/REQ-escalate-reason-verifier-1777076876/tasks.md
+++ b/openspec/changes/REQ-escalate-reason-verifier-1777076876/tasks.md
@@ -1,0 +1,14 @@
+# Tasks: REQ-escalate-reason-verifier-1777076876
+
+## Stage: spec
+- [x] author specs/escalate-reason/spec.md scenarios
+- [x] author specs/escalate-reason/contract.spec.yaml
+
+## Stage: implementation
+- [x] webhook.py §5.8: set ctx.escalated_reason="verifier-decision" when event==VERIFY_ESCALATE
+- [x] escalate.py _is_transient: update explicit check from "verifier-decision-escalate" to "verifier-decision"
+- [x] test_actions_smoke.py: update test_escalate_non_transient_immediate to use "verifier-decision"
+
+## Stage: PR
+- [x] git push feat/REQ-escalate-reason-verifier-1777076876
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/actions/escalate.py
+++ b/orchestrator/src/orchestrator/actions/escalate.py
@@ -38,7 +38,7 @@ _TRANSIENT_REASONS = {
 
 def _is_transient(body_event: str | None, reason: str) -> bool:
     """判断是不是 transient 失败：值得 auto-resume continue 一次"""
-    if reason == "verifier-decision-escalate":
+    if reason == "verifier-decision":
         return False  # verifier 主观判，不重试
     if body_event == "session.failed":
         return True

--- a/orchestrator/src/orchestrator/webhook.py
+++ b/orchestrator/src/orchestrator/webhook.py
@@ -309,6 +309,13 @@ async def webhook(request: Request) -> JSONResponse:
         await req_state.update_context(pool, req_id, patch)
         ctx = {**ctx, **patch}
 
+    # ─── 5.8 VERIFY_ESCALATE → 预置 escalated_reason ────────────────────────
+    # escalate action 从 ctx.escalated_reason 读 reason；没设则 fallback 到
+    # body.event.replace(".", "-") = "session-completed"，语义不明。
+    if event == Event.VERIFY_ESCALATE:
+        await req_state.update_context(pool, req_id, {"escalated_reason": "verifier-decision"})
+        ctx = {**ctx, "escalated_reason": "verifier-decision"}
+
     # ─── 6. 推进状态机（engine 内部循环 emit）─────────────────────────────
     result = await engine.step(
         pool,

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -191,7 +191,7 @@ async def test_escalate_real_after_retries_exhausted(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_escalate_non_transient_immediate(monkeypatch):
-    """verifier-decision-escalate (非 session.failed) → 直接真 escalate，不 retry"""
+    """verifier-decision (非 session.failed) → 直接真 escalate，不 retry"""
     from orchestrator.actions import escalate as mod
     fake = make_fake_bkd()
     patch_bkd(monkeypatch, "escalate", fake)
@@ -201,11 +201,11 @@ async def test_escalate_non_transient_immediate(monkeypatch):
         body=body, req_id="REQ-9", tags=["verifier"],
         ctx={
             "intent_issue_id": "intent-1",
-            "escalated_reason": "verifier-decision-escalate",
+            "escalated_reason": "verifier-decision",
         },
     )
     assert out["escalated"] is True
-    assert out["reason"] == "verifier-decision-escalate"
+    assert out["reason"] == "verifier-decision"
     fake.follow_up_issue.assert_not_awaited()
     fake.merge_tags_and_update.assert_awaited_once()
 

--- a/orchestrator/tests/test_contract_escalate_reason.py
+++ b/orchestrator/tests/test_contract_escalate_reason.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 from typing import ClassVar
 from unittest.mock import AsyncMock
 
-import pytest
-
 
 class _FakePool:
     """Minimal asyncpg pool fake: ordered fetchrow returns + recorded execute calls."""

--- a/orchestrator/tests/test_contract_escalate_reason.py
+++ b/orchestrator/tests/test_contract_escalate_reason.py
@@ -1,0 +1,158 @@
+"""Contract tests for escalated_reason on verifier decisions (REQ-escalate-reason-verifier-1777076876).
+
+Black-box behavioral contracts derived from:
+  openspec/changes/REQ-escalate-reason-verifier-1777076876/specs/escalate-reason/spec.md
+
+Scenarios:
+  ERV-S1  verifier escalate sets ctx.escalated_reason="verifier-decision" before engine.step
+  ERV-S2  _is_transient("verifier-decision") returns False — no auto-resume
+"""
+from __future__ import annotations
+
+from typing import ClassVar
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class _FakePool:
+    """Minimal asyncpg pool fake: ordered fetchrow returns + recorded execute calls."""
+
+    def __init__(self, fetchrow_returns=()):
+        self._returns = list(fetchrow_returns)
+        self._pos = 0
+        self.execute_calls: list[tuple] = []
+
+    async def fetchrow(self, sql: str, *args):
+        if self._pos < len(self._returns):
+            v = self._returns[self._pos]
+            self._pos += 1
+            return v
+        return None
+
+    async def execute(self, sql: str, *args):
+        self.execute_calls.append((sql, args))
+
+
+# ─── ERV-S1: verifier escalate → ctx.escalated_reason = "verifier-decision" ─
+
+
+async def test_s1_verifier_escalate_sets_reason_verifier_decision(monkeypatch):
+    """
+    ERV-S1: When a verifier session.completed results in VERIFY_ESCALATE, the webhook MUST
+    set ctx.escalated_reason = "verifier-decision" (via update_context) before engine.step.
+    """
+    import orchestrator.observability as obs
+    from orchestrator import engine, webhook
+    from orchestrator import router as router_lib
+    from orchestrator.state import Event, ReqState
+    from orchestrator.store import db, dedup
+    from orchestrator.store import req_state as rs_mod
+
+    context_updates: list[dict] = []
+    step_snapshots: list[list[dict]] = []
+
+    monkeypatch.setattr(dedup, "check_and_record", AsyncMock(return_value="new"))
+    monkeypatch.setattr(dedup, "mark_processed", AsyncMock())
+    monkeypatch.setattr(db, "get_pool", lambda: _FakePool())
+    monkeypatch.setattr(obs, "record_event", AsyncMock())
+
+    class _BKD:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get_issue(self, *a, **kw):
+            class R:
+                tags: ClassVar = ["REQ-erv1", "verifier", "result:escalate"]
+
+            return R()
+
+        async def update_issue(self, *a, **kw):
+            pass
+
+    monkeypatch.setattr(webhook, "BKDClient", _BKD)
+    monkeypatch.setattr(router_lib, "extract_req_id", lambda tags, num=None: "REQ-erv1")
+    monkeypatch.setattr(router_lib, "derive_event", lambda evt, tags: Event.VERIFY_ESCALATE)
+
+    class _Row:
+        state = ReqState.REVIEW_RUNNING
+        context: ClassVar = {}
+
+    monkeypatch.setattr(rs_mod, "get", AsyncMock(return_value=_Row()))
+    monkeypatch.setattr(rs_mod, "insert_init", AsyncMock())
+
+    async def _capture_update_context(*args, **kwargs):
+        # args: (pool, req_id, patch_dict) or similar — capture whatever patch dict is passed
+        for a in args:
+            if isinstance(a, dict):
+                context_updates.append(dict(a))
+        for v in kwargs.values():
+            if isinstance(v, dict):
+                context_updates.append(dict(v))
+
+    monkeypatch.setattr(rs_mod, "update_context", _capture_update_context)
+
+    async def _capture_step(*args, **kwargs):
+        step_snapshots.append(list(context_updates))
+        return {"action": "ok"}
+
+    monkeypatch.setattr(engine, "step", _capture_step)
+
+    class _Req:
+        headers: ClassVar = {"authorization": "Bearer test-webhook-token"}
+
+        async def json(self):
+            return {
+                "event": "session.completed",
+                "issueId": "issue-erv1",
+                "projectId": "proj-erv1",
+                "executionId": "exec-erv1",
+                "tags": ["REQ-erv1", "verifier", "result:escalate"],
+            }
+
+    await webhook.webhook(_Req())
+
+    # Contract 1: update_context must be called with escalated_reason = "verifier-decision"
+    reason_updates = [u for u in context_updates if "escalated_reason" in u]
+    assert reason_updates, (
+        "webhook MUST call update_context with escalated_reason='verifier-decision' "
+        f"for VERIFY_ESCALATE. All context updates captured: {context_updates}"
+    )
+    assert reason_updates[-1]["escalated_reason"] == "verifier-decision", (
+        "escalated_reason MUST be 'verifier-decision', "
+        f"got {reason_updates[-1]['escalated_reason']!r}"
+    )
+
+    # Contract 2: the reason must be set BEFORE engine.step is called
+    assert step_snapshots, "engine.step must be called after VERIFY_ESCALATE"
+    updates_at_step_time = step_snapshots[0]
+    assert any("escalated_reason" in u for u in updates_at_step_time), (
+        "ctx.escalated_reason MUST be set via update_context BEFORE engine.step is called. "
+        f"context_updates at engine.step call time: {updates_at_step_time}"
+    )
+
+
+# ─── ERV-S2: verifier-decision is not transient → no auto-resume ─────────────
+
+
+async def test_s2_verifier_decision_not_transient():
+    """
+    ERV-S2: _is_transient("verifier-decision") MUST return False.
+    A verifier escalation is a deliberate AI decision — auto-resume MUST NOT be triggered.
+    """
+    from orchestrator.actions.escalate import _is_transient
+
+    # body_event="session.completed" simulates normal verifier session completion;
+    # reason="verifier-decision" is what webhook sets when VERIFY_ESCALATE is derived.
+    result = _is_transient("session.completed", "verifier-decision")
+
+    assert result is False, (
+        f"_is_transient('session.completed', 'verifier-decision') MUST return False (non-transient); "
+        f"got {result!r}. verifier-decision is an intentional escalation — no auto-resume follow-up."
+    )


### PR DESCRIPTION
## Summary

- **Bug**: When a verifier agent returns `action=escalate`, webhook.py never set `ctx.escalated_reason` before calling `engine.step`. The `escalate` action fell back to `body.event.replace(".", "-")` = `"session-completed"` — semantically meaningless and bypassed the `_is_transient` guard.
- **Fix**: Added webhook §5.8 that patches `ctx.escalated_reason = "verifier-decision"` whenever `event == Event.VERIFY_ESCALATE`, before `engine.step` is called.
- **Consistency**: Updated `_is_transient`'s explicit check from `"verifier-decision-escalate"` → `"verifier-decision"` to match the canonical value now set by webhook.

## Files changed

| File | Change |
|---|---|
| `orchestrator/src/orchestrator/webhook.py` | §5.8: set `escalated_reason` on VERIFY_ESCALATE |
| `orchestrator/src/orchestrator/actions/escalate.py` | `_is_transient`: update explicit check value |
| `orchestrator/tests/test_actions_smoke.py` | Update test to use `"verifier-decision"` |
| `openspec/changes/REQ-escalate-reason-verifier-1777076876/` | Spec + proposal + tasks |

## Test plan

- [x] `test_escalate_non_transient_immediate` — verifier-decision → real escalate, no auto-resume
- [x] `test_escalate_canonical_signal_overrides_stale_ctx` — watchdog.stuck still overrides stale ctx
- [x] `test_escalate_action_error_is_transient` — action-error still triggers auto-resume
- [x] 111 tests pass (all tests except pre-existing httpx_mock fixture gap in pr-ci-watch checker tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)