### PR TITLE
fix(pr_ci_watch): emit PR_CI_TIMEOUT (not PR_CI_FAIL) on config error

### DIFF
--- a/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
@@ -55,9 +55,10 @@ async def _run_checker(*, req_id: str, ctx: dict) -> dict:
             repos=repos,
         )
     except ValueError as e:
+        # Config error → ESCALATED directly (PR_CI_TIMEOUT), not verifier (PR_CI_FAIL).
         log.error("create_pr_ci_watch.config_error", req_id=req_id, error=str(e))
         return {
-            "emit": Event.PR_CI_FAIL.value,
+            "emit": Event.PR_CI_TIMEOUT.value,
             "reason": f"config error: {e}"[:200],
             "exit_code": -1,
         }


### PR DESCRIPTION
## Summary
- `create_pr_ci_watch._run_checker` previously caught `ValueError` from the checker (raised when no repos are provided / no open PR found for the branch yet) and emitted `Event.PR_CI_FAIL`, which transitions the REQ to `REVIEW_RUNNING` and spawns a verifier session.
- Verifier can only re-derive "this is infra/config, escalate" — wasted agent cost and noise on the dashboard.
- Switching to `Event.PR_CI_TIMEOUT` transitions `PR_CI_RUNNING → ESCALATED` directly via the existing `escalate` action, parking the REQ with the explicit `config error: …` reason.

## Why this came up
`REQ-escalate-reason-audit-1777084279` (verifier issue `9p5rzuc7`) was itself tripped by exactly this bug: the REQ ran without `SISYPHUS_BUSINESS_REPO` env / `involved_repos` ctx, so the checker raised `ValueError`, the action emitted `PR_CI_FAIL`, and a verifier was spun up only to escalate. PR #69 (`REQ-fixer-round-cap`) hit a related but separate failure mode (GHA never fired → check-runs=0 → verifier).

## Test plan
- [x] Existing state-machine tests in `test_state.py` still cover `PR_CI_RUNNING + PR_CI_TIMEOUT → ESCALATED`.
- [ ] No new unit test added — the change is a 1-line emit constant, exercised by the same paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)