### PR TITLE
feat(watchdog): tag done-archive failures as 'archive-failed' (not generic)

### DIFF
--- a/openspec/changes/REQ-archive-failure-watchdog-1777084279/proposal.md
+++ b/openspec/changes/REQ-archive-failure-watchdog-1777084279/proposal.md
@@ -1,0 +1,49 @@
+# REQ-archive-failure-watchdog-1777084279: feat(watchdog): detect done-archive session.failed + escalate with reason archive-failed
+
+## 问题
+
+`done-archive` 阶段的 BKD agent 失败时（合 PR / openspec apply 出错 / agent 主动 abort），
+sisyphus 的兜底链路最终都把它打成通用 reason：
+
+- BKD 真发 `session.failed` webhook → escalate.py canonical 分支 → `reason="session-failed"`
+- BKD 漏发 webhook → watchdog 兜底 stuck 检测 → `body.event="watchdog.stuck"` → `reason="watchdog-stuck"`
+
+两条路都掩盖了"是 archive 阶段失败"这个关键事实。M7 dashboard 04-fail-kind-distribution
+按 `reason` 分组统计——archive 失败被淹没在 `session-failed` / `watchdog-stuck` 里，
+没法独立看到"过去 7 天 N 次 done-archive 失败"这种针对性指标，团队很难判定
+done-archive prompt / 业务 repo 的 archive Makefile target 是否需要优化。
+
+## 方案
+
+给 ARCHIVING 阶段的失败配一个独立 canonical signal：`archive.failed` → `archive-failed`。
+
+### watchdog.py
+- 新增 `_STATE_FAILURE_EVENT: dict[ReqState, str]` 映射，目前只列 `ARCHIVING → "archive.failed"`
+- `_check_and_escalate` 构造 `_SyntheticBody` 时按 state 取对应 event；非 ARCHIVING 仍是 `"watchdog.stuck"`
+- 不动 `_STATE_ISSUE_KEY`、_SKIP_STATES、SQL 等，最小改动
+
+### escalate.py
+- `_CANONICAL_SIGNALS` 加 `"archive.failed"` —— body.event 直接 slug 化得到 `"archive-failed"`
+- `_TRANSIENT_REASONS` 加 `"archive-failed"` 和 `"archive-failed-after-2-retries"`
+- `_is_transient` 把 `body_event=="archive.failed"` 也判 transient（auto-resume 一次）
+- BKD 真发 session.failed webhook 路径：当 `body.issueId == ctx.archive_issue_id` 时
+  把 reason override 为 `"archive-failed"`
+- final_reason bumping：retry 用完时若原 reason 是 `archive-failed` →
+  `archive-failed-after-2-retries`（区别于通用 `session-failed-after-2-retries`）
+- `is_session_failed_path` 改用 `_CANONICAL_SIGNALS` 集合（自动包含 `archive.failed`）
+
+### state.py
+不动。SESSION_FAILED 已经在 ARCHIVING 上有 self-loop transition（state.py 213-223），
+escalate action 自己手 CAS 推到 ESCALATED。
+
+## 取舍
+
+- **不引入新 Event 枚举值**：复用 `Event.SESSION_FAILED`，state machine 不需改 transition table。
+  reason 细分纯走 escalate action 内部逻辑 + body.event 字符串区分，最小爆炸半径。
+- **保留 auto-resume 行为**：archive 阶段失败可能是 BKD agent transient 卡死 / GitHub API 5xx，
+  跟其他阶段一样给两次 follow-up "continue" 续作业的机会。不为了 reason 细分牺牲恢复能力。
+- **ctx.archive_issue_id 匹配做二次 override**：webhook session.failed 路径没法靠 body.event
+  自标记，但 done_archive action 已经把 archive_issue_id 落 ctx，issue id 匹配比再读
+  req_state（多一次 DB 调用）便宜且无 race。
+- **dashboard 不改**：04-fail-kind-distribution 已经按 `reason:*` tag value group by，
+  新出现的 `archive-failed` / `archive-failed-after-2-retries` 自动多两条柱子。

--- a/openspec/changes/REQ-archive-failure-watchdog-1777084279/specs/archive-failure/contract.spec.yaml
+++ b/openspec/changes/REQ-archive-failure-watchdog-1777084279/specs/archive-failure/contract.spec.yaml
@@ -1,0 +1,57 @@
+capability: archive-failure
+version: "1.0"
+description: |
+  done-archive 阶段失败的细分 reason 标签。
+  watchdog 用 archive.failed synthetic event；escalate 用 ctx.archive_issue_id
+  做二次 override 覆盖 BKD session.failed webhook 路径。
+  最终 reason 标 "archive-failed" / "archive-failed-after-2-retries"
+  让 dashboard M7 04-fail-kind-distribution 能独立统计 archive 阶段崩溃。
+
+constants:
+  archive_failed_event: "archive.failed"
+  archive_failed_reason: "archive-failed"
+  archive_failed_after_retries_reason: "archive-failed-after-2-retries"
+
+modules:
+  watchdog:
+    file: orchestrator/src/orchestrator/watchdog.py
+    additions:
+      - name: _STATE_FAILURE_EVENT
+        kind: dict
+        signature: "dict[ReqState, str]"
+        semantics: |
+          state → SyntheticBody.event override.
+          ARCHIVING → "archive.failed". 未列出 state 默认 "watchdog.stuck".
+    behavior:
+      - "_check_and_escalate 构造 _SyntheticBody 时按 state 取 _STATE_FAILURE_EVENT，缺省 watchdog.stuck"
+
+  escalate:
+    file: orchestrator/src/orchestrator/actions/escalate.py
+    additions:
+      - name: archive.failed in _CANONICAL_SIGNALS
+      - name: archive-failed in _TRANSIENT_REASONS
+      - name: archive-failed-after-2-retries in _TRANSIENT_REASONS
+      - name: _is_transient(body_event="archive.failed") = True
+    behavior:
+      - id: webhook_path_override
+        when: 'body.event == "session.failed" AND body.issueId == ctx.archive_issue_id'
+        then: 'reason 强制 = "archive-failed"'
+      - id: final_reason_bumping
+        when: 'reason == "archive-failed" AND retry_count >= _MAX_AUTO_RETRY'
+        then: 'final_reason = "archive-failed-after-2-retries"'
+      - id: cas_to_escalated
+        when: 'body.event in _CANONICAL_SIGNALS (now includes archive.failed)'
+        then: '手 CAS state → ESCALATED + cleanup runner（与 session.failed/watchdog.stuck 同路径）'
+
+state_machine:
+  unchanged: true
+  rationale: |
+    复用 Event.SESSION_FAILED + (ARCHIVING, SESSION_FAILED) self-loop transition。
+    reason 细分纯走 escalate action 内部，不动 transition table 减少爆炸半径。
+
+dashboards:
+  affected:
+    - observability/queries/sisyphus/04-fail-kind-distribution.sql
+  change: |
+    无需改 SQL —— 已按 reason:* tag value group by。
+    新出现的 archive-failed / archive-failed-after-2-retries 自动多两条柱子。

