### PR TITLE
chore(orch): drop stale 77k9z58j project + silence runner_gc disk_check 403

### DIFF
--- a/openspec/changes/REQ-orch-noise-cleanup-1777078500/proposal.md
+++ b/openspec/changes/REQ-orch-noise-cleanup-1777078500/proposal.md
@@ -1,0 +1,67 @@
+# REQ-orch-noise-cleanup-1777078500: chore(orch): drop stale 77k9z58j project + silence runner_gc disk_check 403
+
+## 问题
+
+orchestrator 后台 task 在生产 INFO 日志里持续刷两条无意义噪声：
+
+1. **`snapshot.list_failed project_id=77k9z58j`** —— 每 `snapshot_interval_sec`
+   (默认 300s) 一次 WARN。`req_state` 里曾经写过 project `77k9z58j` 的行，但
+   该 BKD project 已停用 / 已删 / 已迁移。snapshot loop 走 `SELECT DISTINCT
+   project_id FROM req_state` 取项目列表，无脑去 BKD 拉 → 拿 4xx/网络错 →
+   `log.warning("snapshot.list_failed", ...)` 反复打。
+
+2. **`runner_gc` 磁盘探测 403** —— `node_disk_usage_ratio` 调 `core_v1.list_node`
+   是 cluster-scoped 的 `nodes:list`，但 orchestrator 的 RBAC（runner-rbac.yaml）
+   只在 `sisyphus-runners` namespace 内授 pod / pvc Role。每次 GC 周期
+   (`runner_gc_interval_sec` 默认 900s) 都吃 `ApiException(403)`。当前已 catch
+   到 `log.debug` 应当被 INFO 滤掉，但实测 dev (`log_level: DEBUG`) 时把日志带
+   noise；以及 INFO 下 *kubernetes* 客户端底层会经 stderr/urllib3 log
+   出 forbid 信息（部署日志 grep 出来过）。
+
+两条都不影响功能，只是 churn。
+
+## 方案
+
+### 1. snapshot 加项目排除清单（config-driven）
+
+新增 setting `snapshot_exclude_project_ids: list[str]`（env 名
+`SISYPHUS_SNAPSHOT_EXCLUDE_PROJECT_IDS`，逗号分隔）。`sync_once` 把
+`req_state` 里取出的 `project_id` 列表先过 exclude 集合，再发 BKD list-issues。
+
+helm `values.yaml` 默认值放 `["77k9z58j"]`，把已知历史死项目排除掉。
+将来再有死项目，运维加一个 env 即可，不动代码。
+
+为啥不直接 SQL 删 `req_state` 行：
+- `req_state` 是审计/state-machine truth；不删
+- 死项目 row 永远不会再 transition；保留无害
+- 排除只发生在 snapshot loop 这一处
+
+### 2. runner_gc 把"RBAC 缺权限"识别为 first-class，silent 跳过
+
+在 `gc_once` 内：
+- catch `kubernetes.client.ApiException` 单独
+- `e.status == 403`：判定为 RBAC 拒绝，记一个**进程级** flag
+  `_DISK_CHECK_DISABLED`。第一次 hit 用 `log.warning` 打一句明显
+  ("runner_gc.disk_check_rbac_denied …")，之后 GC tick 直接 short-circuit
+  跳过 disk-check (`disk_pressure=False`)，不再发 list_node 请求、不再 log。
+- 其他异常 (500 / 网络抖) 维持原来 `log.debug`，不卡 GC 主流程。
+
+收益：
+- 生产唯一一次明显告警，让 ops 知道"这个集群没给 nodes:list 权限，
+  disk-pressure 兜底自动失活"
+- 之后日志安静；不再每 15 min 一次刷
+- 不再消耗 K8s API 配额做注定失败的请求
+
+### 不做
+
+- 不动 RBAC 给 nodes:list —— 这是 ops 政策选择，不在编排层范围
+- 不引入"cluster-RBAC mode 开关"配置 —— first-call probe 已经够用
+- 不删 `req_state` 历史行 —— 见上
+
+## 取舍
+
+- exclude list 设计成 list 而非"严格白名单"：白名单要求新项目接入前
+  改 helm values 才能 snapshot；体验差。黑名单只解决"已知死项目"问题。
+- 进程级 flag 不持久化：orchestrator 重启就重新 probe 一次。这是 feature
+  not bug —— 重启时 ops 能感知 RBAC 是否补上。
+- 进程级 flag 用模块级变量（不是 settings），因为运行时才知道是不是 403。

--- a/openspec/changes/REQ-orch-noise-cleanup-1777078500/specs/orch-noise-cleanup/contract.spec.yaml
+++ b/openspec/changes/REQ-orch-noise-cleanup-1777078500/specs/orch-noise-cleanup/contract.spec.yaml
@@ -1,0 +1,50 @@
+capability: orch-noise-cleanup
+version: "1.0"
+description: |
+  Two operational noise reductions in orchestrator background loops:
+    1. snapshot loop honours an exclude list of stale BKD project_ids
+       (default ships with "77k9z58j").
+    2. runner_gc detects RBAC 403 on nodes:list and disables the
+       disk-pressure probe after one warn, instead of failing every tick.
+
+settings:
+  snapshot_exclude_project_ids:
+    module: orchestrator.config
+    env_var: SISYPHUS_SNAPSHOT_EXCLUDE_PROJECT_IDS
+    type: list[str]
+    default: []
+    parsing: "pydantic 默认 list 解析（逗号分隔 / JSON 数组）"
+    helm_default:
+      file: orchestrator/helm/values.yaml
+      key: env.snapshot_exclude_project_ids
+      value: ["77k9z58j"]
+    semantics: |
+      sync_once 在迭代 SELECT DISTINCT project_id FROM req_state 结果时，
+      过滤掉所有出现在此列表中的 project_id。被排除的 project 不发 BKD
+      list_issues 请求、不上报到 snapshot.synced.projects、不产生
+      snapshot.list_failed warning。
+
+functions:
+  sync_once:
+    module: orchestrator.snapshot
+    behavior_change: |
+      project_ids = [p for p in req_state_distinct
+                     if p not in settings.snapshot_exclude_project_ids]
+      若过滤后为空 → 直接 return 0（与无 project_id 时一致）
+    backward_compat: |
+      未设置 SISYPHUS_SNAPSHOT_EXCLUDE_PROJECT_IDS 或设为空时行为保持不变。
+
+  gc_once:
+    module: orchestrator.runner_gc
+    behavior_change: |
+      新增模块级 flag _DISK_CHECK_DISABLED（bool, default False）。
+      gc_once 进入 disk-check 分支前先看 flag：
+        - 已禁用 → 跳过 node_disk_usage_ratio 调用，disk_pressure=False
+        - 未禁用 → 调 node_disk_usage_ratio：
+            * ApiException(status=403) → flag 置 True；log.warning
+              "runner_gc.disk_check_rbac_denied"（一次）
+            * 其他异常 → log.debug "runner_gc.disk_check_failed"
+            * 成功 → 维持原 ratio > threshold 判逻辑
+    rationale: |
+      orchestrator RBAC 是 namespace-scoped Role（runner-rbac.yaml），
+      没授 cluster-scoped nodes:list。修 RBAC 是 ops 政策选择；编排层降级处理。

