### PR TITLE
fix(pr_ci_watch): re-fetch head SHA each polling tick

### DIFF
--- a/openspec/changes/REQ-pr-ci-watch-sha-refresh-1777076876/proposal.md
+++ b/openspec/changes/REQ-pr-ci-watch-sha-refresh-1777076876/proposal.md
@@ -1,0 +1,26 @@
+# REQ-pr-ci-watch-sha-refresh-1777076876: fix(pr_ci_watch): re-fetch head SHA each polling tick
+
+## 问题
+
+`pr_ci_watch` 在启动时只拉一次 PR 的 head SHA，整个轮询周期都用这个固定的 SHA 查 check-runs。
+如果 dev agent 在 CI 运行中途 force-push（更新代码修 bug），检查器会继续盯着旧 SHA 的 check-runs，
+导致：
+- 新 SHA 的 CI 结果被完全忽略
+- 旧 SHA 的 CI 变绿 → 错误地 pass（实际新代码的 CI 可能还没跑完或失败）
+- force-push 后无任何感知，整体轮询结果不可信
+
+## 方案
+
+每个 polling tick 重新拉一次 head SHA（`_get_pr_info`），检测变化后：
+1. SHA 变化（force-push）→ 清空该 repo 的 check-runs 缓存，从新 SHA 重新轮询
+2. 翻转次数超过 5 次（`_MAX_SHA_FLIPS=5`）→ fail，reason=`too-many-sha-flips`（防止无限 churn）
+3. PR 被 merge → 立即 pass（merged → CI 必已过，或 repo 主动决策）
+4. PR 被 close（未 merge）→ fail，reason=`pr-closed-without-merge`
+5. refetch 失败（HTTP 错误 / PR 一时找不到）→ 警告 + retry，与 check-run API 错误语义一致
+
+超时保持原有 1800s，不变。
+
+## 范围
+
+只改 `orchestrator/src/orchestrator/checkers/pr_ci_watch.py` 及其测试。
+不改 schema、不改 Metabase 看板（只加 `log.info("sha_flip", ...)` 便于观测）。

--- a/openspec/changes/REQ-pr-ci-watch-sha-refresh-1777076876/specs/pr-ci-watch-sha-refresh/spec.md
+++ b/openspec/changes/REQ-pr-ci-watch-sha-refresh-1777076876/specs/pr-ci-watch-sha-refresh/spec.md
@@ -1,0 +1,59 @@
+## MODIFIED Requirements
+
+### Requirement: pr_ci_watch 每 tick 重新拉 head SHA 以检测 force-push
+
+The `watch_pr_ci` checker SHALL re-fetch the PR head SHA on every polling tick (not just once at startup). When the fetched SHA differs from the cached SHA, the system MUST clear the check-runs cache for that repo and restart polling against the new SHA. The system MUST log a `sha_flip` event at INFO level with fields `old`, `new`, and `flip_count` each time a SHA change is detected.
+
+#### Scenario: PRCISHAR-S1 force-push 后切换到新 SHA 继续轮询
+
+- **GIVEN** PR 初始 head SHA 为 sha_A，sha_A 的 check-runs pending
+- **WHEN** 下一 tick 重新拉 PR info 返回 sha_B（force-push）
+- **THEN** sha_A 的 check-runs 缓存被清除，系统从 sha_B 的 check-runs 继续轮询
+
+#### Scenario: PRCISHAR-S2 新 SHA 的 check-runs 最终通过 → overall pass
+
+- **GIVEN** force-push 后切换到 sha_B（flip_count=1 ≤ 5）
+- **WHEN** sha_B 的所有 check-runs completed 且全部 conclusion 为绿色
+- **THEN** `watch_pr_ci` 返回 passed=True, exit_code=0
+
+### Requirement: SHA 翻转超过 5 次时 fail with too-many-sha-flips
+
+The system SHALL track SHA flip count per repo. If the flip count exceeds 5 (i.e., the 6th force-push is detected), the system MUST set `terminal_verdict="fail"` for that repo and return a `CheckResult` with `passed=False`, `exit_code=1`, and `stdout_tail` containing the string `too-many-sha-flips`. Each repo MUST track its flip count independently (per-repo restart semantics).
+
+#### Scenario: PRCISHAR-S3 翻转 5 次以内继续轮询
+
+- **GIVEN** 单个 repo 已发生 5 次 SHA 翻转（flip_count=5）
+- **WHEN** 拉到第 5 次新 SHA
+- **THEN** 继续正常轮询，不触发 too-many-sha-flips
+
+#### Scenario: PRCISHAR-S4 翻转第 6 次 → fail too-many-sha-flips
+
+- **GIVEN** 单个 repo flip_count 已为 5
+- **WHEN** 检测到第 6 次 SHA 变化（flip_count 变为 6）
+- **THEN** `watch_pr_ci` 返回 passed=False, exit_code=1，stdout_tail 包含 `too-many-sha-flips`
+
+### Requirement: PR merged 时立即 pass，closed 时立即 fail
+
+The system SHALL detect PR state changes on every polling tick. When `_get_pr_info` returns state `"merged"`, the system MUST set the terminal verdict for that repo to `"pass"` without waiting for check-runs. When `_get_pr_info` returns state `"closed"` (closed without merge), the system MUST set the terminal verdict to `"fail"` with reason `pr-closed-without-merge`. If all repos reach terminal `"pass"`, `watch_pr_ci` MUST return immediately with `passed=True`.
+
+#### Scenario: PRCISHAR-S5 PR merged 后 watch_pr_ci 立即返 pass
+
+- **GIVEN** PR 在 loop 某 tick 被 merge（`merged_at` 非 null）
+- **WHEN** re-fetch 返回 state="merged"
+- **THEN** `watch_pr_ci` 返回 passed=True，stdout_tail 含 "merged"，不再拉 check-runs
+
+#### Scenario: PRCISHAR-S6 PR closed（未 merge）→ fail pr-closed-without-merge
+
+- **GIVEN** PR 在 loop 某 tick 被关闭但未 merge（`merged_at` 为 null）
+- **WHEN** re-fetch 返回 state="closed"
+- **THEN** `watch_pr_ci` 返回 passed=False, exit_code=1，stdout_tail 含 `pr-closed-without-merge`
+
+### Requirement: PR info refetch 失败时 retry 直到 deadline
+
+The system SHALL treat PR info refetch failures (both `httpx.HTTPError` and `ValueError` from "no PR found") during the polling loop as transient errors. The system MUST log a WARNING and continue to the next tick without immediately returning a failure. This behavior MUST be consistent with how check-run API errors are handled. Only the initial PR fetch (before the loop) SHALL fail fast on errors.
+
+#### Scenario: PRCISHAR-S7 loop 内 refetch HTTP 错误 → 警告并重试
+
+- **GIVEN** `_get_pr_info` 在第 N 个 tick 抛出 `httpx.HTTPError`（下一个 tick 恢复正常）
+- **WHEN** `watch_pr_ci` 捕获到该错误
+- **THEN** 记录 WARNING 日志，使用缓存的 SHA 继续拉 check-runs，不返回 fail；下一 tick 恢复正常拉取