--- a/openspec/changes/REQ-archive-failure-watchdog-1777084279/specs/archive-failure/spec.md
+++ b/openspec/changes/REQ-archive-failure-watchdog-1777084279/specs/archive-failure/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: watchdog 在 ARCHIVING 状态贴 archive 专属失败信号
+
+The watchdog SHALL emit `body.event="archive.failed"` (instead of the generic
+`"watchdog.stuck"`) when escalating a stuck REQ whose current state is `ARCHIVING`.
+The synthetic body MUST still carry `Event.SESSION_FAILED` so the state machine's
+existing `(ARCHIVING, SESSION_FAILED)` self-loop transition fires unchanged; only
+the `body.event` string used by `escalate` action for reason derivation differs.
+For all other in-flight states the watchdog MUST keep emitting the generic
+`"watchdog.stuck"` event so existing behavior is preserved.
+
+#### Scenario: ARCH-S1 ARCHIVING 卡死 + session=failed → body.event="archive.failed"
+
+- **GIVEN** `req_state` 表中存在 REQ `REQ-arch-1`，state=`archiving`，updated_at 超过
+  `watchdog_stuck_threshold_sec`，ctx 含 `archive_issue_id="arch-1"`
+- **AND** BKD `get_issue("arch-1")` 返回 `session_status="failed"`
+- **WHEN** `watchdog._tick()` 触发
+- **THEN** `engine.step` 被调用一次，`body.event == "archive.failed"`，`event == Event.SESSION_FAILED`，
+  `cur_state == ReqState.ARCHIVING`
+
+#### Scenario: ARCH-S2 非 ARCHIVING state 仍贴 generic watchdog.stuck
+
+- **GIVEN** REQ `REQ-st-1`，state=`staging-test-running` 卡死，session=failed
+- **WHEN** `watchdog._tick()` 触发
+- **THEN** `engine.step` 被调用一次，`body.event == "watchdog.stuck"`（非 archive 路径不受影响）
+
+### Requirement: escalate action 把 archive 阶段失败的 reason 标成 archive-failed
+
+The escalate action SHALL produce `reason="archive-failed"` (and tag the intent
+issue with `reason:archive-failed`) for any failure of the done-archive BKD
+session. This MUST cover both observation paths:
+
+1. The watchdog path, where `body.event == "archive.failed"` (canonical signal added by this change).
+2. The BKD-webhook path, where `body.event == "session.failed"` AND the failed
+   issue id matches `ctx.archive_issue_id` (recorded by the `done_archive` action).
+
+For unrelated `session.failed` events (issue id does not match `archive_issue_id`)
+the escalate action MUST keep the existing `reason="session-failed"` derivation.
+
+The auto-resume policy SHALL apply equally to `archive-failed` failures
+(`_is_transient(...)` returns `True`), giving the done-archive agent up to
+`_MAX_AUTO_RETRY` follow-up "continue" attempts before final escalation.
+After retries are exhausted, the final reason MUST be `archive-failed-after-2-retries`
+(distinct from the generic `session-failed-after-2-retries`).
+
+#### Scenario: ARCH-S3 watchdog 路径 archive.failed → reason archive-failed
+
+- **GIVEN** `body.event="archive.failed"`，`ctx={"intent_issue_id":"intent-1","archive_issue_id":"arch-1"}`，
+  `auto_retry_count` 缺省为 0
+- **WHEN** `escalate(...)` 被调用
+- **THEN** 返回 `{"auto_resumed": True, "reason": "archive-failed", "retry": 1}`，
+  BKD `follow_up_issue` 被调用一次（"continue" prompt），`merge_tags_and_update` 没被调
+
+#### Scenario: ARCH-S4 BKD session.failed webhook 路径 + issue 匹配 → reason archive-failed
+
+- **GIVEN** `body.event="session.failed"`，`body.issueId="arch-2"`，
+  `ctx={"intent_issue_id":"intent-1","archive_issue_id":"arch-2"}`，retry=0
+- **WHEN** `escalate(...)` 被调用
+- **THEN** 返回 `{"auto_resumed": True, "reason": "archive-failed", "retry": 1}`
+
+#### Scenario: ARCH-S5 session.failed 但 issue 不是 archive 的 → reason 保持 session-failed
+
+- **GIVEN** `body.event="session.failed"`，`body.issueId="dev-1"`，
+  `ctx={"archive_issue_id":"arch-other"}`（不匹配）
+- **WHEN** `escalate(...)` 被调用
+- **THEN** 返回的 reason 仍是 `"session-failed"`（不被 archive override 误标）
+
+#### Scenario: ARCH-S6 archive-failed retry 用完 → final reason archive-failed-after-2-retries
+
+- **GIVEN** `body.event="archive.failed"`，`ctx={"archive_issue_id":"arch-1","auto_retry_count":2}`，
+  当前 state=`archiving`
+- **WHEN** `escalate(...)` 被调用
+- **THEN** 返回 `{"escalated": True, "reason": "archive-failed-after-2-retries"}`，
+  intent issue 被加 tag `reason:archive-failed-after-2-retries`，REQ state CAS 到 `ESCALATED`