--- a/openspec/changes/REQ-orch-noise-cleanup-1777078500/specs/orch-noise-cleanup/spec.md
+++ b/openspec/changes/REQ-orch-noise-cleanup-1777078500/specs/orch-noise-cleanup/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: snapshot loop 支持配置驱动的 project_id 排除清单
+
+The system SHALL allow operators to declare a list of BKD `project_id` values
+that the bkd_snapshot loop MUST skip. The list MUST be provided through the
+setting `snapshot_exclude_project_ids` (env var
+`SISYPHUS_SNAPSHOT_EXCLUDE_PROJECT_IDS`, comma-separated). Each iteration of
+`sync_once` MUST filter the project IDs read from `req_state` against this
+exclude list before issuing any BKD `list-issues` call. Any project_id present
+in the exclude list MUST NOT generate a `snapshot.list_failed` warning, MUST
+NOT consume BKD API quota, and MUST NOT be reported in the
+`snapshot.synced.projects` log line.
+
+#### Scenario: ORCHN-S1 排除单个项目时跳过 BKD 调用
+
+- **GIVEN** `req_state` 里的 distinct project_id 是 `["alive-1", "77k9z58j"]`
+- **AND** `settings.snapshot_exclude_project_ids = ["77k9z58j"]`
+- **WHEN** `sync_once()` 被调用
+- **THEN** `BKDClient.list_issues` 仅以 `"alive-1"` 调一次，不再以 `"77k9z58j"` 调
+- **AND** `snapshot.list_failed` 不被记录
+
+#### Scenario: ORCHN-S2 排除清单为空时保持原行为
+
+- **GIVEN** `settings.snapshot_exclude_project_ids = []`
+- **AND** `req_state` 里的 distinct project_id 是 `["alive-1", "alive-2"]`
+- **WHEN** `sync_once()` 被调用
+- **THEN** `BKDClient.list_issues` 被调用两次，每个 project_id 一次
+
+#### Scenario: ORCHN-S3 全部 project_id 都被排除时短路返回 0
+
+- **GIVEN** `settings.snapshot_exclude_project_ids = ["only-proj"]`
+- **AND** `req_state` 里 distinct project_id 仅为 `["only-proj"]`
+- **WHEN** `sync_once()` 被调用
+- **THEN** 返回 0，且 `BKDClient.list_issues` 不被调用
+
+### Requirement: runner_gc 在 nodes:list 缺权限时优雅降级
+
+The system SHALL detect Kubernetes API 403 (Forbidden) responses on the
+`nodes:list` call inside `runner_gc.gc_once` and treat them as a permanent
+RBAC denial for the orchestrator's ServiceAccount. On the first occurrence of
+a 403, the system MUST emit exactly one `runner_gc.disk_check_rbac_denied`
+warning. On all subsequent GC ticks, the system MUST skip the disk-pressure
+check entirely without issuing the underlying `list_node` API call and without
+emitting any further log line for the disabled probe. The skip MUST be
+equivalent to `disk_pressure=False`, so retention-based GC behavior is
+preserved. Other (non-403) exceptions raised by `node_disk_usage_ratio` MUST
+continue to be logged at debug level (`runner_gc.disk_check_failed`) without
+disabling future probes.
+
+#### Scenario: ORCHN-S4 首次 403 时 warn 一次并禁用后续 disk-check
+
+- **GIVEN** orchestrator 进程刚启动，disk-check 还未禁用
+- **AND** `core_v1.list_node` 抛出 `ApiException(status=403)`
+- **WHEN** `gc_once()` 被调用
+- **THEN** `log.warning("runner_gc.disk_check_rbac_denied", ...)` 被打一次
+- **AND** 进程级 flag 标记 disk-check 已禁用
+- **AND** 返回结果 `disk_pressure=False`
+
+#### Scenario: ORCHN-S5 disk-check 已禁用后 gc_once 不再调 list_node
+
+- **GIVEN** 上一轮 GC 已把 disk-check 禁用
+- **WHEN** `gc_once()` 再次被调用
+- **THEN** `node_disk_usage_ratio` 不被调用
+- **AND** 没有任何 `runner_gc.disk_check_*` 日志被记录
+- **AND** 返回结果 `disk_pressure=False`
+
+#### Scenario: ORCHN-S6 非 403 异常仍走 debug 不禁用
+
+- **GIVEN** `node_disk_usage_ratio` 抛出 `ApiException(status=500)`
+- **WHEN** `gc_once()` 被调用
+- **THEN** `log.debug("runner_gc.disk_check_failed", ...)` 被记录
+- **AND** disk-check 进程级 flag 保持未禁用（下一轮仍会再尝试）
+
+#### Scenario: ORCHN-S7 disk-check 正常 ratio > threshold 时仍能触发紧急清理
+
+- **GIVEN** RBAC 健全（list_node 200 OK），`ratio=0.9`，threshold=0.8
+- **WHEN** `gc_once()` 被调用
+- **THEN** `runner_gc.disk_pressure` warning 被记录
+- **AND** 返回结果 `disk_pressure=True`

--- a/openspec/changes/REQ-orch-noise-cleanup-1777078500/tasks.md
+++ b/openspec/changes/REQ-orch-noise-cleanup-1777078500/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: REQ-orch-noise-cleanup-1777078500
+
+## Stage: spec
+
+- [x] `openspec/changes/REQ-orch-noise-cleanup-1777078500/proposal.md`
+- [x] `openspec/changes/REQ-orch-noise-cleanup-1777078500/tasks.md`
+- [x] `openspec/changes/REQ-orch-noise-cleanup-1777078500/specs/orch-noise-cleanup/spec.md`
+- [x] `openspec/changes/REQ-orch-noise-cleanup-1777078500/specs/orch-noise-cleanup/contract.spec.yaml`
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/config.py`：新增 `snapshot_exclude_project_ids: list[str]`
+- [x] `orchestrator/src/orchestrator/snapshot.py`：`sync_once` 在 `project_ids` 上应用 exclude 过滤
+- [x] `orchestrator/src/orchestrator/runner_gc.py`：把 `ApiException(status==403)` 单独识别为 RBAC 拒绝；进程级 flag short-circuit 后续 disk-check
+- [x] `orchestrator/helm/values.yaml`：把 `77k9z58j` 写到默认 exclude 列表
+- [x] `orchestrator/helm/templates/configmap.yaml`：注入 `SISYPHUS_SNAPSHOT_EXCLUDE_PROJECT_IDS` env
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_snapshot.py`：新 case `test_sync_once_filters_excluded_projects` 验证 exclude
+- [x] `orchestrator/tests/test_runner_gc.py`：新 case 验证 403 第一次 warn 后 short-circuit；非 403 异常仍走 debug
+
+## Stage: PR
+
+- [x] git push feat/REQ-orch-noise-cleanup-1777078500
+- [x] gh pr create

