### PR TITLE
fix(engine): close orphan verifier stage_run on VERIFY_PASS self-loop

### DIFF
--- a/openspec/changes/REQ-verifier-stagerun-close-1777105576/proposal.md
+++ b/openspec/changes/REQ-verifier-stagerun-close-1777105576/proposal.md
@@ -1,0 +1,75 @@
+# REQ-verifier-stagerun-close-1777105576: fix(verifier): close orphan verifier stage_run on VERIFY_PASS path
+
+## 问题
+
+verifier-agent 决策 `pass` 走主链 `apply_verify_pass` 时，对应的 `stage_runs` 行 `verifier`
+**永远不被 close**：`ended_at IS NULL` 一直挂着。指标看板（M14e Q12/Q13 verifier 决策吞吐 /
+平均时长）按 `ended_at` group 都漏算 PASS 路径，verifier 的 `pass` outcome 在 `stage_runs`
+上完全不可见，只能从 `verifier_decisions` 倒推。久了 `stage_runs` 表上 stage='verifier' 行
+有大量 orphan，运维 `SELECT count(*) WHERE stage='verifier' AND ended_at IS NULL` 看着像
+卡死。
+
+## 根因
+
+`engine._record_stage_transitions` 用 transition 表声明的 `cur_state → next_state` 来决定
+要不要 close 上一阶段 + open 下一阶段。同 state（`cur == next`）就 early-return 不动 stage_run。
+
+`(REVIEW_RUNNING, VERIFY_PASS)` 在 `state.py` 里就声明成自循环：
+
+```python
+(ReqState.REVIEW_RUNNING, Event.VERIFY_PASS):
+    Transition(ReqState.REVIEW_RUNNING, "apply_verify_pass", ...)
+```
+
+所以 engine.step CAS 完 + 跑 `_record_stage_transitions` 时直接 early-return，verifier 的
+stage_run 不被关。
+
+外面看 self-loop 是因为 next_state 由 `ctx.verifier_stage` 动态决定（不同 stage 路向不同
+target），transition 表没法静态写。`apply_verify_pass` action 内部手工 `cas_transition`
+把 state 推到 target stage_running，再链式 emit 该 stage 的 done/pass 事件。这条手工 CAS
+**绕过 `_record_stage_transitions`**，所以 verifier 那条 run 没人收。
+
+对照其他 verifier 决策路径：
+
+- `VERIFY_FIX_NEEDED` → `REVIEW_RUNNING → FIXER_RUNNING`（不同 state）→ `_record_stage_transitions`
+  正常 close verifier（outcome=`fix`）+ open fixer。✓
+- `VERIFY_ESCALATE` → `REVIEW_RUNNING → ESCALATED`（不同 state）→ 正常 close verifier（outcome=`escalate`）。✓
+
+只有 PASS 是自循环 → 漏 close。
+
+## 方案
+
+`engine._record_stage_transitions` 在 `cur_state == next_state` early-return **之前**先做一次
+精准 close：当 `cur_state == REVIEW_RUNNING and event == Event.VERIFY_PASS` 时，调
+`stage_runs.close_latest_stage_run(pool, req_id, "verifier", outcome="pass")` 把当前 verifier
+那条 run 收掉。
+
+不需要 open 新的 stage_run：apply_verify_pass 内部 CAS 到 target stage（如 `SPEC_LINT_RUNNING`）
+是为了"verifier 判 pass 等同于该 stage 已通过"，不是真重跑该 stage。链式 emit 紧接着推到下
+一 stage（如 `CHALLENGER_RUNNING`），那一步会通过 `_record_stage_transitions` 正常 open
+challenger 的 run。
+
+代码改 1 处（engine.py），新增 1 个分支 + 必要 try/except 包裹（best-effort，跟同函数其他写
+入对齐，失败只 log 不抛）。
+
+## 取舍
+
+- **不改 transition 表**：把 `(REVIEW_RUNNING, VERIFY_PASS)` 改成 `→ X_RUNNING` 的"显式" target
+  做不到 —— next_state 由 ctx 动态决定，transition 表是静态映射。继续保 self-loop + action
+  内部手工 CAS 是最小侵入。
+- **只 close、不 open**：apply_verify_pass 的"绕过 stage_running"语义是有意为之（verifier
+  代该 stage 出 PASS 决策），不应该再为该 stage 凭空开一条 stage_run。
+- **outcome 写死 `pass`**：到达 `(REVIEW_RUNNING, VERIFY_PASS)` 这一条分支必然是 verifier
+  的 PASS 决策，没必要再走 `_EVENT_TO_OUTCOME` 查表（虽然查也是 `pass`）。
+- **不动 ESCALATED + VERIFY_PASS**：用户续 escalated verifier issue 写新 decision=pass 时
+  cur_state 是 `ESCALATED`（不是 `REVIEW_RUNNING`），且彼时 verifier stage_run 已经在前一次
+  `REVIEW_RUNNING → ESCALATED` 的 close 路径里收掉了。新 fix 不需要覆盖这条。
+- **不补历史 orphan**：不写 migration 回填已有 `ended_at IS NULL` 的老 verifier 行 ——
+  那是观测污染，不影响主流程；运维 ad-hoc SQL 自己 backfill 即可。
+
+## 兼容性
+
+- 行为对齐：上线后 verifier `pass` 路径会正常 close stage_run，Metabase 看板自动正确。
+- 既有 orphan：留着不补；前文已说不写 migration。
+- 数据库 schema：不动。
+- `verifier_decisions` 表：不动。

