### PR TITLE
fix(webhook): drop issue.updated without REQ tag and intent tag

### DIFF
--- a/openspec/changes/REQ-router-noise-filter-1777109307/proposal.md
+++ b/openspec/changes/REQ-router-noise-filter-1777109307/proposal.md
@@ -1,0 +1,80 @@
+# REQ-router-noise-filter-1777109307: fix(webhook): drop issue.updated without REQ tag and intent tag
+
+## 问题
+
+BKD webhook 把整 project 所有 `issue.updated` 推过来，包括跟任何 sisyphus REQ 工作流
+都不相关的 issue：用户手动改的 lab 票、看板列上随手拖动改 status、贴评论等。
+
+`webhook.py` 现有的早期 noise filter（line 138-152）只挡 `session.completed`：
+
+```python
+if (
+    body.event == "session.completed"
+    and not router_lib.extract_req_id(tags)
+):
+    ...skip
+```
+
+`issue.updated` 走不到这条 filter。它们流到下游：
+
+1. `obs.record_event("webhook.received", ...)` —— observability 表灌满无关事件，污染 Q1/Q2 看板
+2. `router_lib.derive_event(body.event, tags)` —— 跑完后绝大多数返 `None`
+3. `event is None` → return skip （**功能上没事**，但白跑一遭）
+4. `event_seen` 表写一条 dedup 记录 + mark_processed —— Postgres 写放大，纯噪音
+
+实测：BKD 一个有几十张 issue 的 project，光"用户拖卡"就能每分钟产几次 `issue.updated`，
+对应 sisyphus 这边几次无效写。
+
+## 根因
+
+早期 noise filter 范围太窄：只覆盖 `session.completed`，没覆盖 `issue.updated`。
+设计当时只考虑了 "session 事件可能是别的 REQ 的孤儿" 这一种噪音；没考虑 BKD 把 project
+所有 issue 的 update 都广播这件事。
+
+## 方案
+
+扩展早期 noise filter，把 `issue.updated` 也纳入：
+
+- `issue.updated` 唯一两种合法触发场景：
+  1. **已 tag REQ-N 的 issue 上的更新** —— 如 race fallback 路径（`issue.updated` 看到
+     stage tag + result tag 后兜底 fire 主链事件，见 router.py:226-256）
+  2. **用户在 intent issue 上打 `intent:intake` / `intent:analyze` tag** —— 触发新 REQ
+     创建（INTENT_INTAKE / INTENT_ANALYZE 入口）
+- 其他都是噪音，**早 skip 早开**
+
+filter 条件：`issue.updated` 且**没** REQ-N tag 且**没** intent 入口 tag → skip。
+
+具体做法（webhook.py 改动）：
+
+1. 把现有 session filter 旁边的判断重组为更通用的 noise filter 段。
+2. 新增 `has_req_tag = bool(router_lib.extract_req_id(tags))` 和
+   `has_intent_tag = "intent:intake" in tags or "intent:analyze" in tags`。
+3. session.completed 路径不变（保持 "没 REQ tag → skip"）。
+4. 新增 issue.updated 路径："没 REQ tag 且没 intent tag → skip"。
+5. 命中时一样：写 mark_processed（让 BKD 不重发）+ return skip + log.debug + 不调
+   obs.record_event。
+
+## 取舍
+
+- **不挡 session.failed**：scope 控住。session.failed 比 session.completed 罕见，
+  noise 量小；保留它落 obs 也方便排查 "哪个无关 BKD agent 挂了"。
+- **保留 dedup 写**：filter 命中也调 `dedup.mark_processed(pool, eid)`。理由跟现有
+  session filter 一致：BKD 至少一次重发，让重发也走同一 skip 路径，避免重复 BKD `get_issue`
+  / log spam。`event_seen` 行写一条 NULL→NOW 的 update 是 cheap，比下游路径便宜。
+- **不引新 setting / env**：filter 是硬规则，不需要运维开关。要"暂时关 filter 排查问题"
+  的场景没业务价值。
+- **filter 在 tag resolution 之后**：跟现有 session filter 同位置。issue.updated 几乎都
+  带 tags（BKD payload 自带），所以前置 BKD `get_issue` 不会被 noise 触发。结构对称，
+  改动小。
+- **`init:STATE` tag 不算入合法入口**：实际使用都是 `init:STATE` + `REQ-N` 配对（中流
+  注入既有工作流），单独打 `init:STATE` 不带 REQ 就过 filter 没意义；需要这种用法的
+  场景另外加 `intent:analyze` 即可。
+
+## 兼容性
+
+- 既有 REQ：本来就走 has_req_tag=True 路径，行为不变。
+- 既有 INTENT 入口：has_intent_tag=True 路径，行为不变。
+- 现有 session.completed filter 路径：行为不变（同条件、同返回）。
+- 唯一变化：之前会 fall through 到 `event is None → skip` 的 issue.updated noise，现在
+  在更早处 skip。downstream 行为完全相同（最终都 return skip + mark_processed）；只是少
+  跑 `obs.record_event` 和 `derive_event`。无 migration。

--- a/openspec/changes/REQ-router-noise-filter-1777109307/specs/router-noise-filter/contract.spec.yaml
+++ b/openspec/changes/REQ-router-noise-filter-1777109307/specs/router-noise-filter/contract.spec.yaml
@@ -1,0 +1,60 @@
+capability: router-noise-filter
+version: "1.0"
+description: |
+  Early webhook noise filter that drops BKD `issue.updated` events unrelated to
+  any sisyphus REQ workflow. Without this filter, BKD's project-wide broadcast
+  of `issue.updated` (from random user activity on unrelated issues) flows
+  through obs.record_event + derive_event + dedup writes, polluting the event
+  log and burning Postgres write quota for no operational value.
+
+  An `issue.updated` event is treated as relevant when it carries either:
+    - a REQ-* tag (relates to an existing tracked workflow), OR
+    - an `intent:intake` / `intent:analyze` tag (entry point for a new REQ).
+  Otherwise, the handler short-circuits to skip.
+
+  This filter coexists with the existing `session.completed`-without-REQ-tag
+  filter; together they form the early-noise branch in webhook.py.
+
+webhook:
+  module: orchestrator.webhook
+  entry: webhook(request)
+  noise_filter_position: |
+    Runs AFTER tag resolution (line ~130-135 in webhook.py: tags = body.tags
+    or fetched via BKDClient.get_issue when missing) and AFTER dedup
+    check_and_record, but BEFORE obs.record_event("webhook.received") and
+    BEFORE router.derive_event.
+
+  preconditions_for_skip:
+    issue_updated_branch:
+      - "body.event == 'issue.updated'"
+      - "router.extract_req_id(tags) is None"
+      - "'intent:intake' not in tags"
+      - "'intent:analyze' not in tags"
+    session_completed_branch:
+      - "body.event == 'session.completed'"
+      - "router.extract_req_id(tags) is None"
+
+  skip_postconditions:
+    - "dedup.mark_processed(pool, eid) is called exactly once"
+    - "Returns {'action': 'skip', 'reason': '<branch-specific>'}"
+    - "obs.record_event('webhook.received', ...) is NOT called"
+    - "router.derive_event is NOT called"
+    - "engine.step is NOT called"
+
+  skip_reasons:
+    issue_updated: "issue.updated without REQ or intent tag"
+    session_completed: "session event without REQ tag"
+
+intent_entry_tags:
+  - "intent:intake"
+  - "intent:analyze"
+  semantics: |
+    These two tags are the legitimate entry points for new REQ creation via
+    issue.updated. The handler MUST allow them through the noise filter even
+    when no REQ-* tag is present (REQ-* is assigned later by extract_req_id's
+    issueNumber fallback at line ~232).
+
+non_goals:
+  - "Filter session.failed: out of scope; rare event, useful for forensic logs."
+  - "Add settings/env knob to disable the filter: not configurable; the rule
+     is deterministic and there is no operational use case for bypassing it."

