### PR TITLE
feat(engine+watchdog): hard cap fixer rounds at N (default 5)

### DIFF
--- a/openspec/changes/REQ-fixer-round-cap-1777078900/proposal.md
+++ b/openspec/changes/REQ-fixer-round-cap-1777078900/proposal.md
@@ -1,0 +1,65 @@
+# REQ-fixer-round-cap-1777078900: feat(engine+watchdog): hard cap fixer rounds at N (default 5)
+
+## 问题
+
+verifier-agent decision=fix → `start_fixer` 起 fixer-agent 跑一轮 → 跑完回 `invoke_verifier_after_fix` 复查 → 新 verifier 又判 fix → 再起一轮 fixer …… 这条 verifier↔fixer 子链没有任何机制性出口。
+
+实证场景：spec 自相矛盾、fixer-agent 改不动根因、scope 描述含糊导致 fixer 总是改错位置 —— sisyphus 会无限制起 fixer 烧 BKD session quota / GHCR rate / human attention。
+
+`actions/_verifier.py:start_fixer` 已经渲染了 `round_n=ctx.get("fixer_round", 1)` 给 bugfix prompt，但**没有任何代码增加 `ctx.fixer_round`**，这条字段恒为 1，prompt 显示的 round 也永远是 1。
+
+## 根因
+
+- 计数从未实现：start_fixer 读 ctx.fixer_round 但不写。
+- 没有 cap 阈值与逃生事件 —— 状态机里 FIXER_RUNNING 唯一出口是 FIXER_DONE → REVIEW_RUNNING（继续验），无 escalate 出口。
+- escalate 路径自 #50 引入 auto-resume 后，watchdog 兜底场景下若 reason 被解读为 `watchdog-stuck`/`session-failed` 就会 BKD follow-up "continue"，无意中把已超 cap 的 fixer 又续上去。
+
+## 方案
+
+### 计数 + 硬 cap（engine 路径）
+
+`actions/_verifier.py:start_fixer` 在创建新 fixer issue 之前：
+
+1. 读 `current = int(ctx.get("fixer_round") or 0)`
+2. 算 `next_round = current + 1`
+3. 若 `next_round > settings.fixer_round_cap`（默认 5）：
+   - `req_state.update_context(escalated_reason="fixer-round-cap", fixer_round_cap_hit=cap)`
+   - 不创 fixer issue，return `{"emit": "verify.escalate", "reason": "fixer-round-cap", "fixer_round": current, "cap": cap}`
+4. 否则：用 `next_round` 创 issue（带 `round:N` tag、bugfix prompt 渲 `ROUND=N`），跑完 `req_state.update_context(fixer_round=next_round, ...)`
+
+### 状态机：补 FIXER_RUNNING → ESCALATED transition
+
+新增 `(ReqState.FIXER_RUNNING, Event.VERIFY_ESCALATE) → Transition(ESCALATED, "escalate", "fixer round 触顶 / start_fixer 自判 escalate")`。
+
+start_fixer chained-emit `verify.escalate` 后由 engine 复用既有 `escalate` action 收口（reason、tag、runner cleanup、CAS 推 ESCALATED 全在 escalate 内做）。
+
+### config: fixer_round_cap 新 setting
+
+`Settings` 新增 `fixer_round_cap: int = 5`（环境变量 `SISYPHUS_FIXER_ROUND_CAP`）。运维可通过 helm values 覆盖：调高给 fixer 更多机会，调低更早叫人。
+
+### escalate.py: fixer-round-cap 是 hard reason
+
+新增 `_HARD_REASONS = {"fixer-round-cap"}`：
+
+- reason 解析：`ctx.escalated_reason ∈ _HARD_REASONS` 时**不被 `body.event ∈ _CANONICAL_SIGNALS` 覆盖** —— 否则 watchdog.stuck 事件会把已设的 fixer-round-cap 重写为 watchdog-stuck（误归 transient → auto-resume → 续上去 → 死循环回归）
+- `_is_transient`：`reason ∈ _HARD_REASONS` 永远返回 False，跳过 auto-resume 直接真 escalate
+
+### watchdog.py: defense in depth
+
+`_check_and_escalate` 在 emit SESSION_FAILED 之前，若 `state == FIXER_RUNNING and ctx.fixer_round >= settings.fixer_round_cap`，写 `escalated_reason="fixer-round-cap"` 到 ctx。
+
+正常路径下 start_fixer 自检 cap 已早一步 escalate；本 hook 兜 start_fixer 写 ctx 后 emit 失败 / 中途崩溃留下的孤儿 FIXER_RUNNING（30 min 后被 watchdog 扫到），保证最终 reason 仍是 fixer-round-cap、不被 auto-resume。
+
+## 取舍
+
+- **counter 含义**：`ctx.fixer_round` 表示"已成功起过的 fixer 轮数"。第一次 start_fixer 写 1，第 N 次写 N。第 N+1 次（`next_round > cap`）被拒。cap=5 = "允许 5 轮"，第 6 次起 escalate。
+- **不做 per-stage cap**：不区分 spec_lint / staging_test / pr_ci 等 stage 的 fixer round 各自计数 —— 同一 REQ 全程共享一个 round 计数。理由：跨 stage 反复修往往是同根因，分开计数反而模糊问题信号。
+- **不引新 BKD agent**：不开 escalate-helper agent 或 fixer-coordinator，全靠状态机 + 既有 escalate action。
+- **不重置 round 计数**：用户 follow-up escalated REQ 续上来时不会自动清零 fixer_round。理由：如果用户判断"还有救"想继续修，应该自己 PATCH ctx 或把 cap 调高 —— 否则等于绕过 cap 没意义。
+- **watchdog 不缩短阈值**：fixer round 超 cap 不立刻 escalate（要等 30 min 卡死阈值）。理由：cap 检查在 start_fixer 入口已硬挡，watchdog 是兜底；若入口正常工作，永远走不到 watchdog 路径。
+
+## 兼容性
+
+- 既有 REQ：ctx 没 fixer_round 字段 → 视为 0，第一次 start_fixer 写 1，正常推进。无 migration。
+- 老的 `(REVIEW_RUNNING, VERIFY_ESCALATE) → ESCALATED + escalate` transition 不动；新增 `(FIXER_RUNNING, VERIFY_ESCALATE) → ESCALATED + escalate` 是叠加，老 verifier→escalate 路径走原来的。
+- bugfix.md.j2 渲染参数 `round_n` 老的恒为 1，新值 1..N 单调递增；模板不需要改。

--- a/openspec/changes/REQ-fixer-round-cap-1777078900/specs/fixer-round-cap/contract.spec.yaml
+++ b/openspec/changes/REQ-fixer-round-cap-1777078900/specs/fixer-round-cap/contract.spec.yaml
@@ -1,0 +1,94 @@
+capability: fixer-round-cap
+version: "1.0"
+description: |
+  Hard cap on the number of verifier→fixer rounds per REQ.
+  Default cap = 5. Each successful start_fixer counts as one round.
+  Round (cap+1) triggers escalate with reason "fixer-round-cap" instead of
+  spawning a new fixer agent.
+
+  This bounds the verifier↔fixer subloop so spec-self-contradiction or
+  fixer-can't-resolve scenarios stop burning BKD session quota and human
+  attention.
+
+settings:
+  fixer_round_cap:
+    module: orchestrator.config
+    type: int
+    default: 5
+    env: SISYPHUS_FIXER_ROUND_CAP
+    semantics: |
+      Maximum number of fixer rounds per REQ. The (cap+1)-th invocation of
+      start_fixer escalates instead of creating a fixer issue.
+
+context_fields:
+  fixer_round:
+    type: int
+    initial: 0
+    increment: |
+      start_fixer: ctx.fixer_round = current + 1, written to req_state.context
+      via req_state.update_context AFTER the fixer issue is created.
+    semantics: "Number of fixer issues already started for this REQ."
+
+  escalated_reason:
+    type: string
+    written_by:
+      - "start_fixer when next_round > cap → 'fixer-round-cap'"
+      - "watchdog._check_and_escalate when state=FIXER_RUNNING + fixer_round >= cap → 'fixer-round-cap'"
+    consumed_by: "actions/escalate.py — _HARD_REASONS check"
+
+  fixer_round_cap_hit:
+    type: int
+    written_by:
+      - "start_fixer when escalating due to cap"
+      - "watchdog defense-in-depth"
+    semantics: "Records the cap value that was tripped (for diagnostics)."
+
+state_machine_changes:
+  added_transitions:
+    - from: FIXER_RUNNING
+      event: VERIFY_ESCALATE
+      to: ESCALATED
+      action: escalate
+      reason: "fixer round 触顶 / start_fixer 自判 escalate"
+
+actions:
+  start_fixer:
+    module: orchestrator.actions._verifier
+    cap_check_semantics: |
+      1. current_round = int(ctx.get("fixer_round") or 0)
+      2. next_round = current_round + 1
+      3. IF next_round > settings.fixer_round_cap:
+           a. update_context(escalated_reason="fixer-round-cap",
+                            fixer_round_cap_hit=cap)
+           b. RETURN {"emit": "verify.escalate", "reason": "fixer-round-cap",
+                      "fixer_round": current_round, "cap": cap}
+           c. NO fixer issue is created (BKDClient.create_issue NOT called)
+      4. ELSE: create fixer issue with tag "round:N", render bugfix prompt with
+         round_n=next_round, then update_context(fixer_round=next_round, ...)
+
+  escalate:
+    module: orchestrator.actions.escalate
+    hard_reasons:
+      - "fixer-round-cap"
+    reason_resolution_priority:
+      - "ctx.escalated_reason if ∈ _HARD_REASONS"
+      - "body.event slug if ∈ _CANONICAL_SIGNALS"
+      - "ctx.escalated_reason if set"
+      - "body.event slug fallback"
+    is_transient_invariant:
+      - "reason ∈ _HARD_REASONS → False (no auto-resume)"
+
+  watchdog:
+    module: orchestrator.watchdog
+    function: _check_and_escalate
+    cap_defense_semantics: |
+      IF state == FIXER_RUNNING AND ctx.fixer_round >= settings.fixer_round_cap:
+        update_context(escalated_reason="fixer-round-cap",
+                       fixer_round_cap_hit=cap)
+        log "watchdog.fixer_round_cap_hit"
+      THEN proceed with normal SESSION_FAILED emission. escalate.py picks up
+      the hard reason and skips auto-resume.
+
+intent_issue_tags_added_on_cap_escalate:
+  - "escalated"
+  - "reason:fixer-round-cap"