--- a/openspec/changes/REQ-verifier-stagerun-close-1777105576/specs/verifier-stagerun-close/contract.spec.yaml
+++ b/openspec/changes/REQ-verifier-stagerun-close-1777105576/specs/verifier-stagerun-close/contract.spec.yaml
@@ -1,0 +1,58 @@
+capability: verifier-stagerun-close
+version: "1.0"
+description: |
+  Engine MUST close the verifier stage_run when the verifier returns
+  decision=pass, even though the (REVIEW_RUNNING, VERIFY_PASS) transition is
+  declared as a self-loop in the state machine.
+
+  Without this fix, every PASS-decision verifier leaves an orphan stage_runs
+  row (ended_at IS NULL) for stage='verifier', which (a) hides the verifier's
+  PASS outcome from Metabase dashboards that join on ended_at and (b) makes
+  the orphan-stage-run health metric falsely report stuck verifier runs.
+
+modules:
+  engine:
+    module: orchestrator.engine
+    function: _record_stage_transitions
+    invariants:
+      - "MUST close stage_runs row for stage='verifier' with outcome='pass' when (cur_state == REVIEW_RUNNING) AND (event == Event.VERIFY_PASS), regardless of whether next_state == cur_state"
+      - "MUST be best-effort: any error during the close is logged via 'engine.stage_runs.write_failed' and MUST NOT raise out of _record_stage_transitions"
+      - "MUST preserve the existing behavior for other (REVIEW_RUNNING, *) self-loop events: only VERIFY_PASS triggers the explicit close"
+
+  store:
+    module: orchestrator.store.stage_runs
+    function: close_latest_stage_run
+    semantics: "Returns id of the closed row, or None if no open verifier row exists for the REQ. Either outcome is acceptable here — None means the verifier stage_run was already closed (e.g., a stray VERIFY_PASS replay), which is harmless."
+
+state_machine_context:
+  transitions_in_scope:
+    - from: REVIEW_RUNNING
+      event: VERIFY_PASS
+      to: REVIEW_RUNNING   # self-loop in transition table
+      action: apply_verify_pass
+      note: "apply_verify_pass internally CAS's REVIEW_RUNNING → target stage_running based on ctx.verifier_stage; this internal CAS bypasses _record_stage_transitions"
+
+  transitions_out_of_scope:
+    - from: REVIEW_RUNNING
+      event: VERIFY_FIX_NEEDED
+      to: FIXER_RUNNING
+      note: "different states → existing close+open path already closes verifier with outcome='fix'"
+    - from: REVIEW_RUNNING
+      event: VERIFY_ESCALATE
+      to: ESCALATED
+      note: "different states → existing path closes verifier with outcome='escalate'"
+    - from: ESCALATED
+      event: VERIFY_PASS
+      to: ESCALATED
+      note: "user follow-up on escalated verifier; verifier stage_run was already closed when REVIEW_RUNNING → ESCALATED happened earlier"
+
+stage_runs_outcomes:
+  verifier_pass:
+    stage: verifier
+    outcome: pass
+    fail_reason: null
+    written_by: "engine._record_stage_transitions on (REVIEW_RUNNING, VERIFY_PASS)"
+
+dashboard_impact:
+  - "Q12 verifier-decision throughput: PASS rows now have ended_at set → counted in time-bucketed aggregates"
+  - "Q13 verifier average duration: PASS-decision durations now reflect in averages (previously NULL → excluded by AVG(duration_sec))"