--- a/openspec/changes/REQ-archive-failure-watchdog-1777084279/tasks.md
+++ b/openspec/changes/REQ-archive-failure-watchdog-1777084279/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: REQ-archive-failure-watchdog-1777084279
+
+## Stage: spec
+- [x] `openspec/changes/REQ-archive-failure-watchdog-1777084279/proposal.md`
+- [x] `openspec/changes/REQ-archive-failure-watchdog-1777084279/tasks.md`
+- [x] `openspec/changes/REQ-archive-failure-watchdog-1777084279/specs/archive-failure/spec.md`
+- [x] `openspec/changes/REQ-archive-failure-watchdog-1777084279/specs/archive-failure/contract.spec.yaml`
+
+## Stage: implementation
+- [x] 改 `orchestrator/src/orchestrator/watchdog.py`：新增 `_STATE_FAILURE_EVENT` 映射 + `_check_and_escalate` 构造 SyntheticBody 时取 state 对应 event
+- [x] 改 `orchestrator/src/orchestrator/actions/escalate.py`：
+  - `_CANONICAL_SIGNALS` 加 `"archive.failed"`
+  - `_TRANSIENT_REASONS` 加 `"archive-failed"` / `"archive-failed-after-2-retries"`
+  - `_is_transient` 识别 `body_event=="archive.failed"`
+  - reason 二次 override：`session.failed` webhook + `body.issueId == ctx.archive_issue_id` → `"archive-failed"`
+  - final_reason bumping：`reason=="archive-failed"` + retry 用完 → `"archive-failed-after-2-retries"`
+  - `is_session_failed_path` 改用 `_CANONICAL_SIGNALS` 集合（包含 archive.failed）
+
+## Stage: tests
+- [x] `orchestrator/tests/test_watchdog.py`：
+  - 扩 `_patch_engine` 捕获 `body_event`
+  - 加 ARCH-S1 case：ARCHIVING 卡死 → body.event="archive.failed"
+  - 加 ARCH-S2 case：非 ARCHIVING 仍 body.event="watchdog.stuck"
+- [x] `orchestrator/tests/test_actions_smoke.py`：
+  - 加 `test_escalate_archive_failed_from_watchdog`（ARCH-S3）
+  - 加 `test_escalate_archive_failed_from_bkd_session_failed_webhook`（ARCH-S4）
+  - 加 `test_escalate_session_failed_unrelated_issue_unchanged`（ARCH-S5）
+  - 加 `test_escalate_archive_failed_real_after_retries_exhausted`（ARCH-S6）
+
+## Stage: PR
+- [ ] git push feat/REQ-archive-failure-watchdog-1777084279
+- [ ] gh pr create

--- a/orchestrator/src/orchestrator/actions/escalate.py
+++ b/orchestrator/src/orchestrator/actions/escalate.py
@@ -32,7 +32,9 @@ _TRANSIENT_REASONS = {
     "session-failed",
     "watchdog-stuck",
     "runner-pod-not-ready",
+    "archive-failed",  # done-archive 阶段失败（state==ARCHIVING）
     "session-failed-after-2-retries",  # 兜底防自循环
+    "archive-failed-after-2-retries",  # 兜底防自循环（archive 路径）
 }
 
 
@@ -44,6 +46,8 @@ def _is_transient(body_event: str | None, reason: str) -> bool:
         return True
     if body_event == "watchdog.stuck":
         return True  # watchdog 兜底永远值得续一次（BKD 漏发 webhook / process 卡住等）
+    if body_event == "archive.failed":
+        return True  # watchdog 在 ARCHIVING 阶段贴的 archive 专属信号
     if reason in _TRANSIENT_REASONS:
         return True
     if reason.startswith("action-error:"):
@@ -54,7 +58,13 @@ def _is_transient(body_event: str | None, reason: str) -> bool:
     return False
 
 
-_CANONICAL_SIGNALS = {"session.failed", "watchdog.stuck"}
+# canonical 失败信号：body.event 取这几个值时，reason 直接由 body.event slug 化得到
+# （避免被前轮 ctx.escalated_reason 毒化）。
+# - session.failed: BKD 真发的 webhook
+# - watchdog.stuck: watchdog 兜底
+# - archive.failed: watchdog 在 ARCHIVING state 贴的细分信号（让 reason="archive-failed"
+#   能在 dashboard 上跟通用 watchdog-stuck 区分）
+_CANONICAL_SIGNALS = {"session.failed", "watchdog.stuck", "archive.failed"}
 
 
 @register("escalate", idempotent=True)
@@ -73,6 +83,17 @@ async def escalate(*, body, req_id, tags, ctx):
         reason = (ctx or {}).get("escalated_reason") or (
             (body.event or "unknown").replace(".", "-")[:40]
         )
+    # 二次 override：BKD 真发的 session.failed webhook 也能识别 archive 阶段
+    # （body.issueId == ctx.archive_issue_id 说明是 done-archive agent 崩溃）。
+    # watchdog 路径已经直接贴 body.event="archive.failed"，命中上面的 canonical 分支
+    # 自然得到 "archive-failed"；这里专门补 BKD webhook 路径。
+    archive_issue_id = (ctx or {}).get("archive_issue_id")
+    if (
+        body.event == "session.failed"
+        and archive_issue_id
+        and failed_issue_id == archive_issue_id
+    ):
+        reason = "archive-failed"
     retry_count = (ctx or {}).get("auto_retry_count", 0)
 
     # ─── 1. transient + retry < 2 → auto-resume ────────────────────────────
