### PR TITLE
feat(watchdog): detect intake session.completed without result tag

### DIFF
--- a/openspec/changes/REQ-watchdog-intake-no-result-1777078182/proposal.md
+++ b/openspec/changes/REQ-watchdog-intake-no-result-1777078182/proposal.md
@@ -1,0 +1,59 @@
+# REQ-watchdog-intake-no-result-1777078182: feat(watchdog): detect intake session.completed without result tag
+
+## 问题
+
+intake-agent session.completed 后**必须** PATCH `result:pass` 或 `result:fail` tag，
+router (`derive_event` for `session.completed` + `intake` tag) 才会派发 `INTAKE_PASS` /
+`INTAKE_FAIL`。如果 agent 忘了这一步：
+
+- `session.completed` webhook 来了，tags 不含 result:* → router 返回 `None` → 无 event fire
+- 后续也没有 `issue.updated` 事件触发 race fallback（agent 已退出）
+- REQ state 永远卡在 `INTAKING`
+
+watchdog 的通用 stuck 检测会兜底，但有两个问题：
+1. body.event=`watchdog.stuck` 是 `_CANONICAL_SIGNALS`，escalate.py 把 reason 锁成
+   `watchdog-stuck`，无法体现这是个 prompt-bug（intake-agent 实现没收尾）；
+2. `watchdog-stuck` 被 `_is_transient` 判为 transient → 走 auto-resume follow-up
+   "continue, you were interrupted"。但 intake session 已经 completed，没有进程在跑，
+   follow-up 唤不醒，浪费 2 次 retry 才进真 escalated。
+
+## 方案
+
+### 检测
+
+watchdog 在通用兜底之前，先识别 intake-no-result-tag 这一具体形态：
+
+```
+state == INTAKING
+  AND BKD issue.session_status != "running"
+  AND issue.tags ∩ {"result:pass", "result:fail"} == ∅
+```
+
+满足 → 走专属路径（reason="intake-no-result-tag"），不满足 → 走原通用 watchdog_stuck 路径。
+
+### 专属 escalate 通路
+
+新 body.event = `watchdog.intake_no_result_tag`：
+- 不在 `_CANONICAL_SIGNALS` → escalate.py 优先采用 ctx.escalated_reason（watchdog
+  预先 PATCH 进 ctx 的 `intake-no-result-tag`），最终 BKD intent issue 上加
+  `escalated` + `reason:intake-no-result-tag`；
+- 不在 `_TRANSIENT_REASONS` 也不匹配 `_is_transient` 的 body.event 分支 → 跳过
+  auto-resume，直接真 escalate；
+- 加入 `_SESSION_END_SIGNALS`（即原 `is_session_failed_path` 集合）→ escalate
+  末尾的手动 CAS → ESCALATED + `cleanup_runner` 仍跑，REQ 进终态。
+
+### artifact_checks 落表
+
+写一条 `artifact_checks`：`stage="watchdog:intake-no-result-tag"`，
+`reason="intake-no-result-tag"`，`stderr_tail` 含 session_status + stuck 秒数，
+M7 dashboard 可分桶看这条 prompt-bug 的发生频率。
+
+## 取舍
+
+- **不改 router**：router 看到 session.completed 无 result tag 主动 escalate 也可行，
+  但 router 是同步阻塞 webhook handler 的路径，引入 BKD 二次调用 / artifact 写入会
+  拖慢主链。watchdog 异步独立，更适合兜底语义。
+- **BKD 查不到 issue 时降级走通用 watchdog_stuck**：保持原有 auto-resume 兜底，
+  避免误判（issue 真删了的极端场景下 ctx 不脏化）。
+- **不识别"有 result tag 但卡住"的形态**：那是 router 漏 fire 的另一类问题，
+  超本 REQ 范围，仍走通用 stuck 路径（人工排查）。

--- a/openspec/changes/REQ-watchdog-intake-no-result-1777078182/specs/watchdog/contract.spec.yaml
+++ b/openspec/changes/REQ-watchdog-intake-no-result-1777078182/specs/watchdog/contract.spec.yaml
@@ -1,0 +1,70 @@
+capability: watchdog
+version: "1.1"
+description: |
+  Watchdog gains a dedicated detection path for the "intake-no-result-tag"
+  prompt-bug class: intake-agent session.completed without PATCHing
+  result:pass / result:fail tag, leaving REQ stuck in INTAKING state.
+
+state_to_issue_key_changes:
+  added:
+    - state: INTAKING
+      ctx_key: intent_issue_id
+      reason: "intake-agent reuses the intent issue; watchdog needs the id to query session_status + tags"
+
+new_helper_functions:
+  _is_intake_no_result_tag:
+    module: orchestrator.watchdog
+    signature: "(state: ReqState, issue: Issue | None) -> bool"
+    semantics: |
+      Returns True iff state == INTAKING AND issue is not None AND
+      issue.session_status != "running" AND issue.tags has no overlap
+      with {"result:pass", "result:fail"}.
+    pure: true
+
+new_constants:
+  module: orchestrator.watchdog
+  values:
+    _INTAKE_RESULT_TAGS: '{"result:pass", "result:fail"}'
+    _INTAKE_NO_RESULT_EVENT: "watchdog.intake_no_result_tag"
+    _INTAKE_NO_RESULT_REASON: "intake-no-result-tag"
+
+artifact_checks_emitted:
+  intake_no_result:
+    stage: "watchdog:intake-no-result-tag"
+    cmd: "watchdog:intake-no-result-tag"
+    reason: "intake-no-result-tag"
+    passed: false
+    exit_code: -1
+  generic_stuck:
+    stage: "watchdog:<state>"
+    cmd: "watchdog:<state>"
+    reason: "watchdog_stuck"
+    passed: false
+    exit_code: -1
+
+ctx_writes_by_watchdog:
+  - key: escalated_reason
+    value: "intake-no-result-tag"
+    written_by: "orchestrator.watchdog._check_and_escalate"
+    written_when: "intake-no-result-tag detection True"
+    purpose: "feed escalate.py via non-canonical body.event path"
+
+escalate_changes:
+  module: orchestrator.actions.escalate
+  added_constants:
+    _SESSION_END_SIGNALS:
+      - session.failed
+      - watchdog.stuck
+      - watchdog.intake_no_result_tag
+  is_session_failed_path:
+    old: 'body.event in ("session.failed", "watchdog.stuck")'
+    new: 'body.event in _SESSION_END_SIGNALS'
+  reason_resolution_for_intake_no_result:
+    body_event: watchdog.intake_no_result_tag
+    canonical_signals_match: false   # intentionally NOT in _CANONICAL_SIGNALS
+    reason_source: ctx.escalated_reason
+    expected_reason: intake-no-result-tag
+  transient_classification:
+    body_event: watchdog.intake_no_result_tag
+    is_transient: false
+    auto_resume: skipped