--- a/openspec/changes/REQ-verifier-stagerun-close-1777105576/specs/verifier-stagerun-close/spec.md
+++ b/openspec/changes/REQ-verifier-stagerun-close-1777105576/specs/verifier-stagerun-close/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: engine 在 (REVIEW_RUNNING, VERIFY_PASS) 必须 close 当前 verifier stage_run
+
+The orchestrator engine SHALL close the open `stage_runs` row for `stage='verifier'` whenever
+a state-machine transition is dispatched with `cur_state == ReqState.REVIEW_RUNNING` and
+`event == Event.VERIFY_PASS`. The close MUST set `outcome='pass'`, MUST happen via
+`stage_runs.close_latest_stage_run`, and MUST NOT depend on `next_state` differing from
+`cur_state`. This requirement closes the orphan path created because
+`(REVIEW_RUNNING, VERIFY_PASS)` is declared as a self-loop in the transition table while
+`apply_verify_pass` internally CAS's the REQ to a different stage.
+
+#### Scenario: VSC-S1 VERIFY_PASS self-loop closes verifier stage_run with outcome=pass
+
+- **GIVEN** orchestrator engine receives `(cur_state=REVIEW_RUNNING, event=VERIFY_PASS)`
+- **AND** there is an open `stage_runs` row with `stage='verifier'` and `ended_at IS NULL` for the REQ
+- **WHEN** `engine._record_stage_transitions` runs after CAS
+- **THEN** `stage_runs.close_latest_stage_run(pool, req_id, "verifier", outcome="pass")` is called exactly once for that REQ
+
+#### Scenario: VSC-S2 close 是 best-effort，失败只 log 不抛
+
+- **GIVEN** `stage_runs.close_latest_stage_run` 抛异常（如 DB 暂时不可用）
+- **WHEN** `engine._record_stage_transitions` 在 (REVIEW_RUNNING, VERIFY_PASS) 路径调用 close
+- **THEN** 异常被 try/except 捕获并通过 `engine.stage_runs.write_failed` log warning，不向 `engine.step` 上抛，不影响主流程
+
+### Requirement: engine 不得改变其他 verifier 决策路径的 stage_run 行为
+
+The fix MUST be scoped to `event == Event.VERIFY_PASS` on `cur_state == ReqState.REVIEW_RUNNING`.
+The orchestrator MUST continue to handle the other verifier decision events through the existing
+generic close+open path: `VERIFY_FIX_NEEDED` and `VERIFY_ESCALATE` lead to a state change
+(REVIEW_RUNNING → FIXER_RUNNING / ESCALATED) and SHALL still close the verifier stage_run via
+`_EVENT_TO_OUTCOME` mapping (`fix` / `escalate` respectively). Other self-loop events on
+REVIEW_RUNNING (e.g. `SESSION_FAILED` chained via the watchdog) MUST NOT trigger the explicit
+verifier close.
+
+#### Scenario: VSC-S3 VERIFY_FIX_NEEDED 仍走原 close+open 路径
+
+- **GIVEN** orchestrator 收到 `(cur_state=REVIEW_RUNNING, event=VERIFY_FIX_NEEDED)` → next_state=FIXER_RUNNING
+- **WHEN** `_record_stage_transitions` 跑
+- **THEN** verifier stage_run 通过通用 close-on-leave 路径关闭（outcome=`fix`），fixer stage_run 通过通用 open-on-enter 路径打开
+
+#### Scenario: VSC-S4 REVIEW_RUNNING + SESSION_FAILED self-loop 不触发 verifier close
+
+- **GIVEN** orchestrator 收到 `(cur_state=REVIEW_RUNNING, event=SESSION_FAILED)`（transitions 表里是 self-loop → escalate action 自决）
+- **WHEN** `_record_stage_transitions` 跑
+- **THEN** 不调用 `close_latest_stage_run`（保留给 escalate action 决定真 escalate 后由后续 transition close）