--- a/openspec/changes/REQ-fixer-round-cap-1777078900/specs/fixer-round-cap/spec.md
+++ b/openspec/changes/REQ-fixer-round-cap-1777078900/specs/fixer-round-cap/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: start_fixer 在每次起 fixer 之前必须自检 fixer round cap
+
+The `start_fixer` action MUST evaluate `next_round = (ctx.fixer_round or 0) + 1` against `settings.fixer_round_cap` (default 5) before invoking BKD to create a new fixer issue. When `next_round > cap`, the action MUST NOT create a fixer issue, MUST persist `escalated_reason="fixer-round-cap"` and `fixer_round_cap_hit=cap` to the REQ context, and MUST return `{"emit": "verify.escalate"}` so that the engine drives the standard escalate path. When `next_round <= cap`, the action MUST persist `fixer_round = next_round` to context and tag the new fixer issue with `round:N`.
+
+#### Scenario: FRC-S1 第一次 start_fixer 写 round=1
+
+- **GIVEN** REQ context 不含 `fixer_round` 字段（fresh REQ）
+- **WHEN** start_fixer 被调度
+- **THEN** ctx.fixer_round = 1，BKD create_issue 调用一次，issue tags 含 `round:1`，bugfix prompt 渲染 `ROUND=1`
+
+#### Scenario: FRC-S2 round 计数随每轮单调递增
+
+- **GIVEN** REQ context.fixer_round = 2（已起过 2 轮）
+- **WHEN** start_fixer 被调度（verifier 第三次判 fix）
+- **THEN** ctx.fixer_round 更新为 3，新 issue tag 含 `round:3`，bugfix prompt 渲 `ROUND=3`
+
+#### Scenario: FRC-S3 第 (cap+1) 次 start_fixer 触发 escalate
+
+- **GIVEN** REQ context.fixer_round = 5，settings.fixer_round_cap = 5
+- **WHEN** start_fixer 被调度
+- **THEN** BKD create_issue 不被调用；ctx.escalated_reason = "fixer-round-cap"，ctx.fixer_round_cap_hit = 5；返回 `{"emit": "verify.escalate", "reason": "fixer-round-cap", "fixer_round": 5, "cap": 5}`
+
+#### Scenario: FRC-S4 cap 可通过 settings 覆盖
+
+- **GIVEN** settings.fixer_round_cap = 2 + REQ context.fixer_round = 2
+- **WHEN** start_fixer 被调度
+- **THEN** 触发 cap escalate（next_round=3 > cap=2），不创 fixer issue
+
+### Requirement: 状态机必须支持 FIXER_RUNNING 在 VERIFY_ESCALATE 事件下推进到 ESCALATED
+
+The state machine MUST define a transition `(FIXER_RUNNING, VERIFY_ESCALATE) → (ESCALATED, action="escalate")`. This transition allows `start_fixer` to chained-emit `verify.escalate` when the cap is hit, reusing the standard `escalate` action for reason persistence, intent issue tagging, and runner cleanup. The transition MUST coexist with the existing `(REVIEW_RUNNING, VERIFY_ESCALATE) → ESCALATED` transition without behavior change to that path.
+
+#### Scenario: FRC-S5 FIXER_RUNNING + VERIFY_ESCALATE 推到 ESCALATED
+
+- **GIVEN** state machine 当前 state=FIXER_RUNNING
+- **WHEN** Event.VERIFY_ESCALATE 被 dispatch
+- **THEN** decide() 返回非 None Transition：next_state=ESCALATED，action="escalate"
+
+### Requirement: escalate.py 必须把 fixer-round-cap 作为 hard reason
+
+The `escalate` action MUST treat `"fixer-round-cap"` as a hard reason: when present in `ctx.escalated_reason`, it MUST be preserved as the final escalate reason even if `body.event` is in `_CANONICAL_SIGNALS` (e.g., `watchdog.stuck`, `session.failed`). The `_is_transient` helper MUST return False whenever `reason == "fixer-round-cap"`, regardless of `body_event`. This MUST prevent the escalate path from auto-resuming the BKD session via follow-up "continue", which would otherwise restart the verifier↔fixer loop after the cap was tripped.
+
+#### Scenario: FRC-S6 ctx hard reason 压过 canonical body.event
+
+- **GIVEN** body.event="watchdog.stuck"，ctx.escalated_reason="fixer-round-cap"
+- **WHEN** escalate action 跑
+- **THEN** 输出 reason="fixer-round-cap"（不被 watchdog-stuck 覆盖）；不调 BKD follow_up_issue（不 auto-resume）；调 BKD merge_tags_and_update 加 tag `escalated` + `reason:fixer-round-cap`
+
+#### Scenario: FRC-S7 _is_transient 对 fixer-round-cap 永远返 False
+
+- **GIVEN** `_is_transient` 单测调用
+- **WHEN** reason="fixer-round-cap"，body_event 取 "session.failed" / "watchdog.stuck" / None
+- **THEN** 全返 False
+
+### Requirement: watchdog 必须在 FIXER_RUNNING 卡死且 round 已达 cap 时标 reason
+
+The `watchdog._check_and_escalate` function MUST, before emitting `Event.SESSION_FAILED`, check if `state == ReqState.FIXER_RUNNING` and `int(ctx.get("fixer_round") or 0) >= settings.fixer_round_cap`. When both conditions hold, the watchdog MUST persist `escalated_reason="fixer-round-cap"` and `fixer_round_cap_hit=cap` to the REQ context (and update the in-memory ctx so downstream `engine.step` sees it). This defense-in-depth path covers orphan FIXER_RUNNING REQs left behind when start_fixer wrote ctx but its emit failed mid-flight.
+
+#### Scenario: FRC-S8 watchdog 兜底标 reason
+
+- **GIVEN** REQ row state=FIXER_RUNNING + ctx.fixer_round=5 + cap=5 + 卡死时间超阈值
+- **WHEN** watchdog._tick 跑
+- **THEN** req_state.update_context 被调，写入 escalated_reason="fixer-round-cap"；engine.step 被调，event=SESSION_FAILED
+
+#### Scenario: FRC-S9 watchdog 在 round<cap 时不写 fixer-round-cap
+
+- **GIVEN** REQ row state=FIXER_RUNNING + ctx.fixer_round=2 + cap=5 + 卡死时间超阈值
+- **WHEN** watchdog._tick 跑
+- **THEN** req_state.update_context 没写入 escalated_reason="fixer-round-cap"（走原 watchdog-stuck 路径）