--- a/openspec/changes/REQ-pr-ci-watch-sha-refresh-1777076876/tasks.md
+++ b/openspec/changes/REQ-pr-ci-watch-sha-refresh-1777076876/tasks.md
@@ -1,0 +1,31 @@
+# Tasks for REQ-pr-ci-watch-sha-refresh-1777076876
+
+## Stage: contract / spec
+
+- [x] author specs/pr-ci-watch-sha-refresh/spec.md — SHA 翻转检测、flip 限制、PR merged/closed 处理、refetch retry 语义
+
+## Stage: implementation
+
+- [x] 修改 `_get_pr_info` 返回 3-tuple `(pr_number, sha, state)` 支持 open/merged/closed 区分
+- [x] 添加 `_RepoState` dataclass 跟踪 per-repo sha、flip_count、terminal_verdict
+- [x] 重构 `watch_pr_ci` 主循环：每 tick 重新拉 PR info，检测 SHA 翻转 + PR 状态变化
+- [x] SHA 翻转：log sha_flip、flip_count 超 5 → terminal fail reason=too-many-sha-flips
+- [x] PR merged → terminal pass；PR closed → terminal fail reason=pr-closed-without-merge
+- [x] refetch 失败（HTTP/ValueError）→ 警告 + retry，不立即 fail
+- [x] 删除原有 `cmd_label` 静态字符串，改为 closure 函数确保 SHA 更新后 cmd 同步
+
+## Stage: unit test
+
+- [x] 更新 `patch_pr_lookup` 及所有 `fake_lookup` mock 返回 3-tuple（兼容新签名）
+- [x] 更新 `test_watch_pr_ci_per_req_repos_override_env`：assertion 改为 `set(looked_up)` 覆盖多次调用
+- [x] 新增 `test_watch_pr_ci_sha_flip_restarts_check_runs`：force-push 后从新 SHA 轮询
+- [x] 新增 `test_watch_pr_ci_too_many_sha_flips`：超 5 次翻转 → fail
+- [x] 新增 `test_watch_pr_ci_pr_merged_returns_pass`：loop 中 PR 被 merge → 立即 pass
+- [x] 新增 `test_watch_pr_ci_pr_closed_returns_fail`：loop 中 PR 被 close → fail
+- [x] 新增 `test_watch_pr_ci_initial_pr_already_merged`：初始 fetch 发现已 merge → 立即 pass
+- [x] 新增 `test_watch_pr_ci_pr_refetch_error_retries`：loop 内 refetch HTTP 失败 → 重试
+
+## Stage: PR
+
+- [x] git push feat/REQ-pr-ci-watch-sha-refresh-1777076876
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/checkers/pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/checkers/pr_ci_watch.py
@@ -6,6 +6,15 @@ SISYPHUS_BUSINESS_REPO（兼容旧单仓 REQ）。
 
 dev agent 只需 push branch + 创 PR，不用回写任何东西。
 
+SHA 刷新（force-push 检测）：
+- 每 tick 重新拉 head SHA；SHA 变化时重置 check-runs 缓存，从新 SHA 开始判
+- 单 repo 最多允许 _MAX_SHA_FLIPS 次翻转，超限 → fail reason=too-many-sha-flips
+- refetch 失败（HTTP / 找不到 PR）→ 警告 + retry，与 check-run API 错误一致
+
+PR 状态变化：
+- merged → pass（PR 被合并）
+- closed without merge → fail reason=pr-closed-without-merge
+
 多仓 REQ 行为：
 - 任一 repo 的 PR check-runs 红 → 整体 fail
 - 任一 repo 上找不到 open PR → fail（说明 dev agent 没 push 完）
@@ -13,7 +22,8 @@ dev agent 只需 push branch + 创 PR，不用回写任何东西。
 - 还有 pending → 等
 
 GH API:
-- GET /repos/{owner}/{repo}/pulls?head={owner}:{branch}&state=open  → PR list（含 number + head.sha）
+- GET /repos/{owner}/{repo}/pulls?head={owner}:{branch}&state=open  → open PR（含 head.sha）
+- GET /repos/{owner}/{repo}/pulls?head={owner}:{branch}&state=closed → closed/merged PR
 - GET /repos/{owner}/{repo}/commits/{sha}/check-runs                 → check_runs[]
 
 退出码：
@@ -26,6 +36,7 @@ from __future__ import annotations
 import asyncio
 import os
 import time
+from dataclasses import dataclass
 
 import httpx
 import structlog
@@ -37,9 +48,20 @@ log = structlog.get_logger(__name__)
 
 _GH_API = "https://api.github.com"
 _TAIL = 2048
+_MAX_SHA_FLIPS = 5
 
 _PASS_CONCLUSIONS = {"success", "neutral", "skipped"}
 _FAIL_CONCLUSIONS = {"failure", "cancelled", "timed_out", "action_required", "stale"}