--- a/openspec/changes/REQ-verifier-stagerun-close-1777105576/tasks.md
+++ b/openspec/changes/REQ-verifier-stagerun-close-1777105576/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: REQ-verifier-stagerun-close-1777105576
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/engine.py:_record_stage_transitions`：在 `cur_state == next_state` early-return 之前，新增分支：当 `cur_state == ReqState.REVIEW_RUNNING and event == Event.VERIFY_PASS` → `await stage_runs.close_latest_stage_run(pool, req_id, "verifier", outcome="pass")`，包在 try/except 里 best-effort
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_engine.py`：扩 `FakePool` 让它能记录 `INSERT INTO stage_runs` / `UPDATE stage_runs` 调用（之前是 NotImplementedError 被 try/except 吃掉）
+- [x] `orchestrator/tests/test_engine.py:test_verify_pass_closes_orphan_verifier_stage_run` —— REVIEW_RUNNING + VERIFY_PASS → 验 stage_runs UPDATE 被调，stage='verifier'，outcome='pass'
+- [x] `orchestrator/tests/test_engine.py:test_verify_fix_needed_still_closes_verifier_via_normal_path` —— 回归测：REVIEW_RUNNING + VERIFY_FIX_NEEDED → FIXER_RUNNING 路径仍走原 close+open 逻辑
+- [x] `orchestrator/tests/test_engine.py:test_review_running_self_loop_other_event_does_not_close` —— 只在 `event == VERIFY_PASS` 时 close，其他 self-loop 事件（如 SESSION_FAILED）不动 stage_run
+
+## Stage: spec
+
+- [x] `openspec/changes/REQ-verifier-stagerun-close-1777105576/proposal.md`
+- [x] `openspec/changes/REQ-verifier-stagerun-close-1777105576/tasks.md`
+- [x] `openspec/changes/REQ-verifier-stagerun-close-1777105576/specs/verifier-stagerun-close/contract.spec.yaml`
+- [x] `openspec/changes/REQ-verifier-stagerun-close-1777105576/specs/verifier-stagerun-close/spec.md`
+
+## Stage: PR
+
+- [x] git push feat/REQ-verifier-stagerun-close-1777105576
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/engine.py
+++ b/orchestrator/src/orchestrator/engine.py
@@ -82,7 +82,21 @@ async def _record_stage_transitions(
     - 进入 *_RUNNING（cur ≠ next）→ open 新一条 run
     - 自循环（mark_*_reviewed_and_check / apply_verify_pass 等）不动
     任何错误只 log 不抛，避免拖垮主流程。
+
+    例外：(REVIEW_RUNNING, VERIFY_PASS) 是 transition 表声明的 self-loop，但
+    apply_verify_pass action 内部手工 CAS 把 state 推到 target stage_running，那条手工
+    CAS 绕过本函数。如果不在这里显式 close verifier 那条 run，stage_runs 会留 orphan
+    （ended_at IS NULL），Q12/Q13 verifier 看板漏掉 PASS 决策。
     """
+    if cur_state == ReqState.REVIEW_RUNNING and event == Event.VERIFY_PASS:
+        try:
+            await stage_runs.close_latest_stage_run(
+                pool, req_id, "verifier", outcome="pass",
+            )
+        except Exception as e:
+            log.warning("engine.stage_runs.write_failed",
+                        req_id=req_id, cur=cur_state.value, nxt=next_state.value,
+                        evt=event.value, error=str(e))
     if cur_state == next_state:
         return
     try:

--- a/orchestrator/tests/test_contract_verifier_stagerun_close.py
+++ b/orchestrator/tests/test_contract_verifier_stagerun_close.py
@@ -1,0 +1,264 @@
+"""
+Contract tests for REQ-verifier-stagerun-close-1777105576:
+fix(verifier): close orphan verifier stage_run on VERIFY_PASS path
+
+Black-box behavioral contracts derived from:
+  openspec/changes/REQ-verifier-stagerun-close-1777105576/specs/verifier-stagerun-close/spec.md
+  openspec/changes/REQ-verifier-stagerun-close-1777105576/specs/verifier-stagerun-close/contract.spec.yaml
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is wrong, escalate to spec_fixer to correct the spec, not the test.
+
+Scenarios covered:
+  VSC-S1  VERIFY_PASS self-loop closes verifier stage_run with outcome=pass
+  VSC-S2  close 是 best-effort，失败只 log 不抛
+  VSC-S3  VERIFY_FIX_NEEDED 仍走原 close+open 路径
+  VSC-S4  REVIEW_RUNNING + SESSION_FAILED self-loop 不触发 verifier close
+
+Module under test:
+  orchestrator.engine._record_stage_transitions(pool, req_id, cur_state, next_state, event)
+Store contract (orchestrator.store.stage_runs):
+  close_latest_stage_run(pool, req_id, stage, outcome) -> id | None
+  open_stage_run(pool, req_id, stage, ...) -> id | None
+"""
+from __future__ import annotations
+
+import pytest
+import structlog.testing
+from unittest.mock import AsyncMock
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+class _FakePool:
+    """Minimal asyncpg pool stub: accepts calls, captures execute for inspection."""
+
+    def __init__(self):
+        self.execute_calls: list = []
+
+    async def execute(self, sql: str, *args):
+        self.execute_calls.append((sql, args))
+
+    async def fetch(self, sql: str, *args):
+        return []
+
+    async def fetchrow(self, sql: str, *args):
+        return None
+
+    async def fetchval(self, sql: str, *args):
+        return None
+
+
+class _FakeStageRuns:
+    """
+    Fake orchestrator.store.stage_runs module stub.
+
+    Captures calls to close_latest_stage_run and open_stage_run.
+    All other attributes return an AsyncMock so any awaited call succeeds without
+    manually listing every function in the real module.
+    """
+
+    def __init__(self, close_side_effect=None):
+        self._close_side_effect = close_side_effect
+        self._close_calls: list = []
+        self._open_calls: list = []
+
+    async def close_latest_stage_run(self, pool, req_id, stage, outcome=None, fail_reason=None, **kw):
+        self._close_calls.append({"req_id": req_id, "stage": stage, "outcome": outcome})
+        if self._close_side_effect is not None:
+            raise self._close_side_effect
+        return "fake-run-id-closed"
+
+    async def insert_stage_run(self, pool, req_id, stage, **kw):
+        self._open_calls.append({"req_id": req_id, "stage": stage})
+        return 42  # fake run_id int
+
+    def __getattr__(self, name: str):
+        """Return a fresh AsyncMock for any other stage_runs function the engine calls."""
+        return AsyncMock(return_value=None)
+
+
+def _make_fake_stage_runs(close_side_effect=None) -> _FakeStageRuns:
+    return _FakeStageRuns(close_side_effect=close_side_effect)
+
+
+# ─── VSC-S1: VERIFY_PASS self-loop MUST close verifier stage_run ─────────────
+
+
+async def test_vsc_s1_verify_pass_closes_verifier_stage_run(monkeypatch):
+    """
+    VSC-S1: _record_stage_transitions MUST call close_latest_stage_run(pool, req_id,
+    "verifier", outcome="pass") exactly once when cur_state=REVIEW_RUNNING and
+    event=VERIFY_PASS, even though next_state == cur_state (self-loop in transition table).
+
+    Invariant: close MUST happen regardless of cur_state == next_state equality.
+    """
+    import orchestrator.engine as engine_mod
+    from orchestrator.state import Event, ReqState
+
+    fake_sr = _make_fake_stage_runs()
+    monkeypatch.setattr(engine_mod, "stage_runs", fake_sr)
+
+    pool = _FakePool()
+    req_id = "REQ-vsc-test-001"
+
+    await engine_mod._record_stage_transitions(
+        pool,
+        req_id=req_id,
+        cur_state=ReqState.REVIEW_RUNNING,
+        next_state=ReqState.REVIEW_RUNNING,  # self-loop
+        event=Event.VERIFY_PASS,
+    )
+
+    verifier_closes = [c for c in fake_sr._close_calls if c["stage"] == "verifier"]
+
+    assert len(verifier_closes) == 1, (
+        f"VSC-S1: close_latest_stage_run MUST be called exactly once for stage='verifier' "
+        f"on (REVIEW_RUNNING, VERIFY_PASS) self-loop; "
+        f"got {len(verifier_closes)} call(s): {verifier_closes}"
+    )
+    assert verifier_closes[0]["outcome"] == "pass", (
+        f"VSC-S1: outcome MUST be 'pass'; got {verifier_closes[0]['outcome']!r}. "
+        f"Contract: close_latest_stage_run(pool, req_id, 'verifier', outcome='pass')"
+    )
+    assert verifier_closes[0]["req_id"] == req_id, (
+        f"VSC-S1: req_id '{req_id}' MUST be forwarded to close_latest_stage_run; "
+        f"got {verifier_closes[0]['req_id']!r}"
+    )
+
+    # Invariant: self-loop means no new stage_run should be inserted
+    assert fake_sr._open_calls == [], (
+        f"VSC-S1: on (REVIEW_RUNNING→REVIEW_RUNNING) self-loop, insert_stage_run MUST NOT "
+        f"be called (no new stage is entered); got: {fake_sr._open_calls}"
+    )
+
+
+# ─── VSC-S2: close failure MUST be logged and MUST NOT propagate ─────────────
+
+
+async def test_vsc_s2_close_error_logged_not_raised(monkeypatch):
+    """
+    VSC-S2: When close_latest_stage_run raises an exception, _record_stage_transitions
+    MUST catch it and log a warning/error with event 'engine.stage_runs.write_failed'.
+    The exception MUST NOT propagate to the caller (best-effort semantic).
+    """
+    import orchestrator.engine as engine_mod
+    from orchestrator.state import Event, ReqState
+
+    db_error = RuntimeError("simulated DB transient failure")
+    fake_sr = _make_fake_stage_runs(close_side_effect=db_error)
+    monkeypatch.setattr(engine_mod, "stage_runs", fake_sr)
+
+    pool = _FakePool()
+
+    with structlog.testing.capture_logs() as log_records:
+        try:
+            await engine_mod._record_stage_transitions(
+                pool,
+                req_id="REQ-vsc-test-002",
+                cur_state=ReqState.REVIEW_RUNNING,
+                next_state=ReqState.REVIEW_RUNNING,
+                event=Event.VERIFY_PASS,
+            )
+        except Exception as exc:
+            pytest.fail(
+                f"VSC-S2: _record_stage_transitions MUST NOT raise when "
+                f"close_latest_stage_run fails (best-effort contract); "
+                f"raised {type(exc).__name__}: {exc}"
+            )
+
+    all_events = [r.get("event", "") for r in log_records]
+    logged_levels = [(r.get("event", ""), r.get("log_level", "")) for r in log_records]
+
+    warning_or_error_events = [
+        r["event"]
+        for r in log_records
+        if r.get("log_level") in ("warning", "error", "warn")
+    ]
+    assert any("engine.stage_runs.write_failed" in e for e in warning_or_error_events), (
+        f"VSC-S2: MUST emit a warning/error log with event 'engine.stage_runs.write_failed' "
+        f"when close_latest_stage_run raises; "
+        f"actual log events+levels: {logged_levels!r}"
+    )
+
+
+# ─── VSC-S3: VERIFY_FIX_NEEDED uses existing generic close+open path ──────────
+
+
+async def test_vsc_s3_verify_fix_needed_normal_close_open(monkeypatch):
+    """
+    VSC-S3: (REVIEW_RUNNING, VERIFY_FIX_NEEDED) → next_state=FIXER_RUNNING (state change).
+    _record_stage_transitions MUST:
+    - close the verifier stage_run with outcome='fix' via the generic close-on-leave path
+    - open a fixer stage_run via the generic open-on-enter path
+
+    This verifies the existing behavior is preserved and not accidentally broken by the
+    VERIFY_PASS fix — the explicit close branch MUST only trigger on VERIFY_PASS.
+    """
+    import orchestrator.engine as engine_mod
+    from orchestrator.state import Event, ReqState
+
+    fake_sr = _make_fake_stage_runs()
+    monkeypatch.setattr(engine_mod, "stage_runs", fake_sr)
+
+    pool = _FakePool()
+
+    await engine_mod._record_stage_transitions(
+        pool,
+        req_id="REQ-vsc-test-003",
+        cur_state=ReqState.REVIEW_RUNNING,
+        next_state=ReqState.FIXER_RUNNING,
+        event=Event.VERIFY_FIX_NEEDED,
+    )
+
+    verifier_closes = [c for c in fake_sr._close_calls if c["stage"] == "verifier"]
+    assert len(verifier_closes) >= 1, (
+        f"VSC-S3: verifier stage_run MUST be closed on VERIFY_FIX_NEEDED (leave REVIEW_RUNNING); "
+        f"close_calls: {fake_sr._close_calls}"
+    )
+    assert verifier_closes[0]["outcome"] == "fix", (
+        f"VSC-S3: verifier close outcome MUST be 'fix' for VERIFY_FIX_NEEDED; "
+        f"got {verifier_closes[0]['outcome']!r}. "
+        f"Contract: _EVENT_TO_OUTCOME[VERIFY_FIX_NEEDED] == 'fix'"
+    )
+
+    fixer_opens = [o for o in fake_sr._open_calls if o["stage"] == "fixer"]
+    assert len(fixer_opens) >= 1, (
+        f"VSC-S3: fixer stage_run MUST be opened on enter FIXER_RUNNING; "
+        f"open_calls: {fake_sr._open_calls}"
+    )
+
+
+# ─── VSC-S4: SESSION_FAILED self-loop MUST NOT close verifier stage_run ───────
+
+
+async def test_vsc_s4_session_failed_self_loop_no_verifier_close(monkeypatch):
+    """
+    VSC-S4: (REVIEW_RUNNING, SESSION_FAILED) is a self-loop (next_state == cur_state).
+    _record_stage_transitions MUST NOT call close_latest_stage_run for stage='verifier'.
+    Only event == VERIFY_PASS triggers the explicit verifier close; other self-loop
+    events (e.g. SESSION_FAILED dispatched by the watchdog) must not.
+    """
+    import orchestrator.engine as engine_mod
+    from orchestrator.state import Event, ReqState
+
+    fake_sr = _make_fake_stage_runs()
+    monkeypatch.setattr(engine_mod, "stage_runs", fake_sr)
+
+    pool = _FakePool()
+
+    await engine_mod._record_stage_transitions(
+        pool,
+        req_id="REQ-vsc-test-004",
+        cur_state=ReqState.REVIEW_RUNNING,
+        next_state=ReqState.REVIEW_RUNNING,  # self-loop
+        event=Event.SESSION_FAILED,
+    )
+
+    verifier_closes = [c for c in fake_sr._close_calls if c["stage"] == "verifier"]
+    assert verifier_closes == [], (
+        f"VSC-S4: close_latest_stage_run MUST NOT be called for stage='verifier' "
+        f"on (REVIEW_RUNNING, SESSION_FAILED) self-loop — only VERIFY_PASS triggers "
+        f"the explicit verifier close; got {len(verifier_closes)} call(s): {verifier_closes}"
+    )

--- a/orchestrator/tests/test_contract_verifier_stagerun_close.py
+++ b/orchestrator/tests/test_contract_verifier_stagerun_close.py
@@ -28,7 +28,6 @@ from unittest.mock import AsyncMock
 import pytest
 import structlog.testing
 
-
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
 

--- a/orchestrator/tests/test_contract_verifier_stagerun_close.py
+++ b/orchestrator/tests/test_contract_verifier_stagerun_close.py
@@ -23,9 +23,10 @@ Store contract (orchestrator.store.stage_runs):
 """
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 import structlog.testing
-from unittest.mock import AsyncMock
 
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -168,7 +169,6 @@ async def test_vsc_s2_close_error_logged_not_raised(monkeypatch):
                 f"raised {type(exc).__name__}: {exc}"
             )
 
