### PR TITLE
fix(pr_ci_watch): treat all-green-but-no-GHA check-runs as fail (REQ-pr-ci-no-gha)

### DIFF
--- a/openspec/changes/REQ-pr-ci-no-gha-1777105576/proposal.md
+++ b/openspec/changes/REQ-pr-ci-no-gha-1777105576/proposal.md
@@ -1,0 +1,48 @@
+# REQ-pr-ci-no-gha-1777105576: fix(pr_ci_watch): treat all-green-but-no-GHA check-runs as fail
+
+## 问题
+
+`pr_ci_watch._classify` 把"全 completed + 全绿"无条件判 `pass`，**不检查这些
+check-run 是否真的来自 GitHub Actions**。当 PR 目标分支不在源仓 `ci.yml` 触发
+列表（force-push 落到非 `main` 分支 / workflow 被禁 / GHA webhook miss 整套）时，
+GHA 一次没跑；GitHub 上只剩 `claude-review` 这种 review-only bot 报 success，
+旧实现把它当全绿 pass —— sisyphus 直接推进到 accept 阶段，原 bug 还在。
+
+真实事故（REQ-acceptance-e2e-1777084500，2026-04-25 03:32）：dev-fixer push 后
+PR #205 上只有 `app.slug == "anthropic-claude"` 的 `claude-review` check-run 报
+success；pr_ci_watch 返 PR_CI_PASS；verifier-agent 二次审才 catch 到"GHA 一次
+没跑"，主观判 escalate。**机械层应该自己识别这种假阳性 pass，不让 verifier 兜底**。
+
+## 方案
+
+`pr_ci_watch._classify` 增加 `no-gha` verdict：全绿但 0 条 GHA check-run → 不当 pass。
+
+GHA 识别规则：check-run 的 `app.slug == "github-actions"`。GitHub REST 文档约定
+`/repos/{repo}/commits/{sha}/check-runs` 返回的每条 run 含 `app.slug` 标识哪个
+GitHub App 跑的；GHA workflow 产的 check-run 这个字段恒为 `"github-actions"`。
+
+`watch_pr_ci` 主循环把 `no-gha` 与 `fail` 同等对待 → 返 `passed=False, exit_code=1`，
+`stdout_tail` 形如 `<repo>: no-gha-checks-ran (only non-CI signals: <name>=<conclusion> ...)`，
+让 verifier / 人工审一眼能看出"GHA 没跑"。
+
+边界：
+- 有任一 pending check-run → 仍判 `pending`（GHA workflow 可能刚要起，给它机会）
+- 混合 GHA + review-only 且全绿 → `pass`（review bot 不污染正常 CI 通过判定）
+- check-run 缺 `app` 字段 → 保守当非 GHA（未知来源不能撑 pass）
+- 空 runs（PR 刚开 0 条 check-run）→ 仍判 `pending`（与原行为一致，给 GHA 上车机会，
+  最终超时走 124）
+
+## 范围
+
+只改 `orchestrator/src/orchestrator/checkers/pr_ci_watch.py` 及其测试。
+不改状态机 / 事件 / DB schema / verifier prompt。pr_ci verifier 收到
+`PR_CI_FAIL` reason `no-gha-checks-ran` 走原来的失败决策路径即可。
+
+## 不做
+
+- 不在 prod 把 `_GHA_APP_SLUG` 设成可配置 —— 整个 sisyphus 流水线契约就锁死
+  GHA，没必要把"什么算 CI"做成开关。
+- 不改 verifier prompt —— 现有 `verifier/pr_ci_fail.md.j2` 已经能基于 stdout_tail
+  做决策；新增 `no-gha-checks-ran` reason 是字符串自描述，verifier 读得懂。
+- 不动 SHA flip / merge / closed 已有 terminal 路径 —— 它们和 `_classify` 是
+  正交两套判决，互不影响。