+
+
+@dataclass
+class _RepoState:
+    repo: str
+    pr_number: int
+    sha: str
+    flip_count: int = 0
+    terminal_verdict: str | None = None  # "pass" | "fail" once decided
+    terminal_reason: str | None = None
 
 
 async def watch_pr_ci(
@@ -51,6 +73,8 @@ async def watch_pr_ci(
 ) -> CheckResult:
     """轮询所有 repos 的 PR check-runs → 全绿 / 任一失败 / 超时返 CheckResult。
 
+    每 tick 重新拉 head SHA：force-push 自动切新 SHA；超过 _MAX_SHA_FLIPS 次翻转 → fail。
+    merged → pass；closed without merge → fail；refetch 失败 → retry 到 deadline。
     repos 优先于 SISYPHUS_BUSINESS_REPO 环境变量（per-REQ involved_repos 优先于全局）。
     """
     repo_list = repos or ([os.getenv("SISYPHUS_BUSINESS_REPO")] if os.getenv("SISYPHUS_BUSINESS_REPO") else [])
@@ -73,12 +97,20 @@ async def watch_pr_ci(
 
     start = time.monotonic()
     async with httpx.AsyncClient(base_url=_GH_API, headers=headers, timeout=30.0) as client:
-        # 1. 查每个 repo 的 PR number + head.sha
-        pr_infos: list[tuple[str, int, str]] = []  # [(repo, pr_number, sha)]
+        # Initial PR fetch: fail fast if no PR exists for any repo
+        states: list[_RepoState] = []
         for repo in repo_list:
             try:
-                pr_number, sha = await _get_pr_info(client, repo, branch)
-                pr_infos.append((repo, pr_number, sha))
+                pr_number, sha, pr_state = await _get_pr_info(client, repo, branch)
+                state = _RepoState(repo=repo, pr_number=pr_number, sha=sha)
+                if pr_state == "merged":
+                    state.terminal_verdict = "pass"
+                    log.info("checker.pr_ci_watch.pr_merged", repo=repo, pr=pr_number)
+                elif pr_state == "closed":
+                    state.terminal_verdict = "fail"
+                    state.terminal_reason = "pr-closed-without-merge"
+                    log.info("checker.pr_ci_watch.pr_closed", repo=repo, pr=pr_number)
+                states.append(state)
             except httpx.HTTPError as e:
                 log.exception("checker.pr_ci_watch.pr_lookup_failed",
                               repo=repo, branch=branch)
@@ -89,7 +121,6 @@ async def watch_pr_ci(
                     cmd=f"watch-pr-ci {repo}@{branch}",
                 )
             except ValueError as e:
-                # No open PR found
                 return CheckResult(
                     passed=False, exit_code=1,
                     stdout_tail="", stderr_tail=str(e)[:_TAIL],
@@ -97,19 +128,77 @@ async def watch_pr_ci(
                     cmd=f"watch-pr-ci {repo}@{branch}",
                 )
 
-        cmd_label = "watch-pr-ci " + " ".join(f"{r}#{n}@{s[:8]}" for r, n, s in pr_infos)
+        def _cmd_label() -> str:
+            return "watch-pr-ci " + " ".join(f"{s.repo}#{s.pr_number}@{s.sha[:8]}" for s in states)
+
         deadline = start + timeout_sec
         per_repo_runs: dict[str, list[dict]] = {}
 
         while True:
-            api_error = None
-            for repo, _, sha in pr_infos:
+            # Re-fetch PR info each tick to detect force-pushes and PR state changes
+            for state in states:
+                if state.terminal_verdict is not None:
+                    continue
                 try:
-                    per_repo_runs[repo] = await _get_check_runs(client, repo, sha)
+                    _, new_sha, pr_state = await _get_pr_info(client, state.repo, branch)
+                    if pr_state == "merged":
+                        log.info("checker.pr_ci_watch.pr_merged",
+                                 repo=state.repo, pr=state.pr_number)
+                        state.terminal_verdict = "pass"
+                    elif pr_state == "closed":
+                        log.info("checker.pr_ci_watch.pr_closed",
+                                 repo=state.repo, pr=state.pr_number)
+                        state.terminal_verdict = "fail"
+                        state.terminal_reason = "pr-closed-without-merge"
+                    elif new_sha != state.sha:
+                        log.info("checker.pr_ci_watch.sha_flip",
+                                 repo=state.repo, old=state.sha[:8], new=new_sha[:8],
+                                 flip_count=state.flip_count + 1)
+                        state.flip_count += 1
+                        state.sha = new_sha
+                        per_repo_runs.pop(state.repo, None)  # clear stale runs
+                        if state.flip_count > _MAX_SHA_FLIPS:
+                            state.terminal_verdict = "fail"
+                            state.terminal_reason = "too-many-sha-flips"
+                            log.warning("checker.pr_ci_watch.too_many_sha_flips",
+                                        repo=state.repo, flips=state.flip_count)
+                except (httpx.HTTPError, ValueError) as e:
+                    # Consistent with check-run API errors: retry until deadline
+                    log.warning("checker.pr_ci_watch.pr_refetch_error",
+                                repo=state.repo, error=str(e))
+
+            # Early exit: any terminal fail (too-many-sha-flips / pr-closed)
+            if any(s.terminal_verdict == "fail" for s in states):
+                parts = [
+                    f"{s.repo}: {s.terminal_reason}"
+                    for s in states if s.terminal_verdict == "fail"
+                ]
+                return CheckResult(
+                    passed=False, exit_code=1,
+                    stdout_tail=" | ".join(parts)[:_TAIL],
+                    stderr_tail="", duration_sec=time.monotonic() - start, cmd=_cmd_label(),
+                )
+
+            # Early exit: all repos merged (all terminal pass)
+            if all(s.terminal_verdict == "pass" for s in states):
+                parts = [f"{s.repo}: merged" for s in states]
+                return CheckResult(
+                    passed=True, exit_code=0,
+                    stdout_tail=" | ".join(parts)[:_TAIL],
+                    stderr_tail="", duration_sec=time.monotonic() - start, cmd=_cmd_label(),
+                )
+
+            # Fetch check-runs for non-terminal repos
+            api_error = None
+            for state in states:
+                if state.terminal_verdict is not None:
+                    continue
+                try:
+                    per_repo_runs[state.repo] = await _get_check_runs(client, state.repo, state.sha)
                 except httpx.HTTPError as e:
-                    api_error = (repo, e)
+                    api_error = (state.repo, e)
                     log.warning("checker.pr_ci_watch.api_error",
-                                repo=repo, sha=sha[:8], error=str(e))
+                                repo=state.repo, sha=state.sha[:8], error=str(e))
 
             if api_error and time.monotonic() >= deadline:
                 repo, e = api_error
@@ -117,60 +206,75 @@ async def watch_pr_ci(
                     passed=False, exit_code=124,
                     stdout_tail="",
                     stderr_tail=f"API error at deadline for {repo}: {e}"[:_TAIL],
-                    duration_sec=time.monotonic() - start, cmd=cmd_label,
+                    duration_sec=time.monotonic() - start, cmd=_cmd_label(),
                 )
             if api_error:
                 await asyncio.sleep(poll_interval_sec)
                 continue
 
-            # 聚合判 verdict：任一 fail → fail；全部 pass → pass；否则 pending
-            verdicts = {repo: _classify(runs) for repo, runs in per_repo_runs.items()}
+            # Compute verdicts: terminal overrides check-run classification
+            verdicts: dict[str, str] = {}
+            for state in states:
+                if state.terminal_verdict is not None:
+                    verdicts[state.repo] = state.terminal_verdict
+                else:
+                    verdicts[state.repo] = _classify(per_repo_runs.get(state.repo, []))
+
             log.info("checker.pr_ci_watch.poll",
                      verdicts=verdicts,
-                     run_counts={r: len(rs) for r, rs in per_repo_runs.items()})
+                     run_counts={s.repo: len(per_repo_runs.get(s.repo, [])) for s in states},
+                     sha_flips={s.repo: s.flip_count for s in states if s.flip_count > 0})
 
             if any(v == "fail" for v in verdicts.values()):
-                summary_parts = [
-                    f"{repo}: {_summarize(runs, failed_only=True)}"
-                    for repo, runs in per_repo_runs.items()
-                    if verdicts[repo] == "fail"
-                ]
+                parts = []
+                for state in states:
+                    if verdicts[state.repo] != "fail":
+                        continue
+                    if state.terminal_verdict == "fail":
+                        parts.append(f"{state.repo}: {state.terminal_reason}")
+                    else:
+                        runs = per_repo_runs.get(state.repo, [])
+                        parts.append(f"{state.repo}: {_summarize(runs, failed_only=True)}")
                 return CheckResult(
                     passed=False, exit_code=1,
-                    stdout_tail=" | ".join(summary_parts)[:_TAIL],
-                    stderr_tail="", duration_sec=time.monotonic() - start, cmd=cmd_label,
+                    stdout_tail=" | ".join(parts)[:_TAIL],
+                    stderr_tail="", duration_sec=time.monotonic() - start, cmd=_cmd_label(),
                 )
+
             if all(v == "pass" for v in verdicts.values()):
-                summary_parts = [
-                    f"{repo}: {_summarize(runs)}"
-                    for repo, runs in per_repo_runs.items()
+                parts = [
+                    f"{state.repo}: merged" if state.terminal_verdict == "pass"
+                    else f"{state.repo}: {_summarize(per_repo_runs.get(state.repo, []))}"
+                    for state in states
                 ]
                 return CheckResult(
                     passed=True, exit_code=0,
-                    stdout_tail=" | ".join(summary_parts)[:_TAIL],
-                    stderr_tail="", duration_sec=time.monotonic() - start, cmd=cmd_label,
+                    stdout_tail=" | ".join(parts)[:_TAIL],
+                    stderr_tail="", duration_sec=time.monotonic() - start, cmd=_cmd_label(),
                 )
 
             if time.monotonic() + poll_interval_sec >= deadline:
                 summary_parts = [
-                    f"{repo}: {_summarize(runs)}"
-                    for repo, runs in per_repo_runs.items()
+                    f"{state.repo}: {_summarize(per_repo_runs.get(state.repo, []))}"
+                    for state in states
                 ]
                 return CheckResult(
                     passed=False, exit_code=124,
                     stdout_tail=" | ".join(summary_parts)[:_TAIL],
                     stderr_tail=f"timeout after {timeout_sec}s, still pending",
-                    duration_sec=time.monotonic() - start, cmd=cmd_label,
+                    duration_sec=time.monotonic() - start, cmd=_cmd_label(),
                 )
             await asyncio.sleep(poll_interval_sec)
 
 
 # ── GH API helpers ───────────────────────────────────────────────────────
 
-async def _get_pr_info(client: httpx.AsyncClient, repo: str, branch: str) -> tuple[int, str]:
-    """查 branch 对应的 open PR，返 (pr_number, head_sha)。
+async def _get_pr_info(client: httpx.AsyncClient, repo: str, branch: str) -> tuple[int, str, str]:
+    """查 branch 对应的 PR，返 (pr_number, head_sha, state)。
 
-    用 GitHub REST API `head` 过滤器（替代旧 gh CLI 调用），全程 async 不阻塞事件循环。
+    state: "open" | "merged" | "closed"（closed without merge）。
+    先查 open PR（最常见）；没找到再查 closed 判断是合并还是直接关闭。
+    两种情况都找不到 → ValueError。
     """
     owner, _ = repo.split("/", 1)
     r = await client.get(
@@ -178,11 +282,23 @@ async def _get_pr_info(client: httpx.AsyncClient, repo: str, branch: str) -> tup
         params={"head": f"{owner}:{branch}", "state": "open"},
     )
     r.raise_for_status()
-    pulls = r.json()
-    if not pulls:
-        raise ValueError(f"No open PR found for branch {branch} in {repo}")
-    pr = pulls[0]
-    return int(pr["number"]), str(pr["head"]["sha"])
+    open_pulls = r.json()
+    if open_pulls:
+        pr = open_pulls[0]
+        return int(pr["number"]), str(pr["head"]["sha"]), "open"
+
+    # No open PR – check if merged or closed without merge
+    r = await client.get(
+        f"/repos/{repo}/pulls",
+        params={"head": f"{owner}:{branch}", "state": "closed"},
+    )
+    r.raise_for_status()
+    closed_pulls = r.json()
+    if not closed_pulls:
+        raise ValueError(f"No PR found for branch {branch} in {repo}")
+    pr = closed_pulls[0]
+    pr_state = "merged" if pr.get("merged_at") is not None else "closed"
+    return int(pr["number"]), str(pr["head"]["sha"]), pr_state
 
 
 async def _get_check_runs(client: httpx.AsyncClient, repo: str, sha: str) -> list[dict]:

--- a/orchestrator/tests/test_checkers_pr_ci_watch.py
+++ b/orchestrator/tests/test_checkers_pr_ci_watch.py
@@ -1,7 +1,9 @@
-"""checkers/pr_ci_watch.py 单测：mock GitHub API，验全绿/任一失败/全失败/超时。
+"""checkers/pr_ci_watch.py 单测：mock GitHub API，验全绿/任一失败/全失败/超时/SHA翻转/PR合并关闭。
 
 M15：watch_pr_ci(req_id, branch, ...)，repo 从 SISYPHUS_BUSINESS_REPO env 读，
 pr_number + head.sha 用 GitHub REST API `head` 过滤器按 branch 查（这里 mock 掉），不再读 manifest。
+
+SHA refresh（force-push 检测）：每 tick 重新拉 head SHA，SHA 变化时重置 check-runs 缓存。
 """
 from __future__ import annotations
 
@@ -25,13 +27,13 @@ def _run(name: str, status: str = "completed", conclusion: str | None = "success
 
 
 def patch_pr_lookup(monkeypatch, *, repo: str = "phona/ubox-crosser", pr_number: int | None = 42):
-    """SISYPHUS_BUSINESS_REPO env + mock _get_pr_info 返指定 (number, sha)。"""
+    """SISYPHUS_BUSINESS_REPO env + mock _get_pr_info 返指定 (number, sha, state)。"""
     monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", repo)
 
-    async def fake_lookup(client, _repo: str, _branch: str) -> tuple[int, str]:
+    async def fake_lookup(client, _repo: str, _branch: str) -> tuple[int, str, str]:
         if pr_number is None:
             raise ValueError("No open PR found")
-        return pr_number, "deadbeef" * 5
+        return pr_number, "deadbeef" * 5, "open"
 
     monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
 
@@ -170,7 +172,7 @@ async def test_watch_pr_ci_pr_lookup_http_error(monkeypatch):
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
     monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/ubox-crosser")
 
-    async def fake_lookup_fail(client, _repo: str, _branch: str) -> tuple[int, str]:
+    async def fake_lookup_fail(client, _repo: str, _branch: str) -> tuple[int, str, str]:
         raise httpx.HTTPError("mocked API error")
     monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup_fail)
 
@@ -218,7 +220,7 @@ async def test_watch_pr_ci_returns_fail_when_no_pr(monkeypatch):
     """找不到对应 PR → 返 fail CheckResult（exit=1），不再抛 ValueError 让 caller 处理。"""
     monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/ubox-crosser")
 
-    async def fake_lookup_none(client, _repo: str, _branch: str) -> tuple[int, str]:
+    async def fake_lookup_none(client, _repo: str, _branch: str) -> tuple[int, str, str]:
         raise ValueError("No open PR found for branch")
     monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup_none)
 
@@ -235,9 +237,9 @@ async def test_watch_pr_ci_per_req_repos_override_env(monkeypatch):
 
     looked_up: list[str] = []
 
-    async def fake_lookup(client, repo: str, _branch: str):
+    async def fake_lookup(client, repo: str, _branch: str) -> tuple[int, str, str]:
         looked_up.append(repo)
-        return (101, "abc1234567890def")
+        return (101, "abc1234567890def", "open")
 
     async def fake_check_runs(client, _repo: str, _sha: str):
         return [_run("CI", conclusion="success")]
@@ -252,7 +254,7 @@ async def test_watch_pr_ci_per_req_repos_override_env(monkeypatch):
     )
     assert result.passed
     # env var 完全没被用到，只用 caller 给的 repo
