### PR TITLE
fix(actions): pass project_id+project_alias to render() in 5 stage actions

### DIFF
--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -99,6 +99,8 @@ async def invoke_verifier(
         artifact_paths=artifact_paths or [],
         stderr_tail=stderr_tail or "",
         history=history or [],
+        project_id=project_id,
+        project_alias=project_id,
     )
 
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
@@ -244,6 +246,8 @@ async def start_fixer(*, body, req_id, tags, ctx):
             source_issue_id=ctx.get("verifier_issue_id", ""),
             branch=branch,
             workdir=f"{settings.workdir_root}/feat-{req_id}",
+            project_id=proj,
+            project_alias=proj,
         )
         # 把 verifier 的 scope / reason 叠进 prompt 作为上下文
         if scope or reason:

--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -116,6 +116,8 @@ async def create_accept(*, body, req_id, tags, ctx):
             namespace=namespace,
             source_issue_id=source_issue_id,
             accept_env=accept_env,
+            project_id=proj,
+            project_alias=proj,
         )
         await bkd.follow_up_issue(project_id=proj, issue_id=issue.id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue.id, status_id="working")

--- a/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
@@ -110,6 +110,8 @@ async def _dispatch_bkd_agent(*, body, req_id: str, ctx: dict) -> dict:
             "pr_ci_watch.md.j2",
             req_id=req_id,
             source_issue_id=source_issue_id,
+            project_id=proj,
+            project_alias=proj,
         )
         await bkd.follow_up_issue(project_id=proj, issue_id=issue.id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue.id, status_id="working")

--- a/orchestrator/src/orchestrator/actions/create_staging_test.py
+++ b/orchestrator/src/orchestrator/actions/create_staging_test.py
@@ -107,6 +107,8 @@ async def _dispatch_bkd_agent(*, body, req_id: str, ctx: dict) -> dict:
             "staging_test.md.j2",
             req_id=req_id,
             source_issue_id=source_issue_id,
+            project_id=proj,
+            project_alias=proj,
         )
         await bkd.follow_up_issue(project_id=proj, issue_id=issue.id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue.id, status_id="working")

--- a/orchestrator/src/orchestrator/actions/done_archive.py
+++ b/orchestrator/src/orchestrator/actions/done_archive.py
@@ -35,6 +35,8 @@ async def done_archive(*, body, req_id, tags, ctx):
             "done_archive.md.j2",
             req_id=req_id, branch=branch, workdir=workdir,
             accept_issue_id=accept_issue_id,
+            project_id=proj,
+            project_alias=proj,
         )
         await bkd.follow_up_issue(project_id=proj, issue_id=issue.id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue.id, status_id="working")


### PR DESCRIPTION
## Summary

`tools_whitelist.md.j2` (included in 8 stage prompts) has hardcoded fallbacks `PROJECT=workflowtest` / `illwkr1k` when `project_id`/`project_alias` jinja vars aren't passed. Five actions were spawning BKD agent prompts without these vars, so each spawned agent got the wrong PROJECT baked in and queried the wrong BKD project for its own issue → `Issue not found` → silent failure.

## Hit live

REQ-watchdog-intake-no-result-1777078182 in BKD project 1vo4eafy (sisyphus dogfood): done-archive agent searched `workflowtest` instead of `1vo4eafy`, never found its own issue \`qxpo6qwd\`, ended in `failed` session state.

## Fix

Add `project_id=proj, project_alias=proj` to all 5 affected `render()` call sites:

- `done_archive.py` ← user-visible (archive is last stage)
- `create_accept.py`
- `create_pr_ci_watch.py`
- `create_staging_test.py`
- `_verifier.py` (both `invoke_verifier` render + `start_fixer`'s bugfix render)

Already-correct (don't touch): `start_intake.py`, `start_analyze.py`, `start_analyze_with_finalized_intent.py`, `start_challenger.py`.

## Test plan

- [x] Syntax lint
- [ ] Unit tests
- [ ] Verify next sisyphus REQ archives cleanly (currently 1 REQ at `analyze` stage will hit done-archive shortly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)