--- a/openspec/changes/REQ-fixer-round-cap-1777078900/tasks.md
+++ b/openspec/changes/REQ-fixer-round-cap-1777078900/tasks.md
@@ -1,0 +1,55 @@
+# Tasks: REQ-fixer-round-cap-1777078900
+
+## Stage: config
+
+- [x] `orchestrator/src/orchestrator/config.py`：新增 `fixer_round_cap: int = 5` setting（env `SISYPHUS_FIXER_ROUND_CAP`）
+
+## Stage: state machine
+
+- [x] `orchestrator/src/orchestrator/state.py`：新增 `(FIXER_RUNNING, VERIFY_ESCALATE) → Transition(ESCALATED, "escalate", ...)` transition，让 start_fixer 能 chained-emit 进 escalate
+
+## Stage: implementation (engine)
+
+- [x] `orchestrator/src/orchestrator/actions/_verifier.py:start_fixer`：
+  - 在创建 fixer issue 之前读 `ctx.fixer_round` (default 0)，算 `next_round`
+  - 若 `next_round > settings.fixer_round_cap` → 写 `escalated_reason=fixer-round-cap` + `fixer_round_cap_hit=cap` 到 ctx，return `{"emit": "verify.escalate"}`
+  - 否则用 `next_round` 作为 round 号建 issue（tag `round:N`、bugfix prompt `ROUND=N`）+ 持久化 `fixer_round=next_round`
+- [x] `orchestrator/src/orchestrator/actions/escalate.py`：
+  - 新增 `_HARD_REASONS = {"fixer-round-cap"}`
+  - reason 解析优先级：`ctx hard reason` > `body.event ∈ canonical signals` > `ctx soft reason` > `body event slug`
+  - `_is_transient`：`reason ∈ _HARD_REASONS` → 永远返 False（不 auto-resume）
+
+## Stage: implementation (watchdog)
+
+- [x] `orchestrator/src/orchestrator/watchdog.py:_check_and_escalate`：emit SESSION_FAILED 之前检查 `state == FIXER_RUNNING and ctx.fixer_round >= settings.fixer_round_cap`，若命中：
+  - `req_state.update_context(escalated_reason="fixer-round-cap", fixer_round_cap_hit=cap)`
+  - 把 ctx 内存副本同步标记
+  - log `watchdog.fixer_round_cap_hit`
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_state.py`：EXPECTED 表加 `(FIXER_RUNNING, VERIFY_ESCALATE) → ESCALATED + escalate`
+- [x] `orchestrator/tests/test_verifier.py`：
+  - `test_start_fixer_persists_round_counter` —— 多次调用累计 round + 写 ctx + bugfix prompt 渲 ROUND
+  - `test_start_fixer_caps_at_default_5` —— round=5 + 第 6 次调 → emit verify.escalate，不创 fixer
+  - `test_start_fixer_cap_respects_setting_override` —— monkeypatch cap=2，验运维覆盖生效
+  - `test_start_fixer_first_round_with_no_ctx_field` —— ctx 没字段时视为 0
+- [x] `orchestrator/tests/test_actions_smoke.py`：
+  - `test_escalate_fixer_round_cap_is_hard_reason` —— body.event=watchdog.stuck + ctx hard reason → 不 auto-resume
+  - `test_escalate_fixer_round_cap_session_completed_path` —— body.event=session.completed 路径
+  - `test_is_transient_treats_fixer_round_cap_as_hard` —— 单测 `_is_transient`
+- [x] `orchestrator/tests/test_watchdog.py`：
+  - `test_fixer_round_cap_marks_reason` —— FIXER_RUNNING + round=cap → 写 escalated_reason
+  - `test_fixer_round_below_cap_does_not_mark` —— round<cap → 不写
+
+## Stage: spec
+
+- [x] `openspec/changes/REQ-fixer-round-cap-1777078900/proposal.md`
+- [x] `openspec/changes/REQ-fixer-round-cap-1777078900/tasks.md`
+- [x] `openspec/changes/REQ-fixer-round-cap-1777078900/specs/fixer-round-cap/contract.spec.yaml`
+- [x] `openspec/changes/REQ-fixer-round-cap-1777078900/specs/fixer-round-cap/spec.md`
+
+## Stage: PR
+
+- [x] git push feat/REQ-fixer-round-cap-1777078900
+- [x] gh pr create

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -54,3 +54,4 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
 ]
+

--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -206,6 +206,12 @@ async def start_fixer(*, body, req_id, tags, ctx):
     stage 优先从当前 verifier issue 的 tags 取（`verify:<stage>`）—— 多 verifier 并发
     时 ctx.verifier_stage 可能被后来者覆盖，从触发本次 transition 的 issue tag 直读
     更稳。
+
+    硬 cap 防 verifier↔fixer 死循环：
+      ctx.fixer_round 是"已起过的 round 数"。本次将起的是 next_round = current + 1。
+      next_round > settings.fixer_round_cap 时不再起 fixer，emit VERIFY_ESCALATE 走
+      标准 escalate（reason=fixer-round-cap，escalate.py 识别为 hard reason，不会被
+      auto-resume 绕过）。
     """
     proj = body.projectId
     ctx = ctx or {}
@@ -221,6 +227,29 @@ async def start_fixer(*, body, req_id, tags, ctx):
     reason = ctx.get("verifier_reason") or ""
     branch = ctx.get("branch") or f"feat/{req_id}"
 
+    pool = db.get_pool()
+
+    # ─── round cap：第 N+1 次 start_fixer 直接 escalate（不起 fixer）───────
+    current_round = int(ctx.get("fixer_round") or 0)
+    next_round = current_round + 1
+    cap = settings.fixer_round_cap
+    if next_round > cap:
+        await req_state.update_context(pool, req_id, {
+            "escalated_reason": "fixer-round-cap",
+            "fixer_round_cap_hit": cap,
+        })
+        log.warning(
+            "start_fixer.round_cap_exceeded",
+            req_id=req_id, stage=stage, fixer=fixer,
+            current_round=current_round, cap=cap,
+        )
+        return {
+            "emit": Event.VERIFY_ESCALATE.value,
+            "reason": "fixer-round-cap",
+            "fixer_round": current_round,
+            "cap": cap,
+        }
+
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         issue = await bkd.create_issue(
             project_id=proj,
@@ -231,6 +260,7 @@ async def start_fixer(*, body, req_id, tags, ctx):
                 f"fixer:{fixer}",
                 f"parent-stage:{stage}",
                 f"parent-id:{ctx.get('verifier_issue_id', '')}",
+                f"round:{next_round}",
             ],
             status_id="todo",
             use_worktree=True,
@@ -239,7 +269,7 @@ async def start_fixer(*, body, req_id, tags, ctx):
         # 通用 bugfix prompt 作为过渡；PR4 再做每类 fixer 专用模板。
         prompt = render(
             "bugfix.md.j2",
-            req_id=req_id, round_n=ctx.get("fixer_round", 1),
+            req_id=req_id, round_n=next_round,
             kind=f"verifier-{fixer}",
             source_issue_id=ctx.get("verifier_issue_id", ""),
             branch=branch,
@@ -251,16 +281,20 @@ async def start_fixer(*, body, req_id, tags, ctx):
         await bkd.follow_up_issue(project_id=proj, issue_id=issue.id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue.id, status_id="working")
 
-    pool = db.get_pool()
     await req_state.update_context(pool, req_id, {
         "fixer_issue_id": issue.id,
         "fixer_role": fixer,
         "fixer_scope": scope,
+        "fixer_round": next_round,
     })
 
     log.info("start_fixer.done",
-             req_id=req_id, fixer=fixer, stage=stage, issue_id=issue.id)
-    return {"fixer_issue_id": issue.id, "fixer": fixer, "stage": stage}
+             req_id=req_id, fixer=fixer, stage=stage, issue_id=issue.id,
+             round=next_round, cap=cap)
+    return {
+        "fixer_issue_id": issue.id, "fixer": fixer, "stage": stage,
+        "fixer_round": next_round,
+    }
 
 
 @register("invoke_verifier_after_fix", idempotent=False)

--- a/orchestrator/src/orchestrator/actions/escalate.py
+++ b/orchestrator/src/orchestrator/actions/escalate.py
@@ -35,9 +35,18 @@ _TRANSIENT_REASONS = {
     "session-failed-after-2-retries",  # 兜底防自循环
 }
 
+# Hard reasons：明确叫人停 + 不允许 auto-resume 绕过。
+# 即使 body.event 是 canonical 信号（watchdog.stuck / session.failed），ctx 里只要
+# 写了这些 reason，escalate 就用它（避免 watchdog 把 fixer-round-cap 这类硬终止
+# 二次包装成 watchdog-stuck → 被 _is_transient 判 transient → 继续 auto-resume → 再
+# 多起一轮 fixer，回到死循环）。
+_HARD_REASONS = {"fixer-round-cap"}
+
 
 def _is_transient(body_event: str | None, reason: str) -> bool:
     """判断是不是 transient 失败：值得 auto-resume continue 一次"""
+    if reason in _HARD_REASONS:
+        return False  # 硬停，绝不 auto-resume
     if reason == "verifier-decision-escalate":
         return False  # verifier 主观判，不重试
     if body_event == "session.failed":
@@ -63,14 +72,19 @@ async def escalate(*, body, req_id, tags, ctx):
     intent_issue_id = (ctx or {}).get("intent_issue_id") or body.issueId
     failed_issue_id = body.issueId  # 这次崩的具体 BKD issue
     # reason 优先级：
-    #   1. body.event 是 canonical 失败信号（session.failed / watchdog.stuck）
+    #   1. ctx hard reason（fixer-round-cap 等）—— 即使 body.event 是 canonical
+    #      信号也不能被覆盖，否则 watchdog.stuck 会把 hard 终止误归为 transient
+    #   2. body.event 是 canonical 失败信号（session.failed / watchdog.stuck）
     #      → 用 body.event（最新一手信号；避免被前轮 ctx.escalated_reason 毒化）
-    #   2. ctx.escalated_reason 已被 caller 细分（engine action-error 等）
-    #   3. fallback：body.event 转 slug
-    if body.event in _CANONICAL_SIGNALS:
+    #   3. ctx.escalated_reason 已被 caller 细分（engine action-error 等）
+    #   4. fallback：body.event 转 slug
+    ctx_reason = (ctx or {}).get("escalated_reason")
+    if ctx_reason in _HARD_REASONS:
+        reason = ctx_reason
+    elif body.event in _CANONICAL_SIGNALS:
         reason = body.event.replace(".", "-")[:40]
     else:
-        reason = (ctx or {}).get("escalated_reason") or (
+        reason = ctx_reason or (
             (body.event or "unknown").replace(".", "-")[:40]
         )
     retry_count = (ctx or {}).get("auto_retry_count", 0)

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -139,5 +139,12 @@ class Settings(BaseSettings):
     watchdog_interval_sec: int = 60           # 每 60s 扫一次
     watchdog_stuck_threshold_sec: int = 1800  # 30 min 无 transition 视为卡死
 
+    # ─── 防 verifier↔fixer 死循环：硬封顶 fixer round 数 ─────────────────
+    # 每次 verifier decision=fix 都会 start_fixer 起新一轮 fixer agent，跑完回 verifier
+    # 复查；verifier 再判 fix 又起一轮。某些场景（spec 自相矛盾 / fixer 改不动根因）
+    # 会无限循环。第 N+1 次 start_fixer 到达 cap → escalate（reason=fixer-round-cap）
+    # 让人介入。N 默认 5；调高 = 给 fixer 更多机会，调低 = 更早叫人。
+    fixer_round_cap: int = 5
+
 
 settings = Settings()  # type: ignore[call-arg]

--- a/orchestrator/src/orchestrator/state.py
+++ b/orchestrator/src/orchestrator/state.py
@@ -184,6 +184,13 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
         Transition(ReqState.REVIEW_RUNNING, "invoke_verifier_after_fix",
                    "fixer 完 → 再跑 verifier 复查"),
 
+    # start_fixer 自检 fixer_round 超 cap → 走主链 escalate（不跑新 fixer）。
+    # 复用 escalate action 把 reason / tag / runner 清理收口，避免 start_fixer 内
+    # 自己开第二条 escalate 实现。
+    (ReqState.FIXER_RUNNING, Event.VERIFY_ESCALATE):
+        Transition(ReqState.ESCALATED, "escalate",
+                   "fixer round 触顶 / start_fixer 自判 escalate"),
+
     # ─── 终态 ───────────────────────────────────────────────────────────
     (ReqState.ARCHIVING, Event.ARCHIVE_DONE):
         Transition(ReqState.DONE, None, "REQ complete"),

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -26,7 +26,7 @@ from .bkd import BKDClient
 from .checkers._types import CheckResult
 from .config import settings
 from .state import Event, ReqState
-from .store import artifact_checks, db
+from .store import artifact_checks, db, req_state
 
 log = structlog.get_logger(__name__)
 
@@ -132,6 +132,27 @@ async def _check_and_escalate(row) -> bool:
 
     # 2. 写 artifact_checks 记一笔，给 dashboard M7 04-fail-kind-distribution 抓
     pool = db.get_pool()
+
+    # 防 verifier↔fixer 死循环兜底：FIXER_RUNNING 卡住且 fixer_round 已达 cap →
+    # 显式标 escalated_reason=fixer-round-cap，escalate.py 会识别为 hard reason
+    # 直接终止（不 auto-resume）+ tag intent issue reason:fixer-round-cap。
+    # 正常路径下 start_fixer 自检 cap 已早一步 escalate；本 hook 兜 start_fixer
+    # 写 ctx 后 emit 失败 / 中途崩溃留下的孤儿 FIXER_RUNNING。
+    fx_round = int(ctx.get("fixer_round") or 0)
+    cap = settings.fixer_round_cap
+    if state == ReqState.FIXER_RUNNING and fx_round >= cap:
+        try:
+            await req_state.update_context(pool, req_id, {
+                "escalated_reason": "fixer-round-cap",
+                "fixer_round_cap_hit": cap,
+            })
+            ctx["escalated_reason"] = "fixer-round-cap"
+            log.warning("watchdog.fixer_round_cap_hit",
+                        req_id=req_id, fixer_round=fx_round, cap=cap)
+        except Exception as e:
+            log.warning("watchdog.fixer_round_cap_tag_failed",
+                        req_id=req_id, error=str(e))
+
     check = CheckResult(
         passed=False,
         exit_code=-1,

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -257,6 +257,86 @@ async def test_escalate_action_error_is_transient(monkeypatch):
     fake.follow_up_issue.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_escalate_fixer_round_cap_is_hard_reason(monkeypatch):
+    """ctx.escalated_reason='fixer-round-cap' 即使 body.event 是 canonical 信号
+    （watchdog.stuck / session.failed）也不能被覆盖、不能 auto-resume。
+
+    保护场景：watchdog 检到孤儿 FIXER_RUNNING（start_fixer 写完 ctx 但 emit 失败），
+    若 escalate 把 reason 重写成 watchdog-stuck → 误判 transient → auto-resume →
+    BKD 续上去 → fixer 继续跑 → 死循环回归。
+    """
+    from orchestrator.actions import escalate as mod
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, "escalate", fake)
+    patch_db(monkeypatch, "escalate")
+    from unittest.mock import AsyncMock
+
+    from orchestrator import k8s_runner as krunner
+    from orchestrator.store import req_state as rs
+
+    class FakeRow:
+        state = type("S", (), {"value": "fixer-running"})()
+    monkeypatch.setattr(rs, "get", AsyncMock(return_value=FakeRow()))
+    monkeypatch.setattr(rs, "cas_transition", AsyncMock(return_value=True))
+    monkeypatch.setattr(krunner, "get_controller", lambda: type("C", (), {"cleanup_runner": AsyncMock()})())
+
+    body = make_body(issue_id="src-1", event="watchdog.stuck")
+    out = await mod.escalate(
+        body=body, req_id="REQ-9", tags=["watchdog:fixer-running"],
+        ctx={
+            "intent_issue_id": "intent-1",
+            "escalated_reason": "fixer-round-cap",
+            "fixer_round": 5,
+        },
+    )
+    # ctx hard reason 压过 canonical → reason 保留 fixer-round-cap，不 auto-resume
+    assert out["escalated"] is True
+    assert out["reason"] == "fixer-round-cap"
+    fake.follow_up_issue.assert_not_awaited()
+    fake.merge_tags_and_update.assert_awaited_once()
+    # 加的 tag 含 reason:fixer-round-cap
+    _, mtu_kwargs = fake.merge_tags_and_update.call_args
+    add_tags = mtu_kwargs.get("add") or []
+    assert "escalated" in add_tags
+    assert "reason:fixer-round-cap" in add_tags
+
+
+@pytest.mark.asyncio
+async def test_escalate_fixer_round_cap_session_completed_path(monkeypatch):
+    """start_fixer 主链路径：body.event=session.completed（verifier 完成事件触发）。
+    ctx.escalated_reason=fixer-round-cap → 真 escalate（非 transient），且
+    is_session_failed_path=False，依赖 engine 已 CAS 推 ESCALATED（这里只验 action 行为）。
+    """
+    from orchestrator.actions import escalate as mod
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, "escalate", fake)
+    patch_db(monkeypatch, "escalate")
+
+    body = make_body(issue_id="vfy-1", event="session.completed")
+    out = await mod.escalate(
+        body=body, req_id="REQ-9", tags=["verifier"],
+        ctx={
+            "intent_issue_id": "intent-1",
+            "escalated_reason": "fixer-round-cap",
+        },
+    )
+    assert out["escalated"] is True
+    assert out["reason"] == "fixer-round-cap"
+    fake.follow_up_issue.assert_not_awaited()
+    fake.merge_tags_and_update.assert_awaited_once()
+
+
+def test_is_transient_treats_fixer_round_cap_as_hard():
+    """单测：_is_transient 对 fixer-round-cap 永远返 False，不论 body.event。"""
+    from orchestrator.actions.escalate import _is_transient
+    assert _is_transient("session.failed", "fixer-round-cap") is False
+    assert _is_transient("watchdog.stuck", "fixer-round-cap") is False
+    assert _is_transient(None, "fixer-round-cap") is False
+    # sanity: 老的 transient 仍 transient
+    assert _is_transient("session.failed", "session-failed") is True
+
+
 # ─── done_archive ─────────────────────────────────────────────────────────
 @pytest.mark.asyncio
 async def test_done_archive(monkeypatch):

--- a/orchestrator/tests/test_contract_fixer_round_cap.py
+++ b/orchestrator/tests/test_contract_fixer_round_cap.py
@@ -1,0 +1,564 @@
+"""
+Contract tests for REQ-fixer-round-cap-1777078900:
+feat(engine+watchdog): hard cap fixer rounds at N (default 5)
+
+Black-box behavioral contracts derived from:
+  openspec/changes/REQ-fixer-round-cap-1777078900/specs/fixer-round-cap/spec.md
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is wrong, escalate to spec_fixer to correct the spec, not the test.
+
+Scenarios covered:
+  FRC-S1  第一次 start_fixer 写 round=1，BKD create_issue 调用一次，tag 含 round:1
+  FRC-S2  round 计数随每轮单调递增（fixer_round=2 → 3，tag round:3）
+  FRC-S3  第 (cap+1) 次 start_fixer 触发 escalate（不创 BKD issue，返回 emit:verify.escalate）
+  FRC-S4  cap 可通过 settings 覆盖（cap=2, round=2 → 触发 cap）
+  FRC-S5  FIXER_RUNNING + VERIFY_ESCALATE → decide() 返回 ESCALATED transition
+  FRC-S6  escalate: ctx hard reason "fixer-round-cap" 压过 canonical body.event
+  FRC-S7  _is_transient(body_event, "fixer-round-cap") 永远返回 False
+  FRC-S8  watchdog 兜底：FIXER_RUNNING + round>=cap → 写 escalated_reason="fixer-round-cap"
+  FRC-S9  watchdog 在 round<cap 时不写 fixer-round-cap reason
+
+Function signatures (verified via inspect without reading source):
+  start_fixer(*, body, req_id, tags, ctx) -> dict
+  _is_transient(body_event: str | None, reason: str) -> bool
+  _check_and_escalate(row) -> bool
+  body.projectId: str  (body is an object with .projectId, not a plain dict)
+  row keys: req_id, project_id, state, context, stuck_sec, updated_at, intent_issue_id
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _make_settings(fixer_round_cap: int = 5) -> Any:
+    s = MagicMock()
+    s.fixer_round_cap = fixer_round_cap
+    s.watchdog_timeout_secs = 1800
+    s.watchdog_interval_secs = 30
+    return s
+
+
+def _make_req_row(
+    state_val: str,
+    ctx: dict,
+    req_id: str = "REQ-test-1234",
+    stuck_secs: int = 3600,
+) -> dict:
+    """Build a minimal req row dict as _check_and_escalate expects from DB query."""
+    return {
+        "req_id": req_id,
+        "project_id": "test-project",
+        "state": state_val,
+        "context": ctx,
+        "stuck_sec": stuck_secs,
+        "updated_at": datetime.now(UTC) - timedelta(seconds=stuck_secs),
+        "intent_issue_id": "intent-issue-1",
+        "created_at": datetime.now(UTC) - timedelta(seconds=stuck_secs + 100),
+    }
+
+
+def _make_body(project_id: str = "test-project") -> Any:
+    """Create a body object with .projectId (as start_fixer expects)."""
+    b = MagicMock()
+    b.projectId = project_id
+    return b
+
+
+def _make_mock_pool() -> AsyncMock:
+    pool = AsyncMock()
+    pool.fetchrow.return_value = None
+    pool.execute.return_value = None
+    return pool
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Part 1: State machine transition  FRC-S5
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestStateMachineTransitionFRCS5:
+    """Spec: state machine MUST define (FIXER_RUNNING, VERIFY_ESCALATE) → ESCALATED."""
+
+    def test_frc_s5_fixer_running_verify_escalate_decides_escalated(self):
+        """
+        FRC-S5: decide(FIXER_RUNNING, VERIFY_ESCALATE) must return a non-None
+        Transition with next_state=ESCALATED and action='escalate'.
+        """
+        from orchestrator.state import ReqState, Event, decide
+
+        result = decide(ReqState.FIXER_RUNNING, Event.VERIFY_ESCALATE)
+
+        assert result is not None, (
+            "decide(FIXER_RUNNING, VERIFY_ESCALATE) must return a non-None Transition; "
+            "got None — transition is missing from state machine"
+        )
+        assert result.next_state == ReqState.ESCALATED, (
+            f"next_state must be ESCALATED, got {result.next_state!r}"
+        )
+        assert result.action == "escalate", (
+            f"action must be 'escalate', got {result.action!r}"
+        )
+
+    def test_frc_s5_existing_review_running_verify_escalate_still_works(self):
+        """
+        Spec coexistence: existing (REVIEW_RUNNING, VERIFY_ESCALATE) → ESCALATED
+        must not be broken by adding the new FIXER_RUNNING transition.
+        """
+        from orchestrator.state import ReqState, Event, decide
+
+        result = decide(ReqState.REVIEW_RUNNING, Event.VERIFY_ESCALATE)
+
+        assert result is not None, (
+            "decide(REVIEW_RUNNING, VERIFY_ESCALATE) must still return a Transition "
+            "(existing transition must not be removed)"
+        )
+        assert result.next_state == ReqState.ESCALATED
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Part 2: _is_transient invariant  FRC-S7
+# Signature: _is_transient(body_event: str | None, reason: str) -> bool
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestIsTransientFRCS7:
+    """Spec: _is_transient MUST return False for reason='fixer-round-cap', all body_events."""
+
+    @pytest.mark.parametrize("body_event", ["session.failed", "watchdog.stuck", None])
+    def test_frc_s7_fixer_round_cap_is_never_transient(self, body_event):
+        """
+        FRC-S7: _is_transient(body_event, 'fixer-round-cap') must always return False.
+        Signature: _is_transient(body_event: str|None, reason: str).
+        """
+        from orchestrator.actions.escalate import _is_transient
+
+        result = _is_transient(body_event, "fixer-round-cap")
+
+        assert result is False, (
+            f"_is_transient({body_event!r}, 'fixer-round-cap') must return False; "
+            f"got {result!r}. A True result would enable auto-resume, "
+            "restarting the verifier↔fixer loop after cap was tripped."
+        )
+
+    def test_frc_s7_fixer_round_cap_in_hard_reasons(self):
+        """
+        Structural: 'fixer-round-cap' must be in escalate._HARD_REASONS.
+        """
+        import orchestrator.actions.escalate as escalate_mod
+
+        hard_reasons = getattr(escalate_mod, "_HARD_REASONS", None)
+        assert hard_reasons is not None, (
+            "escalate module must define _HARD_REASONS set; attribute not found"
+        )
+        assert "fixer-round-cap" in hard_reasons, (
+            f"'fixer-round-cap' must be in _HARD_REASONS; found: {hard_reasons!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Part 3: start_fixer cap logic  FRC-S1, S2, S3, S4
+# Signature: start_fixer(*, body, req_id, tags, ctx)
+# Patches: settings, req_state, BKDClient, orchestrator.store.db.get_pool
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _start_fixer_patches(settings, mock_req_state, mock_bkd_cls):
+    """Return a list of patch contexts for start_fixer tests."""
+    return [
+        patch("orchestrator.actions._verifier.settings", settings),
+        patch("orchestrator.actions._verifier.req_state", mock_req_state),
+        patch("orchestrator.actions._verifier.BKDClient", mock_bkd_cls),
+        patch("orchestrator.store.db.get_pool", return_value=_make_mock_pool()),
+    ]
+
+
+class TestStartFixerCapLogicFRCS3S4:
+    """Black-box contract: start_fixer MUST enforce fixer_round_cap."""
+
+    async def test_frc_s3_cap_hit_returns_escalate_emit(self):
+        """
+        FRC-S3: ctx.fixer_round=5, cap=5 → start_fixer MUST return
+        {"emit":"verify.escalate","reason":"fixer-round-cap","fixer_round":5,"cap":5}
+        and MUST NOT call BKD create_issue.
+        """
+        from orchestrator.actions._verifier import start_fixer
+
+        ctx = {"fixer_round": 5}
+        settings = _make_settings(fixer_round_cap=5)
+        created_issues: list = []
+
+        mock_bkd_inst = AsyncMock()
+
+        async def _no_create(*args, **kwargs):
+            created_issues.append((args, kwargs))
+            return {"data": {"id": "must-not-be-called"}}
+
+        mock_bkd_inst.create_issue.side_effect = _no_create
+        mock_bkd_cls = MagicMock(return_value=mock_bkd_inst)
+
+        mock_req_state = AsyncMock()
+        written_ctx: dict = {}
+
+        async def _capture_ctx(*args, **updates):
+            written_ctx.update(updates)
+            for a in args:
+                if isinstance(a, dict):
+                    written_ctx.update(a)
+
+        mock_req_state.update_context.side_effect = _capture_ctx
+
+        patches = _start_fixer_patches(settings, mock_req_state, mock_bkd_cls)
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await start_fixer(
+                body=_make_body(),
+                req_id="REQ-test",
+                tags=["verifier", "REQ-test"],
+                ctx=ctx,
+            )
+
+        assert isinstance(result, dict), (
+            f"start_fixer must return a dict when cap hit; got {type(result)}"
+        )
+        assert result.get("emit") == "verify.escalate", (
+            f"emit must be 'verify.escalate' when cap hit; got {result!r}"
+        )
+        assert result.get("reason") == "fixer-round-cap", (
+            f"reason must be 'fixer-round-cap'; got {result!r}"
+        )
+        assert result.get("cap") == 5, (
+            f"cap field must be 5; got {result!r}"
+        )
+        assert result.get("fixer_round") == 5, (
+            f"fixer_round field must report current round=5; got {result!r}"
+        )
+        assert len(created_issues) == 0, (
+            f"BKD create_issue MUST NOT be called when cap hit; "
+            f"was called {len(created_issues)} time(s)"
+        )
+        assert written_ctx.get("escalated_reason") == "fixer-round-cap", (
+            f"ctx.escalated_reason must be 'fixer-round-cap'; "
+            f"update_context received: {written_ctx!r}"
+        )
+        assert written_ctx.get("fixer_round_cap_hit") == 5, (
+            f"ctx.fixer_round_cap_hit must be 5; update_context received: {written_ctx!r}"
+        )
+
+    async def test_frc_s4_custom_cap_enforced(self):
+        """
+        FRC-S4: settings.fixer_round_cap=2 + ctx.fixer_round=2 →
+        next_round=3 > cap=2 → escalate, no BKD issue.
+        """
+        from orchestrator.actions._verifier import start_fixer
+
+        ctx = {"fixer_round": 2}
+        settings = _make_settings(fixer_round_cap=2)
+        created_issues: list = []
+
+        mock_bkd_inst = AsyncMock()
+        mock_bkd_inst.create_issue.side_effect = lambda *a, **kw: (
+            created_issues.append(True) or {"data": {"id": "x"}}
+        )
+        mock_bkd_cls = MagicMock(return_value=mock_bkd_inst)
+        mock_req_state = AsyncMock()
+
+        patches = _start_fixer_patches(settings, mock_req_state, mock_bkd_cls)
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await start_fixer(
+                body=_make_body(),
+                req_id="REQ-test",
+                tags=[],
+                ctx=ctx,
+            )
+
+        assert isinstance(result, dict), (
+            f"start_fixer must return dict when cap hit (cap=2, round=2); got {type(result)}"
+        )
+        assert result.get("emit") == "verify.escalate", (
+            f"Must escalate when cap=2 and round=2; got emit={result.get('emit')!r}"
+        )
+        assert len(created_issues) == 0, (
+            "BKD create_issue must not be called when custom cap is hit"
+        )
+
+
+class TestStartFixerCounterFRCS1S2:
+    """Contract: fixer_round counter is written and issue is tagged round:N."""
+
+    async def test_frc_s1_first_call_writes_round_1_and_tags_issue(self):
+        """
+        FRC-S1: Fresh REQ (no fixer_round). start_fixer must write fixer_round=1,
+        call BKD create_issue once, and include tag 'round:1'.
+        """
+        from orchestrator.actions._verifier import start_fixer
+
+        ctx = {}
+        settings = _make_settings(fixer_round_cap=5)
+
+        written_ctx: dict = {}
+        mock_req_state = AsyncMock()
+
+        async def _capture_ctx(*args, **updates):
+            written_ctx.update(updates)
+            for a in args:
+                if isinstance(a, dict):
+                    written_ctx.update(a)
+
+        mock_req_state.update_context.side_effect = _capture_ctx
+
+        captured_create_calls: list = []
+
+        async def _capture_create(title=None, tags=None, **kwargs):
+            captured_create_calls.append({"title": title, "tags": tags or []})
+            issue = MagicMock()
+            issue.id = "fixer-issue-1"
+            return issue
+
+        # BKDClient is used as `async with BKDClient(...) as bkd:`, so set
+        # the side_effect on __aenter__().create_issue, not on the instance directly.
+        mock_bkd_inner = AsyncMock()
+        mock_bkd_inner.create_issue.side_effect = _capture_create
+        mock_bkd_inst = AsyncMock()
+        mock_bkd_inst.__aenter__ = AsyncMock(return_value=mock_bkd_inner)
+        mock_bkd_cls = MagicMock(return_value=mock_bkd_inst)
+
+        patches = _start_fixer_patches(settings, mock_req_state, mock_bkd_cls)
+        with patches[0], patches[1], patches[2], patches[3]:
+            await start_fixer(
+                body=_make_body(),
+                req_id="REQ-test",
+                tags=["verifier", "REQ-test"],
+                ctx=ctx,
+            )
+
+        assert written_ctx.get("fixer_round") == 1, (
+            f"start_fixer must write fixer_round=1 for first call; "
+            f"update_context received: {written_ctx!r}"
+        )
+        assert len(captured_create_calls) == 1, (
+            f"start_fixer must call BKD create_issue once for first round; "
+            f"called {len(captured_create_calls)} time(s)"
+        )
+        all_tags = captured_create_calls[0]["tags"]
+        assert "round:1" in all_tags, (
+            f"First fixer issue must include tag 'round:1'; got tags: {all_tags!r}"
+        )
+
+    async def test_frc_s2_round_2_increments_to_3_and_tags_issue(self):
+        """
+        FRC-S2: ctx.fixer_round=2 → start_fixer must write fixer_round=3 and tag 'round:3'.
+        """
+        from orchestrator.actions._verifier import start_fixer
+
+        ctx = {"fixer_round": 2}
+        settings = _make_settings(fixer_round_cap=5)
+
+        written_ctx: dict = {}
+        mock_req_state = AsyncMock()
+
+        async def _capture_ctx(*args, **updates):
+            written_ctx.update(updates)
+            for a in args:
+                if isinstance(a, dict):
+                    written_ctx.update(a)
+
+        mock_req_state.update_context.side_effect = _capture_ctx
+
+        captured_tags: list = []
+
+        async def _capture_create(title=None, tags=None, **kwargs):
+            captured_tags.append(tags or [])
+            issue = MagicMock()
+            issue.id = "fixer-issue-3"
+            return issue
+
+        mock_bkd_inner = AsyncMock()
+        mock_bkd_inner.create_issue.side_effect = _capture_create
+        mock_bkd_inst = AsyncMock()
+        mock_bkd_inst.__aenter__ = AsyncMock(return_value=mock_bkd_inner)
+        mock_bkd_cls = MagicMock(return_value=mock_bkd_inst)
+
+        patches = _start_fixer_patches(settings, mock_req_state, mock_bkd_cls)
+        with patches[0], patches[1], patches[2], patches[3]:
+            await start_fixer(
+                body=_make_body(),
+                req_id="REQ-test",
+                tags=[],
+                ctx=ctx,
+            )
+
+        assert written_ctx.get("fixer_round") == 3, (
+            f"With fixer_round=2, must write fixer_round=3; "
+            f"update_context received: {written_ctx!r}"
+        )
+        if captured_tags:
+            assert "round:3" in captured_tags[0], (
+                f"Issue must be tagged 'round:3'; got tags: {captured_tags[0]!r}"
+            )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Part 4: escalate hard reason preservation  FRC-S6
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestEscalateHardReasonFRCS6:
+    """Spec: 'fixer-round-cap' is a hard reason that ctx preserves over body.event."""
+
+    def test_frc_s6_hard_reason_registered(self):
+        """_HARD_REASONS must contain 'fixer-round-cap'."""
+        import orchestrator.actions.escalate as escalate_mod
+
+        hard_reasons = getattr(escalate_mod, "_HARD_REASONS", None)
+        assert hard_reasons is not None, (
+            "escalate must define _HARD_REASONS; attribute not found"
+        )
+        assert "fixer-round-cap" in hard_reasons, (
+            f"'fixer-round-cap' must be in _HARD_REASONS; found: {hard_reasons!r}"
+        )
+
+    @pytest.mark.parametrize("body_event", ["watchdog.stuck", "session.failed"])
+    def test_frc_s6_fixer_round_cap_not_transient_for_canonical_events(self, body_event):
+        """
+        FRC-S6: _is_transient(body_event, 'fixer-round-cap') must return False
+        for canonical signal body events.
+        """
+        from orchestrator.actions.escalate import _is_transient
+
+        result = _is_transient(body_event, "fixer-round-cap")
+        assert result is False, (
+            f"_is_transient({body_event!r}, 'fixer-round-cap') returned True; "
+            "this would cause auto-resume of the fixer, defeating the cap"
+        )
+
+    def test_frc_s6_hard_and_canonical_signals_dont_overlap(self):
+        """
+        Structural: _HARD_REASONS and _CANONICAL_SIGNALS must not overlap.
+        """
+        import orchestrator.actions.escalate as escalate_mod
+
+        canonical = getattr(escalate_mod, "_CANONICAL_SIGNALS", set())
+        hard = getattr(escalate_mod, "_HARD_REASONS", set())
+
+        if canonical and hard:
+            overlap = hard & canonical
+            assert not overlap, (
+                f"_HARD_REASONS and _CANONICAL_SIGNALS must not overlap; "
+                f"overlap: {overlap!r}"
+            )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Part 5: watchdog defense-in-depth  FRC-S8, S9
+# Signature: _check_and_escalate(row: dict) -> bool
+# Row keys: req_id, project_id, state, context, stuck_sec, updated_at, intent_issue_id
+# Patches: watchdog.settings, watchdog.req_state, watchdog.engine, watchdog.db
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestWatchdogDefenseFRCS8S9:
+    """
+    Spec: watchdog._check_and_escalate MUST write escalated_reason='fixer-round-cap'
+    before SESSION_FAILED when state=FIXER_RUNNING and fixer_round>=cap.
+    """
+
+    def _make_watchdog_patches(self, settings, mock_req_state, mock_engine):
+        from orchestrator import watchdog as wd
+        return [
+            patch.object(wd, "settings", settings),
+            patch.object(wd, "req_state", mock_req_state),
+            patch.object(wd, "engine", mock_engine),
+            patch("orchestrator.store.db.get_pool", return_value=_make_mock_pool()),
+        ]
+
+    async def test_frc_s8_watchdog_marks_fixer_round_cap_when_cap_exceeded(self):
+        """
+        FRC-S8: state=FIXER_RUNNING, ctx.fixer_round=5, cap=5, stuck>threshold →
+        req_state.update_context must be called with escalated_reason='fixer-round-cap'.
+        """
+        from orchestrator import watchdog as watchdog_mod
+        from orchestrator.state import ReqState
+
+        ctx = {"fixer_round": 5}
+        settings = _make_settings(fixer_round_cap=5)
+
+        written_ctx: dict = {}
+        mock_req_state = AsyncMock()
+
+        async def _capture_ctx(*args, **updates):
+            written_ctx.update(updates)
+            for a in args:
+                if isinstance(a, dict):
+                    written_ctx.update(a)
+
+        mock_req_state.update_context.side_effect = _capture_ctx
+
+        mock_engine = MagicMock()
+        mock_engine.step = AsyncMock()
+
+        state_str = (
+            ReqState.FIXER_RUNNING.value
+            if hasattr(ReqState.FIXER_RUNNING, "value")
+            else str(ReqState.FIXER_RUNNING)
+        )
+        row = _make_req_row(state_val=state_str, ctx=ctx, stuck_secs=3600)
+
+        p = self._make_watchdog_patches(settings, mock_req_state, mock_engine)
+        with p[0], p[1], p[2], p[3]:
+            await watchdog_mod._check_and_escalate(row)
+
+        assert written_ctx.get("escalated_reason") == "fixer-round-cap", (
+            f"watchdog must write escalated_reason='fixer-round-cap' when "
+            f"FIXER_RUNNING and fixer_round(5) >= cap(5); "
+            f"update_context received: {written_ctx!r}"
+        )
+
+    async def test_frc_s9_watchdog_does_not_mark_fixer_round_cap_when_below_cap(self):
+        """
+        FRC-S9: state=FIXER_RUNNING, ctx.fixer_round=2, cap=5, stuck>threshold →
+        req_state.update_context must NOT write escalated_reason='fixer-round-cap'.
+        """
+        from orchestrator import watchdog as watchdog_mod
+        from orchestrator.state import ReqState
+
+        ctx = {"fixer_round": 2}
+        settings = _make_settings(fixer_round_cap=5)
+
+        written_ctx: dict = {}
+        mock_req_state = AsyncMock()
+
+        async def _capture_ctx(*args, **updates):
+            written_ctx.update(updates)
+            for a in args:
+                if isinstance(a, dict):
+                    written_ctx.update(a)
+
+        mock_req_state.update_context.side_effect = _capture_ctx
+
+        mock_engine = MagicMock()
+        mock_engine.step = AsyncMock()
+
+        state_str = (
+            ReqState.FIXER_RUNNING.value
+            if hasattr(ReqState.FIXER_RUNNING, "value")
+            else str(ReqState.FIXER_RUNNING)
+        )
+        row = _make_req_row(state_val=state_str, ctx=ctx, stuck_secs=3600)
+
+        p = self._make_watchdog_patches(settings, mock_req_state, mock_engine)
+        with p[0], p[1], p[2], p[3]:
+            await watchdog_mod._check_and_escalate(row)
+
+        assert written_ctx.get("escalated_reason") != "fixer-round-cap", (
+            f"watchdog must NOT write escalated_reason='fixer-round-cap' when "
+            f"fixer_round(2) < cap(5); got: {written_ctx!r}"
+        )

--- a/orchestrator/tests/test_state.py
+++ b/orchestrator/tests/test_state.py
@@ -38,6 +38,8 @@ EXPECTED = [
     (ReqState.REVIEW_RUNNING,       Event.VERIFY_FIX_NEEDED,   ReqState.FIXER_RUNNING,       "start_fixer"),
     (ReqState.REVIEW_RUNNING,       Event.VERIFY_ESCALATE,     ReqState.ESCALATED,           "escalate"),
     (ReqState.FIXER_RUNNING,        Event.FIXER_DONE,          ReqState.REVIEW_RUNNING,      "invoke_verifier_after_fix"),
+    # fixer round cap：start_fixer 自检超 cap → 链 emit verify.escalate 走 escalate
+    (ReqState.FIXER_RUNNING,        Event.VERIFY_ESCALATE,     ReqState.ESCALATED,           "escalate"),
 ]
 
 

--- a/orchestrator/tests/test_verifier.py
+++ b/orchestrator/tests/test_verifier.py
@@ -452,6 +452,125 @@ async def test_start_fixer_defaults_to_dev(monkeypatch):
     assert out["fixer"] == "dev"
 
 
+# ─── 7. fixer round cap ────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_start_fixer_persists_round_counter(monkeypatch):
+    """每次 start_fixer 都把下一轮号写进 ctx.fixer_round。
+
+    第一次：ctx.fixer_round 不存在 → 写 1。第 N 次：写 N。
+    bugfix prompt 的 round_n 同时升到 next_round（上一版恒为 1，看不出轮次）。
+    """
+    from orchestrator.actions import _verifier as v
+    fake = make_fake_bkd()
+    fake.create_issue.return_value = FakeIssue(id="fix-3")
+    patch_bkd(monkeypatch, fake)
+
+    patches: list = []
+
+    async def fake_update(pool, req_id, patch):
+        patches.append(patch)
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+
+    out = await v.start_fixer(
+        body=make_body(), req_id="REQ-9", tags=[],
+        ctx={"verifier_stage": "dev_cross_check", "fixer_round": 2},
+    )
+    assert out["fixer_round"] == 3
+    # ctx 写了 fixer_round=3
+    rounds = [p for p in patches if "fixer_round" in p]
+    assert rounds and rounds[-1]["fixer_round"] == 3
+    # 创 issue 时带 round:3 tag
+    _, kwargs = fake.create_issue.await_args
+    assert "round:3" in kwargs["tags"]
+    # bugfix prompt 渲染里出现 ROUND=3
+    _, fu = fake.follow_up_issue.await_args
+    assert "ROUND=3" in fu["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_start_fixer_caps_at_default_5(monkeypatch):
+    """ctx.fixer_round=5（已起 5 轮）+ 第 6 次调 start_fixer → escalate（不开 fixer）。"""
+    from orchestrator.actions import _verifier as v
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, fake)
+
+    patches: list = []
+
+    async def fake_update(pool, req_id, patch):
+        patches.append(patch)
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+
+    out = await v.start_fixer(
+        body=make_body(), req_id="REQ-9", tags=["verify:dev_cross_check"],
+        ctx={"verifier_stage": "dev_cross_check", "fixer_round": 5},
+    )
+    # 不创 fixer issue
+    fake.create_issue.assert_not_called()
+    fake.follow_up_issue.assert_not_called()
+    # emit verify.escalate
+    assert out["emit"] == Event.VERIFY_ESCALATE.value
+    assert out["reason"] == "fixer-round-cap"
+    # ctx 标了 escalated_reason
+    reasons = [p for p in patches if "escalated_reason" in p]
+    assert reasons
+    assert reasons[-1]["escalated_reason"] == "fixer-round-cap"
+    assert reasons[-1]["fixer_round_cap_hit"] == 5
+
+
+@pytest.mark.asyncio
+async def test_start_fixer_cap_respects_setting_override(monkeypatch):
+    """settings.fixer_round_cap 可被运维覆盖。设 cap=2 + 已跑 2 轮 → 第 3 次 escalate。"""
+    from orchestrator.actions import _verifier as v
+    fake = make_fake_bkd()
+    fake.create_issue.return_value = FakeIssue(id="fix-cap")
+    patch_bkd(monkeypatch, fake)
+
+    async def fake_update(pool, req_id, patch):
+        pass
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+    monkeypatch.setattr("orchestrator.actions._verifier.settings.fixer_round_cap", 2)
+
+    # 跑第 2 轮（next=2，恰好等于 cap，allowed）
+    out = await v.start_fixer(
+        body=make_body(), req_id="REQ-9", tags=[],
+        ctx={"verifier_stage": "dev_cross_check", "fixer_round": 1},
+    )
+    assert out["fixer_round"] == 2
+
+    # 跑第 3 轮（next=3 > cap=2 → escalate）
+    out2 = await v.start_fixer(
+        body=make_body(), req_id="REQ-9", tags=[],
+        ctx={"verifier_stage": "dev_cross_check", "fixer_round": 2},
+    )
+    assert out2["emit"] == Event.VERIFY_ESCALATE.value
+    assert out2["reason"] == "fixer-round-cap"
+
+
+@pytest.mark.asyncio
+async def test_start_fixer_first_round_with_no_ctx_field(monkeypatch):
+    """ctx 里完全没 fixer_round 字段 → 视为 0，next_round=1，正常起 fixer。"""
+    from orchestrator.actions import _verifier as v
+    fake = make_fake_bkd()
+    fake.create_issue.return_value = FakeIssue(id="fix-first")
+    patch_bkd(monkeypatch, fake)
+
+    async def fake_update(pool, req_id, patch):
+        pass
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+
+    out = await v.start_fixer(
+        body=make_body(), req_id="REQ-9", tags=[],
+        ctx={"verifier_stage": "dev_cross_check"},
+    )
+    assert out["fixer_round"] == 1
+    fake.create_issue.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_invoke_verifier_for_staging_test_fail(monkeypatch):
     """B2：专门 handler 写死 stage=staging_test，不再从 tags sniff。

--- a/orchestrator/tests/test_watchdog.py
+++ b/orchestrator/tests/test_watchdog.py
@@ -258,6 +258,75 @@ async def test_loop_disabled_returns_immediately(monkeypatch):
     await watchdog.run_loop()   # 不应 hang
 
 
+# ─── Case 9b：FIXER_RUNNING + fixer_round 已到 cap → 标 escalated_reason=fixer-round-cap ─
+@pytest.mark.asyncio
+async def test_fixer_round_cap_marks_reason(monkeypatch):
+    """defense in depth：start_fixer 写完 ctx.fixer_round 后挂掉 / engine.step 失败
+    留下孤儿 FIXER_RUNNING；watchdog 30 min 后扫到，发现 round 已达 cap → 把
+    escalated_reason 标 fixer-round-cap，escalate.py 会识别为 hard reason 不
+    auto-resume + tag intent issue reason:fixer-round-cap。
+    """
+    pool = FakePool(rows=[
+        _row("REQ-FX", ReqState.FIXER_RUNNING.value,
+             ctx={
+                 "fixer_issue_id": "fix-9",
+                 "fixer_round": 5,
+                 "intent_issue_id": "intent-fx",
+             }),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, FakeIssue(session_status="failed", id="fix-9"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    update_calls: list = []
+
+    async def fake_update(pool, req_id, patch):
+        update_calls.append((req_id, patch))
+
+    monkeypatch.setattr("orchestrator.watchdog.req_state.update_context", fake_update)
+    # 显式锁 cap 默认为 5（防 helm values 覆盖污染测试）
+    monkeypatch.setattr("orchestrator.watchdog.settings.fixer_round_cap", 5)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    # 写了 escalated_reason=fixer-round-cap
+    assert any(
+        p.get("escalated_reason") == "fixer-round-cap" for _, p in update_calls
+    )
+    # 仍走 SESSION_FAILED 推到 escalate
+    assert step_calls[0]["event"] == Event.SESSION_FAILED
+
+
+@pytest.mark.asyncio
+async def test_fixer_round_below_cap_does_not_mark(monkeypatch):
+    """FIXER_RUNNING + fixer_round < cap → 不写 fixer-round-cap，走原 watchdog-stuck 路径。"""
+    pool = FakePool(rows=[
+        _row("REQ-FX", ReqState.FIXER_RUNNING.value,
+             ctx={"fixer_issue_id": "fix-9", "fixer_round": 2,
+                  "intent_issue_id": "intent-fx"}),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, FakeIssue(session_status="failed", id="fix-9"))
+    _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    update_calls: list = []
+
+    async def fake_update(pool, req_id, patch):
+        update_calls.append((req_id, patch))
+
+    monkeypatch.setattr("orchestrator.watchdog.req_state.update_context", fake_update)
+    monkeypatch.setattr("orchestrator.watchdog.settings.fixer_round_cap", 5)
+
+    await watchdog._tick()
+
+    assert not any(
+        p.get("escalated_reason") == "fixer-round-cap" for _, p in update_calls
+    )
+
+
 # ─── Case 9：engine.step 抛异常不阻塞后续 row ─────────────────────────────
 @pytest.mark.asyncio
 async def test_engine_step_failure_isolated(monkeypatch):


### PR DESCRIPTION
## Summary

- 防 verifier↔fixer 死循环：每个 REQ fixer 轮数硬封顶（`SISYPHUS_FIXER_ROUND_CAP`，默认 5），第 N+1 次 `start_fixer` escalate（reason `fixer-round-cap`）而不是再开一轮
- 修 `ctx.fixer_round` 长期只读不写的 bug —— 现在每次 start_fixer 持久化下一轮号，bugfix prompt 与 issue tag (`round:N`) 同步
- escalate 路径补 hard reason 概念 —— `fixer-round-cap` 不会被 watchdog.stuck / session.failed 这类 canonical 信号覆盖，也不会被 auto-resume 绕过死灰复燃

## 涉及

- `orchestrator/src/orchestrator/config.py` — 新 `fixer_round_cap` setting
- `orchestrator/src/orchestrator/state.py` — 补 `(FIXER_RUNNING, VERIFY_ESCALATE) → ESCALATED + escalate` transition
- `orchestrator/src/orchestrator/actions/_verifier.py` — `start_fixer` cap check + counter increment
- `orchestrator/src/orchestrator/actions/escalate.py` — `_HARD_REASONS = {"fixer-round-cap"}`，reason 解析新优先级 + `_is_transient` 硬返 False
- `orchestrator/src/orchestrator/watchdog.py` — defense in depth，FIXER_RUNNING 卡死且 round ≥ cap → 标 reason
- openspec change `REQ-fixer-round-cap-1777078900`：proposal / tasks / spec / contract（9 个 scenario）

## Test plan

- [x] `pytest -q`：397 passed（含新增 11 个 scenario test）
- [x] `ruff check`：clean
- [x] `openspec validate REQ-fixer-round-cap-1777078900`：valid
- [x] `scripts/check-scenario-refs.sh`：所有 scenario 引用解析通过
- [ ] 真实 REQ 烟测：手工 PATCH 一个 ESCALATED REQ 让 verifier 连续判 fix，验第 6 次 start_fixer 真 escalate（reason tag = `reason:fixer-round-cap`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)