--- a/orchestrator/helm/templates/configmap.yaml
+++ b/orchestrator/helm/templates/configmap.yaml
@@ -18,3 +18,6 @@ data:
   SISYPHUS_SKIP_REVIEWER: {{ .Values.env.skip_reviewer | quote }}
   SISYPHUS_SKIP_ARCHIVE: {{ .Values.env.skip_archive | quote }}
   SISYPHUS_TEST_MODE: {{ .Values.env.test_mode | quote }}
+  {{- with .Values.env.snapshot_exclude_project_ids }}
+  SISYPHUS_SNAPSHOT_EXCLUDE_PROJECT_IDS: {{ join "," . | quote }}
+  {{- end }}

--- a/orchestrator/helm/values.yaml
+++ b/orchestrator/helm/values.yaml
@@ -74,6 +74,10 @@ env:
   workdir_root: /var/sisyphus-ci
   # 不存任何 project_id / repo_url —— project_id 来自 webhook，
   # repo_url 来自 agent 自己 `git remote get-url origin`
+  # snapshot loop 排除已知死项目（每 5min 一次的 BKD list_issues 失败 noise）。
+  # 新增死项目走这里加 env，不动代码。
+  snapshot_exclude_project_ids:
+    - 77k9z58j
   # ─── Mock / 调试开关（生产全 false）─────────────────────────────
   # 任一 stage skip = create_<stage> 不调 BKD agent，直接 emit done/pass
   # test_mode: true = 全部 skip，秒级走完整 state 机

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -64,6 +64,11 @@ class Settings(BaseSettings):
     # bkd_snapshot 同步间隔（秒）。0 = 不跑（替代 n8n 5min cron）
     snapshot_interval_sec: int = 300
 
+    # 已知死项目排除清单（snapshot loop 跳过 BKD list_issues 调用，避免 5min 一次
+    # 的 snapshot.list_failed warning）。env 用逗号分隔或 JSON 数组：
+    #   SISYPHUS_SNAPSHOT_EXCLUDE_PROJECT_IDS=77k9z58j,old-proj
+    snapshot_exclude_project_ids: list[str] = Field(default_factory=list)
+
     # 不存任何 repo / project_id：
     # - repo URL 由 agent 自己 `git remote get-url origin` 取（在 BKD session cwd 里）
     # - project_id 来自 webhook payload；snapshot 扫描 req_state.project_id distinct（多项目自然支持）

--- a/orchestrator/src/orchestrator/runner_gc.py
+++ b/orchestrator/src/orchestrator/runner_gc.py
@@ -13,6 +13,7 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 
 import structlog
+from kubernetes.client import ApiException
 
 from . import k8s_runner
 from .config import settings
@@ -23,6 +24,11 @@ log = structlog.get_logger(__name__)
 
 # 状态机里"终态"和"进行中"的区分
 _TERMINAL_STATES = {"done", "escalated"}
+
+# 进程级 flag：node_disk_usage_ratio 拿到 403（RBAC 缺 nodes:list）时置 True，
+# 后续 GC tick 直接 short-circuit 跳过 disk-check，不再发请求/打日志。
+# 重启 orchestrator 会重新探测一次。
+_DISK_CHECK_DISABLED = False
 
 
 async def _active_req_ids(*, ignore_retention: bool = False) -> set[str]:
@@ -64,16 +70,29 @@ async def gc_once() -> dict:
         return {"skipped": "no runner controller"}
 
     # 检查磁盘压力。压时 escalated PVC 也立即清（不留 retention）。
+    # 若上一次因 RBAC 403 已禁用 disk-check，直接跳，不再发请求。
+    global _DISK_CHECK_DISABLED
     disk_pressure = False
-    try:
-        ratio = await rc.node_disk_usage_ratio()
-        if ratio > settings.runner_gc_disk_pressure_threshold:
-            log.warning("runner_gc.disk_pressure", ratio=round(ratio, 2),
-                        threshold=settings.runner_gc_disk_pressure_threshold)
-            disk_pressure = True
-    except Exception as e:
-        # 取不到磁盘指标 → 退回正常 retention 模式
-        log.debug("runner_gc.disk_check_failed", error=str(e))
+    if not _DISK_CHECK_DISABLED:
+        try:
+            ratio = await rc.node_disk_usage_ratio()
+            if ratio > settings.runner_gc_disk_pressure_threshold:
+                log.warning("runner_gc.disk_pressure", ratio=round(ratio, 2),
+                            threshold=settings.runner_gc_disk_pressure_threshold)
+                disk_pressure = True
+        except ApiException as e:
+            if e.status == 403:
+                # RBAC 没给 nodes:list（orchestrator Role 是 ns-scoped），
+                # 永久降级：之后不再探测，留 retention-only 路径
+                _DISK_CHECK_DISABLED = True
+                log.warning("runner_gc.disk_check_rbac_denied",
+                            hint="ServiceAccount lacks cluster-scoped nodes:list; "
+                                 "disk-pressure emergency purge disabled until restart")
+            else:
+                log.debug("runner_gc.disk_check_failed", error=str(e), status=e.status)
+        except Exception as e:
+            # 取不到磁盘指标 → 退回正常 retention 模式
+            log.debug("runner_gc.disk_check_failed", error=str(e))
 
     active = await _active_req_ids(ignore_retention=disk_pressure)
     cleaned = await rc.gc_orphans(active)

--- a/orchestrator/src/orchestrator/snapshot.py
+++ b/orchestrator/src/orchestrator/snapshot.py
@@ -97,7 +97,8 @@ async def sync_once() -> int:
     main_pool = db.get_pool()
 
     rows_proj = await main_pool.fetch("SELECT DISTINCT project_id FROM req_state")
-    project_ids = [r["project_id"] for r in rows_proj]
+    excluded = set(settings.snapshot_exclude_project_ids)
+    project_ids = [r["project_id"] for r in rows_proj if r["project_id"] not in excluded]
     if not project_ids:
         log.info("snapshot.no_projects_yet")
         return 0

--- a/orchestrator/tests/test_contract_orch_noise_cleanup.py
+++ b/orchestrator/tests/test_contract_orch_noise_cleanup.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import logging
 
+import structlog.testing
+
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
 
@@ -45,9 +47,11 @@ class _FakePool:
 class _FakeSettings:
     """Minimal settings stub for snapshot/runner_gc contract tests."""
 
-    def __init__(self, exclude=(), runner_gc_disk_threshold=0.8, **kw):
+    def __init__(self, exclude=(), runner_gc_disk_pressure_threshold=0.8,
+                 pvc_retain_on_escalate_days=1, **kw):
         self.snapshot_exclude_project_ids = list(exclude)
-        self.runner_gc_disk_threshold = runner_gc_disk_threshold
+        self.runner_gc_disk_pressure_threshold = runner_gc_disk_pressure_threshold
+        self.pvc_retain_on_escalate_days = pvc_retain_on_escalate_days
         self.bkd_base_url = "https://bkd.example.test/api"
         self.bkd_token = "test-token"
         self.snapshot_interval_sec = 300
@@ -79,6 +83,7 @@ async def test_orchn_s1_excluded_project_not_called(monkeypatch):
 
     pool = _FakePool(project_ids=["alive-1", "77k9z58j"])
     monkeypatch.setattr(db, "get_pool", lambda: pool)