@@ -106,7 +127,10 @@ async def escalate(*, body, req_id, tags, ctx):
     # ─── 2. 真 escalate：retry 用完 / non-transient (verifier escalate / intake-fail / pr-ci-timeout 等) ─
     final_reason = reason
     if retry_count >= _MAX_AUTO_RETRY and _is_transient(body.event, reason):
-        final_reason = "session-failed-after-2-retries"
+        if reason == "archive-failed":
+            final_reason = "archive-failed-after-2-retries"
+        else:
+            final_reason = "session-failed-after-2-retries"
 
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         try:
@@ -127,10 +151,10 @@ async def escalate(*, body, req_id, tags, ctx):
     # SESSION_FAILED 类路径下 transition 是 self-loop（state 没动），需手动 CAS 推到
     # ESCALATED 并清 runner。
     # 触发源：BKD 真发的 session.failed webhook，或 watchdog 内部 emit Event.SESSION_FAILED
-    # （body.event="watchdog.stuck"）。
+    # （body.event="watchdog.stuck" 通用 / "archive.failed" 在 ARCHIVING state 上）。
     # 其他事件路径（如 INTAKE_FAIL / PR_CI_TIMEOUT / VERIFY_ESCALATE）的 transition
     # 已在 state.py 写死 next_state=ESCALATED，engine 已经做过 CAS + cleanup，这里跳过。
-    is_session_failed_path = body.event in ("session.failed", "watchdog.stuck")
+    is_session_failed_path = body.event in _CANONICAL_SIGNALS
     if is_session_failed_path:
         row = await req_state.get(pool, req_id)
         if row and row.state != ReqState.ESCALATED:

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -46,6 +46,15 @@ _STATE_ISSUE_KEY: dict[ReqState, str | None] = {
     ReqState.ARCHIVING: "archive_issue_id",
 }
 