-    all_events = [r.get("event", "") for r in log_records]
     logged_levels = [(r.get("event", ""), r.get("log_level", "")) for r in log_records]
 
     warning_or_error_events = [

--- a/orchestrator/tests/test_engine.py
+++ b/orchestrator/tests/test_engine.py
@@ -25,10 +25,16 @@ class FakeReq:
 
 
 class FakePool:
-    """模拟 asyncpg.Pool 的 fetchrow / execute，支持 req_state CAS + ctx patch。"""
+    """模拟 asyncpg.Pool 的 fetchrow / execute，支持 req_state CAS + ctx patch。
+
+    `stage_runs_calls` 记录 (op, sql, args)，op ∈ {"insert", "close", "update"}，
+    用于断言 `engine._record_stage_transitions` 的副作用。
+    """
 
     def __init__(self, initial: dict[str, FakeReq]):
         self.rows = initial
+        self.stage_runs_calls: list[tuple[str, str, tuple]] = []
+        self._next_stage_run_id = 1
 
     async def fetchrow(self, sql: str, *args):
         sql_stripped = sql.strip()
@@ -58,6 +64,17 @@ class FakePool:
                 except (json.JSONDecodeError, TypeError):
                     pass
             return {"req_id": req_id}
+        if sql_stripped.startswith("INSERT INTO stage_runs"):
+            self.stage_runs_calls.append(("insert", sql_stripped, args))
+            row_id = self._next_stage_run_id
+            self._next_stage_run_id += 1
+            return {"id": row_id}
+        if sql_stripped.startswith("UPDATE stage_runs"):
+            # close_latest_stage_run uses subquery with RETURNING id; pretend a row matched.
+            self.stage_runs_calls.append(("close", sql_stripped, args))
+            row_id = self._next_stage_run_id
+            self._next_stage_run_id += 1
+            return {"id": row_id}
         raise NotImplementedError(sql[:60])
 
     async def execute(self, sql: str, *args):
@@ -69,6 +86,10 @@ class FakePool:
             r = self.rows.get(req_id)
             if r:
                 r.context.update(patch)
+            return
+        if sql_stripped.startswith("UPDATE stage_runs"):
+            # update_stage_run path (no RETURNING). Recorded for completeness.
+            self.stage_runs_calls.append(("update", sql_stripped, args))
             return
         raise NotImplementedError(sql[:60])
 
@@ -407,3 +428,111 @@ async def test_recursion_depth_guard(stub_actions, monkeypatch):
         if not current:
             break
     assert found_error, "Expected recursion guard error in chained results"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# REQ-verifier-stagerun-close: VERIFY_PASS self-loop must close verifier stage_run
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_verify_pass_closes_orphan_verifier_stage_run(stub_actions):
+    """(REVIEW_RUNNING, VERIFY_PASS) 是 transition 表的 self-loop，但
+    apply_verify_pass 内部手 CAS，绕过 _record_stage_transitions。fix 后 engine 必须
+    显式 close verifier 那条 stage_run（outcome='pass'），否则 ended_at 永远 NULL。
+    """
+    calls, reg = stub_actions
+
+    async def apply_verify_pass(*, body, req_id, tags, ctx):
+        calls.append(("apply_verify_pass", {"req_id": req_id}))
+        return {"ok": True}
+
+    reg["apply_verify_pass"] = apply_verify_pass
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.REVIEW_RUNNING.value)})
+    body = type("B", (), {"issueId": "v-1", "projectId": "p", "event": "session.completed"})()
+    await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["verifier", "REQ-1", "verify:spec_lint"],
+        cur_state=ReqState.REVIEW_RUNNING,
+        ctx={"verifier_stage": "spec_lint"}, event=Event.VERIFY_PASS,
+    )
+
+    # transition 表声明的 self-loop：state 不变
+    assert pool.rows["REQ-1"].state == ReqState.REVIEW_RUNNING.value
+
+    # close_latest_stage_run 必须被调一次：req_id, stage='verifier', outcome='pass', fail_reason=None
+    closes = [c for c in pool.stage_runs_calls if c[0] == "close"]
+    assert len(closes) == 1, f"expected exactly 1 close, got {pool.stage_runs_calls!r}"
+    _, _, args = closes[0]
+    assert args[0] == "REQ-1"
+    assert args[1] == "verifier"
+    assert args[2] == "pass"
+    assert args[3] is None
+
+    # 不应该 open 任何新 stage_run（self-loop 不进入新 *_RUNNING）
+    inserts = [c for c in pool.stage_runs_calls if c[0] == "insert"]
+    assert inserts == []
+
+
+@pytest.mark.asyncio
+async def test_verify_fix_needed_still_closes_verifier_via_normal_path(stub_actions):
+    """REGRESSION: VERIFY_FIX_NEEDED → REVIEW_RUNNING → FIXER_RUNNING 是不同 state，应仍走
+    通用 close-on-leave + open-on-enter 路径：verifier outcome='fix' + 新开 fixer。
+    """
+    calls, reg = stub_actions
+
+    async def start_fixer(*, body, req_id, tags, ctx):
+        calls.append(("start_fixer", {"req_id": req_id}))
+        return {"ok": True}
+
+    reg["start_fixer"] = start_fixer
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.REVIEW_RUNNING.value)})
+    body = type("B", (), {"issueId": "v-1", "projectId": "p", "event": "session.completed"})()
+    await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["verifier", "REQ-1", "verify:dev_cross_check"],
+        cur_state=ReqState.REVIEW_RUNNING,
+        ctx={"verifier_stage": "dev_cross_check"}, event=Event.VERIFY_FIX_NEEDED,
+    )
+
+    assert pool.rows["REQ-1"].state == ReqState.FIXER_RUNNING.value
+
+    closes = [c for c in pool.stage_runs_calls if c[0] == "close"]
+    inserts = [c for c in pool.stage_runs_calls if c[0] == "insert"]
+    # 通用 close: verifier outcome='fix'（不是 'pass'）
+    assert len(closes) == 1, pool.stage_runs_calls
+    args = closes[0][2]
+    assert args[1] == "verifier"
+    assert args[2] == "fix"
+    # 通用 open: fixer
+    assert len(inserts) == 1
+    insert_args = inserts[0][2]
+    assert insert_args[1] == "fixer"
+
+
+@pytest.mark.asyncio
+async def test_review_running_self_loop_other_event_does_not_close_verifier(stub_actions):
+    """fix 必须只在 event == VERIFY_PASS 触发；其他 REVIEW_RUNNING self-loop 事件
+    （如 SESSION_FAILED 经状态机 self-loop 给 escalate action 自决）不动 verifier stage_run。
+    """
+    calls, reg = stub_actions
+
+    async def escalate(*, body, req_id, tags, ctx):
+        calls.append(("escalate", {"req_id": req_id}))
+        return {"ok": True}
+
+    reg["escalate"] = escalate
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.REVIEW_RUNNING.value)})
+    body = type("B", (), {"issueId": "v-1", "projectId": "p", "event": "session.failed"})()
+    await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["verifier", "REQ-1"],
+        cur_state=ReqState.REVIEW_RUNNING, ctx={}, event=Event.SESSION_FAILED,
+    )
+
+    # 没 close 任何 stage_run（escalate action 自己决定真 escalate 后由后续 transition close）
+    closes = [c for c in pool.stage_runs_calls if c[0] == "close"]
+    assert closes == [], f"unexpected close on SESSION_FAILED self-loop: {closes!r}"