+    monkeypatch.setattr(db, "get_obs_pool", lambda: _FakePool())
     monkeypatch.setattr(snapshot, "BKDClient", _FakeBKD)
     monkeypatch.setattr(snapshot, "settings", _FakeSettings(exclude=["77k9z58j"]))
 
@@ -117,6 +122,7 @@ async def test_orchn_s2_empty_exclude_calls_all_projects(monkeypatch):
 
     pool = _FakePool(project_ids=["alive-1", "alive-2"])
     monkeypatch.setattr(db, "get_pool", lambda: pool)
+    monkeypatch.setattr(db, "get_obs_pool", lambda: _FakePool())
     monkeypatch.setattr(snapshot, "BKDClient", _FakeBKD)
     monkeypatch.setattr(snapshot, "settings", _FakeSettings(exclude=[]))
 
@@ -157,6 +163,7 @@ async def test_orchn_s3_all_excluded_returns_zero(monkeypatch):
 
     pool = _FakePool(project_ids=["only-proj"])
     monkeypatch.setattr(db, "get_pool", lambda: pool)
+    monkeypatch.setattr(db, "get_obs_pool", lambda: _FakePool())
     monkeypatch.setattr(snapshot, "BKDClient", _FakeBKD)
     monkeypatch.setattr(snapshot, "settings", _FakeSettings(exclude=["only-proj"]))
 
@@ -174,7 +181,7 @@ async def test_orchn_s3_all_excluded_returns_zero(monkeypatch):
 # ─── ORCHN-S4: 首次 403 时 warn 一次并禁用后续 disk-check ────────────────────
 
 
-async def test_orchn_s4_first_403_warns_and_disables(monkeypatch, caplog):
+async def test_orchn_s4_first_403_warns_and_disables(monkeypatch):
     """
     ORCHN-S4: gc_once 在 node_disk_usage_ratio 抛出 ApiException(status=403) 时：
     - 必须发出一条包含 'runner_gc.disk_check_rbac_denied' 的 WARNING 日志
@@ -187,15 +194,17 @@ async def test_orchn_s4_first_403_warns_and_disables(monkeypatch, caplog):
 
     monkeypatch.setattr(gc_mod, "_DISK_CHECK_DISABLED", False)
 
-    def _raise_403(*a, **kw):
-        raise ApiException(status=403)
+    class _FakeController:
+        async def node_disk_usage_ratio(self):
+            raise ApiException(status=403)
+        async def gc_orphans(self, keep):
+            return []
 
-    monkeypatch.setattr(gc_mod, "node_disk_usage_ratio", _raise_403)
+    monkeypatch.setattr(gc_mod.k8s_runner, "get_controller", lambda: _FakeController())
+    monkeypatch.setattr(gc_mod.db, "get_pool", lambda: _FakePool())
 
-    pool = _FakePool()
-
-    with caplog.at_level(logging.WARNING):
-        result = await gc_mod.gc_once(pool)
+    with structlog.testing.capture_logs() as log_records:
+        result = await gc_mod.gc_once()
 
     # flag must be set
     assert gc_mod._DISK_CHECK_DISABLED is True, (
@@ -203,12 +212,10 @@ async def test_orchn_s4_first_403_warns_and_disables(monkeypatch, caplog):
     )
 
     # exactly one warning with the required key
-    warning_msgs = [
-        r.message for r in caplog.records if r.levelno == logging.WARNING
-    ]
-    assert any("runner_gc.disk_check_rbac_denied" in str(m) for m in warning_msgs), (
+    warning_events = [r["event"] for r in log_records if r.get("log_level") == "warning"]
+    assert any("runner_gc.disk_check_rbac_denied" in e for e in warning_events), (
         f"ORCHN-S4: must log warning 'runner_gc.disk_check_rbac_denied'; "
-        f"actual warnings: {warning_msgs}"
+        f"actual warnings: {warning_events}"
     )
 
     # disk_pressure must be False
@@ -221,7 +228,7 @@ async def test_orchn_s4_first_403_warns_and_disables(monkeypatch, caplog):
 # ─── ORCHN-S5: disk-check 已禁用后 gc_once 不再调 list_node ─────────────────
 
 
-async def test_orchn_s5_disabled_skips_node_api(monkeypatch, caplog):
+async def test_orchn_s5_disabled_skips_node_api(monkeypatch):
     """
     ORCHN-S5: _DISK_CHECK_DISABLED=True 时，gc_once 必须：
     - 不调用 node_disk_usage_ratio（不消耗 K8s API 配额）
@@ -234,16 +241,18 @@ async def test_orchn_s5_disabled_skips_node_api(monkeypatch, caplog):
 
     ratio_calls: list = []
 
-    def _should_not_be_called(*a, **kw):
-        ratio_calls.append(a)
-        return 0.0
+    class _FakeController:
+        async def node_disk_usage_ratio(self):
+            ratio_calls.append(True)
+            return 0.0
+        async def gc_orphans(self, keep):
+            return []
 
-    monkeypatch.setattr(gc_mod, "node_disk_usage_ratio", _should_not_be_called)
+    monkeypatch.setattr(gc_mod.k8s_runner, "get_controller", lambda: _FakeController())
+    monkeypatch.setattr(gc_mod.db, "get_pool", lambda: _FakePool())
 
-    pool = _FakePool()
-
-    with caplog.at_level(logging.DEBUG):
-        result = await gc_mod.gc_once(pool)
+    with structlog.testing.capture_logs() as log_records:
+        result = await gc_mod.gc_once()
 
     # node_disk_usage_ratio must NOT be called
     assert ratio_calls == [], (
@@ -252,12 +261,10 @@ async def test_orchn_s5_disabled_skips_node_api(monkeypatch, caplog):
     )
 
     # no disk_check_* logs