--- a/openspec/changes/REQ-router-noise-filter-1777109307/specs/router-noise-filter/spec.md
+++ b/openspec/changes/REQ-router-noise-filter-1777109307/specs/router-noise-filter/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: webhook 必须早期 skip 不带 REQ tag 也不带 intent 入口 tag 的 issue.updated
+
+The webhook handler MUST evaluate, after tag resolution and before invoking
+`router.derive_event` or `observability.record_event`, whether the incoming
+`issue.updated` event is relevant to any sisyphus REQ workflow. The handler
+MUST treat the event as noise and short-circuit when **all** of the following
+hold:
+
+- `body.event == "issue.updated"`
+- `router.extract_req_id(tags)` returns `None` (no `REQ-*` tag in `tags`)
+- `tags` contains **neither** `"intent:intake"` **nor** `"intent:analyze"`
+
+When the event is treated as noise, the handler MUST:
+
+1. Call `dedup.mark_processed(pool, eid)` so BKD's at-least-once retry of the
+   same event ID also short-circuits without reprocessing.
+2. Return `{"action": "skip", "reason": "issue.updated without REQ or intent tag"}`.
+3. NOT call `observability.record_event("webhook.received", ...)` so noise
+   events do not pollute the event log.
+4. NOT call `router.derive_event` or any downstream `engine.step` / state
+   machine code path.
+
+The existing `session.completed` noise filter (skip when no REQ tag) MUST
+continue to behave exactly as before. The two filters MUST coexist as parallel
+branches of the same early-noise section in `webhook.py`.
+
+#### Scenario: RNF-S1 issue.updated 无 REQ tag 无 intent tag → skip
+
+- **GIVEN** webhook 收到 `body.event="issue.updated"`，`tags=["bug", "frontend"]`
+- **WHEN** handler 执行到 noise filter 段
+- **THEN** handler 返回 `{"action": "skip", "reason": "issue.updated without REQ or intent tag"}`
+- **AND** `dedup.mark_processed` 被调用一次（event_id 即本次 webhook 的 eid）
+- **AND** `obs.record_event("webhook.received", ...)` 没有被调用
+- **AND** `router.derive_event` 没有被调用
+- **AND** `engine.step` 没有被调用
+
+#### Scenario: RNF-S2 issue.updated 含 REQ tag → 走下游
+
+- **GIVEN** webhook 收到 `body.event="issue.updated"`，`tags=["REQ-foo", "analyze"]`
+- **WHEN** handler 执行
+- **THEN** noise filter 不命中，handler 继续调 `obs.record_event` + `derive_event` +
+  `engine.step`（按现有路径推进状态机；engine.step 至少被调用一次）
+
+#### Scenario: RNF-S3 issue.updated 仅含 intent:intake tag → 走下游
+
+- **GIVEN** webhook 收到 `body.event="issue.updated"`，`tags=["intent:intake"]`（无 REQ-*）
+- **WHEN** handler 执行
+- **THEN** noise filter 不命中（intent 入口必须能 fire INTENT_INTAKE），handler 继续走
+  下游：`derive_event` 返回 `Event.INTENT_INTAKE` → `engine.step` 被调用
+
+#### Scenario: RNF-S4 issue.updated 仅含 intent:analyze tag → 走下游
+
+- **GIVEN** webhook 收到 `body.event="issue.updated"`，`tags=["intent:analyze"]`（无 REQ-*）
+- **WHEN** handler 执行
+- **THEN** noise filter 不命中，`derive_event` 返回 `Event.INTENT_ANALYZE` → `engine.step`
+  被调用
+
+#### Scenario: RNF-S5 session.completed 无 REQ tag → 旧 filter 仍生效
+
+- **GIVEN** webhook 收到 `body.event="session.completed"`，`tags=["analyze"]`（无 REQ-*）
+- **WHEN** handler 执行
+- **THEN** 命中既有 session.completed noise filter，返回 `{"action": "skip", "reason": "session event without REQ tag"}`，`dedup.mark_processed` 被调用，`engine.step` 未调用