### PR DESCRIPTION
## Summary

REQ-verifier-stagerun-close-1777105576

`(REVIEW_RUNNING, VERIFY_PASS)` is declared as a self-loop in the transition table, so `engine._record_stage_transitions` early-returns and never closes the `verifier` stage_run. `apply_verify_pass` then internally CAS's the REQ to a different stage, but that internal CAS bypasses `_record_stage_transitions` entirely. Result: every PASS-decision verifier leaves a `stage_runs` row with `ended_at IS NULL` — silently dropping PASS outcomes from Q12/Q13 dashboards and inflating any "orphan stage_run" health metric.

The fix is one branch in `_record_stage_transitions`: when `cur_state == REVIEW_RUNNING and event == VERIFY_PASS`, explicitly close the verifier stage_run with `outcome="pass"` before the `cur == next` early-return. Best-effort (try/except logs warning, never raises).

`VERIFY_FIX_NEEDED` and `VERIFY_ESCALATE` paths are unaffected — they already cross to a different `next_state` and close the verifier run via the generic close-on-leave path with the proper outcome (`fix` / `escalate`).

## Test plan

- [x] `pytest tests/test_engine.py` — 14 passing (includes 3 new)
  - `test_verify_pass_closes_orphan_verifier_stage_run` — REVIEW_RUNNING + VERIFY_PASS → exactly one `close_latest_stage_run("verifier", "pass")` call, no inserts, state stays REVIEW_RUNNING
  - `test_verify_fix_needed_still_closes_verifier_via_normal_path` — regression: REVIEW_RUNNING + VERIFY_FIX_NEEDED → close verifier with `fix` + open fixer
  - `test_review_running_self_loop_other_event_does_not_close_verifier` — only VERIFY_PASS triggers; SESSION_FAILED self-loop does not
- [x] `pytest -q` — 482 passing
- [x] `ruff check src/orchestrator/engine.py tests/test_engine.py` — clean
- [x] `openspec validate REQ-verifier-stagerun-close-1777105576 --strict` — valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)