--- a/openspec/changes/REQ-watchdog-intake-no-result-1777078182/specs/watchdog/spec.md
+++ b/openspec/changes/REQ-watchdog-intake-no-result-1777078182/specs/watchdog/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: watchdog identifies intake session completed without result tag
+
+The watchdog MUST detect, as a distinct stuck-stage class, the case where a REQ is
+in state `INTAKING` for longer than `watchdog_stuck_threshold_sec`, the BKD intake
+issue's `session_status` is not `"running"` (i.e. the agent session has ended), and
+the BKD issue's `tags` contain neither `result:pass` nor `result:fail`. When this
+specific condition holds, the watchdog SHALL escalate the REQ with
+`reason="intake-no-result-tag"` rather than the generic `reason="watchdog_stuck"`.
+
+For all other stuck states (including `INTAKING` cases where a `result:*` tag is
+present but the state still did not transition, or where the BKD issue lookup
+failed), the watchdog MUST fall through to the existing generic
+`reason="watchdog_stuck"` escalation path. The intake detection MUST be guarded
+against `issue is None` (BKD lookup failure or stage not mapped to an issue), so
+infrastructure flakiness does not produce false-positive `intake-no-result-tag`
+verdicts.
+
+#### Scenario: WD-S1 INTAKING + session ended + no result tag → intake-no-result-tag
+
+- **GIVEN** a REQ in state `INTAKING` whose `updated_at` exceeds the stuck threshold
+- **AND** the BKD intent issue has `sessionStatus="completed"` and
+  `tags=["intake","REQ-x"]` (no `result:pass`, no `result:fail`)
+- **WHEN** the watchdog tick processes this row
+- **THEN** an `artifact_checks` row is written with
+  `stage="watchdog:intake-no-result-tag"` and `reason="intake-no-result-tag"`
+- **AND** `req_state.update_context` patches `escalated_reason="intake-no-result-tag"`
+- **AND** `engine.step` is invoked with `event=SESSION_FAILED` and
+  `body.event="watchdog.intake_no_result_tag"`
+
+#### Scenario: WD-S2 INTAKING + session running → skip
+
+- **GIVEN** a REQ in state `INTAKING` past the stuck threshold
+- **AND** BKD reports `sessionStatus="running"`
+- **WHEN** the watchdog tick processes this row
+- **THEN** no escalation occurs, no artifact row is written, and `engine.step`
+  is not invoked
+
+#### Scenario: WD-S3 INTAKING + session completed + result:pass → generic stuck path
+
+- **GIVEN** a REQ in state `INTAKING` past the stuck threshold
+- **AND** BKD reports `sessionStatus="completed"` with `tags` including `result:pass`
+- **WHEN** the watchdog tick processes this row
+- **THEN** the artifact row uses generic `stage="watchdog:intaking"` and
+  `reason="watchdog_stuck"`
+- **AND** `body.event="watchdog.stuck"` (not the intake-specific event)
+- **AND** `escalated_reason` is NOT pre-written to ctx by the watchdog
+
+#### Scenario: WD-S4 BKD lookup failure → generic stuck path
+
+- **GIVEN** a REQ in state `INTAKING` past the stuck threshold
+- **AND** the BKD `get_issue` call raises (network / 5xx / issue deleted)
+- **WHEN** the watchdog tick processes this row
+- **THEN** the watchdog escalates via the generic `reason="watchdog_stuck"` path
+- **AND** does NOT misclassify the row as `intake-no-result-tag`
+
+### Requirement: escalate action treats watchdog.intake_no_result_tag as session-end + non-transient
+
+The `escalate` action MUST treat `body.event="watchdog.intake_no_result_tag"` as a
+session-end signal: the action SHALL execute the manual CAS push to `ESCALATED`
+state and the runner cleanup branch (the same branch that runs for `session.failed`
+and `watchdog.stuck`).
+
+The `escalate` action MUST NOT treat `watchdog.intake_no_result_tag` as a transient
+signal: it SHALL skip the auto-resume `follow_up_issue` "continue" path and proceed
+directly to real escalation, since the intake session has already completed and
+auto-resume cannot revive a finished agent.
+
+The reason recorded on the BKD intent issue (the `reason:<value>` tag added
+alongside `escalated`) SHALL be `intake-no-result-tag`, sourced from
+`ctx.escalated_reason` (which the watchdog pre-writes), since
+`watchdog.intake_no_result_tag` is intentionally outside `_CANONICAL_SIGNALS` to
+allow the ctx value to win.
+
+#### Scenario: WD-S5 escalate honors ctx.escalated_reason for intake event
+
+- **GIVEN** `body.event="watchdog.intake_no_result_tag"`
+- **AND** `ctx.escalated_reason="intake-no-result-tag"`
+- **WHEN** the escalate action runs
+- **THEN** the BKD `merge_tags_and_update` call adds `escalated` and
+  `reason:intake-no-result-tag` to the intent issue
+- **AND** `follow_up_issue` is NOT awaited (no auto-resume)
+
+#### Scenario: WD-S6 escalate runs cleanup CAS for intake event
+
+- **GIVEN** `body.event="watchdog.intake_no_result_tag"` and the REQ's current state
+  is `INTAKING` (not yet `ESCALATED`)
+- **WHEN** the escalate action runs
+- **THEN** `req_state.cas_transition` is awaited to push the REQ to `ESCALATED`
+- **AND** the runner cleanup is awaited (`cleanup_runner` called once)