-    assert looked_up == ["ZonEaseTech/ttpos-server-go"]
+    assert set(looked_up) == {"ZonEaseTech/ttpos-server-go"}
 
 
 @pytest.mark.asyncio
@@ -260,9 +262,9 @@ async def test_watch_pr_ci_multi_repo_all_green(monkeypatch):
     """多 repo REQ：所有 repo 都绿 → pass，cmd label 含全部 repo+sha。"""
     looked_up: list[str] = []
 
-    async def fake_lookup(client, repo: str, _branch: str):
+    async def fake_lookup(client, repo: str, _branch: str) -> tuple[int, str, str]:
         looked_up.append(repo)
-        return (1, f"sha-{repo[:4]}aaaa")
+        return (1, f"sha-{repo[:4]}aaaa", "open")
 
     async def fake_check_runs(client, _repo: str, _sha: str):
         return [_run("CI", conclusion="success")]
@@ -283,8 +285,8 @@ async def test_watch_pr_ci_multi_repo_all_green(monkeypatch):
 @pytest.mark.asyncio
 async def test_watch_pr_ci_multi_repo_one_fails(monkeypatch):
     """多 repo REQ：任一 repo CI 红 → 整体 fail，stdout 标出哪个 repo 红。"""
-    async def fake_lookup(client, repo: str, _branch: str):
-        return (1, f"sha-{repo[:4]}aaaa")
+    async def fake_lookup(client, repo: str, _branch: str) -> tuple[int, str, str]:
+        return (1, f"sha-{repo[:4]}aaaa", "open")
 
     async def fake_check_runs(client, repo: str, _sha: str):
         if repo == "b/repo-y":