+# state → 兜底失败时贴在 _SyntheticBody.event 上的字符串。
+# escalate.py 把这串当 canonical signal，slug 化成 reason tag
+# （如 "archive.failed" → "archive-failed"），让 dashboards 能区分
+# done-archive 阶段崩溃 vs 通用 watchdog 卡死。
+# 未列出的 state 默认用 "watchdog.stuck"（→ reason "watchdog-stuck"）。
+_STATE_FAILURE_EVENT: dict[ReqState, str] = {
+    ReqState.ARCHIVING: "archive.failed",
+}
+
 # 排除：终态 + 等人态 + 未入链
 _SKIP_STATES = {
     ReqState.DONE.value,
@@ -152,6 +161,7 @@ async def _check_and_escalate(row) -> bool:
     body = _SyntheticBody(
         projectId=project_id,
         issueId=issue_id or ctx.get("intent_issue_id") or "",
+        event=_STATE_FAILURE_EVENT.get(state, "watchdog.stuck"),
     )
     log.warning(
         "watchdog.escalating",

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -236,6 +236,98 @@ async def test_escalate_canonical_signal_overrides_stale_ctx(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_escalate_archive_failed_from_watchdog(monkeypatch):
+    """REQ-archive-failure-watchdog: watchdog 贴 body.event='archive.failed' →
+    reason='archive-failed'（不是 generic 'watchdog-stuck'），auto-resume 一次。"""
+    from orchestrator.actions import escalate as mod
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, "escalate", fake)
+    patch_db(monkeypatch, "escalate")
+    body = make_body(issue_id="arch-1", event="archive.failed")
+    out = await mod.escalate(
+        body=body, req_id="REQ-9", tags=["done-archive"],
+        ctx={"intent_issue_id": "intent-1", "archive_issue_id": "arch-1"},
+    )
+    # archive.failed 是 canonical → reason 直接 slug 化得 archive-failed
+    assert out["auto_resumed"] is True
+    assert out["reason"] == "archive-failed"
+    fake.follow_up_issue.assert_awaited_once()
+    fake.merge_tags_and_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_escalate_archive_failed_from_bkd_session_failed_webhook(monkeypatch):
+    """REQ-archive-failure-watchdog: BKD 真发的 session.failed webhook + body.issueId
+    匹配 ctx.archive_issue_id → reason 也覆盖为 'archive-failed'（不是默认 'session-failed'），
+    让 dashboard M7 能统一统计 archive 阶段失败。"""
+    from orchestrator.actions import escalate as mod
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, "escalate", fake)
+    patch_db(monkeypatch, "escalate")
+    body = make_body(issue_id="arch-2", event="session.failed")
+    out = await mod.escalate(
+        body=body, req_id="REQ-9", tags=["done-archive"],
+        ctx={"intent_issue_id": "intent-1", "archive_issue_id": "arch-2"},
+    )
+    assert out["auto_resumed"] is True
+    assert out["reason"] == "archive-failed"
+
+
+@pytest.mark.asyncio
+async def test_escalate_session_failed_unrelated_issue_unchanged(monkeypatch):
+    """body.issueId 不是 archive_issue_id（比如 dev / accept 阶段崩溃）→ reason 不变 'session-failed'。
+    确保 archive override 只在 issue 真匹配 archive_issue_id 时生效。"""
+    from orchestrator.actions import escalate as mod
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, "escalate", fake)
+    patch_db(monkeypatch, "escalate")
+    body = make_body(issue_id="dev-1", event="session.failed")
+    out = await mod.escalate(
+        body=body, req_id="REQ-9", tags=["dev"],
+        ctx={"intent_issue_id": "intent-1", "archive_issue_id": "arch-other"},
+    )
+    assert out["reason"] == "session-failed"
+
+
+@pytest.mark.asyncio
+async def test_escalate_archive_failed_real_after_retries_exhausted(monkeypatch):
+    """archive.failed + retry_count=2 → 真 escalate，final_reason='archive-failed-after-2-retries'
+    （区别于通用 'session-failed-after-2-retries'）。"""
+    from orchestrator.actions import escalate as mod
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, "escalate", fake)
+    patch_db(monkeypatch, "escalate")
+    from unittest.mock import AsyncMock
+
+    from orchestrator import k8s_runner as krunner
+    from orchestrator.store import req_state as rs
+
+    class FakeRow:
+        state = type("S", (), {"value": "archiving"})()
+    monkeypatch.setattr(rs, "get", AsyncMock(return_value=FakeRow()))
+    monkeypatch.setattr(rs, "cas_transition", AsyncMock(return_value=True))
+    monkeypatch.setattr(krunner, "get_controller", lambda: type("C", (), {"cleanup_runner": AsyncMock()})())
+
+    body = make_body(issue_id="arch-1", event="archive.failed")
+    out = await mod.escalate(
+        body=body, req_id="REQ-9", tags=["done-archive"],
+        ctx={
+            "intent_issue_id": "intent-1",
+            "archive_issue_id": "arch-1",
+            "auto_retry_count": 2,
+        },
+    )
+    assert out["escalated"] is True
+    assert out["reason"] == "archive-failed-after-2-retries"
+    fake.merge_tags_and_update.assert_awaited_once()
+    fake.follow_up_issue.assert_not_awaited()
+    # 验证 tag merge 用的是 intent_issue_id（不是 archive issue），且 reason tag 正确
+    _, kwargs = fake.merge_tags_and_update.call_args
+    assert "escalated" in kwargs["add"]
+    assert "reason:archive-failed-after-2-retries" in kwargs["add"]
+
+
+@pytest.mark.asyncio
 async def test_escalate_action_error_is_transient(monkeypatch):
     """engine _emit_escalate 注的 ctx.escalated_reason='action-error:...' 应被识别为
     transient（基础设施 flaky）→ auto-resume 一次，给环境恢复机会。

--- a/orchestrator/tests/test_contract_archive_failure.py
+++ b/orchestrator/tests/test_contract_archive_failure.py
@@ -1,0 +1,378 @@
+"""Contract tests for done-archive failure detection (REQ-archive-failure-watchdog-1777084279).
+
+Black-box behavioral contracts derived from:
+  openspec/changes/REQ-archive-failure-watchdog-1777084279/specs/archive-failure/spec.md
+
+Scenarios covered:
+  ARCH-S1  watchdog ARCHIVING 卡死 → body.event="archive.failed" + Event.SESSION_FAILED
+  ARCH-S2  watchdog 非 ARCHIVING state 仍贴 body.event="watchdog.stuck"
+  ARCH-S3  escalate 收到 body.event="archive.failed" → auto_resume + reason="archive-failed"
+  ARCH-S4  escalate 收到 session.failed + issueId 匹配 archive_issue_id → reason="archive-failed"
+  ARCH-S5  escalate 收到 session.failed + issueId 不匹配 → reason 保持 "session-failed"
+  ARCH-S6  archive-failed retry 用完 → escalated + reason="archive-failed-after-2-retries"
+"""
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock
+
+from orchestrator.state import Event, ReqState
+
+
+# ─── Shared fakes (定义独立于 unit test，不复用 unit test 实现) ────────────
+
+
+@dataclass
+class _FakePool:
+    rows: list = field(default_factory=list)
+    executed: list = field(default_factory=list)
+
+    async def fetch(self, sql, *args):
+        return self.rows
+
+    async def execute(self, sql, *args):
+        self.executed.append((sql, args))
+        return None
+
+
+@dataclass
+class _FakeIssue:
+    session_status: str | None = "failed"
+    id: str = "issue-1"
+    project_id: str = "proj-1"
+    issue_number: int = 0
+    title: str = ""
+    status_id: str = "todo"
+    tags: list = field(default_factory=list)
+
+
+def _row(req_id: str, state: str, ctx: dict | None = None, stuck_sec: int = 2000) -> dict:
+    return {
+        "req_id": req_id,
+        "project_id": "proj-1",
+        "state": state,
+        "context": json.dumps(ctx or {}),
+        "stuck_sec": stuck_sec,
+    }
+
+
+def _patch_pool(monkeypatch, pool: _FakePool) -> None:
+    monkeypatch.setattr("orchestrator.watchdog.db.get_pool", lambda: pool)
+
+
+def _patch_bkd_watchdog(monkeypatch, issue: _FakeIssue) -> AsyncMock:
+    fake = AsyncMock()
+    fake.get_issue = AsyncMock(return_value=issue)
+
+    @asynccontextmanager
+    async def _ctx(*a, **kw):
+        yield fake
+
+    monkeypatch.setattr("orchestrator.watchdog.BKDClient", _ctx)
+    return fake
+
+
+def _patch_engine(monkeypatch) -> list[dict]:
+    """捕获 engine.step 调用，包括 body.event（archive.failed 契约的核心断言点）。"""
+    calls: list[dict] = []
+
+    async def fake_step(pool, *, body, req_id, project_id, tags, cur_state, ctx, event, depth=0):
+        calls.append({
+            "req_id": req_id,
+            "project_id": project_id,
+            "cur_state": cur_state,
+            "event": event,
+            "body_event": getattr(body, "event", None),
+            "body_issue": getattr(body, "issueId", None),
+        })
+        return {"action": "escalate", "next_state": "escalated"}
+
+    monkeypatch.setattr("orchestrator.watchdog.engine.step", fake_step)
+    return calls
+
+
+def _patch_artifact(monkeypatch) -> list[dict]:
+    calls: list[dict] = []
+
+    async def fake_insert(pool, req_id, stage, result):
+        calls.append({"req_id": req_id, "stage": stage, "result": result})
+
+    monkeypatch.setattr("orchestrator.watchdog.artifact_checks.insert_check", fake_insert)
+    return calls
+
+
+def _make_bkd_fake() -> AsyncMock:
+    bkd = AsyncMock()
+    bkd.create_issue = AsyncMock(return_value=_FakeIssue(id="new-1"))
+    bkd.update_issue = AsyncMock(return_value=_FakeIssue(id="new-1"))
+    bkd.follow_up_issue = AsyncMock(return_value={})
+    bkd.list_issues = AsyncMock(return_value=[])
+    bkd.get_issue = AsyncMock(return_value=_FakeIssue(id="x", tags=["foo"]))
+    bkd.merge_tags_and_update = AsyncMock(return_value=_FakeIssue(id="x"))
+    return bkd
+
+
+def _patch_bkd_escalate(monkeypatch, fake: AsyncMock) -> None:
+    @asynccontextmanager
+    async def _ctx(*a, **kw):
+        yield fake
+
+    monkeypatch.setattr("orchestrator.actions.escalate.BKDClient", _ctx)
+
+
+def _patch_db_escalate(monkeypatch) -> None:
+    class _Pool:
+        async def execute(self, sql, *args): pass
+        async def fetchrow(self, sql, *args): return None
+
+    monkeypatch.setattr("orchestrator.actions.escalate.db.get_pool", lambda: _Pool())
+
+
+def _make_body(issue_id: str = "src-1", project_id: str = "proj-1", event: str = "session.completed"):
+    return type("Body", (), {
+        "issueId": issue_id,
+        "projectId": project_id,
+        "event": event,
+        "title": "T",
+        "tags": [],
+        "issueNumber": None,
+    })()
+
+
+# ─── ARCH-S1: ARCHIVING 卡死 → body.event="archive.failed" ────────────────
+
+
+async def test_arch_s1_archiving_emits_archive_failed_event(monkeypatch):
+    """
+    ARCH-S1: watchdog._tick() 遇到 state=ARCHIVING + session=failed 时，
+    传给 engine.step 的 body.event 必须是 "archive.failed"（不是 "watchdog.stuck"）。
+    event 参数必须仍是 Event.SESSION_FAILED（复用现有 state machine transition）。
+    """
+    from orchestrator import watchdog
+
+    pool = _FakePool(rows=[
+        _row(
+            "REQ-arch-1",
+            ReqState.ARCHIVING.value,
+            ctx={"archive_issue_id": "arch-1", "intent_issue_id": "intent-1"},
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd_watchdog(monkeypatch, _FakeIssue(session_status="failed", id="arch-1"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result["escalated"] >= 1, "ARCHIVING stuck REQ must be escalated"
+    assert len(step_calls) == 1, f"engine.step must be called exactly once, got {len(step_calls)}"
+
+    call = step_calls[0]
+    assert call["body_event"] == "archive.failed", (
+        f"ARCH-S1 contract: body.event must be 'archive.failed' for ARCHIVING state, "
+        f"got {call['body_event']!r}"
+    )
+    assert call["event"] == Event.SESSION_FAILED, (
+        f"ARCH-S1 contract: state machine event must remain SESSION_FAILED "
+        f"(to reuse existing ARCHIVING self-loop transition), got {call['event']!r}"
+    )
+    assert call["cur_state"] == ReqState.ARCHIVING, (
+        f"cur_state must be ARCHIVING, got {call['cur_state']!r}"
+    )
+
+
+# ─── ARCH-S2: 非 ARCHIVING state 仍贴 watchdog.stuck ──────────────────────
+
+
+async def test_arch_s2_non_archiving_state_keeps_watchdog_stuck(monkeypatch):
+    """
+    ARCH-S2: watchdog 对非 ARCHIVING state（如 STAGING_TEST_RUNNING）触发的 escalate
+    必须仍使用 body.event="watchdog.stuck"（不被 archive 路径污染）。
+    """
+    from orchestrator import watchdog
+
+    pool = _FakePool(rows=[
+        _row(
+            "REQ-st-1",
+            ReqState.STAGING_TEST_RUNNING.value,
+            ctx={"staging_test_issue_id": "st-1", "intent_issue_id": "intent-1"},
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd_watchdog(monkeypatch, _FakeIssue(session_status="failed", id="st-1"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    await watchdog._tick()
+
+    assert len(step_calls) == 1, f"engine.step must be called once, got {len(step_calls)}"
+    call = step_calls[0]
+    assert call["body_event"] == "watchdog.stuck", (
+        f"ARCH-S2 contract: non-ARCHIVING state must keep body.event='watchdog.stuck', "
+        f"got {call['body_event']!r}"
+    )
+
+
+# ─── ARCH-S3: watchdog 路径 archive.failed → reason archive-failed ─────────
+
+
+async def test_arch_s3_watchdog_path_reason_is_archive_failed(monkeypatch):
+    """
+    ARCH-S3: escalate action 收到 body.event="archive.failed" 且 auto_retry_count=0 时，
+    必须 auto-resume（follow_up_issue 一次）并返回 reason="archive-failed"。
+    不得触发 merge_tags_and_update（没真 escalate）。
+    """
+    from orchestrator.actions import escalate as mod
+
+    fake = _make_bkd_fake()
+    _patch_bkd_escalate(monkeypatch, fake)
+    _patch_db_escalate(monkeypatch)
+
+    body = _make_body(issue_id="arch-1", event="archive.failed")
+    out = await mod.escalate(
+        body=body,
+        req_id="REQ-arch-1",
+        tags=["archive"],
+        ctx={"intent_issue_id": "intent-1", "archive_issue_id": "arch-1"},
+    )
+
+    assert out.get("auto_resumed") is True, (
+        f"ARCH-S3 contract: archive.failed on first attempt must auto-resume, got {out!r}"
+    )
+    assert out.get("reason") == "archive-failed", (
+        f"ARCH-S3 contract: reason must be 'archive-failed', got {out.get('reason')!r}"
+    )
+    assert out.get("retry") == 1, (
+        f"ARCH-S3 contract: retry counter must be incremented to 1, got {out.get('retry')!r}"
+    )
+    fake.follow_up_issue.assert_awaited_once()
+    fake.merge_tags_and_update.assert_not_awaited()
+
+
+# ─── ARCH-S4: BKD session.failed + issueId 匹配 archive_issue_id ──────────
+
+
+async def test_arch_s4_session_failed_webhook_archive_issue_match(monkeypatch):
+    """
+    ARCH-S4: escalate 收到 body.event="session.failed" 且 body.issueId 匹配
+    ctx.archive_issue_id 时，reason 必须被 override 为 "archive-failed"。
+    （BKD webhook 路径，watchdog 没机会打 archive.failed 标签）
+    """
+    from orchestrator.actions import escalate as mod
+
+    fake = _make_bkd_fake()
+    _patch_bkd_escalate(monkeypatch, fake)
+    _patch_db_escalate(monkeypatch)
+
+    body = _make_body(issue_id="arch-2", event="session.failed")
+    out = await mod.escalate(
+        body=body,
+        req_id="REQ-arch-2",
+        tags=["archive"],
+        ctx={"intent_issue_id": "intent-1", "archive_issue_id": "arch-2"},
+    )
+
+    assert out.get("auto_resumed") is True, (
+        f"ARCH-S4 contract: archive issue session.failed on first attempt must auto-resume, "
+        f"got {out!r}"
+    )
+    assert out.get("reason") == "archive-failed", (
+        f"ARCH-S4 contract: issueId matching archive_issue_id must override reason to "
+        f"'archive-failed', got {out.get('reason')!r}"
+    )
+    assert out.get("retry") == 1
+
+
+# ─── ARCH-S5: session.failed + issueId 不匹配 → reason 不变 ──────────────
+
+
+async def test_arch_s5_session_failed_non_archive_issue_unaffected(monkeypatch):
+    """
+    ARCH-S5: escalate 收到 body.event="session.failed" 但 body.issueId 与
+    ctx.archive_issue_id 不匹配时，reason 必须保持 "session-failed"。
+    archive override 不得污染无关 session.failed。
+    """
+    from orchestrator.actions import escalate as mod
+
+    fake = _make_bkd_fake()
+    _patch_bkd_escalate(monkeypatch, fake)
+    _patch_db_escalate(monkeypatch)
+
+    body = _make_body(issue_id="dev-1", event="session.failed")
+    out = await mod.escalate(
+        body=body,
+        req_id="REQ-dev-1",
+        tags=["dev"],
+        ctx={"intent_issue_id": "intent-1", "archive_issue_id": "arch-other"},
+    )
+
+    assert out.get("reason") == "session-failed", (
+        f"ARCH-S5 contract: non-matching issueId must keep reason='session-failed', "
+        f"got {out.get('reason')!r}"
+    )
+    assert out.get("reason") != "archive-failed", (
+        "ARCH-S5 contract: archive override must NOT fire when issueId != archive_issue_id"
+    )
+
+
+# ─── ARCH-S6: archive-failed retry 用完 → escalated + after-2-retries ─────
+
+
+async def test_arch_s6_retries_exhausted_final_reason(monkeypatch):
+    """
+    ARCH-S6: escalate 收到 body.event="archive.failed" 且 auto_retry_count=2（已用完）时，
+    必须真 escalate：
+    - 返回 escalated=True
+    - reason = "archive-failed-after-2-retries"
+    - 用 merge_tags_and_update 给 intent issue 加 reason:archive-failed-after-2-retries tag
+    - 不发 follow_up_issue
+    """
+    from orchestrator.actions import escalate as mod
+    from orchestrator import k8s_runner as krunner
+    from orchestrator.store import req_state as rs
+
+    fake = _make_bkd_fake()
+    _patch_bkd_escalate(monkeypatch, fake)
+    _patch_db_escalate(monkeypatch)
+
+    class _Row:
+        state = ReqState.ARCHIVING
+
+    monkeypatch.setattr(rs, "get", AsyncMock(return_value=_Row()))
+    monkeypatch.setattr(rs, "cas_transition", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        krunner,
+        "get_controller",
+        lambda: type("Ctrl", (), {"cleanup_runner": AsyncMock()})(),
+    )
+
+    body = _make_body(issue_id="arch-1", event="archive.failed")
+    out = await mod.escalate(
+        body=body,
+        req_id="REQ-arch-1",
+        tags=["archive"],
+        ctx={
+            "intent_issue_id": "intent-1",
+            "archive_issue_id": "arch-1",
+            "auto_retry_count": 2,
+        },
+    )
+
+    assert out.get("escalated") is True, (
+        f"ARCH-S6 contract: retries exhausted must set escalated=True, got {out!r}"
+    )
+    assert out.get("reason") == "archive-failed-after-2-retries", (
+        f"ARCH-S6 contract: final reason must be 'archive-failed-after-2-retries', "
+        f"got {out.get('reason')!r}"
+    )
+    fake.merge_tags_and_update.assert_awaited_once()
+    fake.follow_up_issue.assert_not_awaited()
+
+    # verify the tag was passed to merge_tags_and_update
+    tag_arg = str(fake.merge_tags_and_update.await_args_list)
+    assert "archive-failed-after-2-retries" in tag_arg, (
+        f"ARCH-S6 contract: intent issue must be tagged with reason:archive-failed-after-2-retries, "
+        f"merge_tags_and_update args: {tag_arg!r}"
+    )

--- a/orchestrator/tests/test_contract_archive_failure.py
+++ b/orchestrator/tests/test_contract_archive_failure.py
@@ -20,7 +20,6 @@ from unittest.mock import AsyncMock
 
 from orchestrator.state import Event, ReqState
 
-
 # ─── Shared fakes (定义独立于 unit test，不复用 unit test 实现) ────────────
 
 
@@ -329,8 +328,8 @@ async def test_arch_s6_retries_exhausted_final_reason(monkeypatch):
     - 用 merge_tags_and_update 给 intent issue 加 reason:archive-failed-after-2-retries tag
     - 不发 follow_up_issue
     """