--- a/openspec/changes/REQ-pr-ci-no-gha-1777105576/specs/pr-ci-no-gha/spec.md
+++ b/openspec/changes/REQ-pr-ci-no-gha-1777105576/specs/pr-ci-no-gha/spec.md
@@ -1,0 +1,53 @@
+# Spec delta — pr-ci-no-gha
+
+## ADDED Requirements
+
+### Requirement: pr_ci_watch SHALL fail when all check-runs are green but none come from GitHub Actions
+
+The system SHALL classify the verdict for a PR as `no-gha` when **all** check-runs are
+`status="completed"` with conclusion in the success set (`success` / `neutral` / `skipped`)
+**and** none of those runs have `app.slug == "github-actions"`. The `watch_pr_ci` polling
+loop MUST treat a `no-gha` verdict as a failure for that repo: it MUST return a
+`CheckResult` with `passed=False`, `exit_code=1`, and a `stdout_tail` segment of the form
+`<repo>: no-gha-checks-ran (only non-CI signals: <name>=<conclusion> ...)` enumerating
+the actual non-GHA check-runs observed (so the verifier-agent and humans can see exactly
+which review-only signals reported success).
+
+A check-run that lacks an `app` field, or whose `app.slug` is anything other than
+`"github-actions"`, MUST NOT count toward the "GHA produced a check-run" condition. This
+keeps third-party review bots (e.g. `claude-review` from `anthropic-claude`,
+Codecov, etc.) from masquerading as a real CI green.
+
+#### Scenario: PRCINOGHA-S1 全绿但只有 review-only check-run → no-gha 判 fail
+
+- **GIVEN** PR head SHA 上只有一条 `app.slug="anthropic-claude"` 的 `claude-review` check-run，conclusion=`success`
+- **WHEN** `_classify` 评估这批 runs
+- **THEN** 返 `no-gha`；`watch_pr_ci` 返 `passed=False, exit_code=1`，`stdout_tail` 包含 `no-gha-checks-ran` 和实际 check-run 名 `claude-review`
+
+#### Scenario: PRCINOGHA-S2 至少一条 GHA + review-only 全绿 → pass
+
+- **GIVEN** PR head SHA 上有 `app.slug="github-actions"` 的 `lint` 报 success **以及** `app.slug="anthropic-claude"` 的 `claude-review` 报 success
+- **WHEN** `_classify` 评估这批 runs
+- **THEN** 返 `pass`（review bot 不污染正常 CI 通过判定）
+
+#### Scenario: PRCINOGHA-S3 check-run 缺 app 字段 → 保守按非 GHA
+
+- **GIVEN** PR head SHA 上一条 check-run 缺 `app` 字段（仅 `name/status/conclusion`），conclusion=`success`
+- **WHEN** `_classify` 评估这批 runs
+- **THEN** 返 `no-gha`（未知来源不能撑 pass）
+
+### Requirement: pending check-runs SHALL override no-gha so GHA workflows can still arrive
+
+The system SHALL prefer `pending` over `no-gha` whenever any check-run is not yet `completed` (`status="in_progress"` / `"queued"`), even if zero GHA check-runs have been observed so far — the GHA workflow may still arrive (webhook propagation delay, `workflow_run` queued behind another commit). Only after **every** check-run is completed and **none** is from GitHub Actions does `_classify` commit to a `no-gha` verdict. The empty-runs case (`runs == []`) MUST continue to return `pending` (existing behavior — GHA hasn't even reported a queued run yet) and MUST NOT be promoted to `no-gha`; the polling loop's existing `exit_code=124` timeout remains the safety net for "GHA never showed up at all."
+
+#### Scenario: PRCINOGHA-S4 有 pending check-run → 不下断 no-gha
+
+- **GIVEN** PR head SHA 上一条 review-only check-run 已 completed=success，**另一条** review-only check-run 仍 `status="in_progress"`
+- **WHEN** `_classify` 评估这批 runs
+- **THEN** 返 `pending`（不当下断 no-gha；继续等 GHA workflow 上车）
+
+#### Scenario: PRCINOGHA-S5 0 条 check-run → 仍判 pending（不变）
+
+- **GIVEN** PR head SHA 的 check-runs 列表为空 `[]`
+- **WHEN** `_classify` 评估
+- **THEN** 返 `pending`（与改动前行为一致，等 GHA 触发；最终超时走 exit_code=124）

--- a/openspec/changes/REQ-pr-ci-no-gha-1777105576/tasks.md
+++ b/openspec/changes/REQ-pr-ci-no-gha-1777105576/tasks.md
@@ -1,0 +1,28 @@
+# Tasks for REQ-pr-ci-no-gha-1777105576
+
+## Stage: contract / spec
+
+- [x] author specs/pr-ci-no-gha/spec.md —— `no-gha` verdict 定义、GHA 识别规则、与 pending/fail 的优先级、`stdout_tail` 格式
+
+## Stage: implementation
+
+- [x] `pr_ci_watch.py`：新增模块常量 `_GHA_APP_SLUG = "github-actions"`
+- [x] `_classify`：返回值新增 `'no-gha'`；遍历 runs 时跟踪 `has_gha`；全绿无 pending 时若 `has_gha=False` 返 `'no-gha'`，否则原 `'pass'`
+- [x] `_classify`：`has_pending` 仍优先于 `no-gha`（pending 等 GHA 上车）
+- [x] `_classify`：缺 `app` 字段保守按非 GHA 处理（不能撑 pass）
+- [x] `watch_pr_ci`：把 `no-gha` 与 `fail` 同等当失败，构造 `stdout_tail` 形如 `<repo>: no-gha-checks-ran (only non-CI signals: ...)` 暴露实际跑了啥
+
+## Stage: unit test
+
+- [x] `test_classify_all_green_but_only_review_only_check_run_is_no_gha` —— 全绿但只有 `anthropic-claude` review bot → `no-gha`
+- [x] `test_classify_mixed_gha_plus_review_is_pass` —— 一条 GHA + 一条 review-only 全绿 → `pass`
+- [x] `test_classify_pending_overrides_no_gha` —— 有 pending 不当下断 `no-gha`
+- [x] `test_classify_check_run_missing_app_field_treated_as_non_gha` —— 缺 `app` 字段全绿 → `no-gha`
+- [x] `test_watch_pr_ci_review_only_check_runs_treated_as_fail` —— 端到端：PR 只有 claude-review → `passed=False, exit_code=1, stdout_tail` 含 `no-gha-checks-ran`
+- [x] 更新现有 `_run` fixture 默认 `app.slug="github-actions"` 兼容老测试
+- [x] 更新 `test_contract_pr_ci_watch_sha_refresh.py` 的 `_pending_cr` / `_success_cr` 给 check-run 加上 `"app": {"slug": "github-actions"}`
+
+## Stage: PR
+
+- [x] git push feat/REQ-pr-ci-no-gha-1777105576
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/checkers/pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/checkers/pr_ci_watch.py
@@ -53,6 +53,12 @@ _MAX_SHA_FLIPS = 5
 _PASS_CONCLUSIONS = {"success", "neutral", "skipped"}
 _FAIL_CONCLUSIONS = {"failure", "cancelled", "timed_out", "action_required", "stale"}
 
+# sisyphus 契约：业务 PR 必须由 GitHub Actions 跑 lint/unit/integration。
+# check-run 的 app.slug == "github-actions" 表示该 check 由 GHA workflow 产生；
+# 别的 slug（如 "anthropic-claude" / 第三方 review bot）属于 review-only signal。
+# 用于检测假阳性 pass：全绿但全是 review-only check-run（GHA 一次没跑）。
+_GHA_APP_SLUG = "github-actions"
+
 
 @dataclass
 class _RepoState:
@@ -225,13 +231,22 @@ async def watch_pr_ci(
                      run_counts={s.repo: len(per_repo_runs.get(s.repo, [])) for s in states},
                      sha_flips={s.repo: s.flip_count for s in states if s.flip_count > 0})
 
-            if any(v == "fail" for v in verdicts.values()):
+            if any(v in ("fail", "no-gha") for v in verdicts.values()):
                 parts = []
                 for state in states:
-                    if verdicts[state.repo] != "fail":
+                    v = verdicts[state.repo]
+                    if v not in ("fail", "no-gha"):
                         continue
                     if state.terminal_verdict == "fail":
                         parts.append(f"{state.repo}: {state.terminal_reason}")
+                    elif v == "no-gha":
+                        # 全绿但 0 条 GHA check-run —— 列出实际跑了啥（露出 review-only bot
+                        # 的真身），给 verifier / 人工审一眼能看出"GHA 没跑"。
+                        runs = per_repo_runs.get(state.repo, [])
+                        parts.append(
+                            f"{state.repo}: no-gha-checks-ran "
+                            f"(only non-CI signals: {_summarize(runs)})"
+                        )
                     else:
                         runs = per_repo_runs.get(state.repo, [])
                         parts.append(f"{state.repo}: {_summarize(runs, failed_only=True)}")
@@ -310,19 +325,28 @@ async def _get_check_runs(client: httpx.AsyncClient, repo: str, sha: str) -> lis
 # ── verdict 计算 ─────────────────────────────────────────────────────────
 
 def _classify(runs: list[dict]) -> str:
-    """返 'pass' / 'fail' / 'pending'。
+    """返 'pass' / 'fail' / 'pending' / 'no-gha'。
 
     - 任一 completed 且 conclusion 红 → fail（fail 优先：早死早超生）
     - 任一未 completed → pending
-    - 全 completed 且 conclusion 全绿 → pass
+    - 全 completed 且 conclusion 全绿 + 至少一条 GHA check-run → pass
+    - 全 completed 且 conclusion 全绿 但 0 条 GHA check-run → no-gha（假阳性 pass）
     - 空 → pending（PR 刚开 GHA 没触发，先等）
+
+    no-gha 触发场景：PR 目标分支不在源仓 ci.yml 触发列表 / workflow 被禁 /
+    GHA webhook miss 整套，导致 lint/unit/integration 一次都没跑；只剩
+    claude-review 这种 review-only bot 报绿。verifier-agent 之前是兜底人肉 catch
+    （REQ-acceptance-e2e-1777084500），机械层应自己识别。
     """
     if not runs:
         return "pending"
 
     has_fail = False
     has_pending = False
+    has_gha = False
     for r in runs:
+        if (r.get("app") or {}).get("slug") == _GHA_APP_SLUG:
+            has_gha = True
         if r.get("status") != "completed":
             has_pending = True
             continue
@@ -332,7 +356,10 @@ def _classify(runs: list[dict]) -> str:
     if has_fail:
         return "fail"
     if has_pending:
+        # 还有 pending 就继续等 —— GHA workflow 可能刚要起；不当下断 no-gha
         return "pending"
+    if not has_gha:
+        return "no-gha"
     return "pass"
 
 

--- a/orchestrator/tests/test_checkers_pr_ci_watch.py
+++ b/orchestrator/tests/test_checkers_pr_ci_watch.py
@@ -22,8 +22,21 @@ def _runs_payload(*runs: dict) -> dict:
     return {"total_count": len(runs), "check_runs": list(runs)}
 
 
-def _run(name: str, status: str = "completed", conclusion: str | None = "success") -> dict:
-    return {"name": name, "status": status, "conclusion": conclusion}
+def _run(
+    name: str,
+    status: str = "completed",
+    conclusion: str | None = "success",
+    app_slug: str = "github-actions",
+) -> dict:
+    """Default app.slug=github-actions matches sisyphus's PR-CI-watch contract
+    (CI = GHA workflows). Pass app_slug="anthropic-claude" / etc. to simulate
+    review-only check-runs that should NOT count as CI success."""
+    return {
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "app": {"slug": app_slug},
+    }
 
 
 def patch_pr_lookup(monkeypatch, *, repo: str = "phona/ubox-crosser", pr_number: int | None = 42):
@@ -521,3 +534,67 @@ def test_classify_pending_when_any_in_progress():
 def test_classify_recognizes_all_fail_conclusions():
     for c in ["failure", "cancelled", "timed_out", "action_required", "stale"]:
         assert pr_ci_watch._classify([_run("x", conclusion=c)]) == "fail", c
+
+
+# ── no-gha 防假阳性 pass（REQ-acceptance-e2e-1777084500 真实事故）─────────
+
+
+def test_classify_all_green_but_only_review_only_check_run_is_no_gha():
+    """全绿但 0 条 GHA app check-run → no-gha（假阳性 pass，应判 fail）。
+
+    REQ-acceptance-e2e-1777084500 真实事故重现：PR 目标分支不在 ci.yml 触发
+    列表，GHA 整套没跑；claude-review 这种 review-only bot 报 success；旧实现
+    把它当全绿 pass，sisyphus 推进到 accept 才被 verifier 人肉 catch。
+    """
+    assert pr_ci_watch._classify([
+        _run("claude-review", app_slug="anthropic-claude"),
+    ]) == "no-gha"
+
+
+def test_classify_mixed_gha_plus_review_is_pass():
+    """有任何 GHA check-run + 全绿 → pass（review bot 不污染正常 CI 跑过的判定）。"""
+    assert pr_ci_watch._classify([
+        _run("lint"),                                            # GHA
+        _run("claude-review", app_slug="anthropic-claude"),      # review-only
+    ]) == "pass"
+
+
+def test_classify_pending_overrides_no_gha():
+    """还有 pending 就别急着断 no-gha —— GHA workflow 可能刚要起。"""
+    assert pr_ci_watch._classify([
+        _run("claude-review", app_slug="anthropic-claude"),
+        _run("setup", status="in_progress", conclusion=None,
+             app_slug="anthropic-claude"),
+    ]) == "pending"
+
+
+def test_classify_check_run_missing_app_field_treated_as_non_gha():
+    """check-run 没 app 字段 → 当 review-only / 未知来源处理（保守不当 GHA）。"""
+    assert pr_ci_watch._classify([
+        {"name": "weird", "status": "completed", "conclusion": "success"},
+    ]) == "no-gha"
+
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_review_only_check_runs_treated_as_fail(
+    httpx_mock, monkeypatch,
+):
+    """端到端：PR 只有 claude-review 报绿 → checker 返 passed=False reason=no-gha。"""
+    monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+    patch_pr_lookup(monkeypatch)
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/commits/"
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/check-runs?per_page=100",
+        json=_runs_payload(_run("claude-review", app_slug="anthropic-claude")),
+    )
+
+    result = await pr_ci_watch.watch_pr_ci(
+        "REQ-9", "feat/REQ-9", poll_interval_sec=1, timeout_sec=60,
+    )
+
+    assert result.passed is False
+    assert result.exit_code == 1
+    assert "no-gha-checks-ran" in result.stdout_tail
+    # 露出实际跑了啥（review-only bot 真身），便于人工 / verifier 一眼判
+    assert "claude-review" in result.stdout_tail

--- a/orchestrator/tests/test_contract_pr_ci_no_gha.py
+++ b/orchestrator/tests/test_contract_pr_ci_no_gha.py
@@ -1,0 +1,234 @@
+"""Contract tests: pr_ci_watch no-GHA verdict (PRCINOGHA-S1 ~ S5).
+
+Black-box challenger. Mock boundaries:
+  • orchestrator.checkers.pr_ci_watch._get_pr_info  ← spec-named boundary
+  • httpx check-runs responses via pytest-httpx      ← external GitHub API boundary
+
+REQ-pr-ci-no-gha-1777105576
+"""
+from __future__ import annotations
+
+import re
+from unittest.mock import patch
+
+from orchestrator.checkers import pr_ci_watch as checker
+from orchestrator.checkers._types import CheckResult
+
+_MODULE = "orchestrator.checkers.pr_ci_watch"
+REPO = "phona/sisyphus"
+BRANCH = "feat/REQ-prcinogha-contract"
+REQ = "REQ-prcinogha-contract-test"
+
+SHA_A = "aaa111bbb222"
+
+FAST_POLL = 0.01
+FAST_TIMEOUT = 30.0
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+def _open(sha: str):
+    return (1, sha, "open")
+
+
+def _merged(sha: str):
+    return (1, sha, "merged")
+
+
+def _cr_url(sha: str) -> re.Pattern:
+    return re.compile(
+        rf"https://api\.github\.com/repos/{re.escape(REPO)}/commits/{re.escape(sha)}/check-runs.*"
+    )
+
+
+def _runs(sha: str, runs: list[dict]) -> dict:
+    return {"total_count": len(runs), "check_runs": runs}
+
+
+def _call_seq(*states):
+    """Produce a _get_pr_info side_effect list; append 100 copies of last state."""
+    last = states[-1]
+    return list(states) + [last] * 100
+
+
+async def _watch(**kw):
+    return await checker.watch_pr_ci(
+        REQ,
+        branch=BRANCH,
+        poll_interval_sec=FAST_POLL,
+        timeout_sec=FAST_TIMEOUT,
+        repos=[REPO],
+        **kw,
+    )
+
+
+# ── S1: all-green but only review-only check-run → no-gha fail ──────────
+
+async def test_prcinogha_s1_review_only_all_green_returns_no_gha_fail(httpx_mock):
+    """S1: All check-runs completed+success but none have app.slug='github-actions'.
+    watch_pr_ci MUST return passed=False, exit_code=1, and stdout_tail containing
+    'no-gha-checks-ran' plus the actual check-run name."""
+    review_runs = _runs(SHA_A, [
+        {
+            "id": 1,
+            "name": "claude-review",
+            "head_sha": SHA_A,
+            "status": "completed",
+            "conclusion": "success",
+            "app": {"slug": "anthropic-claude"},
+        }
+    ])
+    httpx_mock.add_response(url=_cr_url(SHA_A), json=review_runs, is_reusable=True)
+
+    call_iter = iter(_call_seq(_open(SHA_A)))
+
+    async def fake_get_pr_info(*args, **kwargs):
+        return next(call_iter)
+
+    with patch(f"{_MODULE}._get_pr_info", side_effect=fake_get_pr_info):
+        result = await _watch()
+
+    assert isinstance(result, CheckResult)
+    assert result.passed is False
+    assert result.exit_code == 1
+    assert "no-gha-checks-ran" in (result.stdout_tail or "")
+    assert "claude-review" in (result.stdout_tail or "")
+
+
+# ── S2: GHA + review-only, all green → pass ─────────────────────────────
+
+async def test_prcinogha_s2_gha_plus_review_all_green_returns_pass(httpx_mock):
+    """S2: At least one check-run has app.slug='github-actions' and all are
+    completed+success. watch_pr_ci MUST return passed=True, exit_code=0.
+    The review-only bot must not pollute a real CI green."""
+    mixed_runs = _runs(SHA_A, [
+        {
+            "id": 1,
+            "name": "lint",
+            "head_sha": SHA_A,
+            "status": "completed",
+            "conclusion": "success",
+            "app": {"slug": "github-actions"},
+        },
+        {
+            "id": 2,
+            "name": "claude-review",
+            "head_sha": SHA_A,
+            "status": "completed",
+            "conclusion": "success",
+            "app": {"slug": "anthropic-claude"},
+        },
+    ])
+    httpx_mock.add_response(url=_cr_url(SHA_A), json=mixed_runs, is_reusable=True)
+
+    call_iter = iter(_call_seq(_open(SHA_A)))
+
+    async def fake_get_pr_info(*args, **kwargs):
+        return next(call_iter)
+
+    with patch(f"{_MODULE}._get_pr_info", side_effect=fake_get_pr_info):
+        result = await _watch()
+
+    assert isinstance(result, CheckResult)
+    assert result.passed is True
+    assert result.exit_code == 0
+    assert "no-gha-checks-ran" not in (result.stdout_tail or "")
+
+
+# ── S3: check-run missing app field → conservative non-GHA → no-gha fail ─
+
+async def test_prcinogha_s3_missing_app_field_treated_as_non_gha(httpx_mock):
+    """S3: A check-run with no 'app' field MUST be treated as non-GHA (conservative).
+    All such runs completed+success → no-gha verdict → passed=False, exit_code=1.
+    Unknown origin cannot underwrite a CI-green."""
+    no_app_runs = _runs(SHA_A, [
+        {
+            "id": 1,
+            "name": "unknown-bot",
+            "head_sha": SHA_A,
+            "status": "completed",
+            "conclusion": "success",
+            # deliberately omitting "app" field
+        }
+    ])
+    httpx_mock.add_response(url=_cr_url(SHA_A), json=no_app_runs, is_reusable=True)
+
+    call_iter = iter(_call_seq(_open(SHA_A)))
+
+    async def fake_get_pr_info(*args, **kwargs):
+        return next(call_iter)
+
+    with patch(f"{_MODULE}._get_pr_info", side_effect=fake_get_pr_info):
+        result = await _watch()
+
+    assert isinstance(result, CheckResult)
+    assert result.passed is False
+    assert result.exit_code == 1
+    assert "no-gha-checks-ran" in (result.stdout_tail or "")
+
+
+# ── S4: pending check-run overrides no-gha ───────────────────────────────
+
+async def test_prcinogha_s4_pending_check_run_prevents_no_gha(httpx_mock):
+    """S4: One review-only completed+success AND another review-only in_progress.
+    _classify MUST return 'pending' (not 'no-gha') — the GHA workflow may still
+    arrive while any run is in_progress. Polling continues; once PR merges the
+    function returns pass without ever emitting no-gha-checks-ran."""
+    pending_runs = _runs(SHA_A, [
+        {
+            "id": 1,
+            "name": "claude-review",
+            "head_sha": SHA_A,
+            "status": "completed",
+            "conclusion": "success",
+            "app": {"slug": "anthropic-claude"},
+        },
+        {
+            "id": 2,
+            "name": "another-review",
+            "head_sha": SHA_A,
+            "status": "in_progress",
+            "conclusion": None,
+            "app": {"slug": "anthropic-claude"},
+        },
+    ])
+    httpx_mock.add_response(url=_cr_url(SHA_A), json=pending_runs, is_reusable=True)
+
+    # pre-loop: open → loop tick 1: open (check-runs fetched, pending) → tick 2: merged
+    call_iter = iter(_call_seq(_open(SHA_A), _open(SHA_A), _merged(SHA_A)))
+
+    async def fake_get_pr_info(*args, **kwargs):
+        return next(call_iter)
+
+    with patch(f"{_MODULE}._get_pr_info", side_effect=fake_get_pr_info):
+        result = await _watch()
+
+    # MUST resolve via merge, not fail with no-gha
+    assert isinstance(result, CheckResult)
+    assert result.passed is True
+    assert "no-gha-checks-ran" not in (result.stdout_tail or "")
+
+
+# ── S5: empty check-runs → pending (unchanged behavior) ──────────────────
+
+async def test_prcinogha_s5_empty_runs_stays_pending_not_no_gha(httpx_mock):
+    """S5: Zero check-runs MUST still return 'pending', not 'no-gha'.
+    The empty-runs case is explicitly NOT promoted to no-gha verdict; the existing
+    polling loop continues and exit_code=124 timeout remains the safety net for
+    'GHA never showed up at all'. Here the PR merges to provide a clean exit."""
+    empty_runs = _runs(SHA_A, [])
+    httpx_mock.add_response(url=_cr_url(SHA_A), json=empty_runs, is_reusable=True)
+
+    # pre-loop: open → loop tick 1: open (empty runs → pending) → tick 2: merged
+    call_iter = iter(_call_seq(_open(SHA_A), _open(SHA_A), _merged(SHA_A)))
+
+    async def fake_get_pr_info(*args, **kwargs):
+        return next(call_iter)
+
+    with patch(f"{_MODULE}._get_pr_info", side_effect=fake_get_pr_info):
+        result = await _watch()
+
+    # MUST resolve via merge, not fail with no-gha
+    assert isinstance(result, CheckResult)
+    assert result.passed is True
+    assert "no-gha-checks-ran" not in (result.stdout_tail or "")

--- a/orchestrator/tests/test_contract_pr_ci_watch_sha_refresh.py
+++ b/orchestrator/tests/test_contract_pr_ci_watch_sha_refresh.py
@@ -42,16 +42,18 @@ def _closed(sha: str):
 def _cr_url(sha: str) -> re.Pattern:
     return re.compile(rf"https://api\.github\.com/repos/{re.escape(REPO)}/commits/{re.escape(sha)}/check-runs.*")
 
+_GHA_APP = {"slug": "github-actions"}
+
 def _pending_cr(sha: str) -> dict:
     return {
         "total_count": 1,
-        "check_runs": [{"id": 1, "name": "CI", "head_sha": sha, "status": "in_progress", "conclusion": None}],
+        "check_runs": [{"id": 1, "name": "CI", "head_sha": sha, "status": "in_progress", "conclusion": None, "app": _GHA_APP}],
     }
 
 def _success_cr(sha: str) -> dict:
     return {
         "total_count": 1,
-        "check_runs": [{"id": 1, "name": "CI", "head_sha": sha, "status": "completed", "conclusion": "success"}],
+        "check_runs": [{"id": 1, "name": "CI", "head_sha": sha, "status": "completed", "conclusion": "success", "app": _GHA_APP}],
     }
 
 def _call_seq(*states):


### PR DESCRIPTION
## Summary

- `pr_ci_watch._classify` 现在区分 `pass` 和 `no-gha`：全绿但 0 条 GHA check-run 不再当 pass，返新 verdict `no-gha`，主循环把它当 fail（`passed=False, exit_code=1`，`stdout_tail` = `<repo>: no-gha-checks-ran (only non-CI signals: ...)`）
- 边界：有任意 pending → 仍判 `pending`（给 GHA workflow 上车机会）；空 runs → `pending`（不变，最终走 124 timeout）；混合 GHA+review-only 全绿 → `pass`（review bot 不污染）；缺 `app` 字段 → 保守按非 GHA
- 加 4 个 `_classify` 单测 + 1 个端到端测试复现 REQ-acceptance-e2e-1777084500 真实事故；老 `_run` fixture 默认补 `app.slug="github-actions"` 兼容

## Why

REQ-acceptance-e2e-1777084500（2026-04-25 03:32）escalated：dev-fixer push 后 PR #205 目标分支不在源仓 `ci.yml` 触发列表，GHA workflow 一次没跑；只剩 `claude-review`（`anthropic-claude` app）报 success；旧 `_classify` 看 "all completed + all green" 直接判 pass，sisyphus 推进到 accept 阶段时原 bug 还在。verifier-agent 兜底人肉 catch 才发现。

整合契约（`_shared/runner_container.md.j2` + `integration-contracts.md`）就锁死 PR CI 由 GHA 跑，所以 "pass requires at least one `app.slug == 'github-actions'` check-run" 是机械层应该自己判的不变量。这次把它落到代码。

## OpenSpec

`openspec/changes/REQ-pr-ci-no-gha-1777105576/` —— proposal / tasks / specs/pr-ci-no-gha/spec.md（5 个 scenarios PRCINOGHA-S1..S5，`openspec validate --strict` 通过）。

## Test plan

- [x] `uv run pytest tests/test_checkers_pr_ci_watch.py tests/test_contract_pr_ci_watch_sha_refresh.py` 全绿（34 passed）
- [x] `uv run pytest`（全套 484 passed）
- [x] `uv run ruff check src tests` 全绿
- [x] `openspec validate REQ-pr-ci-no-gha-1777105576 --strict` 通过
- [x] `bash scripts/check-scenario-refs.sh` 通过
- [ ] orchestrator-ci.yml 在 PR 上 lint+pytest 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)