--- a/openspec/changes/REQ-router-noise-filter-1777109307/tasks.md
+++ b/openspec/changes/REQ-router-noise-filter-1777109307/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: REQ-router-noise-filter-1777109307
+
+## Stage: implementation (webhook)
+
+- [x] `orchestrator/src/orchestrator/webhook.py`：扩展早期 noise filter，把 `issue.updated`
+  也纳入。条件：`body.event == "issue.updated"` 且**没** REQ-N tag 且**没** `intent:intake` /
+  `intent:analyze` tag → log.debug + `dedup.mark_processed` + `return skip`，不调
+  `obs.record_event` / `derive_event`。
+- [x] 现有 session.completed filter 路径行为不变（同条件、同返回）。
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_contract_router_noise_filter.py`（新文件）：
+  - `test_RNF_S1_issue_updated_no_req_no_intent_skipped` —— issue.updated + tags 既无
+    REQ 也无 intent 入口 → return skip + mark_processed 调过 + obs.record_event 没调过 +
+    engine.step 没调过
+  - `test_RNF_S2_issue_updated_with_req_tag_passes` —— issue.updated + tags 含 REQ-x →
+    继续走下游（engine.step 被调）
+  - `test_RNF_S3_issue_updated_with_intent_intake_passes` —— issue.updated + tags 仅含
+    `intent:intake`，无 REQ → 走下游（INTENT_INTAKE 路径仍能 fire）
+  - `test_RNF_S4_issue_updated_with_intent_analyze_passes` —— issue.updated + tags 仅含
+    `intent:analyze`，无 REQ → 走下游（INTENT_ANALYZE 路径仍能 fire）
+  - `test_RNF_S5_session_completed_no_req_still_skipped` —— 现有 session filter 路径回归
+
+## Stage: spec
+
+- [x] `openspec/changes/REQ-router-noise-filter-1777109307/proposal.md`
+- [x] `openspec/changes/REQ-router-noise-filter-1777109307/tasks.md`
+- [x] `openspec/changes/REQ-router-noise-filter-1777109307/specs/router-noise-filter/contract.spec.yaml`
+- [x] `openspec/changes/REQ-router-noise-filter-1777109307/specs/router-noise-filter/spec.md`
+
+## Stage: PR
+
+- [x] git push feat/REQ-router-noise-filter-1777109307
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/webhook.py
+++ b/orchestrator/src/orchestrator/webhook.py
@@ -136,15 +136,27 @@ async def webhook(request: Request) -> JSONResponse:
     log.info("webhook.received", evt=body.event, issue_id=body.issueId, tags=tags)
 
     # ─── 2.5 早期 noise filter ─────────────────────────────────────────────
-    # BKD 推整 project 所有 session.completed，包括跟当前 REQ 无关的旧 issue。
-    # 没 REQ-N tag 也不是 intent.analyze 入口的，直接 skip 不浪费 derive/CAS。
-    if (
-        body.event == "session.completed"
-        and not router_lib.extract_req_id(tags)
-    ):
+    # BKD 推整 project 所有 webhook 事件，包括跟当前 REQ 无关的旧 issue / 别人手动改的卡。
+    #   session.completed: 没 REQ tag → 别的工作流的孤儿 session，skip
+    #   issue.updated:     没 REQ tag 也没 intent 入口 tag → 跟任何 sisyphus REQ 都没关系
+    #                      （唯一合法触发：REQ workflow 内 issue 的 tag/result 变化，或
+    #                       用户在 intent issue 上打 intent:intake/analyze 触发新 REQ）
+    # 早 skip 避免后续 obs.record_event / derive_event / engine.step 白跑 + 污染 event log。
+    has_req_tag = bool(router_lib.extract_req_id(tags))
+    if body.event == "session.completed" and not has_req_tag:
         log.debug("webhook.skip_no_req_tag", issue_id=body.issueId, tags=tags)
         await dedup.mark_processed(pool, eid)
         return {"action": "skip", "reason": "session event without REQ tag"}
+    if (
+        body.event == "issue.updated"
+        and not has_req_tag
+        and "intent:intake" not in tags
+        and "intent:analyze" not in tags
+    ):
+        log.debug("webhook.skip_no_req_or_intent_tag",
+                  issue_id=body.issueId, tags=tags)
+        await dedup.mark_processed(pool, eid)
+        return {"action": "skip", "reason": "issue.updated without REQ or intent tag"}
     await obs.record_event(
         "webhook.received",
         issue_id=body.issueId, tags=tags,

--- a/orchestrator/tests/test_contract_router_noise_filter.py
+++ b/orchestrator/tests/test_contract_router_noise_filter.py
@@ -85,9 +85,9 @@ def _setup_for_skip(monkeypatch) -> dict:
     derive_calls: list = []
 
     monkeypatch.setattr(dedup, "check_and_record", AsyncMock(return_value="new"))
-    monkeypatch.setattr(dedup, "mark_processed", AsyncMock(side_effect=mark_calls.append))
+    monkeypatch.setattr(dedup, "mark_processed", AsyncMock(side_effect=lambda *a, **kw: mark_calls.append(a)))
     monkeypatch.setattr(db, "get_pool", lambda: _FakePool())
-    monkeypatch.setattr(obs, "record_event", AsyncMock(side_effect=obs_calls.append))
+    monkeypatch.setattr(obs, "record_event", AsyncMock(side_effect=lambda *a, **kw: obs_calls.append(a)))
 
     orig_derive = router_lib.derive_event
 
@@ -122,7 +122,7 @@ def _setup_for_passthrough(monkeypatch, *, req_id: str | None, derive_event_val)
     monkeypatch.setattr(dedup, "check_and_record", AsyncMock(return_value="new"))
     monkeypatch.setattr(dedup, "mark_processed", AsyncMock())
     monkeypatch.setattr(db, "get_pool", lambda: _FakePool())
-    monkeypatch.setattr(obs, "record_event", AsyncMock(side_effect=obs_calls.append))
+    monkeypatch.setattr(obs, "record_event", AsyncMock(side_effect=lambda *a, **kw: obs_calls.append(a)))
     monkeypatch.setattr(router_lib, "extract_req_id", lambda tags, num=None: req_id)
     monkeypatch.setattr(router_lib, "derive_event", lambda evt, tags: derive_event_val)
 
@@ -219,7 +219,7 @@ async def test_rnf_s2_issue_updated_with_req_tag_proceeds(monkeypatch):
     tracking = _setup_for_passthrough(
         monkeypatch,
         req_id="REQ-rnf-s2-test",
-        derive_event_val=Event.SESSION_COMPLETED,
+        derive_event_val=Event.SESSION_FAILED,
     )
 
     req = _make_request("issue.updated", ["REQ-rnf-s2-test", "analyze"])

--- a/orchestrator/tests/test_contract_router_noise_filter.py
+++ b/orchestrator/tests/test_contract_router_noise_filter.py
@@ -1,0 +1,272 @@
+"""Contract tests for early webhook noise filter (REQ-router-noise-filter-1777109307).
+
+Black-box behavioral contracts derived from:
+  openspec/changes/REQ-router-noise-filter-1777109307/specs/router-noise-filter/spec.md
+
+Scenarios covered:
+  RNF-S1  issue.updated 无 REQ tag 无 intent tag → skip + mark_processed + 不 obs/derive/engine
+  RNF-S2  issue.updated 含 REQ tag → 走下游（engine.step 被调）
+  RNF-S3  issue.updated 仅 intent:intake → 走下游（INTENT_INTAKE fire）
+  RNF-S4  issue.updated 仅 intent:analyze → 走下游（INTENT_ANALYZE fire）
+  RNF-S5  session.completed 无 REQ tag → 旧 filter 仍生效
+"""
+from __future__ import annotations
+
+from typing import ClassVar
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class _FakePool:
+    """模拟 asyncpg pool 的最小实现：fetchrow / execute 不报错。"""
+
+    def __init__(self, fetchrow_returns=()):
+        self._returns = list(fetchrow_returns)
+        self._pos = 0
+        self.execute_calls: list[tuple[str, tuple]] = []
+
+    async def fetchrow(self, sql: str, *args):
+        if self._pos < len(self._returns):
+            val = self._returns[self._pos]
+            self._pos += 1
+            return val
+        return None
+
+    async def execute(self, sql: str, *args):
+        self.execute_calls.append((sql, args))
+
+
+def _make_request(*, event: str, tags: list[str], issue_id: str = "issue-x",
+                  project_id: str = "proj-x", execution_id: str = "exec-x"):
+    class _Req:
+        headers: ClassVar = {"authorization": "Bearer test-webhook-token"}
+
+        async def json(self):
+            return {
+                "event": event,
+                "issueId": issue_id,
+                "projectId": project_id,
+                "executionId": execution_id,
+                "tags": tags,
+            }
+
+    return _Req()
+
+
+def _wire_common(monkeypatch):
+    """Wire the minimum mocks shared by all scenarios."""
+    import orchestrator.observability as obs
+    from orchestrator import engine, webhook
+    from orchestrator import router as router_lib
+    from orchestrator.state import ReqState
+    from orchestrator.store import db, dedup
+    from orchestrator.store import req_state as rs_mod
+
+    obs_calls: list = []
+    derive_calls: list = []
+    engine_calls: list = []
+    mark_calls: list = []
+
+    monkeypatch.setattr(dedup, "check_and_record", AsyncMock(return_value="new"))
+    monkeypatch.setattr(dedup, "mark_processed",
+                        AsyncMock(side_effect=lambda *a, **kw: mark_calls.append(a)))
+    monkeypatch.setattr(db, "get_pool", lambda: _FakePool())
+    monkeypatch.setattr(obs, "record_event",
+                        AsyncMock(side_effect=lambda *a, **kw: obs_calls.append((a, kw))))
+
+    # BKDClient: never expected to be hit in the issue.updated branches because the
+    # body always carries tags. Make it raise loud if accidentally instantiated.
+    class _BKD:
+        def __init__(self, *a, **kw): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def get_issue(self, *a, **kw):
+            class R:
+                tags: ClassVar = []
+            return R()
+        async def update_issue(self, *a, **kw): pass
+    monkeypatch.setattr(webhook, "BKDClient", _BKD)
+
+    # Wrap derive_event so we can assert it was/wasn't called without breaking real logic.
+    real_derive = router_lib.derive_event
+
+    def _wrapped_derive(evt, tags, *a, **kw):
+        derive_calls.append((evt, list(tags)))
+        return real_derive(evt, tags, *a, **kw)
+    monkeypatch.setattr(router_lib, "derive_event", _wrapped_derive)
+    monkeypatch.setattr(webhook.router_lib, "derive_event", _wrapped_derive)
+
+    class _Row:
+        state = ReqState.INIT
+        context: ClassVar = {}
+
+    monkeypatch.setattr(rs_mod, "get", AsyncMock(return_value=_Row()))
+    monkeypatch.setattr(rs_mod, "insert_init", AsyncMock())
+    monkeypatch.setattr(rs_mod, "update_context", AsyncMock())
+    monkeypatch.setattr(engine, "step",
+                        AsyncMock(side_effect=lambda *a, **kw:
+                                  engine_calls.append((a, kw)) or {"action": "ok"}))
+
+    return {
+        "obs_calls": obs_calls,
+        "derive_calls": derive_calls,
+        "engine_calls": engine_calls,
+        "mark_calls": mark_calls,
+    }
+
+
+# ─── RNF-S1: issue.updated 无 REQ tag 无 intent tag → skip ─────────────────
+
+@pytest.mark.asyncio
+async def test_rnf_s1_issue_updated_no_req_no_intent_skipped(monkeypatch):
+    """
+    RNF-S1: body.event="issue.updated" + tags 不含 REQ-* 也不含 intent:intake/analyze
+    → 早期 noise filter 命中：return skip + mark_processed 调过 + obs.record_event 没调过
+    + derive_event 没调过 + engine.step 没调过。
+    """
+    from orchestrator import webhook
+
+    spy = _wire_common(monkeypatch)
+
+    req = _make_request(event="issue.updated", tags=["bug", "frontend"])
+    result = await webhook.webhook(req)
+
+    assert result == {
+        "action": "skip",
+        "reason": "issue.updated without REQ or intent tag",
+    }, f"Expected noise-skip dict, got {result!r}"
+
+    assert len(spy["mark_calls"]) == 1, (
+        f"dedup.mark_processed must be called exactly once on noise-skip, "
+        f"got {len(spy['mark_calls'])}"
+    )
+
+    assert spy["obs_calls"] == [], (
+        f"obs.record_event must NOT be called on noise events; "
+        f"got calls: {spy['obs_calls']!r}"
+    )
+
+    assert spy["derive_calls"] == [], (
+        f"router.derive_event must NOT be called on noise-skip path; "
+        f"got calls: {spy['derive_calls']!r}"
+    )
+
+    assert spy["engine_calls"] == [], (
+        f"engine.step must NOT be called on noise-skip path; "
+        f"got calls: {spy['engine_calls']!r}"
+    )
+
+
+# ─── RNF-S2: issue.updated 含 REQ tag → 走下游 ────────────────────────────
+
+@pytest.mark.asyncio
+async def test_rnf_s2_issue_updated_with_req_tag_passes(monkeypatch):
+    """
+    RNF-S2: body.event="issue.updated" + tags 含 REQ-* → noise filter 不命中，
+    handler 继续走下游：engine.step 至少被调用一次。
+    """
+    from orchestrator import webhook
+
+    spy = _wire_common(monkeypatch)
+
+    # tags 含 REQ-* + result tag → router.derive_event 会返回主链事件
+    # （staging-test 走 race fallback 路径），engine.step 必定被调用
+    req = _make_request(
+        event="issue.updated",
+        tags=["REQ-rnf-s2", "staging-test", "result:pass"],
+    )
+    result = await webhook.webhook(req)
+
+    assert result != {"action": "skip", "reason": "issue.updated without REQ or intent tag"}, (
+        f"REQ-tagged issue.updated must NOT hit noise filter; got {result!r}"
+    )
+
+    assert len(spy["engine_calls"]) >= 1, (
+        "engine.step must be called when issue.updated carries a REQ-* tag "
+        "(noise filter must let it through)"
+    )
+
+
+# ─── RNF-S3: issue.updated 仅 intent:intake → 走下游 ──────────────────────
+
+@pytest.mark.asyncio
+async def test_rnf_s3_issue_updated_with_intent_intake_passes(monkeypatch):
+    """
+    RNF-S3: body.event="issue.updated" + tags=["intent:intake"]（无 REQ-*）
+    → noise filter 不命中（intent 入口必须能 fire INTENT_INTAKE）。
+    """
+    from orchestrator import webhook
+
+    spy = _wire_common(monkeypatch)
+
+    req = _make_request(event="issue.updated", tags=["intent:intake"])
+    result = await webhook.webhook(req)
+
+    assert result != {"action": "skip", "reason": "issue.updated without REQ or intent tag"}, (
+        f"intent:intake-tagged issue.updated must NOT hit noise filter; got {result!r}"
+    )
+
+    # derive_event must run to map intent:intake → INTENT_INTAKE
+    assert spy["derive_calls"], (
+        "router.derive_event must be called when intent:intake tag is present "
+        "(noise filter must let it through)"
+    )
+
+
+# ─── RNF-S4: issue.updated 仅 intent:analyze → 走下游 ─────────────────────
+
+@pytest.mark.asyncio
+async def test_rnf_s4_issue_updated_with_intent_analyze_passes(monkeypatch):
+    """
+    RNF-S4: body.event="issue.updated" + tags=["intent:analyze"]（无 REQ-*）
+    → noise filter 不命中，derive_event 应映射出 INTENT_ANALYZE。
+    """
+    from orchestrator import webhook
+
+    spy = _wire_common(monkeypatch)
+
+    req = _make_request(event="issue.updated", tags=["intent:analyze"])
+    result = await webhook.webhook(req)
+
+    assert result != {"action": "skip", "reason": "issue.updated without REQ or intent tag"}, (
+        f"intent:analyze-tagged issue.updated must NOT hit noise filter; got {result!r}"
+    )
+
+    assert spy["derive_calls"], (
+        "router.derive_event must be called when intent:analyze tag is present"
+    )
+
+
+# ─── RNF-S5: session.completed 无 REQ tag → 旧 filter 仍生效 ──────────────
+
+@pytest.mark.asyncio
+async def test_rnf_s5_session_completed_no_req_still_skipped(monkeypatch):
+    """
+    RNF-S5: 既有 session.completed-without-REQ-tag filter 行为回归不变。
+    body.event="session.completed" + tags 不含 REQ-* → return skip + mark_processed 调过
+    + engine.step 没调过。
+    """
+    from orchestrator import webhook
+
+    spy = _wire_common(monkeypatch)
+
+    # session.completed: webhook 会调 BKDClient.get_issue 重拉 tags（line 132）。
+    # _wire_common 的 _BKD.get_issue 默认返空 tags，所以 effective tags = []，
+    # noise filter 命中。
+    req = _make_request(event="session.completed", tags=[])
+    result = await webhook.webhook(req)
+
+    assert result == {
+        "action": "skip",
+        "reason": "session event without REQ tag",
+    }, f"Expected legacy session-skip dict, got {result!r}"
+
+    assert len(spy["mark_calls"]) == 1, (
+        f"dedup.mark_processed must be called exactly once on session noise-skip, "
+        f"got {len(spy['mark_calls'])}"
+    )
+
+    assert spy["engine_calls"] == [], (
+        "engine.step must NOT be called on session.completed noise-skip path"
+    )

--- a/orchestrator/tests/test_contract_router_noise_filter.py
+++ b/orchestrator/tests/test_contract_router_noise_filter.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 from typing import ClassVar
 from unittest.mock import AsyncMock
 
-import pytest
-
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
 

--- a/orchestrator/tests/test_contract_router_noise_filter.py
+++ b/orchestrator/tests/test_contract_router_noise_filter.py
@@ -1,14 +1,14 @@
-"""Contract tests for early webhook noise filter (REQ-router-noise-filter-1777109307).
+"""Contract tests for webhook early noise filter (REQ-router-noise-filter-1777109307).
 
 Black-box behavioral contracts derived from:
   openspec/changes/REQ-router-noise-filter-1777109307/specs/router-noise-filter/spec.md
 
 Scenarios covered:
-  RNF-S1  issue.updated 无 REQ tag 无 intent tag → skip + mark_processed + 不 obs/derive/engine
-  RNF-S2  issue.updated 含 REQ tag → 走下游（engine.step 被调）
-  RNF-S3  issue.updated 仅 intent:intake → 走下游（INTENT_INTAKE fire）
-  RNF-S4  issue.updated 仅 intent:analyze → 走下游（INTENT_ANALYZE fire）
-  RNF-S5  session.completed 无 REQ tag → 旧 filter 仍生效
+  RNF-S1  issue.updated 无 REQ tag 无 intent tag → skip (noise filter)
+  RNF-S2  issue.updated 含 REQ tag → 走下游 (engine.step 被调用)
+  RNF-S3  issue.updated 仅含 intent:intake tag → 走下游 (engine.step 被调用)
+  RNF-S4  issue.updated 仅含 intent:analyze tag → 走下游 (engine.step 被调用)
+  RNF-S5  session.completed 无 REQ tag → 旧 filter 仍生效 (skip)
 """
 from __future__ import annotations
 
@@ -17,45 +17,100 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
 
 class _FakePool:
-    """模拟 asyncpg pool 的最小实现：fetchrow / execute 不报错。"""
+    def __init__(self):
+        self.executed: list = []
 
-    def __init__(self, fetchrow_returns=()):
-        self._returns = list(fetchrow_returns)
-        self._pos = 0
-        self.execute_calls: list[tuple[str, tuple]] = []
-
-    async def fetchrow(self, sql: str, *args):
-        if self._pos < len(self._returns):
-            val = self._returns[self._pos]
-            self._pos += 1
-            return val
+    async def fetchrow(self, sql, *args):
         return None
 
-    async def execute(self, sql: str, *args):
-        self.execute_calls.append((sql, args))
+    async def execute(self, sql, *args):
+        self.executed.append((sql, args))
 
 
-def _make_request(*, event: str, tags: list[str], issue_id: str = "issue-x",
-                  project_id: str = "proj-x", execution_id: str = "exec-x"):
+def _make_request(event: str, tags: list[str], issue_id: str = "issue-rnf") -> object:
     class _Req:
         headers: ClassVar = {"authorization": "Bearer test-webhook-token"}
 
-        async def json(self):
+        async def json(self_inner):
             return {
                 "event": event,
                 "issueId": issue_id,
-                "projectId": project_id,
-                "executionId": execution_id,
+                "projectId": "proj-rnf",
+                "executionId": "exec-rnf",
                 "tags": tags,
             }
 
     return _Req()
 
 
-def _wire_common(monkeypatch):
-    """Wire the minimum mocks shared by all scenarios."""
+def _mock_bkd(monkeypatch, webhook_mod, tags: list[str]) -> None:
+    """Stub BKDClient so get_issue never hits network."""
+
+    class _BKD:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get_issue(self, *a, **kw):
+            class _R:
+                pass
+
+            _R.tags = tags
+            return _R()
+
+        async def update_issue(self, *a, **kw):
+            pass
+
+    monkeypatch.setattr(webhook_mod, "BKDClient", _BKD)
+
+
+def _setup_for_skip(monkeypatch) -> dict:
+    """
+    Minimal mock setup for noise-filter skip scenarios.
+    Returns dict with call-tracking lists.
+    """
+    import orchestrator.observability as obs
+    from orchestrator import router as router_lib
+    from orchestrator.store import db, dedup
+
+    mark_calls: list = []
+    obs_calls: list = []
+    derive_calls: list = []
+
+    monkeypatch.setattr(dedup, "check_and_record", AsyncMock(return_value="new"))
+    monkeypatch.setattr(dedup, "mark_processed", AsyncMock(side_effect=mark_calls.append))
+    monkeypatch.setattr(db, "get_pool", lambda: _FakePool())
+    monkeypatch.setattr(obs, "record_event", AsyncMock(side_effect=obs_calls.append))
+
+    orig_derive = router_lib.derive_event
+
+    def _tracked_derive(evt, tags):
+        derive_calls.append((evt, tags))
+        return orig_derive(evt, tags)
+
+    monkeypatch.setattr(router_lib, "derive_event", _tracked_derive)
+
+    return {
+        "mark_calls": mark_calls,
+        "obs_calls": obs_calls,
+        "derive_calls": derive_calls,
+    }
+
+
+def _setup_for_passthrough(monkeypatch, *, req_id: str | None, derive_event_val) -> dict:
+    """
+    Full mock setup for pass-through scenarios (noise filter should NOT fire).
+    Returns dict with call-tracking lists.
+    """
     import orchestrator.observability as obs
     from orchestrator import engine, webhook
     from orchestrator import router as router_lib
@@ -63,39 +118,15 @@ def _wire_common(monkeypatch):
     from orchestrator.store import db, dedup
     from orchestrator.store import req_state as rs_mod
 
+    step_calls: list = []
     obs_calls: list = []
-    derive_calls: list = []
-    engine_calls: list = []
-    mark_calls: list = []
 
     monkeypatch.setattr(dedup, "check_and_record", AsyncMock(return_value="new"))
-    monkeypatch.setattr(dedup, "mark_processed",
-                        AsyncMock(side_effect=lambda *a, **kw: mark_calls.append(a)))
+    monkeypatch.setattr(dedup, "mark_processed", AsyncMock())
     monkeypatch.setattr(db, "get_pool", lambda: _FakePool())
-    monkeypatch.setattr(obs, "record_event",
-                        AsyncMock(side_effect=lambda *a, **kw: obs_calls.append((a, kw))))
-
-    # BKDClient: never expected to be hit in the issue.updated branches because the
-    # body always carries tags. Make it raise loud if accidentally instantiated.
-    class _BKD:
-        def __init__(self, *a, **kw): pass
-        async def __aenter__(self): return self
-        async def __aexit__(self, *a): return False
-        async def get_issue(self, *a, **kw):
-            class R:
-                tags: ClassVar = []
-            return R()
-        async def update_issue(self, *a, **kw): pass
-    monkeypatch.setattr(webhook, "BKDClient", _BKD)
-
-    # Wrap derive_event so we can assert it was/wasn't called without breaking real logic.
-    real_derive = router_lib.derive_event
-
-    def _wrapped_derive(evt, tags, *a, **kw):
-        derive_calls.append((evt, list(tags)))
-        return real_derive(evt, tags, *a, **kw)
-    monkeypatch.setattr(router_lib, "derive_event", _wrapped_derive)
-    monkeypatch.setattr(webhook.router_lib, "derive_event", _wrapped_derive)
+    monkeypatch.setattr(obs, "record_event", AsyncMock(side_effect=obs_calls.append))
+    monkeypatch.setattr(router_lib, "extract_req_id", lambda tags, num=None: req_id)
+    monkeypatch.setattr(router_lib, "derive_event", lambda evt, tags: derive_event_val)
 
     class _Row:
         state = ReqState.INIT
@@ -104,169 +135,202 @@ def _wire_common(monkeypatch):
     monkeypatch.setattr(rs_mod, "get", AsyncMock(return_value=_Row()))
     monkeypatch.setattr(rs_mod, "insert_init", AsyncMock())
     monkeypatch.setattr(rs_mod, "update_context", AsyncMock())
-    monkeypatch.setattr(engine, "step",
-                        AsyncMock(side_effect=lambda *a, **kw:
-                                  engine_calls.append((a, kw)) or {"action": "ok"}))
+
+    monkeypatch.setattr(
+        engine,
+        "step",
+        AsyncMock(side_effect=lambda *a, **kw: step_calls.append(kw) or {"action": "noop"}),
+    )
+
+    _mock_bkd(monkeypatch, webhook, [])
 
     return {
+        "step_calls": step_calls,
         "obs_calls": obs_calls,
-        "derive_calls": derive_calls,
-        "engine_calls": engine_calls,
-        "mark_calls": mark_calls,
+        "webhook": webhook,
     }
 
 
-# ─── RNF-S1: issue.updated 无 REQ tag 无 intent tag → skip ─────────────────
+# ─── RNF-S1: issue.updated 无 REQ tag 无 intent tag → skip ──────────────────
 
-@pytest.mark.asyncio
-async def test_rnf_s1_issue_updated_no_req_no_intent_skipped(monkeypatch):
+
+async def test_rnf_s1_issue_updated_no_req_no_intent_is_skipped(monkeypatch):
     """
-    RNF-S1: body.event="issue.updated" + tags 不含 REQ-* 也不含 intent:intake/analyze
-    → 早期 noise filter 命中：return skip + mark_processed 调过 + obs.record_event 没调过
-    + derive_event 没调过 + engine.step 没调过。
+    RNF-S1: webhook 收到 issue.updated，tags 不含 REQ-* 也不含 intent:intake /
+    intent:analyze 时，必须命中 noise filter，返回 action=skip + 含 issue.updated 的
+    reason；dedup.mark_processed 被调用一次；obs.record_event / derive_event /
+    engine.step 均不被调用。
     """
-    from orchestrator import webhook
+    from orchestrator import engine, webhook
 
-    spy = _wire_common(monkeypatch)
+    tracking = _setup_for_skip(monkeypatch)
+    _mock_bkd(monkeypatch, webhook, ["bug", "frontend"])
 
-    req = _make_request(event="issue.updated", tags=["bug", "frontend"])
+    step_calls: list = []
+    monkeypatch.setattr(
+        engine,
+        "step",
+        AsyncMock(side_effect=lambda *a, **kw: step_calls.append(kw) or {"action": "noop"}),
+    )
+
+    req = _make_request("issue.updated", ["bug", "frontend"])
     result = await webhook.webhook(req)
 
-    assert result == {
-        "action": "skip",
-        "reason": "issue.updated without REQ or intent tag",
-    }, f"Expected noise-skip dict, got {result!r}"
-
-    assert len(spy["mark_calls"]) == 1, (
-        f"dedup.mark_processed must be called exactly once on noise-skip, "
-        f"got {len(spy['mark_calls'])}"
+    assert isinstance(result, dict), f"Expected dict response, got {type(result)}"
+    assert result.get("action") == "skip", (
+        f"RNF-S1: handler must return action='skip' for noise event, "
+        f"got action={result.get('action')!r}"
     )
 
-    assert spy["obs_calls"] == [], (
-        f"obs.record_event must NOT be called on noise events; "
-        f"got calls: {spy['obs_calls']!r}"
+    reason = result.get("reason", "")
+    assert "issue.updated" in reason, (
+        f"RNF-S1: skip reason must identify 'issue.updated' noise, got reason={reason!r}"
     )
 
-    assert spy["derive_calls"] == [], (
-        f"router.derive_event must NOT be called on noise-skip path; "
-        f"got calls: {spy['derive_calls']!r}"
+    assert len(tracking["mark_calls"]) == 1, (
+        f"RNF-S1: dedup.mark_processed must be called exactly once so BKD at-least-once "
+        f"retry also short-circuits; called {len(tracking['mark_calls'])} times"
     )
 
-    assert spy["engine_calls"] == [], (
-        f"engine.step must NOT be called on noise-skip path; "
-        f"got calls: {spy['engine_calls']!r}"
+    assert len(tracking["obs_calls"]) == 0, (
+        f"RNF-S1: obs.record_event must NOT be called for noise events "
+        f"(must not pollute event log); called {len(tracking['obs_calls'])} times"
+    )
+
+    assert len(tracking["derive_calls"]) == 0, (
+        f"RNF-S1: router.derive_event must NOT be called for noise events; "
+        f"called {len(tracking['derive_calls'])} times"
+    )
+
+    assert len(step_calls) == 0, (
+        f"RNF-S1: engine.step must NOT be called for noise events; "
+        f"called {len(step_calls)} times"
     )
 
 
-# ─── RNF-S2: issue.updated 含 REQ tag → 走下游 ────────────────────────────
+# ─── RNF-S2: issue.updated 含 REQ tag → 走下游 ──────────────────────────────
 
-@pytest.mark.asyncio
-async def test_rnf_s2_issue_updated_with_req_tag_passes(monkeypatch):
+
+async def test_rnf_s2_issue_updated_with_req_tag_proceeds(monkeypatch):
     """
-    RNF-S2: body.event="issue.updated" + tags 含 REQ-* → noise filter 不命中，
-    handler 继续走下游：engine.step 至少被调用一次。
+    RNF-S2: webhook 收到 issue.updated，tags 含 REQ-* tag 时，
+    noise filter 不命中，handler 继续走下游，engine.step 至少被调用一次。
     """
-    from orchestrator import webhook
+    from orchestrator.state import Event
 
-    spy = _wire_common(monkeypatch)
-
-    # tags 含 REQ-* + result tag → router.derive_event 会返回主链事件
-    # （staging-test 走 race fallback 路径），engine.step 必定被调用
-    req = _make_request(
-        event="issue.updated",
-        tags=["REQ-rnf-s2", "staging-test", "result:pass"],
-    )
-    result = await webhook.webhook(req)
-
-    assert result != {"action": "skip", "reason": "issue.updated without REQ or intent tag"}, (
-        f"REQ-tagged issue.updated must NOT hit noise filter; got {result!r}"
+    tracking = _setup_for_passthrough(
+        monkeypatch,
+        req_id="REQ-rnf-s2-test",
+        derive_event_val=Event.SESSION_COMPLETED,
     )
 
-    assert len(spy["engine_calls"]) >= 1, (
-        "engine.step must be called when issue.updated carries a REQ-* tag "
-        "(noise filter must let it through)"
+    req = _make_request("issue.updated", ["REQ-rnf-s2-test", "analyze"])
+    await tracking["webhook"].webhook(req)
+
+    assert len(tracking["step_calls"]) >= 1, (
+        f"RNF-S2: engine.step must be called when issue.updated has a REQ-* tag; "
+        f"called {len(tracking['step_calls'])} times"
     )
 
 
-# ─── RNF-S3: issue.updated 仅 intent:intake → 走下游 ──────────────────────
+# ─── RNF-S3: issue.updated 仅含 intent:intake tag → 走下游 ──────────────────
 
-@pytest.mark.asyncio
-async def test_rnf_s3_issue_updated_with_intent_intake_passes(monkeypatch):
+
+async def test_rnf_s3_issue_updated_intent_intake_proceeds(monkeypatch):
     """
-    RNF-S3: body.event="issue.updated" + tags=["intent:intake"]（无 REQ-*）
-    → noise filter 不命中（intent 入口必须能 fire INTENT_INTAKE）。
+    RNF-S3: webhook 收到 issue.updated，tags 含 intent:intake（无 REQ-* tag）时，
+    noise filter 不命中（intent 入口必须放行），handler 继续走下游，
+    engine.step 至少被调用一次。
     """
-    from orchestrator import webhook
+    from orchestrator import router as router_lib
+    from orchestrator.state import Event
 
-    spy = _wire_common(monkeypatch)
+    tracking = _setup_for_passthrough(
+        monkeypatch,
+        req_id=None,
+        derive_event_val=Event.INTENT_INTAKE,
+    )
+    # No REQ tag in intent:intake event — extract_req_id returns None
+    monkeypatch.setattr(router_lib, "extract_req_id", lambda tags, num=None: None)
 
-    req = _make_request(event="issue.updated", tags=["intent:intake"])
-    result = await webhook.webhook(req)
+    req = _make_request("issue.updated", ["intent:intake"], issue_id="issue-rnf-s3")
+    await tracking["webhook"].webhook(req)
 
-    assert result != {"action": "skip", "reason": "issue.updated without REQ or intent tag"}, (
-        f"intent:intake-tagged issue.updated must NOT hit noise filter; got {result!r}"
+    assert len(tracking["step_calls"]) >= 1, (
+        f"RNF-S3: engine.step must be called for issue.updated with intent:intake; "
+        f"called {len(tracking['step_calls'])} times"
     )
 
-    # derive_event must run to map intent:intake → INTENT_INTAKE
-    assert spy["derive_calls"], (
-        "router.derive_event must be called when intent:intake tag is present "
-        "(noise filter must let it through)"
-    )
+
+# ─── RNF-S4: issue.updated 仅含 intent:analyze tag → 走下游 ─────────────────
 
 
-# ─── RNF-S4: issue.updated 仅 intent:analyze → 走下游 ─────────────────────
-
-@pytest.mark.asyncio
-async def test_rnf_s4_issue_updated_with_intent_analyze_passes(monkeypatch):
+async def test_rnf_s4_issue_updated_intent_analyze_proceeds(monkeypatch):
     """
-    RNF-S4: body.event="issue.updated" + tags=["intent:analyze"]（无 REQ-*）
-    → noise filter 不命中，derive_event 应映射出 INTENT_ANALYZE。
+    RNF-S4: webhook 收到 issue.updated，tags 含 intent:analyze（无 REQ-* tag）时，
+    noise filter 不命中，handler 继续走下游，engine.step 至少被调用一次。
     """
-    from orchestrator import webhook
+    from orchestrator import router as router_lib
+    from orchestrator.state import Event
 
-    spy = _wire_common(monkeypatch)
+    tracking = _setup_for_passthrough(
+        monkeypatch,
+        req_id=None,
+        derive_event_val=Event.INTENT_ANALYZE,
+    )
+    monkeypatch.setattr(router_lib, "extract_req_id", lambda tags, num=None: None)
 
-    req = _make_request(event="issue.updated", tags=["intent:analyze"])
-    result = await webhook.webhook(req)
+    req = _make_request("issue.updated", ["intent:analyze"], issue_id="issue-rnf-s4")
+    await tracking["webhook"].webhook(req)
 
-    assert result != {"action": "skip", "reason": "issue.updated without REQ or intent tag"}, (
-        f"intent:analyze-tagged issue.updated must NOT hit noise filter; got {result!r}"
+    assert len(tracking["step_calls"]) >= 1, (
+        f"RNF-S4: engine.step must be called for issue.updated with intent:analyze; "
+        f"called {len(tracking['step_calls'])} times"
     )
 
-    assert spy["derive_calls"], (
-        "router.derive_event must be called when intent:analyze tag is present"
-    )
+
+# ─── RNF-S5: session.completed 无 REQ tag → 旧 filter 仍生效 ────────────────
 
 
-# ─── RNF-S5: session.completed 无 REQ tag → 旧 filter 仍生效 ──────────────
-
-@pytest.mark.asyncio
 async def test_rnf_s5_session_completed_no_req_still_skipped(monkeypatch):
     """
-    RNF-S5: 既有 session.completed-without-REQ-tag filter 行为回归不变。
-    body.event="session.completed" + tags 不含 REQ-* → return skip + mark_processed 调过
-    + engine.step 没调过。
+    RNF-S5: 新 issue.updated noise filter 加入后，既有 session.completed filter
+    必须仍然生效：session.completed 且 tags 无 REQ-* 时返回 action=skip，
+    reason 包含 'session'，mark_processed 被调用，engine.step 不被调用。
     """
-    from orchestrator import webhook
+    from orchestrator import engine, webhook
 
-    spy = _wire_common(monkeypatch)
+    tracking = _setup_for_skip(monkeypatch)
+    _mock_bkd(monkeypatch, webhook, ["analyze"])
 
-    # session.completed: webhook 会调 BKDClient.get_issue 重拉 tags（line 132）。
-    # _wire_common 的 _BKD.get_issue 默认返空 tags，所以 effective tags = []，
-    # noise filter 命中。
-    req = _make_request(event="session.completed", tags=[])
-    result = await webhook.webhook(req)
-
-    assert result == {
-        "action": "skip",
-        "reason": "session event without REQ tag",
-    }, f"Expected legacy session-skip dict, got {result!r}"
-
-    assert len(spy["mark_calls"]) == 1, (
-        f"dedup.mark_processed must be called exactly once on session noise-skip, "
-        f"got {len(spy['mark_calls'])}"
+    step_calls: list = []
+    monkeypatch.setattr(
+        engine,
+        "step",
+        AsyncMock(side_effect=lambda *a, **kw: step_calls.append(kw) or {"action": "noop"}),
     )
 
-    assert spy["engine_calls"] == [], (
-        "engine.step must NOT be called on session.completed noise-skip path"
+    req = _make_request("session.completed", ["analyze"])
+    result = await webhook.webhook(req)
+
+    assert isinstance(result, dict), f"Expected dict response, got {type(result)}"
+    assert result.get("action") == "skip", (
+        f"RNF-S5: session.completed without REQ tag must return action=skip; "
+        f"got action={result.get('action')!r}"
+    )
+
+    reason = result.get("reason", "")
+    assert "session" in reason, (
+        f"RNF-S5: skip reason for session.completed must mention 'session'; "
+        f"got reason={reason!r}"
+    )
+
+    assert len(tracking["mark_calls"]) == 1, (
+        f"RNF-S5: mark_processed must be called exactly once; "
+        f"called {len(tracking['mark_calls'])} times"
+    )
+
+    assert len(step_calls) == 0, (
+        f"RNF-S5: engine.step must NOT be called when session.completed is noise; "
+        f"called {len(step_calls)} times"
     )

--- a/orchestrator/tests/test_contract_router_noise_filter.py
+++ b/orchestrator/tests/test_contract_router_noise_filter.py
@@ -29,7 +29,7 @@ class _FakePool:
         self.executed.append((sql, args))
 
 
-def _make_request(event: str, tags: list[str], issue_id: str = "issue-rnf") -> object:
+def _make_request(event: str, tags: list[str], issue_id: str = "issue-rnf", issue_number: int | None = None) -> object:
     class _Req:
         headers: ClassVar = {"authorization": "Bearer test-webhook-token"}
 
@@ -37,6 +37,7 @@ def _make_request(event: str, tags: list[str], issue_id: str = "issue-rnf") -> o
             return {
                 "event": event,
                 "issueId": issue_id,
+                "issueNumber": issue_number,
                 "projectId": "proj-rnf",
                 "executionId": "exec-rnf",
                 "tags": tags,
@@ -123,7 +124,11 @@ def _setup_for_passthrough(monkeypatch, *, req_id: str | None, derive_event_val)
     monkeypatch.setattr(dedup, "mark_processed", AsyncMock())
     monkeypatch.setattr(db, "get_pool", lambda: _FakePool())
     monkeypatch.setattr(obs, "record_event", AsyncMock(side_effect=lambda *a, **kw: obs_calls.append(a)))
-    monkeypatch.setattr(router_lib, "extract_req_id", lambda tags, num=None: req_id)
+    monkeypatch.setattr(
+        router_lib,
+        "extract_req_id",
+        lambda tags, num=None: req_id if req_id is not None else (f"REQ-{num}" if num is not None else None),
+    )
     monkeypatch.setattr(router_lib, "derive_event", lambda evt, tags: derive_event_val)
 
     class _Row:
@@ -240,7 +245,6 @@ async def test_rnf_s3_issue_updated_intent_intake_proceeds(monkeypatch):
     noise filter 不命中（intent 入口必须放行），handler 继续走下游，
     engine.step 至少被调用一次。
     """
-    from orchestrator import router as router_lib
     from orchestrator.state import Event
 
     tracking = _setup_for_passthrough(
@@ -248,10 +252,8 @@ async def test_rnf_s3_issue_updated_intent_intake_proceeds(monkeypatch):
         req_id=None,
         derive_event_val=Event.INTENT_INTAKE,
     )
-    # No REQ tag in intent:intake event — extract_req_id returns None
-    monkeypatch.setattr(router_lib, "extract_req_id", lambda tags, num=None: None)
-
-    req = _make_request("issue.updated", ["intent:intake"], issue_id="issue-rnf-s3")
+    # No REQ-* tag; issueNumber fallback provides req_id (real BKD always sends issueNumber)
+    req = _make_request("issue.updated", ["intent:intake"], issue_id="issue-rnf-s3", issue_number=3)
     await tracking["webhook"].webhook(req)
 
     assert len(tracking["step_calls"]) >= 1, (
@@ -268,7 +270,6 @@ async def test_rnf_s4_issue_updated_intent_analyze_proceeds(monkeypatch):
     RNF-S4: webhook 收到 issue.updated，tags 含 intent:analyze（无 REQ-* tag）时，
     noise filter 不命中，handler 继续走下游，engine.step 至少被调用一次。
     """
-    from orchestrator import router as router_lib
     from orchestrator.state import Event
 
     tracking = _setup_for_passthrough(
@@ -276,9 +277,8 @@ async def test_rnf_s4_issue_updated_intent_analyze_proceeds(monkeypatch):
         req_id=None,
         derive_event_val=Event.INTENT_ANALYZE,
     )
-    monkeypatch.setattr(router_lib, "extract_req_id", lambda tags, num=None: None)
-
-    req = _make_request("issue.updated", ["intent:analyze"], issue_id="issue-rnf-s4")
+    # No REQ-* tag; issueNumber fallback provides req_id (real BKD always sends issueNumber)
+    req = _make_request("issue.updated", ["intent:analyze"], issue_id="issue-rnf-s4", issue_number=4)
     await tracking["webhook"].webhook(req)
 
     assert len(tracking["step_calls"]) >= 1, (


### PR DESCRIPTION
## Summary

- REQ-router-noise-filter-1777109307
- Extend the early webhook noise filter to also drop `issue.updated` events that carry no REQ tag and no intent entry tag
- Same shape as the existing `session.completed`-without-REQ filter: `dedup.mark_processed` + return skip, no `obs.record_event` / `derive_event` / `engine.step`

## Motivation

BKD broadcasts `issue.updated` for every issue in a project — random user activity on unrelated cards (drag between columns, comments, manual tag edits) was previously falling through to:

1. `obs.record_event("webhook.received", ...)` → polluted Q1/Q2 metabase boards
2. `router.derive_event` → almost always `None`
3. `event_seen` insert + `mark_processed` → Postgres write amplification for noise

The early filter catches them now. `issue.updated` is treated as relevant only when it carries either a `REQ-*` tag (tracked workflow) or `intent:intake` / `intent:analyze` (new-REQ entry). Everything else short-circuits.

## Test plan

- [x] `tests/test_contract_router_noise_filter.py` (5 new scenarios RNF-S1..S5)
  - issue.updated noise → skip + no downstream calls
  - issue.updated with REQ tag → passes filter
  - issue.updated with intent:intake / intent:analyze (no REQ) → passes filter
  - session.completed no REQ → existing filter still fires (regression)
- [x] `uv run pytest tests/test_contract_router_noise_filter.py` — 5/5 pass
- [x] `uv run pytest tests/test_router.py tests/test_webhook_*.py tests/test_engine.py tests/test_contract_webhook_dedup.py` — 66/66 pass (no regressions)
- [x] `uv run pytest` full suite — 487 pass; 18 pre-existing pytest-httpx fixture errors unrelated to this change
- [x] `uv run ruff check src/orchestrator/webhook.py tests/test_contract_router_noise_filter.py` — clean
- [x] `openspec validate REQ-router-noise-filter-1777109307 --strict` — valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)