-    disk_check_logs = [
-        r for r in caplog.records if "runner_gc.disk_check" in str(r.message)
-    ]
-    assert disk_check_logs == [], (
+    disk_check_events = [r for r in log_records if "runner_gc.disk_check" in r.get("event", "")]
+    assert disk_check_events == [], (
         f"ORCHN-S5: no runner_gc.disk_check_* log must be emitted when disabled; "
-        f"got: {[r.message for r in disk_check_logs]}"
+        f"got: {[r['event'] for r in disk_check_events]}"
     )
 
     # disk_pressure must be False
@@ -270,7 +277,7 @@ async def test_orchn_s5_disabled_skips_node_api(monkeypatch, caplog):
 # ─── ORCHN-S6: 非 403 异常仍走 debug 不禁用 ─────────────────────────────────
 
 
-async def test_orchn_s6_non_403_debug_no_disable(monkeypatch, caplog):
+async def test_orchn_s6_non_403_debug_no_disable(monkeypatch):
     """
     ORCHN-S6: node_disk_usage_ratio 抛出 ApiException(status=500) 时：
     - 必须记录 DEBUG 日志 'runner_gc.disk_check_failed'
@@ -283,15 +290,17 @@ async def test_orchn_s6_non_403_debug_no_disable(monkeypatch, caplog):
 
     monkeypatch.setattr(gc_mod, "_DISK_CHECK_DISABLED", False)
 
-    def _raise_500(*a, **kw):
-        raise ApiException(status=500)
+    class _FakeController:
+        async def node_disk_usage_ratio(self):
+            raise ApiException(status=500)
+        async def gc_orphans(self, keep):
+            return []
 
-    monkeypatch.setattr(gc_mod, "node_disk_usage_ratio", _raise_500)
+    monkeypatch.setattr(gc_mod.k8s_runner, "get_controller", lambda: _FakeController())
+    monkeypatch.setattr(gc_mod.db, "get_pool", lambda: _FakePool())
 
-    pool = _FakePool()
-
-    with caplog.at_level(logging.DEBUG):
-        await gc_mod.gc_once(pool)
+    with structlog.testing.capture_logs() as log_records:
+        await gc_mod.gc_once()
 
     # flag must remain False
     assert gc_mod._DISK_CHECK_DISABLED is False, (
@@ -299,28 +308,24 @@ async def test_orchn_s6_non_403_debug_no_disable(monkeypatch, caplog):
     )
 
     # must log debug with 'runner_gc.disk_check_failed'
-    debug_msgs = [
-        r.message for r in caplog.records if r.levelno == logging.DEBUG
-    ]
-    assert any("runner_gc.disk_check_failed" in str(m) for m in debug_msgs), (
+    debug_events = [r["event"] for r in log_records if r.get("log_level") == "debug"]
+    assert any("runner_gc.disk_check_failed" in e for e in debug_events), (
         f"ORCHN-S6: must log debug 'runner_gc.disk_check_failed' for non-403 exception; "
-        f"debug messages: {debug_msgs}"
+        f"debug events: {debug_events}"
     )
 
     # must NOT emit rbac_denied warning
-    warning_msgs = [
-        r.message for r in caplog.records if r.levelno == logging.WARNING
-    ]
-    assert not any("runner_gc.disk_check_rbac_denied" in str(m) for m in warning_msgs), (
+    warning_events = [r["event"] for r in log_records if r.get("log_level") == "warning"]
+    assert not any("runner_gc.disk_check_rbac_denied" in e for e in warning_events), (
         f"ORCHN-S6: must NOT log rbac_denied warning for non-403 exception; "
-        f"warnings: {warning_msgs}"
+        f"warning events: {warning_events}"
     )
 
 
 # ─── ORCHN-S7: 正常 ratio > threshold 触发 disk_pressure=True ───────────────
 
 
-async def test_orchn_s7_high_ratio_triggers_disk_pressure(monkeypatch, caplog):
+async def test_orchn_s7_high_ratio_triggers_disk_pressure(monkeypatch):
     """
     ORCHN-S7: node_disk_usage_ratio 返回 0.9（> threshold 0.8）时：
     - 必须记录 'runner_gc.disk_pressure' WARNING
@@ -329,23 +334,27 @@ async def test_orchn_s7_high_ratio_triggers_disk_pressure(monkeypatch, caplog):
     import orchestrator.runner_gc as gc_mod
 
     monkeypatch.setattr(gc_mod, "_DISK_CHECK_DISABLED", False)
-    monkeypatch.setattr(gc_mod, "node_disk_usage_ratio", lambda *a, **kw: 0.9)
 
-    fake_settings = _FakeSettings(runner_gc_disk_threshold=0.8)
+    class _FakeController:
+        async def node_disk_usage_ratio(self):
+            return 0.9
+        async def gc_orphans(self, keep):
+            return []
+
+    monkeypatch.setattr(gc_mod.k8s_runner, "get_controller", lambda: _FakeController())
+    monkeypatch.setattr(gc_mod.db, "get_pool", lambda: _FakePool())
+
+    fake_settings = _FakeSettings(runner_gc_disk_pressure_threshold=0.8)
     monkeypatch.setattr(gc_mod, "settings", fake_settings)
 
-    pool = _FakePool()
-
-    with caplog.at_level(logging.WARNING):
-        result = await gc_mod.gc_once(pool)
+    with structlog.testing.capture_logs() as log_records:
+        result = await gc_mod.gc_once()
 
     # must log disk_pressure warning
-    warning_msgs = [
-        r.message for r in caplog.records if r.levelno == logging.WARNING
-    ]
-    assert any("runner_gc.disk_pressure" in str(m) for m in warning_msgs), (
+    warning_events = [r["event"] for r in log_records if r.get("log_level") == "warning"]
+    assert any("runner_gc.disk_pressure" in e for e in warning_events), (
         f"ORCHN-S7: must log 'runner_gc.disk_pressure' warning when ratio=0.9 > 0.8; "
-        f"warnings: {warning_msgs}"
+        f"warning events: {warning_events}"
     )
 
     # disk_pressure must be True

--- a/orchestrator/tests/test_contract_orch_noise_cleanup.py
+++ b/orchestrator/tests/test_contract_orch_noise_cleanup.py
@@ -1,0 +1,356 @@
+"""Contract tests for orch-noise-cleanup (REQ-orch-noise-cleanup-1777078500).
+
+Black-box behavioral contracts derived from:
+  openspec/changes/REQ-orch-noise-cleanup-1777078500/specs/orch-noise-cleanup/spec.md
+
+Scenarios covered:
+  ORCHN-S1  排除单个项目时跳过 BKD 调用
+  ORCHN-S2  排除清单为空时保持原行为
+  ORCHN-S3  全部 project_id 都被排除时短路返回 0
+  ORCHN-S4  首次 403 时 warn 一次并禁用后续 disk-check
+  ORCHN-S5  disk-check 已禁用后 gc_once 不再调 list_node
+  ORCHN-S6  非 403 异常仍走 debug 不禁用
+  ORCHN-S7  disk-check 正常 ratio > threshold 时仍能触发紧急清理
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+class _FakePool:
+    """asyncpg pool stub: returns preset project_id rows, captures execute calls."""
+
+    def __init__(self, project_ids=()):
+        self._project_ids = list(project_ids)
+        self.query_log: list = []
+
+    async def fetch(self, sql: str, *args):
+        self.query_log.append(("fetch", sql, args))
+        return [{"project_id": pid} for pid in self._project_ids]
+
+    async def fetchval(self, sql: str, *args):
+        self.query_log.append(("fetchval", sql, args))
+        return None
+
+    async def fetchrow(self, sql: str, *args):
+        self.query_log.append(("fetchrow", sql, args))
+        return None
+
+    async def execute(self, sql: str, *args):
+        self.query_log.append(("execute", sql, args))
+
+
+class _FakeSettings:
+    """Minimal settings stub for snapshot/runner_gc contract tests."""
+
+    def __init__(self, exclude=(), runner_gc_disk_threshold=0.8, **kw):
+        self.snapshot_exclude_project_ids = list(exclude)
+        self.runner_gc_disk_threshold = runner_gc_disk_threshold
+        self.bkd_base_url = "https://bkd.example.test/api"
+        self.bkd_token = "test-token"
+        self.snapshot_interval_sec = 300
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+# ─── ORCHN-S1: 排除单个项目时跳过 BKD 调用 ──────────────────────────────────
+
+
+async def test_orchn_s1_excluded_project_not_called(monkeypatch):
+    """
+    ORCHN-S1: snapshot_exclude_project_ids=["77k9z58j"] 时，
+    sync_once 必须不以 "77k9z58j" 调用 BKDClient.list_issues，
+    只以 "alive-1" 调用一次。
+    """
+    from orchestrator import snapshot
+    from orchestrator.store import db
+
+    list_issues_calls: list[str] = []
+
+    class _FakeBKD:
+        def __init__(self, *a, **kw): ...
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def list_issues(self, project_id, **kw):
+            list_issues_calls.append(project_id)
+            return []
+
+    pool = _FakePool(project_ids=["alive-1", "77k9z58j"])
+    monkeypatch.setattr(db, "get_pool", lambda: pool)
+    monkeypatch.setattr(snapshot, "BKDClient", _FakeBKD)
+    monkeypatch.setattr(snapshot, "settings", _FakeSettings(exclude=["77k9z58j"]))
+
+    await snapshot.sync_once()
+
+    assert "77k9z58j" not in list_issues_calls, (
+        "ORCHN-S1: BKDClient.list_issues MUST NOT be called for excluded '77k9z58j'; "
+        f"actual calls: {list_issues_calls}"
+    )
+    assert "alive-1" in list_issues_calls, (
+        f"ORCHN-S1: BKDClient.list_issues must be called for non-excluded 'alive-1'; "
+        f"actual calls: {list_issues_calls}"
+    )
+
+
+# ─── ORCHN-S2: 排除清单为空时保持原行为 ──────────────────────────────────────
+
+
+async def test_orchn_s2_empty_exclude_calls_all_projects(monkeypatch):
+    """
+    ORCHN-S2: snapshot_exclude_project_ids=[] 时，
+    sync_once 必须为每个 project_id 调用 BKDClient.list_issues（共 2 次）。
+    """
+    from orchestrator import snapshot
+    from orchestrator.store import db
+
+    list_issues_calls: list[str] = []
+
+    class _FakeBKD:
+        def __init__(self, *a, **kw): ...
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def list_issues(self, project_id, **kw):
+            list_issues_calls.append(project_id)
+            return []
+
+    pool = _FakePool(project_ids=["alive-1", "alive-2"])
+    monkeypatch.setattr(db, "get_pool", lambda: pool)
+    monkeypatch.setattr(snapshot, "BKDClient", _FakeBKD)
+    monkeypatch.setattr(snapshot, "settings", _FakeSettings(exclude=[]))
+
+    await snapshot.sync_once()
+
+    assert "alive-1" in list_issues_calls, (
+        f"ORCHN-S2: 'alive-1' must be included in calls; got: {list_issues_calls}"
+    )
+    assert "alive-2" in list_issues_calls, (
+        f"ORCHN-S2: 'alive-2' must be included in calls; got: {list_issues_calls}"
+    )
+    assert len(list_issues_calls) == 2, (
+        f"ORCHN-S2: exactly 2 list_issues calls expected, got {len(list_issues_calls)}: "
+        f"{list_issues_calls}"
+    )
+
+
+# ─── ORCHN-S3: 全部 project_id 都被排除时短路返回 0 ─────────────────────────
+
+
+async def test_orchn_s3_all_excluded_returns_zero(monkeypatch):
+    """
+    ORCHN-S3: 所有 project_id 都在 exclude list 时，
+    sync_once 必须返回 0 且不调用 BKDClient.list_issues。
+    """
+    from orchestrator import snapshot
+    from orchestrator.store import db
+
+    list_issues_calls: list[str] = []
+
+    class _FakeBKD:
+        def __init__(self, *a, **kw): ...
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def list_issues(self, project_id, **kw):
+            list_issues_calls.append(project_id)
+            return []
+
+    pool = _FakePool(project_ids=["only-proj"])
+    monkeypatch.setattr(db, "get_pool", lambda: pool)
+    monkeypatch.setattr(snapshot, "BKDClient", _FakeBKD)
+    monkeypatch.setattr(snapshot, "settings", _FakeSettings(exclude=["only-proj"]))
+
+    result = await snapshot.sync_once()
+
+    assert result == 0, (
+        f"ORCHN-S3: sync_once must return 0 when all project_ids excluded; got {result!r}"
+    )
+    assert list_issues_calls == [], (
+        f"ORCHN-S3: BKDClient.list_issues must NOT be called when all excluded; "
+        f"got: {list_issues_calls}"
+    )
+
+
+# ─── ORCHN-S4: 首次 403 时 warn 一次并禁用后续 disk-check ────────────────────
+
+
+async def test_orchn_s4_first_403_warns_and_disables(monkeypatch, caplog):
+    """
+    ORCHN-S4: gc_once 在 node_disk_usage_ratio 抛出 ApiException(status=403) 时：
+    - 必须发出一条包含 'runner_gc.disk_check_rbac_denied' 的 WARNING 日志
+    - 必须把进程级 _DISK_CHECK_DISABLED flag 置为 True
+    - 返回结果 disk_pressure=False
+    """
+    import orchestrator.runner_gc as gc_mod
+    from kubernetes.client.exceptions import ApiException
+
+    monkeypatch.setattr(gc_mod, "_DISK_CHECK_DISABLED", False)
+
+    def _raise_403(*a, **kw):
+        raise ApiException(status=403)
+
+    monkeypatch.setattr(gc_mod, "node_disk_usage_ratio", _raise_403)
+
+    pool = _FakePool()
+
+    with caplog.at_level(logging.WARNING):
+        result = await gc_mod.gc_once(pool)
+
+    # flag must be set
+    assert gc_mod._DISK_CHECK_DISABLED is True, (
+        "ORCHN-S4: _DISK_CHECK_DISABLED must be True after first 403"
+    )
+
+    # exactly one warning with the required key
+    warning_msgs = [
+        r.message for r in caplog.records if r.levelno == logging.WARNING
+    ]
+    assert any("runner_gc.disk_check_rbac_denied" in str(m) for m in warning_msgs), (
+        f"ORCHN-S4: must log warning 'runner_gc.disk_check_rbac_denied'; "
+        f"actual warnings: {warning_msgs}"
+    )
+
+    # disk_pressure must be False
+    disk_pressure = result.get("disk_pressure") if isinstance(result, dict) else getattr(result, "disk_pressure", None)
+    assert disk_pressure is False, (
+        f"ORCHN-S4: result disk_pressure must be False; got {result!r}"
+    )
+
+
+# ─── ORCHN-S5: disk-check 已禁用后 gc_once 不再调 list_node ─────────────────
+
+
+async def test_orchn_s5_disabled_skips_node_api(monkeypatch, caplog):
+    """
+    ORCHN-S5: _DISK_CHECK_DISABLED=True 时，gc_once 必须：
+    - 不调用 node_disk_usage_ratio（不消耗 K8s API 配额）
+    - 不记录任何 runner_gc.disk_check_* 日志
+    - 返回 disk_pressure=False
+    """
+    import orchestrator.runner_gc as gc_mod
+
+    monkeypatch.setattr(gc_mod, "_DISK_CHECK_DISABLED", True)
+
+    ratio_calls: list = []
+
+    def _should_not_be_called(*a, **kw):
+        ratio_calls.append(a)
+        return 0.0
+
+    monkeypatch.setattr(gc_mod, "node_disk_usage_ratio", _should_not_be_called)
+
+    pool = _FakePool()
+
+    with caplog.at_level(logging.DEBUG):
+        result = await gc_mod.gc_once(pool)
+
+    # node_disk_usage_ratio must NOT be called
+    assert ratio_calls == [], (
+        f"ORCHN-S5: node_disk_usage_ratio must NOT be called when _DISK_CHECK_DISABLED=True; "
+        f"was called {len(ratio_calls)} time(s)"
+    )
+
+    # no disk_check_* logs
+    disk_check_logs = [
+        r for r in caplog.records if "runner_gc.disk_check" in str(r.message)
+    ]
+    assert disk_check_logs == [], (
+        f"ORCHN-S5: no runner_gc.disk_check_* log must be emitted when disabled; "
+        f"got: {[r.message for r in disk_check_logs]}"
+    )
+
+    # disk_pressure must be False
+    disk_pressure = result.get("disk_pressure") if isinstance(result, dict) else getattr(result, "disk_pressure", None)
+    assert disk_pressure is False, (
+        f"ORCHN-S5: result disk_pressure must be False when disk-check disabled; got {result!r}"
+    )
+
+
+# ─── ORCHN-S6: 非 403 异常仍走 debug 不禁用 ─────────────────────────────────
+
+
+async def test_orchn_s6_non_403_debug_no_disable(monkeypatch, caplog):
+    """
+    ORCHN-S6: node_disk_usage_ratio 抛出 ApiException(status=500) 时：
+    - 必须记录 DEBUG 日志 'runner_gc.disk_check_failed'
+    - _DISK_CHECK_DISABLED 必须保持 False（下一轮仍会重试）
+    - 不得发出 WARNING
+    """
+    import orchestrator.runner_gc as gc_mod
+    from kubernetes.client.exceptions import ApiException
+
+    monkeypatch.setattr(gc_mod, "_DISK_CHECK_DISABLED", False)
+
+    def _raise_500(*a, **kw):
+        raise ApiException(status=500)
+
+    monkeypatch.setattr(gc_mod, "node_disk_usage_ratio", _raise_500)
+
+    pool = _FakePool()
+
+    with caplog.at_level(logging.DEBUG):
+        await gc_mod.gc_once(pool)
+
+    # flag must remain False
+    assert gc_mod._DISK_CHECK_DISABLED is False, (
+        "ORCHN-S6: _DISK_CHECK_DISABLED must remain False after non-403 exception"
+    )
+
+    # must log debug with 'runner_gc.disk_check_failed'
+    debug_msgs = [
+        r.message for r in caplog.records if r.levelno == logging.DEBUG
+    ]
+    assert any("runner_gc.disk_check_failed" in str(m) for m in debug_msgs), (
+        f"ORCHN-S6: must log debug 'runner_gc.disk_check_failed' for non-403 exception; "
+        f"debug messages: {debug_msgs}"
+    )
+
+    # must NOT emit rbac_denied warning
+    warning_msgs = [
+        r.message for r in caplog.records if r.levelno == logging.WARNING
+    ]
+    assert not any("runner_gc.disk_check_rbac_denied" in str(m) for m in warning_msgs), (
+        f"ORCHN-S6: must NOT log rbac_denied warning for non-403 exception; "
+        f"warnings: {warning_msgs}"
+    )
+
+
+# ─── ORCHN-S7: 正常 ratio > threshold 触发 disk_pressure=True ───────────────
+
+
+async def test_orchn_s7_high_ratio_triggers_disk_pressure(monkeypatch, caplog):
+    """
+    ORCHN-S7: node_disk_usage_ratio 返回 0.9（> threshold 0.8）时：
+    - 必须记录 'runner_gc.disk_pressure' WARNING
+    - 返回 disk_pressure=True
+    """
+    import orchestrator.runner_gc as gc_mod
+
+    monkeypatch.setattr(gc_mod, "_DISK_CHECK_DISABLED", False)
+    monkeypatch.setattr(gc_mod, "node_disk_usage_ratio", lambda *a, **kw: 0.9)
+
+    fake_settings = _FakeSettings(runner_gc_disk_threshold=0.8)
+    monkeypatch.setattr(gc_mod, "settings", fake_settings)
+
+    pool = _FakePool()
+
+    with caplog.at_level(logging.WARNING):
+        result = await gc_mod.gc_once(pool)
+
+    # must log disk_pressure warning
+    warning_msgs = [
+        r.message for r in caplog.records if r.levelno == logging.WARNING
+    ]
+    assert any("runner_gc.disk_pressure" in str(m) for m in warning_msgs), (
+        f"ORCHN-S7: must log 'runner_gc.disk_pressure' warning when ratio=0.9 > 0.8; "
+        f"warnings: {warning_msgs}"
+    )
+
+    # disk_pressure must be True
+    disk_pressure = result.get("disk_pressure") if isinstance(result, dict) else getattr(result, "disk_pressure", None)
+    assert disk_pressure is True, (
+        f"ORCHN-S7: result disk_pressure must be True when ratio > threshold; got {result!r}"
+    )

--- a/orchestrator/tests/test_contract_orch_noise_cleanup.py
+++ b/orchestrator/tests/test_contract_orch_noise_cleanup.py
@@ -14,8 +14,6 @@ Scenarios covered:
 """
 from __future__ import annotations
 
-import logging
-
 import structlog.testing
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/orchestrator/tests/test_contract_orch_noise_cleanup.py
+++ b/orchestrator/tests/test_contract_orch_noise_cleanup.py
@@ -16,9 +16,6 @@ from __future__ import annotations
 
 import logging
 
-import pytest
-
-
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
 
@@ -184,8 +181,9 @@ async def test_orchn_s4_first_403_warns_and_disables(monkeypatch, caplog):
     - 必须把进程级 _DISK_CHECK_DISABLED flag 置为 True
     - 返回结果 disk_pressure=False
     """
-    import orchestrator.runner_gc as gc_mod
     from kubernetes.client.exceptions import ApiException
+
+    import orchestrator.runner_gc as gc_mod
 
     monkeypatch.setattr(gc_mod, "_DISK_CHECK_DISABLED", False)
 
@@ -279,8 +277,9 @@ async def test_orchn_s6_non_403_debug_no_disable(monkeypatch, caplog):
     - _DISK_CHECK_DISABLED 必须保持 False（下一轮仍会重试）
     - 不得发出 WARNING
     """
-    import orchestrator.runner_gc as gc_mod
     from kubernetes.client.exceptions import ApiException
+
+    import orchestrator.runner_gc as gc_mod
 
     monkeypatch.setattr(gc_mod, "_DISK_CHECK_DISABLED", False)
 

--- a/orchestrator/tests/test_runner_gc.py
+++ b/orchestrator/tests/test_runner_gc.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from kubernetes.client import ApiException
 
 from orchestrator import k8s_runner, runner_gc
 
@@ -32,6 +33,14 @@ def mock_controller(monkeypatch):
     k8s_runner.set_controller(fake)
     yield fake
     k8s_runner.set_controller(None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_disk_check_flag():
+    """每个 case 前后重置 _DISK_CHECK_DISABLED，防止前一 test 把它置为 True。"""
+    runner_gc._DISK_CHECK_DISABLED = False
+    yield
+    runner_gc._DISK_CHECK_DISABLED = False
 
 
 @pytest.mark.asyncio
@@ -116,3 +125,50 @@ async def test_skips_when_no_controller(monkeypatch):
     k8s_runner.set_controller(None)
     result = await runner_gc.gc_once()
     assert "skipped" in result
+
+
+@pytest.mark.asyncio
+async def test_disk_check_403_disables_after_first_warn(monkeypatch, mock_controller, capsys):
+    """ApiException(403) → 进程级 flag 置 True；warn 一次，disk_pressure=False。"""
+    pool = _FakePool([_row("REQ-1", "analyzing")])
+    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
+    mock_controller.node_disk_usage_ratio = AsyncMock(
+        side_effect=ApiException(status=403, reason="Forbidden"),
+    )
+
+    assert runner_gc._DISK_CHECK_DISABLED is False
+    result = await runner_gc.gc_once()
+
+    assert result["disk_pressure"] is False
+    assert runner_gc._DISK_CHECK_DISABLED is True
+    out = capsys.readouterr().out
+    assert "disk_check_rbac_denied" in out
+
+
+@pytest.mark.asyncio
+async def test_disk_check_short_circuits_after_disabled(monkeypatch, mock_controller):
+    """_DISK_CHECK_DISABLED=True 时不再调 node_disk_usage_ratio。"""
+    pool = _FakePool([_row("REQ-1", "analyzing")])
+    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
+    mock_controller.node_disk_usage_ratio = AsyncMock(return_value=0.5)
+    runner_gc._DISK_CHECK_DISABLED = True
+
+    result = await runner_gc.gc_once()
+
+    assert result["disk_pressure"] is False
+    mock_controller.node_disk_usage_ratio.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_disk_check_non_403_keeps_probe_alive(monkeypatch, mock_controller):
+    """ApiException(500) → 不禁用，下一轮还会再尝试。"""
+    pool = _FakePool([_row("REQ-1", "analyzing")])
+    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
+    mock_controller.node_disk_usage_ratio = AsyncMock(
+        side_effect=ApiException(status=500, reason="Internal"),
+    )
+
+    result = await runner_gc.gc_once()
+
+    assert result["disk_pressure"] is False
+    assert runner_gc._DISK_CHECK_DISABLED is False  # 没禁用

--- a/orchestrator/tests/test_snapshot.py
+++ b/orchestrator/tests/test_snapshot.py
@@ -76,6 +76,75 @@ async def test_sync_once_no_projects_yet(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_sync_once_filters_excluded_projects(monkeypatch):
+    """exclude 清单里的 project_id 不发 list_issues，也不报错。"""
+    captured: list[tuple] = []
+
+    class FakeConn:
+        async def execute(self, sql, *args):
+            captured.append((sql.strip()[:30], args))
+
+        def transaction(self):
+            @asynccontextmanager
+            async def _t():
+                yield
+            return _t()
+
+    class FakeObsPool:
+        def acquire(self):
+            @asynccontextmanager
+            async def _a():
+                yield FakeConn()
+            return _a()
+
+    fake_bkd = AsyncMock()
+    fake_bkd.list_issues = AsyncMock(return_value=[
+        make_issue(id="a", tags=["dev", "REQ-1"]),
+    ])
+
+    @asynccontextmanager
+    async def _client_ctx(*a, **kw):
+        yield fake_bkd
+
+    monkeypatch.setattr(snapshot.db, "get_obs_pool", lambda: FakeObsPool())
+    monkeypatch.setattr(snapshot.db, "get_pool",
+                        lambda: FakeMainPool(["alive-1", "77k9z58j"]))
+    monkeypatch.setattr(snapshot, "BKDClient", _client_ctx)
+    monkeypatch.setattr(snapshot.settings, "snapshot_exclude_project_ids",
+                        ["77k9z58j"])
+
+    n = await snapshot.sync_once()
+
+    assert n == 1
+    # 只调一次：alive-1。77k9z58j 被过滤
+    assert fake_bkd.list_issues.await_count == 1
+    assert fake_bkd.list_issues.await_args.args[0] == "alive-1"
+
+
+@pytest.mark.asyncio
+async def test_sync_once_all_projects_excluded(monkeypatch):
+    """所有 project 都被排除 → 不调 BKD，返 0。"""
+    fake_bkd = AsyncMock()
+    fake_bkd.list_issues = AsyncMock()
+
+    @asynccontextmanager
+    async def _client_ctx(*a, **kw):
+        yield fake_bkd
+
+    monkeypatch.setattr(snapshot.db, "get_obs_pool", lambda: object())
+    monkeypatch.setattr(snapshot.db, "get_pool",
+                        lambda: FakeMainPool(["only-proj"]))
+    monkeypatch.setattr(snapshot, "BKDClient", _client_ctx)
+    monkeypatch.setattr(snapshot.settings, "snapshot_exclude_project_ids",
+                        ["only-proj"])
+
+    n = await snapshot.sync_once()
+
+    assert n == 0
+    fake_bkd.list_issues.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_sync_once_upserts_per_project(monkeypatch):
     """两个 project 各 1 issue，应当 UPSERT 2 行。"""
     captured: list[tuple] = []


### PR DESCRIPTION
## Summary

Two operational noise reductions in orchestrator background loops:

1. **snapshot loop exclude list** — new setting
   `snapshot_exclude_project_ids` (env `SISYPHUS_SNAPSHOT_EXCLUDE_PROJECT_IDS`,
   comma-separated). `sync_once` filters BKD project IDs read from `req_state`
   against this list before issuing `list_issues`. Helm `values.yaml` ships
   with `["77k9z58j"]` so the long-dead BKD project stops triggering
   `snapshot.list_failed` warnings every 5min. New dead projects → add env,
   no code change.

2. **runner_gc disk_check graceful degrade on RBAC 403** — orchestrator's
   `runner-rbac.yaml` is namespace-scoped Role on `sisyphus-runners`; it
   does not authorize `nodes:list`. `node_disk_usage_ratio` therefore hits
   `ApiException(status=403)` every GC tick. Now caught explicitly: first
   403 logs one `runner_gc.disk_check_rbac_denied` warning and sets a
   process-level flag; subsequent ticks short-circuit the probe entirely
   (no API call, no log line). Restart re-probes. Retention-based GC
   path is unaffected. Non-403 exceptions still go to debug as before.

## Why

Both fired ~constantly in production INFO logs and consumed BKD / K8s
API quota for nothing. No functional impact, just churn.

## Test plan

- [x] `pytest tests/test_snapshot.py tests/test_runner_gc.py` — 17 passed (3 new snapshot cases + 3 new runner_gc cases)
- [x] full suite: 388 passed (6 pre-existing `httpx_mock` errors unrelated)
- [x] `ruff check` clean
- [x] `openspec validate REQ-orch-noise-cleanup-1777078500` valid
- [x] `scripts/check-scenario-refs.sh` clean (15 scenarios defined, 0 dangling refs)

REQ-orch-noise-cleanup-1777078500