--- a/openspec/changes/REQ-watchdog-intake-no-result-1777078182/tasks.md
+++ b/openspec/changes/REQ-watchdog-intake-no-result-1777078182/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: REQ-watchdog-intake-no-result-1777078182
+
+## Stage: spec
+
+- [x] `openspec/changes/REQ-watchdog-intake-no-result-1777078182/proposal.md`
+- [x] `openspec/changes/REQ-watchdog-intake-no-result-1777078182/tasks.md`
+- [x] `openspec/changes/REQ-watchdog-intake-no-result-1777078182/specs/watchdog/spec.md`
+- [x] `openspec/changes/REQ-watchdog-intake-no-result-1777078182/specs/watchdog/contract.spec.yaml`
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/watchdog.py`：
+  - 加 `INTAKING → intent_issue_id` 到 `_STATE_ISSUE_KEY`
+  - 加纯函数 `_is_intake_no_result_tag(state, issue)`
+  - `_check_and_escalate` 区分 intake-no-result-tag vs 通用 stuck，写专属
+    artifact_checks stage/reason，预先 PATCH ctx.escalated_reason，体设 body.event
+- [x] `orchestrator/src/orchestrator/actions/escalate.py`：
+  - 加 `_SESSION_END_SIGNALS`（含 `watchdog.intake_no_result_tag`），
+    `is_session_failed_path` 改用此集合，确保 cleanup CAS + runner 清理仍跑
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_watchdog.py`：
+  - 纯函数 grid case (`_is_intake_no_result_tag`)
+  - 集成 case：INTAKING + completed + 无 result → 专属 path
+  - 集成 case：INTAKING + completed + result:pass → fall through 通用 path
+  - 集成 case：INTAKING + running → skip
+  - 集成 case：BKD lookup 失败 → fall through 通用 path
+- [x] `orchestrator/tests/test_actions_smoke.py`：
+  - 新增 escalate.py 处理 body.event=watchdog.intake_no_result_tag 的 case
+    （直接真 escalate + reason 透传 ctx + cleanup 跑）
+
+## Stage: PR
+
+- [x] git push feat/REQ-watchdog-intake-no-result-1777078182
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/actions/escalate.py
+++ b/orchestrator/src/orchestrator/actions/escalate.py
@@ -56,6 +56,17 @@ def _is_transient(body_event: str | None, reason: str) -> bool:
 
 _CANONICAL_SIGNALS = {"session.failed", "watchdog.stuck"}
 
+# 走 SESSION_FAILED transition 的 body.event 都需要在 escalate 末尾手动 CAS 推到
+# ESCALATED + 清 runner（transition 是 self-loop，engine 不自动清）。
+# watchdog.intake_no_result_tag：watchdog 检测到 intake 完成但忘 PATCH result tag，
+#   这类终止信号必须走 cleanup（session 已 done，绕开 _CANONICAL_SIGNALS 让
+#   escalate.py 优先采用 ctx.escalated_reason="intake-no-result-tag"）。
+_SESSION_END_SIGNALS = {
+    "session.failed",
+    "watchdog.stuck",
+    "watchdog.intake_no_result_tag",
+}
+
 
 @register("escalate", idempotent=True)
 async def escalate(*, body, req_id, tags, ctx):
@@ -130,7 +141,7 @@ async def escalate(*, body, req_id, tags, ctx):
     # （body.event="watchdog.stuck"）。
     # 其他事件路径（如 INTAKE_FAIL / PR_CI_TIMEOUT / VERIFY_ESCALATE）的 transition
     # 已在 state.py 写死 next_state=ESCALATED，engine 已经做过 CAS + cleanup，这里跳过。
-    is_session_failed_path = body.event in ("session.failed", "watchdog.stuck")
+    is_session_failed_path = body.event in _SESSION_END_SIGNALS
     if is_session_failed_path:
         row = await req_state.get(pool, req_id)
         if row and row.state != ReqState.ESCALATED:

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -26,14 +26,24 @@ from .bkd import BKDClient
 from .checkers._types import CheckResult
 from .config import settings
 from .state import Event, ReqState
-from .store import artifact_checks, db
+from .store import artifact_checks, db, req_state
 
 log = structlog.get_logger(__name__)