@@ -304,6 +306,189 @@ async def test_watch_pr_ci_multi_repo_one_fails(monkeypatch):
     # 只输出失败的 repo 摘要
     assert "b/repo-y" in result.stdout_tail
     assert "failure" in result.stdout_tail
+
+
+# ── SHA 翻转（force-push）检测 ────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_sha_flip_restarts_check_runs(monkeypatch):
+    """force-push 后 SHA 变化 → 清除旧 check-runs，从新 SHA 重新轮询，最终通过。"""
+    sha_a = "a" * 40
+    sha_b = "b" * 40
+    call_count = [0]
+
+    async def fake_lookup(client, repo: str, branch: str) -> tuple[int, str, str]:
+        call_count[0] += 1
+        # 前两次调用（initial + loop tick 1）返回 sha_a；之后返回 sha_b
+        sha = sha_a if call_count[0] <= 2 else sha_b
+        return (1, sha, "open")
+
+    runs_fetched_for: list[str] = []
+
+    async def fake_check_runs(client, repo: str, sha: str) -> list[dict]:
+        runs_fetched_for.append(sha[:8])
+        if sha == sha_b:
+            return [_run("CI", conclusion="success")]
+        return [_run("CI", status="in_progress", conclusion=None)]
+
+    async def fast_sleep(_):
+        return None
+
+    monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
+    monkeypatch.setattr(pr_ci_watch, "_get_check_runs", fake_check_runs)
+    monkeypatch.setattr(pr_ci_watch.asyncio, "sleep", fast_sleep)
+    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/repo")
+
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9",
+                                            poll_interval_sec=1, timeout_sec=60)
+
+    assert result.passed is True
+    assert result.exit_code == 0
+    # SHA 翻转后 cmd 应反映新 SHA
+    assert sha_b[:8] in result.cmd
+
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_too_many_sha_flips(monkeypatch):
+    """SHA 翻转超过 5 次 → fail reason=too-many-sha-flips。"""
+    call_count = [0]
+
+    async def fake_lookup(client, repo: str, branch: str) -> tuple[int, str, str]:
+        call_count[0] += 1
+        # 每次调用返回不同 SHA，模拟持续 force-push
+        sha = f"{call_count[0]:040x}"
+        return (1, sha, "open")
+
+    async def fake_check_runs(client, repo: str, sha: str) -> list[dict]:
+        return [_run("CI", status="in_progress", conclusion=None)]
+
+    async def fast_sleep(_):
+        return None
+
+    monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
+    monkeypatch.setattr(pr_ci_watch, "_get_check_runs", fake_check_runs)
+    monkeypatch.setattr(pr_ci_watch.asyncio, "sleep", fast_sleep)
+    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/repo")
+
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9",
+                                            poll_interval_sec=0, timeout_sec=60)
+
+    assert result.passed is False
+    assert result.exit_code == 1
+    assert "too-many-sha-flips" in result.stdout_tail
+
+
+# ── PR merged / closed 检测 ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_pr_merged_returns_pass(monkeypatch):
+    """loop 轮询中 PR 被 merge → 立即返 pass（不等 check-runs）。"""
+    call_count = [0]
+
+    async def fake_lookup(client, repo: str, branch: str) -> tuple[int, str, str]:
+        call_count[0] += 1
+        # initial fetch → open；loop tick 1 re-fetch → merged
+        state = "open" if call_count[0] == 1 else "merged"
+        return (1, "a" * 40, state)
+
+    check_run_calls = [0]
+
+    async def fake_check_runs(client, repo: str, sha: str) -> list[dict]:
+        check_run_calls[0] += 1
+        return [_run("CI", status="in_progress", conclusion=None)]
+
+    monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
+    monkeypatch.setattr(pr_ci_watch, "_get_check_runs", fake_check_runs)
+    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/repo")
+
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9",
+                                            poll_interval_sec=0, timeout_sec=60)
+
+    assert result.passed is True
+    assert result.exit_code == 0
+    assert "merged" in result.stdout_tail
+    # 检测到 merged 后不再拉 check-runs
+    assert check_run_calls[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_pr_closed_returns_fail(monkeypatch):
+    """loop 轮询中 PR 被关闭（未 merge）→ fail reason=pr-closed-without-merge。"""
+    call_count = [0]
+
+    async def fake_lookup(client, repo: str, branch: str) -> tuple[int, str, str]:
+        call_count[0] += 1
+        state = "open" if call_count[0] == 1 else "closed"
+        return (1, "a" * 40, state)
+
+    async def fake_check_runs(client, repo: str, sha: str) -> list[dict]:
+        return [_run("CI", conclusion="success")]
+
+    monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
+    monkeypatch.setattr(pr_ci_watch, "_get_check_runs", fake_check_runs)
+    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/repo")
+
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9",
+                                            poll_interval_sec=0, timeout_sec=60)
+
+    assert result.passed is False
+    assert result.exit_code == 1
+    assert "pr-closed-without-merge" in result.stdout_tail
+
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_initial_pr_already_merged(monkeypatch):
+    """初始 fetch 就发现 PR 已 merge → 立即 pass（连 loop 都不需等）。"""
+    async def fake_lookup(client, repo: str, branch: str) -> tuple[int, str, str]:
+        return (1, "a" * 40, "merged")
+
+    check_run_calls = [0]
+
+    async def fake_check_runs(client, repo: str, sha: str) -> list[dict]:
+        check_run_calls[0] += 1
+        return []
+
+    monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
+    monkeypatch.setattr(pr_ci_watch, "_get_check_runs", fake_check_runs)
+    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/repo")
+
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9",
+                                            poll_interval_sec=0, timeout_sec=60)
+
+    assert result.passed is True
+    assert "merged" in result.stdout_tail
+    assert check_run_calls[0] == 0
+
+
+# ── refetch 失败重试 ──────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_pr_refetch_error_retries(monkeypatch):
+    """loop 内 _get_pr_info 抛 HTTP 错误 → 警告 + retry，不立即 fail。"""
+    call_count = [0]
+
+    async def fake_lookup(client, repo: str, branch: str) -> tuple[int, str, str]:
+        call_count[0] += 1
+        if call_count[0] == 2:  # loop tick 1 re-fetch 失败
+            raise httpx.HTTPError("transient error")
+        return (1, "a" * 40, "open")
+
+    async def fake_check_runs(client, repo: str, sha: str) -> list[dict]:
+        return [_run("CI", conclusion="success")]
+
+    async def fast_sleep(_):
+        return None
+
+    monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
+    monkeypatch.setattr(pr_ci_watch, "_get_check_runs", fake_check_runs)
+    monkeypatch.setattr(pr_ci_watch.asyncio, "sleep", fast_sleep)
+    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/repo")
+
+    # tick 1: re-fetch 失败但 check-runs 用 cached SHA 成功 → pass
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9",
+                                            poll_interval_sec=1, timeout_sec=60)
+
+    assert result.passed is True
 
 
 # ── _classify 单测 ───────────────────────────────────────────────────────