-    from orchestrator.actions import escalate as mod
     from orchestrator import k8s_runner as krunner
+    from orchestrator.actions import escalate as mod
     from orchestrator.store import req_state as rs
 
     fake = _make_bkd_fake()

--- a/orchestrator/tests/test_watchdog.py
+++ b/orchestrator/tests/test_watchdog.py
@@ -79,6 +79,7 @@ def _patch_engine(monkeypatch):
             "event": event,
             "body_issue": getattr(body, "issueId", None),
             "body_proj": getattr(body, "projectId", None),
+            "body_event": getattr(body, "event", None),
         })
         return {"action": "escalate", "next_state": "escalated"}
 
@@ -256,6 +257,51 @@ async def test_loop_disabled_returns_immediately(monkeypatch):
     monkeypatch.setattr("orchestrator.watchdog.settings.watchdog_enabled", False)
     # 无需 mock _tick / asyncio.sleep — 直接 return 不进 while
     await watchdog.run_loop()   # 不应 hang
+
+
+# ─── Case ARCHIVING：state==ARCHIVING + session=failed → body.event="archive.failed" ─
+@pytest.mark.asyncio
+async def test_archiving_stuck_uses_archive_failed_synthetic_event(monkeypatch):
+    """REQ-archive-failure-watchdog: ARCHIVING 卡死时 watchdog 贴 body.event='archive.failed'，
+    让 escalate 把 reason 标成 'archive-failed' 而不是通用 'watchdog-stuck'，
+    M7 04-fail-kind-distribution dashboard 才能区分 done-archive 阶段崩溃 vs 通用卡死。"""
+    pool = FakePool(rows=[
+        _row("REQ-arch-1", ReqState.ARCHIVING.value,
+             ctx={"archive_issue_id": "arch-1", "intent_issue_id": "intent-1"}),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, FakeIssue(session_status="failed", id="arch-1"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    assert len(step_calls) == 1
+    assert step_calls[0]["cur_state"] == ReqState.ARCHIVING
+    assert step_calls[0]["event"] == Event.SESSION_FAILED
+    # 关键：贴的是 archive 专属 synthetic event（不是通用 watchdog.stuck）
+    assert step_calls[0]["body_event"] == "archive.failed"
+    assert step_calls[0]["body_issue"] == "arch-1"
+
+
+# ─── Case 非 ARCHIVING 仍用通用 watchdog.stuck（确保我们没误改其他 state）─────
+@pytest.mark.asyncio
+async def test_non_archiving_keeps_generic_watchdog_stuck_event(monkeypatch):
+    """STAGING_TEST_RUNNING 等非 ARCHIVING state 仍贴 body.event='watchdog.stuck'。
+    确保 archive 细分逻辑没污染其他 state。"""
+    pool = FakePool(rows=[
+        _row("REQ-st-1", ReqState.STAGING_TEST_RUNNING.value,
+             ctx={"staging_test_issue_id": "st-1"}),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, FakeIssue(session_status="failed", id="st-1"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    await watchdog._tick()
+
+    assert step_calls[0]["body_event"] == "watchdog.stuck"
 
 
 # ─── Case 9：engine.step 抛异常不阻塞后续 row ─────────────────────────────


### PR DESCRIPTION
REQ-archive-failure-watchdog-1777084279

## Summary

- Watchdog 在 ARCHIVING state 卡死时贴 `body.event="archive.failed"` 替代通用 `"watchdog.stuck"`，escalate.py 把它当 canonical signal slug 化为 `reason="archive-failed"`
- BKD 真发的 `session.failed` webhook 时，若 `body.issueId == ctx.archive_issue_id` 也覆盖 reason 为 `"archive-failed"`，两条路径汇到同一桶
- retry 用完时 final reason 升级为 `"archive-failed-after-2-retries"`（区别于通用 `"session-failed-after-2-retries"`）
- M7 04-fail-kind-distribution 因此能独立统计 done-archive 阶段崩溃，跟通用 watchdog-stuck / session-failed 区分（dashboard SQL 不需改）

## 不动的

- `state.py` —— 复用 `Event.SESSION_FAILED` + `(ARCHIVING, SESSION_FAILED)` self-loop transition
- 其他 state 的 watchdog 行为（仍 `body.event="watchdog.stuck"`，`reason="watchdog-stuck"`）
- auto-resume 策略（archive-failed 仍 transient，给 2 次 follow-up "continue"）
- runner cleanup 路径（`is_session_failed_path` 现在用 `_CANONICAL_SIGNALS` 集合，自动包含 archive.failed）

## Test plan

- [x] `uv run pytest`：393/393 通过（含 4 条新增 escalate case + 2 条新增 watchdog case）
- [x] `uv run ruff check src/ tests/`：lint clean
- [x] `openspec validate REQ-archive-failure-watchdog-1777084279 --strict`：valid
- [x] `scripts/check-scenario-refs.sh`：12 scenarios 引用都解析成功

## Spec

- `openspec/changes/REQ-archive-failure-watchdog-1777084279/`
  - `proposal.md` — 问题 + 方案 + 取舍
  - `specs/archive-failure/spec.md` — 2 requirements / 6 scenarios (ARCH-S1..S6)
  - `specs/archive-failure/contract.spec.yaml` — 模块 / 行为契约

🤖 Generated with [Claude Code](https://claude.com/claude-code)