+
+
+# intake-agent 标记终态结果的 BKD tags（缺一不可：缺 → router 不 fire 主链事件）
+_INTAKE_RESULT_TAGS: frozenset[str] = frozenset({"result:pass", "result:fail"})
+
+# 专属 body.event：让 escalate.py 区分这条路径，绕开 watchdog.stuck 的 canonical
+# 反向覆盖（保留 ctx.escalated_reason="intake-no-result-tag"）+ 跳过 auto-resume
+_INTAKE_NO_RESULT_EVENT: str = "watchdog.intake_no_result_tag"
+_INTAKE_NO_RESULT_REASON: str = "intake-no-result-tag"
 
 
 # state → ctx 里追踪该 stage 当前 agent issue 的 key
 # None 表示没 issue 可查（直接 escalate）
 _STATE_ISSUE_KEY: dict[ReqState, str | None] = {
+    ReqState.INTAKING: "intent_issue_id",        # intake-agent 复用 intent issue
     ReqState.ANALYZING: "intent_issue_id",
     ReqState.SPEC_LINT_RUNNING: None,            # M15: 客观 checker，由 orchestrator 下发不绑 issue
     ReqState.DEV_CROSS_CHECK_RUNNING: None,      # M15: 客观 checker，由 orchestrator 下发不绑 issue
@@ -61,6 +71,21 @@ class _SyntheticBody:
     projectId: str
     issueId: str
     event: str = "watchdog.stuck"
+
+
+def _is_intake_no_result_tag(state: ReqState, issue) -> bool:
+    """state=INTAKING + session 已结束（非 running）+ tags 缺 result:* → 卡死信号。
+
+    intake-agent session.completed 后必须 PATCH `result:pass` / `result:fail` tag
+    让 router 派 INTAKE_PASS/FAIL；忘了打 tag 会导致 webhook 永不 fire 主链事件，
+    REQ 永远卡在 INTAKING。识别此条件就 escalate（不 retry —— session 已 done，
+    auto-resume 也唤不醒已结束的 agent）。
+    """
+    if state != ReqState.INTAKING or issue is None:
+        return False
+    if issue.session_status == "running":
+        return False
+    return not (set(issue.tags or []) & _INTAKE_RESULT_TAGS)
 
 
 async def _tick() -> dict:
@@ -107,13 +132,13 @@ async def _check_and_escalate(row) -> bool:
         issue_id = ctx.get(issue_key)
 
     # 1. 查 BKD session 状态（有 issue_id 才查）
+    issue = None
     still_running = False
     if issue_id:
         try:
             async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
                 issue = await bkd.get_issue(project_id, issue_id)
-            session_status = issue.session_status
-            if session_status == "running":
+            if issue.session_status == "running":
                 still_running = True
                 log.debug(
                     "watchdog.still_running",
@@ -130,33 +155,65 @@ async def _check_and_escalate(row) -> bool:
     if still_running:
         return False
 
-    # 2. 写 artifact_checks 记一笔，给 dashboard M7 04-fail-kind-distribution 抓
+    # 2. 区分细分 stuck reason：
+    #    - INTAKING + session 已结束 + 无 result tag → intake-no-result-tag
+    #    - 其他 → 通用 watchdog_stuck
     pool = db.get_pool()
+    intake_no_result = _is_intake_no_result_tag(state, issue)
+    if intake_no_result:
+        reason = _INTAKE_NO_RESULT_REASON
+        body_event = _INTAKE_NO_RESULT_EVENT
+        stage_label = "watchdog:intake-no-result-tag"
+        stderr_tail = (
+            f"intake session ended (status={issue.session_status}) "
+            f"without result:pass/result:fail tag; stuck for {stuck_sec}s"
+        )
+    else:
+        reason = "watchdog_stuck"
+        body_event = "watchdog.stuck"
+        stage_label = f"watchdog:{state_str}"
+        stderr_tail = f"stuck for {stuck_sec}s in state {state_str}"
+
+    # 3. 写 artifact_checks 记一笔，给 dashboard M7 04-fail-kind-distribution 抓
     check = CheckResult(
         passed=False,
         exit_code=-1,
-        cmd=f"watchdog:{state_str}",
+        cmd=stage_label,
         stdout_tail="",
-        stderr_tail=f"stuck for {stuck_sec}s in state {state_str}",
+        stderr_tail=stderr_tail,
         duration_sec=0.0,
-        reason="watchdog_stuck",
+        reason=reason,
     )
     try:
-        await artifact_checks.insert_check(
-            pool, req_id, f"watchdog:{state_str}", check,
-        )
+        await artifact_checks.insert_check(pool, req_id, stage_label, check)
     except Exception as e:
         log.warning("watchdog.artifact_insert_failed", req_id=req_id, error=str(e))
 
-    # 3. 通过 engine.step 发 SESSION_FAILED → 走 escalate transition
+    # 4. intake-no-result-tag：把 reason 提前落 ctx，escalate.py 经
+    #    "非 canonical body.event → ctx.escalated_reason 优先" 通路读到，
+    #    最终 BKD tag = `reason:intake-no-result-tag`（而非 `reason:watchdog-stuck`）。
+    if intake_no_result:
+        try:
+            await req_state.update_context(
+                pool, req_id, {"escalated_reason": reason},
+            )
+        except Exception as e:
+            log.warning(
+                "watchdog.ctx_update_failed", req_id=req_id, error=str(e),
+            )
+        ctx = {**ctx, "escalated_reason": reason}
+
+    # 5. 通过 engine.step 发 SESSION_FAILED → 走 escalate transition
     body = _SyntheticBody(
         projectId=project_id,
         issueId=issue_id or ctx.get("intent_issue_id") or "",
+        event=body_event,
     )
     log.warning(
         "watchdog.escalating",
         req_id=req_id, state=state_str,
         issue_id=issue_id, stuck_sec=stuck_sec,
+        reason=reason,
     )
     try:
         await engine.step(
@@ -164,7 +221,7 @@ async def _check_and_escalate(row) -> bool:
             body=body,
             req_id=req_id,
             project_id=project_id,
-            tags=[req_id, f"watchdog:{state_str}"],
+            tags=[req_id, stage_label],
             cur_state=state,
             ctx=ctx,
             event=Event.SESSION_FAILED,

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -236,6 +236,54 @@ async def test_escalate_canonical_signal_overrides_stale_ctx(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_escalate_intake_no_result_tag_directly_escalates(monkeypatch):
+    """body.event=watchdog.intake_no_result_tag + ctx.escalated_reason='intake-no-result-tag'
+    → 非 canonical → 用 ctx reason；非 transient → 直接真 escalate（不 retry）；
+    body.event 在 _SESSION_END_SIGNALS → 走 cleanup CAS 推 ESCALATED + 清 runner。"""
+    from orchestrator.actions import escalate as mod
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, "escalate", fake)
+    patch_db(monkeypatch, "escalate")
+
+    from unittest.mock import AsyncMock
+
+    from orchestrator import k8s_runner as krunner
+    from orchestrator.store import req_state as rs
+
+    class FakeRow:
+        state = type("S", (), {"value": "intaking"})()
+    monkeypatch.setattr(rs, "get", AsyncMock(return_value=FakeRow()))
+    cas = AsyncMock(return_value=True)
+    monkeypatch.setattr(rs, "cas_transition", cas)
+    cleanup = AsyncMock()
+    monkeypatch.setattr(
+        krunner, "get_controller",
+        lambda: type("C", (), {"cleanup_runner": cleanup})(),
+    )
+
+    body = make_body(issue_id="intent-1", event="watchdog.intake_no_result_tag")
+    out = await mod.escalate(
+        body=body, req_id="REQ-9", tags=["watchdog:intake-no-result-tag"],
+        ctx={
+            "intent_issue_id": "intent-1",
+            "escalated_reason": "intake-no-result-tag",
+        },
+    )
+    assert out["escalated"] is True
+    # ctx.escalated_reason 优先（非 canonical）→ reason 透传
+    assert out["reason"] == "intake-no-result-tag"
+    # 不 retry
+    fake.follow_up_issue.assert_not_awaited()
+    # 真 escalate：在 intent issue 上加 escalated + reason 标签
+    fake.merge_tags_and_update.assert_awaited_once()
+    args, kwargs = fake.merge_tags_and_update.call_args
+    assert "escalated" in kwargs.get("add", []) or "escalated" in (args[2] if len(args) > 2 else [])
+    # CAS 推 ESCALATED + cleanup 跑（_SESSION_END_SIGNALS 包含本 event）
+    cas.assert_awaited_once()
+    cleanup.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_escalate_action_error_is_transient(monkeypatch):
     """engine _emit_escalate 注的 ctx.escalated_reason='action-error:...' 应被识别为
     transient（基础设施 flaky）→ auto-resume 一次，给环境恢复机会。

--- a/orchestrator/tests/test_contract_watchdog_intake_no_result.py
+++ b/orchestrator/tests/test_contract_watchdog_intake_no_result.py
@@ -1,0 +1,241 @@
+"""Contract tests for REQ-watchdog-intake-no-result-1777078182.
+
+feat(watchdog): detect intake session.completed without result tag, escalate
+with reason intake-no-result-tag.
+
+Black-box behavioral contract verification written by challenger-agent.
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is wrong, escalate to spec_fixer to correct the spec, not the test.
+
+Scenarios covered:
+  WD-S1  INTAKING + session ended + no result tag → intake-no-result-tag
+  WD-S2  INTAKING + session running → skip (no escalation)
+  WD-S3  INTAKING + session completed + result:pass → generic stuck path
+  WD-S4  BKD lookup failure (issue=None) → generic stuck path (not misclassified)
+  WD-S5  escalate honors ctx.escalated_reason for intake event (non-canonical)
+  WD-S6  escalate runs cleanup CAS for intake event (_SESSION_END_SIGNALS)
+"""
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+
+# ─── Contract 1: watchdog new constants ───────────────────────────────────────
+
+
+class TestWatchdogConstantsContract:
+    """Spec: three new constants in orchestrator.watchdog."""
+
+    def test_intake_result_tags_exists_and_correct(self):
+        """Spec: _INTAKE_RESULT_TAGS = {"result:pass", "result:fail"}."""
+        from orchestrator.watchdog import _INTAKE_RESULT_TAGS
+
+        assert _INTAKE_RESULT_TAGS == {"result:pass", "result:fail"}, (
+            f"expected {{'result:pass', 'result:fail'}}, got {_INTAKE_RESULT_TAGS!r}"
+        )
+
+    def test_intake_no_result_event_exists_and_correct(self):
+        """Spec: _INTAKE_NO_RESULT_EVENT = 'watchdog.intake_no_result_tag'."""
+        from orchestrator.watchdog import _INTAKE_NO_RESULT_EVENT
+
+        assert _INTAKE_NO_RESULT_EVENT == "watchdog.intake_no_result_tag", (
+            f"expected 'watchdog.intake_no_result_tag', got {_INTAKE_NO_RESULT_EVENT!r}"
+        )
+
+    def test_intake_no_result_reason_exists_and_correct(self):
+        """Spec: _INTAKE_NO_RESULT_REASON = 'intake-no-result-tag'."""
+        from orchestrator.watchdog import _INTAKE_NO_RESULT_REASON
+
+        assert _INTAKE_NO_RESULT_REASON == "intake-no-result-tag", (
+            f"expected 'intake-no-result-tag', got {_INTAKE_NO_RESULT_REASON!r}"
+        )
+
+
+# ─── Contract 2: _is_intake_no_result_tag pure helper (WD-S1 to WD-S4) ────────
+
+
+class TestIsIntakeNoResultTagContract:
+    """Pure function: (ReqState, Issue | None) -> bool.
+
+    Spec: Returns True iff state == INTAKING AND issue is not None AND
+    issue.session_status != 'running' AND issue.tags has no overlap
+    with {"result:pass", "result:fail"}.
+    """
+
+    def _make_issue(self, session_status: str, tags: list[str]):
+        return SimpleNamespace(session_status=session_status, tags=tags)
+
+    @staticmethod
+    def _intaking():
+        from orchestrator.state import ReqState
+
+        return ReqState.INTAKING
+
+    @staticmethod
+    def _non_intaking():
+        from orchestrator.state import ReqState
+
+        return ReqState.ANALYZING
+
+    def test_function_exists_and_is_callable(self):
+        from orchestrator.watchdog import _is_intake_no_result_tag
+
+        assert callable(_is_intake_no_result_tag)
+
+    def test_function_signature_has_two_parameters(self):
+        from orchestrator.watchdog import _is_intake_no_result_tag
+
+        sig = inspect.signature(_is_intake_no_result_tag)
+        assert len(sig.parameters) == 2, (
+            f"_is_intake_no_result_tag must take 2 params, got {list(sig.parameters)}"
+        )
+
+    def test_wd_s1_intaking_completed_no_result_tag_returns_true(self):
+        """WD-S1: INTAKING + session ended + no result tag → True."""
+        from orchestrator.watchdog import _is_intake_no_result_tag
+
+        issue = self._make_issue("completed", ["intake", "REQ-watchdog-intake-no-result-1777078182"])
+        assert _is_intake_no_result_tag(self._intaking(), issue) is True
+
+    def test_wd_s1_also_triggers_for_other_terminal_statuses(self):
+        """WD-S1: any non-'running' session_status + no result tag → True."""
+        from orchestrator.watchdog import _is_intake_no_result_tag
+
+        for status in ("cancelled", "failed", "error"):
+            issue = self._make_issue(status, ["intake", "REQ-x"])
+            assert _is_intake_no_result_tag(self._intaking(), issue) is True, (
+                f"expected True for session_status={status!r}"
+            )
+
+    def test_wd_s2_intaking_session_running_returns_false(self):
+        """WD-S2: INTAKING + session running → False (agent still active, skip)."""
+        from orchestrator.watchdog import _is_intake_no_result_tag
+
+        issue = self._make_issue("running", ["intake", "REQ-x"])
+        assert _is_intake_no_result_tag(self._intaking(), issue) is False
+
+    def test_wd_s3_intaking_result_pass_returns_false(self):
+        """WD-S3: INTAKING + session completed + result:pass → False (generic stuck)."""
+        from orchestrator.watchdog import _is_intake_no_result_tag
+
+        issue = self._make_issue("completed", ["intake", "REQ-x", "result:pass"])
+        assert _is_intake_no_result_tag(self._intaking(), issue) is False
+
+    def test_wd_s3_intaking_result_fail_returns_false(self):
+        """WD-S3 variant: INTAKING + result:fail → False (generic stuck)."""
+        from orchestrator.watchdog import _is_intake_no_result_tag
+
+        issue = self._make_issue("completed", ["intake", "REQ-x", "result:fail"])
+        assert _is_intake_no_result_tag(self._intaking(), issue) is False
+
+    def test_wd_s4_issue_none_returns_false(self):
+        """WD-S4: BKD lookup failure (issue=None) → False, must not raise."""
+        from orchestrator.watchdog import _is_intake_no_result_tag
+
+        try:
+            result = _is_intake_no_result_tag(self._intaking(), None)
+        except Exception as exc:
+            pytest.fail(
+                f"_is_intake_no_result_tag must not raise when issue=None; got {exc!r}"
+            )
+        assert result is False, (
+            f"BKD lookup failure (issue=None) must return False, got {result!r}"
+        )
+
+    def test_non_intaking_state_returns_false(self):
+        """Only INTAKING state should trigger the detection."""
+        from orchestrator.watchdog import _is_intake_no_result_tag
+
+        issue = self._make_issue("completed", ["intake", "REQ-x"])
+        assert _is_intake_no_result_tag(self._non_intaking(), issue) is False
+
+
+# ─── Contract 3: watchdog state-to-issue-key mapping covers INTAKING ──────────
+
+
+class TestWatchdogStateIssueKeyContract:
+    """Spec: state_to_issue_key_changes adds INTAKING → intent_issue_id.
+
+    Watchdog must know which ctx key to use when looking up the BKD issue
+    for INTAKING state; the ctx key is 'intent_issue_id'.
+    """
+
+    def test_intaking_mapped_to_intent_issue_id(self):
+        """Spec: INTAKING state must use ctx_key='intent_issue_id' for BKD lookup."""
+        import orchestrator.watchdog as wd
+        from orchestrator.state import ReqState
+
+        mapping = None
+        for attr in dir(wd):
+            if attr.startswith("_") and not attr.startswith("__"):
+                val = getattr(wd, attr, None)
+                if isinstance(val, dict) and ReqState.INTAKING in val:
+                    mapping = val
+                    break
+
+        assert mapping is not None, (
+            "orchestrator.watchdog must have a dict mapping ReqState.INTAKING "
+            "to a ctx key string"
+        )
+        assert mapping[ReqState.INTAKING] == "intent_issue_id", (
+            f"INTAKING must map to 'intent_issue_id', got {mapping[ReqState.INTAKING]!r}"
+        )
+
+
+# ─── Contract 4: escalate _SESSION_END_SIGNALS includes intake event (WD-S6) ──
+
+
+class TestEscalateSessionEndSignalsContract:
+    """WD-S6: escalate runs manual CAS → ESCALATED + cleanup_runner for intake event."""
+
+    def test_session_end_signals_constant_exists(self):
+        from orchestrator.actions.escalate import _SESSION_END_SIGNALS
+
+        assert _SESSION_END_SIGNALS is not None
+
+    def test_session_end_signals_contains_intake_no_result_event(self):
+        """WD-S6: watchdog.intake_no_result_tag must be in _SESSION_END_SIGNALS."""
+        from orchestrator.actions.escalate import _SESSION_END_SIGNALS
+
+        assert "watchdog.intake_no_result_tag" in _SESSION_END_SIGNALS, (
+            "_SESSION_END_SIGNALS must include 'watchdog.intake_no_result_tag' "
+            "so escalate runs CAS + cleanup_runner for this event"
+        )
+
+    def test_session_end_signals_preserves_existing_events(self):
+        """Spec: pre-existing session-end events must remain in _SESSION_END_SIGNALS."""
+        from orchestrator.actions.escalate import _SESSION_END_SIGNALS
+
+        for event in ("session.failed", "watchdog.stuck"):
+            assert event in _SESSION_END_SIGNALS, (
+                f"_SESSION_END_SIGNALS must still contain existing event {event!r}"
+            )
+
+
+# ─── Contract 5: escalate non-canonical classification (WD-S5) ────────────────
+
+
+class TestEscalateNonCanonicalContract:
+    """WD-S5: escalate honors ctx.escalated_reason for intake event.
+
+    watchdog.intake_no_result_tag is intentionally NOT in _CANONICAL_SIGNALS
+    so that ctx.escalated_reason='intake-no-result-tag' is used as the reason
+    when tagging the BKD intent issue, instead of a body-derived reason.
+    """
+
+    def test_canonical_signals_exists(self):
+        from orchestrator.actions.escalate import _CANONICAL_SIGNALS
+
+        assert _CANONICAL_SIGNALS is not None
+
+    def test_intake_no_result_not_in_canonical_signals(self):
+        """WD-S5: not in _CANONICAL_SIGNALS → ctx.escalated_reason wins."""
+        from orchestrator.actions.escalate import _CANONICAL_SIGNALS
+
+        assert "watchdog.intake_no_result_tag" not in _CANONICAL_SIGNALS, (
+            "watchdog.intake_no_result_tag must NOT be in _CANONICAL_SIGNALS; "
+            "its reason must come from ctx.escalated_reason pre-written by watchdog"
+        )

--- a/orchestrator/tests/test_contract_watchdog_intake_no_result.py
+++ b/orchestrator/tests/test_contract_watchdog_intake_no_result.py
@@ -22,7 +22,6 @@ from types import SimpleNamespace
 
 import pytest
 
-
 # ─── Contract 1: watchdog new constants ───────────────────────────────────────
 
 

--- a/orchestrator/tests/test_watchdog.py
+++ b/orchestrator/tests/test_watchdog.py
@@ -79,10 +79,26 @@ def _patch_engine(monkeypatch):
             "event": event,
             "body_issue": getattr(body, "issueId", None),
             "body_proj": getattr(body, "projectId", None),
+            "body_event": getattr(body, "event", None),
+            "tags": list(tags or []),
+            "ctx": dict(ctx or {}),
         })
         return {"action": "escalate", "next_state": "escalated"}
 
     monkeypatch.setattr("orchestrator.watchdog.engine.step", fake_step)
+    return calls
+
+
+def _patch_req_state(monkeypatch):
+    """捕获 req_state.update_context 调用（intake-no-result 路径会调）。"""
+    calls: list = []
+
+    async def fake_update_context(pool, req_id, patch):
+        calls.append({"req_id": req_id, "patch": dict(patch or {})})
+
+    monkeypatch.setattr(
+        "orchestrator.watchdog.req_state.update_context", fake_update_context,
+    )
     return calls
 
 
@@ -256,6 +272,188 @@ async def test_loop_disabled_returns_immediately(monkeypatch):
     monkeypatch.setattr("orchestrator.watchdog.settings.watchdog_enabled", False)
     # 无需 mock _tick / asyncio.sleep — 直接 return 不进 while
     await watchdog.run_loop()   # 不应 hang
+
+
+# ─── Case 9a：INTAKING + session.completed 无 result tag → intake-no-result-tag
+@pytest.mark.asyncio
+async def test_intake_no_result_tag_specific_escalation(monkeypatch):
+    """intake-agent session.completed 后忘记 PATCH result:pass/fail tag →
+    watchdog 识别 intake-no-result-tag 路径：写专属 stage_label/reason，
+    body.event=watchdog.intake_no_result_tag，ctx.escalated_reason 预置，
+    engine.step 收到的 ctx 含 escalated_reason='intake-no-result-tag'。"""
+    pool = FakePool(rows=[
+        _row("REQ-INT", ReqState.INTAKING.value,
+             ctx={"intent_issue_id": "intent-int"}),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(
+        monkeypatch,
+        FakeIssue(
+            session_status="completed",
+            id="intent-int",
+            tags=["intake", "REQ-INT"],  # 缺 result:pass / result:fail
+        ),
+    )
+    step_calls = _patch_engine(monkeypatch)
+    art_calls = _patch_artifact(monkeypatch)
+    rs_calls = _patch_req_state(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    # artifact_checks 写专属 stage + reason
+    assert len(art_calls) == 1
+    assert art_calls[0]["stage"] == "watchdog:intake-no-result-tag"
+    assert art_calls[0]["result"].reason == "intake-no-result-tag"
+    assert art_calls[0]["result"].cmd == "watchdog:intake-no-result-tag"
+    # ctx 提前落 escalated_reason（escalate.py 会读到）
+    assert len(rs_calls) == 1
+    assert rs_calls[0]["req_id"] == "REQ-INT"
+    assert rs_calls[0]["patch"] == {"escalated_reason": "intake-no-result-tag"}
+    # engine.step 收到 SESSION_FAILED + 专属 body.event + ctx 已 merge
+    assert len(step_calls) == 1
+    assert step_calls[0]["event"] == Event.SESSION_FAILED
+    assert step_calls[0]["body_event"] == "watchdog.intake_no_result_tag"
+    assert step_calls[0]["body_issue"] == "intent-int"
+    assert step_calls[0]["ctx"].get("escalated_reason") == "intake-no-result-tag"
+
+
+# ─── Case 9b：INTAKING + session.completed + 有 result:pass tag → 走通用 watchdog_stuck
+@pytest.mark.asyncio
+async def test_intake_with_result_tag_falls_through_to_generic_stuck(monkeypatch):
+    """INTAKING 卡住但 result tag 已存在 → 不是 intake-no-result-tag 这个 bug
+    （该是 router 漏 fire 的不同问题，超本 REQ 范围）→ fall through 通用路径。"""
+    pool = FakePool(rows=[
+        _row("REQ-RP", ReqState.INTAKING.value,
+             ctx={"intent_issue_id": "intent-rp"}),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(
+        monkeypatch,
+        FakeIssue(
+            session_status="completed",
+            id="intent-rp",
+            tags=["intake", "REQ-RP", "result:pass"],
+        ),
+    )
+    step_calls = _patch_engine(monkeypatch)
+    art_calls = _patch_artifact(monkeypatch)
+    rs_calls = _patch_req_state(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    # 走通用路径：stage=watchdog:intaking, reason=watchdog_stuck
+    assert art_calls[0]["stage"] == "watchdog:intaking"
+    assert art_calls[0]["result"].reason == "watchdog_stuck"
+    # 不预置 ctx.escalated_reason
+    assert rs_calls == []
+    # body.event 仍是 watchdog.stuck（保 auto-resume + canonical 覆盖原有语义）
+    assert step_calls[0]["body_event"] == "watchdog.stuck"
+
+
+# ─── Case 9c：INTAKING + session.running → skip（不管有没有 result tag）
+@pytest.mark.asyncio
+async def test_intake_session_running_skips(monkeypatch):
+    """intake session 还在跑（agent 可能等用户回 chat）→ watchdog 不动。"""
+    pool = FakePool(rows=[
+        _row("REQ-IR", ReqState.INTAKING.value,
+             ctx={"intent_issue_id": "intent-ir"}),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(
+        monkeypatch,
+        FakeIssue(session_status="running", id="intent-ir", tags=["intake"]),
+    )
+    step_calls = _patch_engine(monkeypatch)
+    art_calls = _patch_artifact(monkeypatch)
+    rs_calls = _patch_req_state(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 0}
+    assert step_calls == []
+    assert art_calls == []
+    assert rs_calls == []
+
+
+# ─── Case 9d：BKD 查 intake issue 失败 → 保守 escalate 走通用 watchdog_stuck
+@pytest.mark.asyncio
+async def test_intake_bkd_lookup_fails_falls_through_to_generic_stuck(monkeypatch):
+    """BKD 查 intake issue 抛异常 → issue=None → 不能确定 result tag 状态
+    → 不走 intake-no-result-tag 专属路径，走通用 watchdog_stuck（保留 auto-resume）。"""
+    pool = FakePool(rows=[
+        _row("REQ-BKD", ReqState.INTAKING.value,
+             ctx={"intent_issue_id": "intent-bkd"}),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, None, side_effect=RuntimeError("BKD 504"))
+    step_calls = _patch_engine(monkeypatch)
+    art_calls = _patch_artifact(monkeypatch)
+    rs_calls = _patch_req_state(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    # BKD 查不到 → issue=None → 不算 intake-no-result-tag → 通用路径
+    assert art_calls[0]["stage"] == "watchdog:intaking"
+    assert art_calls[0]["result"].reason == "watchdog_stuck"
+    assert rs_calls == []
+    assert step_calls[0]["body_event"] == "watchdog.stuck"
+
+
+# ─── Case 9e：纯函数 _is_intake_no_result_tag 单元 case grid
+def test_is_intake_no_result_tag_grid():
+    """纯函数 case grid：state / session_status / tags 三维交叉。"""
+    Issue = type("I", (), {})
+
+    def _mk(status, tags):
+        i = Issue()
+        i.session_status = status
+        i.tags = tags
+        return i
+
+    # state != INTAKING → False (即使其他条件都满足)
+    assert watchdog._is_intake_no_result_tag(
+        ReqState.ANALYZING, _mk("completed", []),
+    ) is False
+
+    # issue is None → False
+    assert watchdog._is_intake_no_result_tag(ReqState.INTAKING, None) is False
+
+    # session 仍 running → False
+    assert watchdog._is_intake_no_result_tag(
+        ReqState.INTAKING, _mk("running", []),
+    ) is False
+
+    # session ended + 有 result:pass → False
+    assert watchdog._is_intake_no_result_tag(
+        ReqState.INTAKING, _mk("completed", ["intake", "result:pass"]),
+    ) is False
+
+    # session ended + 有 result:fail → False
+    assert watchdog._is_intake_no_result_tag(
+        ReqState.INTAKING, _mk("completed", ["intake", "result:fail"]),
+    ) is False
+
+    # session ended + 无 result tag → True
+    assert watchdog._is_intake_no_result_tag(
+        ReqState.INTAKING, _mk("completed", ["intake", "REQ-x"]),
+    ) is True
+
+    # session=cancelled / failed / None 也算 ended → True（只要无 result tag）
+    for status in ("cancelled", "failed", None):
+        assert watchdog._is_intake_no_result_tag(
+            ReqState.INTAKING, _mk(status, ["intake"]),
+        ) is True
+
+    # tags=None / [] 都视作无 result tag
+    assert watchdog._is_intake_no_result_tag(
+        ReqState.INTAKING, _mk("completed", None),
+    ) is True
+    assert watchdog._is_intake_no_result_tag(
+        ReqState.INTAKING, _mk("completed", []),
+    ) is True
 
 
 # ─── Case 9：engine.step 抛异常不阻塞后续 row ─────────────────────────────


### PR DESCRIPTION
## 动机 (REQ-watchdog-intake-no-result-1777078182)

intake-agent `session.completed` 后**必须** PATCH `result:pass` / `result:fail` tag，
router 才会派 `INTAKE_PASS` / `INTAKE_FAIL`。忘了 PATCH → REQ 永远卡在 INTAKING，
现有通用 watchdog 兜底两个问题：
1. body.event=`watchdog.stuck` 是 canonical → reason 锁成 `watchdog-stuck`，看不出
   是 intake-agent 的 prompt-bug
2. `watchdog-stuck` 被判 transient → 浪费 2 次 auto-resume "continue" 才进真 escalate
   （session 已 done，follow-up 唤不醒）

## 方案

- 加纯函数 `_is_intake_no_result_tag(state, issue)`：state=INTAKING + session 非 running
  + tags 缺 `result:*` → True
- watchdog 分流：命中 → 写专属 `stage="watchdog:intake-no-result-tag"`、
  `reason="intake-no-result-tag"`，预先 PATCH `ctx.escalated_reason`，体设
  `body.event="watchdog.intake_no_result_tag"`
- escalate.py 加 `_SESSION_END_SIGNALS`，把新 event 纳入 cleanup CAS 路径；
  新 event 故意**不**进 `_CANONICAL_SIGNALS`，让 ctx.escalated_reason 成为最终 reason
  来源；不在 `_TRANSIENT_REASONS` / canonical body.event 也避开 auto-resume

## 行为

| 形态 | reason | body.event | auto-resume? |
|---|---|---|---|
| INTAKING + completed + 无 result tag | `intake-no-result-tag` | `watchdog.intake_no_result_tag` | ❌ |
| INTAKING + completed + `result:pass` | `watchdog_stuck` | `watchdog.stuck` | ✅ (transient) |
| INTAKING + running | — (skip) | — | — |
| 任何 state + BKD lookup 失败 | `watchdog_stuck` (fallback) | `watchdog.stuck` | ✅ |

## Test plan

- [x] `pytest orchestrator/tests/test_watchdog.py` — 14/14 passed (5 新 case：纯函数 grid、专属路径、result tag fall-through、session running skip、BKD 失败 fallback)
- [x] `pytest orchestrator/tests/test_actions_smoke.py` — 21/21 passed (1 新 case：escalate 处理新 body.event)
- [x] `pytest orchestrator/tests --ignore=tests/test_checkers_pr_ci_watch.py` — 376/376 passed
- [x] `ruff check src/ tests/` — clean
- [x] `openspec validate REQ-watchdog-intake-no-result-1777078182 --strict` — valid
- [x] `scripts/check-scenario-refs.sh` — 12 scenarios OK

## 文件

- `orchestrator/src/orchestrator/watchdog.py` —— 检测 + 分流
- `orchestrator/src/orchestrator/actions/escalate.py` —— `_SESSION_END_SIGNALS` 收入新 event
- `orchestrator/tests/test_watchdog.py` —— 5 新 case
- `orchestrator/tests/test_actions_smoke.py` —— 1 新 case
- `openspec/changes/REQ-watchdog-intake-no-result-1777078182/` —— proposal / tasks / spec.md (delta) / contract.spec.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)