--- a/orchestrator/tests/test_contract_pr_ci_watch_sha_refresh.py
+++ b/orchestrator/tests/test_contract_pr_ci_watch_sha_refresh.py
@@ -12,10 +12,9 @@ import re
 from unittest.mock import patch
 
 import httpx
-import pytest
 
-from orchestrator.checkers._types import CheckResult
 from orchestrator.checkers import pr_ci_watch as checker
+from orchestrator.checkers._types import CheckResult
 
 _MODULE = "orchestrator.checkers.pr_ci_watch"
 REPO = "phona/sisyphus"

--- a/orchestrator/tests/test_contract_pr_ci_watch_sha_refresh.py
+++ b/orchestrator/tests/test_contract_pr_ci_watch_sha_refresh.py
@@ -1,0 +1,218 @@
+"""Contract tests: pr_ci_watch SHA re-fetch per polling tick (PRCISHAR-S1 ~ S7).
+
+Black-box challenger. Mock boundaries:
+  • orchestrator.checkers.pr_ci_watch._get_pr_info  ← spec-named boundary
+  • httpx check-runs responses via pytest-httpx      ← external GitHub API boundary
+
+REQ-pr-ci-watch-sha-refresh-1777076876
+"""
+from __future__ import annotations
+
+import re
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from orchestrator.checkers._types import CheckResult
+from orchestrator.checkers import pr_ci_watch as checker
+
+_MODULE = "orchestrator.checkers.pr_ci_watch"
+REPO = "phona/sisyphus"
+BRANCH = "feat/REQ-prcishar-test"
+REQ = "REQ-prcishar-contract-test"
+
+SHA_A = "aaabbb111222"
+SHA_B = "cccddd333444"
+
+FAST_POLL = 0.01
+FAST_TIMEOUT = 30.0
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+def _open(sha: str):
+    return (1, sha, "open")
+
+def _merged(sha: str):
+    return (1, sha, "merged")
+
+def _closed(sha: str):
+    return (1, sha, "closed")
+
+def _cr_url(sha: str) -> re.Pattern:
+    return re.compile(rf"https://api\.github\.com/repos/{re.escape(REPO)}/commits/{re.escape(sha)}/check-runs.*")
+
+def _pending_cr(sha: str) -> dict:
+    return {
+        "total_count": 1,
+        "check_runs": [{"id": 1, "name": "CI", "head_sha": sha, "status": "in_progress", "conclusion": None}],
+    }
+
+def _success_cr(sha: str) -> dict:
+    return {
+        "total_count": 1,
+        "check_runs": [{"id": 1, "name": "CI", "head_sha": sha, "status": "completed", "conclusion": "success"}],
+    }
+
+def _call_seq(*states):
+    """Produce a _get_pr_info side_effect list; append 100 copies of last state."""
+    last = states[-1]
+    return list(states) + [last] * 100
+
+
+async def _watch(**kw):
+    return await checker.watch_pr_ci(
+        REQ,
+        branch=BRANCH,
+        poll_interval_sec=FAST_POLL,
+        timeout_sec=FAST_TIMEOUT,
+        repos=[REPO],
+        **kw,
+    )
+
+
+# ── S1 + S2: force-push → switch to new SHA, new SHA passes ──────────────
+
+async def test_prcishar_s1_s2_force_push_switches_sha_then_passes(httpx_mock):
+    """S1: SHA flip clears check-runs cache and restarts polling against new SHA.
+    S2: new SHA's check-runs complete with success → passed=True.
+    """
+    # pre-loop: SHA_A  |  tick-0: SHA_A (no flip yet)  |  tick-1+: SHA_B (flip!)
+    call_iter = iter(_call_seq(_open(SHA_A), _open(SHA_A), _open(SHA_B)))
+
+    async def fake_get_pr_info(*args, **kwargs):
+        return next(call_iter)
+
+    httpx_mock.add_response(url=_cr_url(SHA_A), json=_pending_cr(SHA_A), is_reusable=True)
+    httpx_mock.add_response(url=_cr_url(SHA_B), json=_success_cr(SHA_B), is_reusable=True)
+
+    with patch(f"{_MODULE}._get_pr_info", side_effect=fake_get_pr_info):
+        result = await _watch()
+
+    assert isinstance(result, CheckResult)
+    assert result.passed is True
+    assert result.exit_code == 0
+
+
+# ── S3: 5 flips → continue polling, eventually pass ──────────────────────
+
+async def test_prcishar_s3_five_flips_does_not_trigger_failure(httpx_mock):
+    """S3: flip_count=5 is within the allowed limit; polling continues normally."""
+    # pre-loop + 5 alternating flips, then stable at SHA_B → pass
+    sha_seq = [SHA_A, SHA_B, SHA_A, SHA_B, SHA_A, SHA_B, SHA_A, SHA_B]
+    call_iter = iter([_open(s) for s in sha_seq] + [_open(SHA_B)] * 100)
+
+    async def fake_get_pr_info(*args, **kwargs):
+        return next(call_iter)
+
+    httpx_mock.add_response(url=_cr_url(SHA_A), json=_pending_cr(SHA_A), is_reusable=True)
+    # SHA_B eventually succeeds
+    httpx_mock.add_response(url=_cr_url(SHA_B), json=_pending_cr(SHA_B), is_reusable=True)
+    httpx_mock.add_response(url=_cr_url(SHA_B), json=_success_cr(SHA_B))
+
+    with patch(f"{_MODULE}._get_pr_info", side_effect=fake_get_pr_info):
+        result = await _watch()
+
+    assert result.passed is True
+    assert "too-many-sha-flips" not in (result.stdout_tail or "")
+
+
+# ── S4: 6th flip → fail too-many-sha-flips ───────────────────────────────
+
+async def test_prcishar_s4_sixth_flip_fails_too_many_sha_flips(httpx_mock):
+    """S4: flip_count reaches 6 → terminal fail with reason too-many-sha-flips."""
+    # pre-loop: SHA_A; 6 alternating flips (A→B→A→B→A→B→A)
+    sha_seq = [SHA_A, SHA_B, SHA_A, SHA_B, SHA_A, SHA_B, SHA_A, SHA_B]
+    call_iter = iter([_open(s) for s in sha_seq] + [_open(SHA_B)] * 100)
+
+    async def fake_get_pr_info(*args, **kwargs):
+        return next(call_iter)
+
+    httpx_mock.add_response(url=_cr_url(SHA_A), json=_pending_cr(SHA_A), is_reusable=True)
+    httpx_mock.add_response(url=_cr_url(SHA_B), json=_pending_cr(SHA_B), is_reusable=True)
+
+    with patch(f"{_MODULE}._get_pr_info", side_effect=fake_get_pr_info):
+        result = await _watch()
+
+    assert result.passed is False
+    assert result.exit_code == 1
+    assert "too-many-sha-flips" in (result.stdout_tail or "")
+
+
+# ── S5: PR merged → pass immediately (no check-runs wait) ────────────────
+
+async def test_prcishar_s5_pr_merged_returns_pass_immediately(httpx_mock):
+    """S5: PR transitions to merged during loop → watch_pr_ci returns passed=True
+    without waiting for check-runs completion."""
+    # pre-loop: open  |  first loop tick: merged
+    call_iter = iter(_call_seq(_open(SHA_A), _merged(SHA_A)))
+
+    async def fake_get_pr_info(*args, **kwargs):
+        return next(call_iter)
+
+    # optional: function might or might not read check-runs before seeing merged
+    httpx_mock.add_response(
+        url=_cr_url(SHA_A), json=_pending_cr(SHA_A),
+        is_reusable=True, is_optional=True,
+    )
+
+    with patch(f"{_MODULE}._get_pr_info", side_effect=fake_get_pr_info):
+        result = await _watch()
+
+    assert result.passed is True
+    assert result.exit_code == 0
+    assert "merged" in (result.stdout_tail or "").lower()
+
+
+# ── S6: PR closed (no merge) → fail pr-closed-without-merge ──────────────
+
+async def test_prcishar_s6_pr_closed_returns_fail(httpx_mock):
+    """S6: PR closed without merge → passed=False, stdout_tail contains
+    pr-closed-without-merge."""
+    call_iter = iter(_call_seq(_open(SHA_A), _closed(SHA_A)))
+
+    async def fake_get_pr_info(*args, **kwargs):
+        return next(call_iter)
+
+    httpx_mock.add_response(
+        url=_cr_url(SHA_A), json=_pending_cr(SHA_A),
+        is_reusable=True, is_optional=True,
+    )
+
+    with patch(f"{_MODULE}._get_pr_info", side_effect=fake_get_pr_info):
+        result = await _watch()
+
+    assert result.passed is False
+    assert result.exit_code == 1
+    assert "pr-closed-without-merge" in (result.stdout_tail or "")
+
+
+# ── S7: in-loop refetch HTTP error → warning + retry, no immediate fail ──
+
+async def test_prcishar_s7_refetch_http_error_retries_not_fail(httpx_mock):
+    """S7: httpx.HTTPError from _get_pr_info inside the loop is treated as transient.
+    System logs a warning, uses cached SHA for check-runs, and continues.
+    Next successful tick resumes normal operation."""
+    call_count = 0
+
+    async def fake_get_pr_info(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            # First in-loop tick: simulates a transient network error
+            raise httpx.HTTPError("transient connection reset")
+        if call_count >= 3:
+            return _merged(SHA_A)
+        return _open(SHA_A)
+
+    # check-runs for cached SHA_A on the error tick
+    httpx_mock.add_response(url=_cr_url(SHA_A), json=_pending_cr(SHA_A), is_reusable=True)
+
+    with patch(f"{_MODULE}._get_pr_info", side_effect=fake_get_pr_info):
+        result = await _watch()
+
+    # must not fail immediately on the error tick
+    assert result.passed is True
+    # _get_pr_info must have been called ≥3 times: initial + error tick + recovery tick
+    assert call_count >= 3


### PR DESCRIPTION
## Summary

- **问题**：`pr_ci_watch` 在启动时只拉一次 head SHA，force-push 后继续盯旧 SHA 的 check-runs，导致结果不可信
- **方案**：每 polling tick 重新拉 PR head SHA，检测 force-push 并切换到新 SHA；同时处理 PR merged/closed 状态变化
- **限制**：单 repo SHA 翻转超 5 次 → fail with `too-many-sha-flips`（防止无限 churn）

## Changes

- `_get_pr_info` 返回 3-tuple `(pr_number, sha, state)`，state 支持 open/merged/closed
- 新增 `_RepoState` dataclass 跟踪 per-repo sha、flip_count、terminal_verdict
- 主循环每 tick 重新拉 PR info：检测 force-push + PR 状态变化（merged → pass，closed → fail）
- SHA 翻转时 log `sha_flip` 事件（old/new/flip_count）；超 5 次 → terminal fail
- loop 内 refetch 失败 → WARNING + retry（与 check-run 错误语义一致，不立即 fail）

## Test plan

- [x] 23 个 unit test 全部通过
- [x] 已有测试：全绿/任一失败/全失败/超时/pending→pass/PR 查询失败/多仓
- [x] 新增测试：SHA flip + 重新轮询、too-many-sha-flips、PR merged/closed、初始 merged、refetch retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)