### PR TITLE
feat(pr_ci_watch): discover involved_repos from runner /workspace/source/*

### DIFF
--- a/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
@@ -5,13 +5,19 @@ feature flag checker_pr_ci_watch_enabled:
   False（默认）: 创建 BKD agent issue（老路，agent 用 gh CLI 轮询，报 tag）
   True: sisyphus 自己调 GitHub REST API 轮询 check-runs，emit PR_CI_PASS/FAIL/TIMEOUT
 
-M15：repo 从环境变量 SISYPHUS_BUSINESS_REPO 拿，branch 从 ctx 或默认 feat/{req_id}。
-不再读 manifest。
+repo 列表来源（M15 哲学：runner 是真理，不维护额外 metadata）：
+  1. runner pod `/workspace/source/*/` discovery（analyze-agent 已 clone 好，跟其它
+     checker 走同一条契约 —— staging_test / dev_cross_check 都遍历这个目录）
+  2. ctx.intake_finalized_intent.involved_repos（intake 阶段 runner 还没起来时的预声明）
+  3. SISYPHUS_BUSINESS_REPO env（M15 manifest 残骸，老单仓 REQ 兼容，建议下线）
 """
 from __future__ import annotations
 
+import re
+
 import structlog
 
+from .. import k8s_runner
 from ..bkd import BKDClient
 from ..checkers import pr_ci_watch as checker
 from ..config import settings
@@ -22,6 +28,9 @@ from . import register, short_title
 from ._skip import skip_if_enabled
 
 log = structlog.get_logger(__name__)
+
+# git@github.com:owner/repo(.git) 或 https://github.com/owner/repo(.git)
+_REMOTE_RE = re.compile(r"github\.com[:/]([^/]+/[^/.]+?)(?:\.git)?$")
 
 
 @register("create_pr_ci_watch", idempotent=False)
@@ -37,14 +46,39 @@ async def create_pr_ci_watch(*, body, req_id, tags, ctx):
 
 # ── 新路：sisyphus 自检 ────────────────────────────────────────────────────
 
+async def _discover_repos_from_runner(req_id: str) -> list[str]:
+    """ls /workspace/source/*/ + git remote → ['owner/repo', ...]，失败返 []。"""
+    cmd = (
+        "for d in /workspace/source/*/; do "
+        "  [ -d \"$d/.git\" ] && git -C \"$d\" remote get-url origin 2>/dev/null; "
+        "done"
+    )
+    try:
+        rc = k8s_runner.get_controller()
+        result = await rc.exec_in_runner(req_id, cmd, timeout_sec=30)
+    except Exception as e:
+        log.warning("create_pr_ci_watch.runner_discovery_failed",
+                    req_id=req_id, error=str(e))
+        return []
+
+    repos: list[str] = []
+    for line in result.stdout.splitlines():
+        m = _REMOTE_RE.search(line.strip())
+        if m:
+            repos.append(m.group(1))
+    log.info("create_pr_ci_watch.runner_discovered", req_id=req_id, repos=repos)
+    return repos
+
+
 async def _run_checker(*, req_id: str, ctx: dict) -> dict:
     log.info("create_pr_ci_watch.checker_path", req_id=req_id)
     branch = ctx.get("branch") or f"feat/{req_id}"
 
-    # per-REQ involved_repos 优先（intake-agent 写的 finalized intent 里有），
-    # checker fallback 到全局 SISYPHUS_BUSINESS_REPO 兼容老 REQ
-    finalized = ctx.get("intake_finalized_intent") or {}
-    repos = finalized.get("involved_repos") or ctx.get("involved_repos")
+    # repo 来源优先级：runner 文件系统（M15 真理）> intake finalized > env fallback
+    repos = await _discover_repos_from_runner(req_id)
+    if not repos:
+        finalized = ctx.get("intake_finalized_intent") or {}
+        repos = finalized.get("involved_repos") or ctx.get("involved_repos")
 
     try:
         result = await checker.watch_pr_ci(

--- a/orchestrator/tests/test_actions_create_pr_ci_watch.py
+++ b/orchestrator/tests/test_actions_create_pr_ci_watch.py
@@ -1,0 +1,82 @@
+"""actions/create_pr_ci_watch.py：runner discovery 单测。
+
+不测 watch_pr_ci 主体（在 test_checkers_pr_ci_watch.py），只测 _discover_repos_from_runner
+对 runner stdout 的解析 + 失败兜底。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock
+
+import pytest
+
+from orchestrator.actions import create_pr_ci_watch as action
+
+
+@dataclass
+class FakeExec:
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
+
+
+def _patch_controller(monkeypatch, fake_exec: AsyncMock) -> None:
+    class FakeRC:
+        def __init__(self, exec_fn):
+            self.exec_in_runner = exec_fn
+
+    monkeypatch.setattr(
+        "orchestrator.actions.create_pr_ci_watch.k8s_runner.get_controller",
+        lambda: FakeRC(fake_exec),
+    )
+
+
+@pytest.mark.asyncio
+async def test_discover_repos_parses_ssh_and_https(monkeypatch):
+    stdout = "\n".join([
+        "git@github.com:phona/sisyphus.git",
+        "https://github.com/ZonEaseTech/ttpos-server-go.git",
+        "https://github.com/phona/ttpos-flutter",
+    ])
+    exec_fn = AsyncMock(return_value=FakeExec(stdout=stdout))
+    _patch_controller(monkeypatch, exec_fn)
+
+    repos = await action._discover_repos_from_runner("REQ-x")
+    assert repos == [
+        "phona/sisyphus",
+        "ZonEaseTech/ttpos-server-go",
+        "phona/ttpos-flutter",
+    ]
+    exec_fn.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_discover_repos_returns_empty_on_exec_error(monkeypatch):
+    exec_fn = AsyncMock(side_effect=RuntimeError("pod not found"))
+    _patch_controller(monkeypatch, exec_fn)
+
+    repos = await action._discover_repos_from_runner("REQ-x")
+    assert repos == []
+
+
+@pytest.mark.asyncio
+async def test_discover_repos_skips_non_github_remotes(monkeypatch):
+    stdout = "\n".join([
+        "git@gitlab.com:foo/bar.git",
+        "git@github.com:phona/sisyphus.git",
+        "ssh://gerrit.example.com/team/proj",
+    ])
+    exec_fn = AsyncMock(return_value=FakeExec(stdout=stdout))
+    _patch_controller(monkeypatch, exec_fn)
+
+    repos = await action._discover_repos_from_runner("REQ-x")
+    assert repos == ["phona/sisyphus"]
+
+
+@pytest.mark.asyncio
+async def test_discover_repos_empty_stdout(monkeypatch):
+    exec_fn = AsyncMock(return_value=FakeExec(stdout=""))
+    _patch_controller(monkeypatch, exec_fn)
+
+    repos = await action._discover_repos_from_runner("REQ-x")
+    assert repos == []


### PR DESCRIPTION
## Summary
- pr_ci_watch was the only checker still pulling repo list from `SISYPHUS_BUSINESS_REPO` env / `ctx.involved_repos`. Every other checker (`staging_test`, `dev_cross_check`, `done_archive`) already obeys the M15 contract — `/workspace/source/*/` in the runner pod is the source of truth.
- Added `_discover_repos_from_runner(req_id)` that does one `kubectl exec` round-trip to `ls /workspace/source/*/` + `git remote get-url origin`, then parses `owner/repo` via regex matching both `git@github.com:owner/repo.git` and `https://github.com/owner/repo` shapes.
- Repo lookup chain: **runner discovery** → ctx.intake_finalized_intent.involved_repos → ctx.involved_repos → `SISYPHUS_BUSINESS_REPO` env. Last two are kept only as fallback for runner-down / pre-clone edge cases.

## Why
`REQ-escalate-reason-audit-1777084279` (verifier issue `9p5rzuc7`) hit a `ValueError` from `watch_pr_ci` because neither `SISYPHUS_BUSINESS_REPO` nor `involved_repos` was set, even though `runner-req-escalate-reason-audit-1777084279` had `/workspace/source/sisyphus/` cloned. Tying repo discovery to the runner removes that whole class of "data lives in the runner but checker can't see it" failures.

Sister PR #72 makes config errors emit `PR_CI_TIMEOUT` (escalate cleanly) instead of `PR_CI_FAIL` (spin up verifier) — independent fix for the rare case discovery still yields nothing.

## Test plan
- [x] `tests/test_actions_create_pr_ci_watch.py` covers SSH/HTTPS parsing, exec failure → empty list, non-github remotes filtered, empty stdout.
- [x] `pytest tests/test_actions_create_pr_ci_watch.py tests/test_checkers_pr_ci_watch.py tests/test_actions_smoke.py tests/test_engine.py tests/test_state.py` → 104 passed.
- [x] `ruff check` clean on changed files.
- [ ] Live verify after deploy: pick a REQ that previously needed env var, confirm `create_pr_ci_watch.runner_discovered` log line shows the right repo list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)