### PR TITLE
fix(checkers): exit non-zero on empty /workspace/source — refuse silent-pass

### DIFF
--- a/openspec/changes/REQ-checker-empty-source-1777113775/proposal.md
+++ b/openspec/changes/REQ-checker-empty-source-1777113775/proposal.md
@@ -1,0 +1,127 @@
+# REQ-checker-empty-source-1777113775: fix(checkers): mechanical checker silent-pass when /workspace/source empty
+
+## 问题
+
+三个机械 checker（`spec_lint` / `dev_cross_check` / `staging_test`）在 runner pod
+里都用同一个 shell 模板遍历业务源码：
+
+```bash
+for repo in /workspace/source/*/; do
+  ...
+done
+[ $fail -eq 0 ]
+```
+
+如果 `/workspace/source` 不存在 / 是空目录 / 全部子目录都被 skip（feat 分支
+fetch 不到、Makefile target 不全、openspec/changes/<REQ>/ 没写）——
+
+- bash 默认 glob 行为下，没匹配项就用字面 pattern (`/workspace/source/*/`) 当
+  唯一一项进 loop
+- 字面项 `cd` 失败 → fetch test 触发 skip 路径 → `continue`
+- 循环结束 `fail` 还是 `0`
+- exit code 0 = **PASS**
+
+也就是说 checker 在**完全没跑任何工具**的情况下报 pass。orchestrator 据此
+emit `*_PASS` 事件，状态机推下一 stage，直到 pr_ci_watch 才可能在 GitHub 上
+看见根本没 PR / PR 早就红了。这条噪音决策被记到 `stage_runs` /
+`verifier_decisions`，腐蚀 M7+M14e 看板的"checker 准确率"指标。
+
+## 根因
+
+shell `for ... in <glob>` + 没有 nullglob + 没有 ran-counter，导致
+"零迭代 / 全跳过 = 全 OK" 的误读，是三个 checker 共有的形状缺陷。
+checker `_build_cmd()` 写的时候只想着"有 repo 时怎么跑"，没把"没 repo"
+当成必须显式失败的状态。
+
+silent-pass 跟 sisyphus 哲学正面冲突：
+
+- **机械 checker 是唯一裁判** —— 在完全没收集到信号的情况下报 pass，
+  等于把"没数据"当成"全 OK"，是裁判失职
+- **失败先验，再试错** —— 没数据应当走 `REVIEW_RUNNING` 让 verifier-agent
+  主观判断（多半是 escalate "源码丢了"），而不是装作绿灯通过
+
+## 方案
+
+在 `_build_cmd()` 模板的开头和结尾加三道 guard，每道都直接 `exit 1`
+并 echo `=== FAIL <stage>: ... ===` 到 stderr 让 verifier 看清：
+
+### Guard A：源目录存在性
+
+```bash
+if [ ! -d /workspace/source ]; then
+  echo "=== FAIL <stage>: /workspace/source missing — refusing to silent-pass ===" >&2
+  exit 1
+fi
+```
+
+抓 PVC 没挂 / clone helper 从没跑过的情况。
+
+### Guard B：源目录非空
+
+```bash
+repo_count=$(find /workspace/source -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
+if [ "$repo_count" -eq 0 ]; then
+  echo "=== FAIL <stage>: /workspace/source empty (0 cloned repos) — refusing to silent-pass ===" >&2
+  exit 1
+fi
+```
+
+抓"目录存在但里面 0 个 cloned repo"的情况。`find -mindepth 1 -maxdepth 1 -type d`
+精确数子目录数，不会被普通文件 / 残留 lock 文件误判。
+
+### Guard C：至少一个 repo 真跑过工具
+
+主循环里加 `ran` 计数器，**只在真的 invoked 工具的分支** `ran=$((ran+1))`：
+
+- spec_lint：仓有 `feat/<REQ>` 分支 + 有 `openspec/changes/<REQ>/` 目录
+- dev_cross_check：仓有 `feat/<REQ>` 分支 + Makefile 含 `^ci-lint:` target
+- staging_test：仓有 `feat/<REQ>` 分支 + Makefile 含 `^ci-unit-test:` + `^ci-integration-test:` target
+
+循环结束后：
+
+```bash
+if [ "$ran" -eq 0 ]; then
+  echo "=== FAIL <stage>: 0 source repos eligible (no feat/<REQ> branch with required artifact) — refusing to silent-pass ===" >&2
+  exit 1
+fi
+```
+
+抓"目录里有 repo，但 agent 没往 `feat/<REQ>` push 任何东西 / 没写 openspec /
+没贴 ttpos-ci 标准 Makefile target"的情况。
+
+### 三 checker 同样改
+
+silent-pass 是模板共有缺陷，三个 checker 同形修，避免再有第四个 checker
+照着旧模板 copy-paste 时复发。
+
+## 取舍
+
+- **为什么 guard 做在 shell cmd 里而不是 Python 包装层** —— checker 的
+  pass/fail 信号唯一来源是 `exec_in_runner` 的退码，让 shell 自己 exit 1
+  最简单；Python 层加 result.exit_code 后处理会跟"timeout/exception → fail"
+  的现有路径分叉。
+
+- **为什么 0 eligible 算 fail 不算 skip** —— 在 sisyphus 状态机里，进入
+  `spec_lint` / `dev_cross_check` / `staging_test` checker 的前提是 analyze /
+  dev 阶段已经 done，agent 已经声明它写完了。这种情况下 0 eligible 仅有两种
+  解释：**(i) agent 谎报 done 但其实没 push**、**(ii) 环境问题（PVC 丢失 /
+  clone 失败）**。两种都该走 `REVIEW_RUNNING` 给 verifier 兜，绝不是绿灯。
+
+- **为什么用 `find -mindepth 1 -maxdepth 1 -type d` 而不是 `shopt -s nullglob`** ——
+  `shopt` 是 bash builtin，但 cmd 在 `kubectl exec ... -- bash -c` 下面跑，
+  混杂层多了一旦 shell 不是 bash（busybox sh 之类）就静默失败。`find` 是
+  POSIX coreutils，在 sisyphus runner pod 镜像里恒定存在，行为确定。
+
+- **跨 stage 的 silent-pass 漏洞还有么** —— `pr_ci_watch` 是直接调
+  GitHub REST API，没有 `/workspace/source/*` 形状的循环；不需要同样的 guard。
+  本 REQ 仅覆盖三个吃 runner pod shell 模板的 checker。
+
+## 影响面
+
+- 仅改 `orchestrator/src/orchestrator/checkers/{spec_lint,dev_cross_check,staging_test}.py`
+  的 `_build_cmd()` 函数；checker action / 状态机 / event 表无变化。
+- 退码 0 的语义不变（"任一仓任一检查失败 → exit 1"原样保留）。
+- 退码 1 增加 4 条新原因（missing / empty / 0-eligible × 3 stages），verifier
+  prompt **不需要改** —— stderr `=== FAIL <stage>: ... ===` 自描述。
+- 历史上跑过 silent-pass 的 REQ 不回溯（事件已经记录在 `stage_runs`），
+  本次仅修向前的行为。

--- a/openspec/changes/REQ-checker-empty-source-1777113775/specs/checker-empty-source-guard/contract.spec.yaml
+++ b/openspec/changes/REQ-checker-empty-source-1777113775/specs/checker-empty-source-guard/contract.spec.yaml
@@ -1,0 +1,84 @@
+capability: checker-empty-source-guard
+version: "1.0"
+description: |
+  Three sisyphus mechanical checkers (spec_lint / dev_cross_check / staging_test)
+  emit a shell template that iterates `/workspace/source/*/` inside the runner
+  pod. Before this change, any of {missing source dir, empty source dir, all
+  repos skipped} caused the for-loop to iterate zero or one (literal-glob)
+  times and the trailing `[ $fail -eq 0 ]` to evaluate true — a silent-pass
+  with zero work performed.
+
+  This capability defines a uniform three-gate guard added to all three
+  checkers: directory existence, non-empty subdirectory count, and a per-loop
+  `ran` counter that fails when no repo was actually verified.
+
+guards:
+  guard_a_source_dir_exists:
+    location: emitted at the very top of the shell template, before any state mutation
+    check: |
+      [ ! -d /workspace/source ] → echo `=== FAIL <stage>: /workspace/source missing — refusing to silent-pass ===` >&2; exit 1
+    rationale: |
+      Catches the runner-pod scenario where the PVC is unmounted or the
+      sisyphus-clone-repos.sh helper was never invoked.
+
+  guard_b_repo_count_nonzero:
+    location: emitted right after guard A, still before any state mutation
+    check: |
+      repo_count=$(find /workspace/source -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
+      [ "$repo_count" -eq 0 ] → echo `=== FAIL <stage>: /workspace/source empty (0 cloned repos) — refusing to silent-pass ===` >&2; exit 1
+    rationale: |
+      Catches the case where the directory exists but contains zero cloned
+      repos (e.g. helper failed mid-clone, or PVC half-wiped). The
+      `find -mindepth 1 -maxdepth 1 -type d` form is POSIX-portable and
+      counts only immediate subdirectories.
+
+  guard_c_at_least_one_repo_eligible:
+    location: emitted after the per-repo for-loop, before the trailing `[ $fail -eq 0 ]`
+    check: |
+      ran=0 (initialized before the loop)
+      ran=$((ran+1)) (incremented inside the per-stage eligibility branch)
+      [ "$ran" -eq 0 ] → echo `=== FAIL <stage>: 0 source repos eligible (no feat/<REQ> branch with required artifact) — refusing to silent-pass ===` >&2; exit 1
+    eligibility_predicates:
+      spec_lint: |
+        repo has feat/<REQ> branch fetchable from origin AND
+        repo has openspec/changes/<REQ>/ directory
+      dev_cross_check: |
+        repo has feat/<REQ> branch fetchable from origin AND
+        repo's root Makefile contains `^ci-lint:` target
+      staging_test: |
+        repo has feat/<REQ> branch fetchable from origin AND
+        repo's root Makefile contains BOTH `^ci-unit-test:` AND `^ci-integration-test:`
+    rationale: |
+      Catches the case where the analyze / dev agent reported done but did
+      not actually push artifacts to feat/<REQ>, or the source repo lacks the
+      ttpos-ci standard Makefile targets. checker SHALL NOT emit *_PASS when
+      it has zero signal.
+
+stderr_format:
+  contract: |
+    All FAIL messages emitted by these guards MUST follow the literal pattern
+    `=== FAIL <stage>: <reason> — refusing to silent-pass ===` with `<stage>`
+    being one of `spec_lint`, `dev_cross_check`, `staging_test`. The verifier
+    prompt at orchestrator/src/orchestrator/prompts/verifier/<stage>_fail.md.j2
+    relies on stderr-tail substring matching for diagnosis hints; uniform
+    prefix keeps the verifier's classification stable.
+
+invariants:
+  exit_code_semantics:
+    - "exit 0: every eligible repo (ran >= 1) passed every per-tool check"
+    - "exit 1: at least one of {missing dir, empty dir, 0 eligible, per-tool fail}"
+    - "exit -1: timeout (handled at the Python wrapper layer, not in shell)"
+
+  no_change_to_pass_path: |
+    On the happy path (>=1 repo with feat/<REQ> branch and required artifacts),
+    the new shell template behaves identically to the previous template. The
+    only added cost is one `find | wc -l` invocation (~10ms) and three integer
+    comparisons. No new dependencies required in the runner-pod image
+    (find / wc / bash are all baseline coreutils).
+
+  three_checkers_share_template_shape: |
+    spec_lint / dev_cross_check / staging_test all emit a structurally parallel
+    shell template. Future checker authors that copy-paste from any of these
+    three SHALL inherit the empty-source guard by default. This shape parity
+    is enforced by tests/test_checkers_empty_source_guard.py which parametrizes
+    the same three guard scenarios across all three `_build_cmd` functions.

--- a/openspec/changes/REQ-checker-empty-source-1777113775/specs/checker-empty-source-guard/spec.md
+++ b/openspec/changes/REQ-checker-empty-source-1777113775/specs/checker-empty-source-guard/spec.md
@@ -1,0 +1,117 @@
+## ADDED Requirements
+
+### Requirement: spec_lint MUST exit non-zero when /workspace/source is missing or empty
+
+The `spec_lint._build_cmd` shell template SHALL run two pre-loop guards before iterating `/workspace/source/*/` and MUST exit with code 1 if either fails. Guard A MUST fire when `/workspace/source` does not exist, emitting stderr `=== FAIL spec_lint: /workspace/source missing — refusing to silent-pass ===`. Guard B MUST fire when `/workspace/source` exists but contains zero immediate subdirectories (counted via `find /workspace/source -mindepth 1 -maxdepth 1 -type d | wc -l`), emitting stderr `=== FAIL spec_lint: /workspace/source empty (0 cloned repos) — refusing to silent-pass ===`. Both gates protect against the runner-pod scenario where the PVC was wiped or the clone helper never ran, in which case the previous template's `for repo in /workspace/source/*/; do ... done` loop iterated zero times and the trailing `[ $fail -eq 0 ]` evaluated true, returning exit code 0 — a silent-pass.
+
+#### Scenario: CESG-S1 spec_lint exits non-zero when /workspace/source is missing
+
+- **GIVEN** a runner pod where `/workspace/source` does not exist (PVC unmounted
+  or sisyphus-clone-repos.sh never invoked)
+- **WHEN** `spec_lint._build_cmd("REQ-X")` is dispatched via `kubectl exec ... -- bash -c`
+- **THEN** the script MUST exit with code 1 and stderr MUST contain the literal
+  substring `FAIL spec_lint` and `missing`
+
+#### Scenario: CESG-S2 spec_lint exits non-zero when /workspace/source has zero subdirectories
+
+- **GIVEN** a runner pod where `/workspace/source` exists but contains zero
+  subdirectories (e.g. only stale lock files, or empty PVC)
+- **WHEN** the spec_lint shell template runs
+- **THEN** the script MUST exit with code 1 before reaching the `for repo in
+  /workspace/source/*/` loop, and stderr MUST contain `FAIL spec_lint` and
+  `empty`
+
+### Requirement: spec_lint MUST exit non-zero when zero source repos are eligible
+
+The shell template emitted by `spec_lint._build_cmd` SHALL maintain a
+`ran` counter initialized to 0 and incremented exclusively inside the branch
+that actually invokes `openspec validate` and `check-scenario-refs.sh`
+(i.e. the repo passed the `git fetch origin feat/<REQ>` checkout AND has a
+`openspec/changes/<REQ>/` directory). After the loop, if `ran -eq 0`, the
+script MUST exit with code 1 and stderr MUST contain the literal substring
+`FAIL spec_lint` and `0 source repos eligible`. This refuses the silent-pass
+where every cloned repo is skipped because the analyze-agent did not push a
+feat branch with the required openspec artifact.
+
+#### Scenario: CESG-S3 spec_lint exits non-zero when no repo has feat/<REQ> + openspec/changes/<REQ>/
+
+- **GIVEN** `/workspace/source/repo-a` exists (real git repo) but has no
+  `feat/REQ-X` branch on origin (analyze-agent failed to push)
+- **WHEN** the spec_lint shell template runs against `REQ-X`
+- **THEN** the per-repo skip path triggers (`[skip] repo-a: no feat branch`),
+  and after the loop the `ran=0` guard fires with exit code 1 and stderr
+  message containing `0 source repos eligible`
+
+### Requirement: dev_cross_check MUST exit non-zero when /workspace/source is missing or empty
+
+The `dev_cross_check._build_cmd` shell template SHALL carry the same two pre-loop guards as spec_lint, with stderr prefix `=== FAIL dev_cross_check: ... ===` so the verifier can attribute the failure correctly. The template MUST exit with code 1 when `/workspace/source` does not exist OR contains zero immediate subdirectories. The implementation MUST be structurally parallel to spec_lint's guard so future checker authors copy a consistent template.
+
+#### Scenario: CESG-S4 dev_cross_check exits non-zero when /workspace/source is missing
+
+- **GIVEN** a runner pod where `/workspace/source` does not exist
+- **WHEN** the dev_cross_check shell template runs
+- **THEN** exit code MUST be 1 and stderr MUST contain `FAIL dev_cross_check`
+  and `missing`
+
+#### Scenario: CESG-S5 dev_cross_check exits non-zero when /workspace/source is empty
+
+- **GIVEN** `/workspace/source` exists with zero subdirectories
+- **WHEN** the dev_cross_check shell template runs
+- **THEN** exit code MUST be 1 and stderr MUST contain `FAIL dev_cross_check`
+  and `empty`
+
+### Requirement: dev_cross_check MUST exit non-zero when zero source repos are eligible
+
+The shell template emitted by `dev_cross_check._build_cmd` SHALL maintain
+a `ran` counter incremented only when the repo has a checkout-able
+`feat/<REQ>` branch AND the repo's root `Makefile` contains the
+`^ci-lint:` target (the existing `grep -q '^ci-lint:'` test). If `ran -eq 0`
+after the loop, the script MUST exit with code 1 and stderr MUST contain the
+literal substring `FAIL dev_cross_check` and `0 source repos eligible`.
+
+#### Scenario: CESG-S6 dev_cross_check exits non-zero when no repo has feat/<REQ> + ci-lint target
+
+- **GIVEN** `/workspace/source/repo-a` exists with `feat/REQ-X` checked out but
+  no `ci-lint:` target in its Makefile (mis-configured source repo)
+- **WHEN** the dev_cross_check shell template runs against `REQ-X`
+- **THEN** the repo is skipped via the existing `[skip] repo-a: no make ci-lint target`
+  path, `ran` stays 0, and the post-loop guard fires with exit code 1 and
+  stderr containing `0 source repos eligible`
+
+### Requirement: staging_test MUST exit non-zero when /workspace/source is missing or empty
+
+The `staging_test._build_cmd` shell template SHALL carry the same two pre-loop guards as spec_lint, with stderr prefix `=== FAIL staging_test: ... ===`, and MUST exit with code 1 when `/workspace/source` does not exist OR contains zero immediate subdirectories. The pre-loop guards MUST run BEFORE the `mkdir -p /tmp/staging-test-logs` and BEFORE the `pids=""` initialization, so that no parallel background subshell is dispatched when the source tree is broken.
+
+#### Scenario: CESG-S7 staging_test exits non-zero when /workspace/source is missing
+
+- **GIVEN** a runner pod where `/workspace/source` does not exist
+- **WHEN** the staging_test shell template runs
+- **THEN** exit code MUST be 1 and stderr MUST contain `FAIL staging_test`
+  and `missing`
+
+#### Scenario: CESG-S8 staging_test exits non-zero when /workspace/source is empty
+
+- **GIVEN** `/workspace/source` exists with zero subdirectories
+- **WHEN** the staging_test shell template runs
+- **THEN** exit code MUST be 1 and stderr MUST contain `FAIL staging_test`
+  and `empty`
+
+### Requirement: staging_test MUST exit non-zero when zero source repos are eligible
+
+The shell template emitted by `staging_test._build_cmd` SHALL maintain a `ran`
+counter incremented only when the repo has a checkout-able `feat/<REQ>`
+branch AND the Makefile contains both `^ci-unit-test:` and
+`^ci-integration-test:` targets. If `ran -eq 0` after the dispatch loop (and
+before the wait loop), the script MUST exit with code 1 and stderr MUST
+contain the literal substring `FAIL staging_test` and `0 source repos eligible`.
+The `ran -eq 0` check MUST run before `for pid_name in $pids; do wait $pid; done`
+so the script does not block waiting on a non-existent pid list.
+
+#### Scenario: CESG-S9 staging_test exits non-zero when no repo has both ci-unit-test and ci-integration-test
+
+- **GIVEN** `/workspace/source/repo-a` exists with `feat/REQ-X` checked out and
+  Makefile that has `ci-unit-test:` but lacks `ci-integration-test:`
+- **WHEN** the staging_test shell template runs against `REQ-X`
+- **THEN** the repo hits the `[skip] repo-a: missing ci-unit-test or
+  ci-integration-test target` path, `ran` stays 0, and the post-loop guard
+  fires with exit code 1 and stderr containing `0 source repos eligible`

--- a/openspec/changes/REQ-checker-empty-source-1777113775/tasks.md
+++ b/openspec/changes/REQ-checker-empty-source-1777113775/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: REQ-checker-empty-source-1777113775
+
+## Stage: spec
+
+- [x] `openspec/changes/REQ-checker-empty-source-1777113775/proposal.md`
+- [x] `openspec/changes/REQ-checker-empty-source-1777113775/tasks.md`
+- [x] `openspec/changes/REQ-checker-empty-source-1777113775/specs/checker-empty-source-guard/spec.md`
+- [x] `openspec/changes/REQ-checker-empty-source-1777113775/specs/checker-empty-source-guard/contract.spec.yaml`
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/checkers/spec_lint.py::_build_cmd`：
+  加 Guard A (`/workspace/source` 目录存在) + Guard B (`find -mindepth 1 -maxdepth 1 -type d` 数子目录) + Guard C (`ran` 计数器，只在仓有 feat 分支 + `openspec/changes/<REQ>/` 时 +1)
+- [x] `orchestrator/src/orchestrator/checkers/dev_cross_check.py::_build_cmd`：
+  加同样三道 guard（C 的 eligibility = 有 feat 分支 + Makefile `^ci-lint:` target）
+- [x] `orchestrator/src/orchestrator/checkers/staging_test.py::_build_cmd`：
+  加同样三道 guard（C 的 eligibility = 有 feat 分支 + Makefile `^ci-unit-test:` + `^ci-integration-test:` target）
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_checkers_spec_lint.py`（新增）：
+  - 既有 pass/fail/timeout 等价覆盖
+  - `test_build_cmd_emits_workspace_source_existence_guard`
+  - `test_build_cmd_emits_repo_count_zero_guard`
+  - `test_build_cmd_emits_zero_eligible_guard`
+- [x] `orchestrator/tests/test_checkers_dev_cross_check.py`：append 同三个 cmd-shape 单测
+- [x] `orchestrator/tests/test_checkers_staging_test.py`：append 同三个 cmd-shape 单测
+- [x] `orchestrator/tests/test_checkers_empty_source_guard.py`（新增，端到端）：
+  - 用 subprocess 跑 patched cmd（把 `/workspace/source` 替换成 tmp_path）
+  - 三个 guard × 三个 checker = 9 个 parametrized case，**真**用 bash exec 验证 exit ≠ 0
+
+## Stage: PR
+
+- [x] git push feat/REQ-checker-empty-source-1777113775
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/checkers/dev_cross_check.py
+++ b/orchestrator/src/orchestrator/checkers/dev_cross_check.py
@@ -26,12 +26,27 @@ _TAIL = 2048
 def _build_cmd(req_id: str) -> str:
     """遍历 /workspace/source/*/，先切到 feat/<REQ>，对含 ci-lint target 的仓跑 make ci-lint。
 
+    Empty-source guard（防 silent-pass）：
+    - /workspace/source 不存在或没任何子目录 → 直接 exit 1
+    - 遍历后 ran=0（feat 分支 fetch 不到 / 没 ci-lint target）→ exit 1
+      checker 不能在零信号情况下报 pass。
+
     BASE_REV 计算：`git merge-base HEAD origin/main`，fallback `origin/develop`、
     `origin/dev`，再失败传空字符串（ci-lint 退化为全量扫描）。
     """
     return (
         "set -o pipefail; "
+        "if [ ! -d /workspace/source ]; then "
+        '  echo "=== FAIL dev_cross_check: /workspace/source missing — refusing to silent-pass ===" >&2; '
+        "  exit 1; "
+        "fi; "
+        "repo_count=$(find /workspace/source -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l); "
+        'if [ "$repo_count" -eq 0 ]; then '
+        '  echo "=== FAIL dev_cross_check: /workspace/source empty (0 cloned repos) — refusing to silent-pass ===" >&2; '
+        "  exit 1; "
+        "fi; "
         "fail=0; "
+        "ran=0; "
         "for repo in /workspace/source/*/; do "
         '  name=$(basename "$repo"); '
         f'  if ! (cd "$repo" && git fetch origin "feat/{req_id}" 2>/dev/null && git checkout -B "feat/{req_id}" "origin/feat/{req_id}" 2>/dev/null); then '
@@ -48,10 +63,15 @@ def _build_cmd(req_id: str) -> str:
         '      echo "=== FAIL: $name ===" >&2; '
         "      fail=1; "
         "    fi; "
+        "    ran=$((ran+1)); "
         "  else "
         '    echo "[skip] $name: no make ci-lint target"; '
         "  fi; "
         "done; "
+        'if [ "$ran" -eq 0 ]; then '
+        f'  echo "=== FAIL dev_cross_check: 0 source repos eligible (no feat/{req_id} branch with make ci-lint target) — refusing to silent-pass ===" >&2; '
+        "  exit 1; "
+        "fi; "
         "[ $fail -eq 0 ]"
     )
 

--- a/orchestrator/src/orchestrator/checkers/spec_lint.py
+++ b/orchestrator/src/orchestrator/checkers/spec_lint.py
@@ -24,6 +24,12 @@ _TAIL = 2048
 def _build_cmd(req_id: str) -> str:
     """遍历 /workspace/source/*/，先切到 feat/<REQ>，对含 openspec/changes/<REQ>/ 的仓跑两项检查。
 
+    Empty-source guard（防 silent-pass）：
+    - /workspace/source 不存在或没任何子目录 → 直接 exit 1（clone helper 没跑 / PVC 被擦）
+    - 遍历后 ran=0（每仓都被 skip：feat 分支 fetch 不到 / 没 openspec/changes/<REQ>/）
+      → exit 1。checker 不能在零信号情况下报 pass。
+
+    主循环：
     1. git fetch origin feat/<REQ> + git checkout -B feat/<REQ> origin/feat/<REQ>
        —— spec/dev 文件由 agent 推到 feat/<REQ> 分支，runner pod 默认在 main。
        fetch 失败 / 没有该 branch → 该仓视为 not involved（agent 没改它），跳过不算 fail。
@@ -34,7 +40,17 @@ def _build_cmd(req_id: str) -> str:
     """
     return (
         "set -o pipefail; "
+        "if [ ! -d /workspace/source ]; then "
+        '  echo "=== FAIL spec_lint: /workspace/source missing — refusing to silent-pass ===" >&2; '
+        "  exit 1; "
+        "fi; "
+        "repo_count=$(find /workspace/source -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l); "
+        'if [ "$repo_count" -eq 0 ]; then '
+        '  echo "=== FAIL spec_lint: /workspace/source empty (0 cloned repos) — refusing to silent-pass ===" >&2; '
+        "  exit 1; "
+        "fi; "
         "fail=0; "
+        "ran=0; "
         "for repo in /workspace/source/*/; do "
         '  name=$(basename "$repo"); '
         f'  if ! (cd "$repo" && git fetch origin "feat/{req_id}" 2>/dev/null && git checkout -B "feat/{req_id}" "origin/feat/{req_id}" 2>/dev/null); then '
@@ -51,10 +67,15 @@ def _build_cmd(req_id: str) -> str:
         '      echo "=== FAIL scenario-refs: $name ===" >&2; '
         "      fail=1; "
         "    fi; "
+        "    ran=$((ran+1)); "
         "  else "
         f'    echo "[skip] $name: no openspec/changes/{req_id}/"; '
         "  fi; "
         "done; "
+        'if [ "$ran" -eq 0 ]; then '
+        f'  echo "=== FAIL spec_lint: 0 source repos eligible (no feat/{req_id} branch with openspec/changes/{req_id}/) — refusing to silent-pass ===" >&2; '
+        "  exit 1; "
+        "fi; "
         "[ $fail -eq 0 ]"
     )
 

--- a/orchestrator/src/orchestrator/checkers/staging_test.py
+++ b/orchestrator/src/orchestrator/checkers/staging_test.py
@@ -37,12 +37,27 @@ def _build_cmd(req_id: str) -> str:
     """对含 ci-unit-test + ci-integration-test target 的每个 source repo 并行起；
     单 repo 内 unit → integration 串行（&&）。
 
+    Empty-source guard（防 silent-pass）：
+    - /workspace/source 不存在或没任何子目录 → 直接 exit 1
+    - 遍历后 ran=0（feat 分支 fetch 不到 / 没两 target）→ exit 1
+      checker 不能在零信号情况下报 pass。
+
     每仓先切到 feat/<REQ>（agent 推到的分支）；fetch/checkout 失败 → not involved 跳过。
     pids 列表存 `pid:name`，结尾按 pid 依次 wait；失败 tail unit + int 各 50 行到 stderr。
     """
     return (
         "set -o pipefail; "
+        "if [ ! -d /workspace/source ]; then "
+        '  echo "=== FAIL staging_test: /workspace/source missing — refusing to silent-pass ===" >&2; '
+        "  exit 1; "
+        "fi; "
+        "repo_count=$(find /workspace/source -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l); "
+        'if [ "$repo_count" -eq 0 ]; then '
+        '  echo "=== FAIL staging_test: /workspace/source empty (0 cloned repos) — refusing to silent-pass ===" >&2; '
+        "  exit 1; "
+        "fi; "
         "fail=0; "
+        "ran=0; "
         "mkdir -p /tmp/staging-test-logs; "
         'pids=""; '
         "for repo in /workspace/source/*/; do "
@@ -61,10 +76,15 @@ def _build_cmd(req_id: str) -> str:
         '      && make ci-integration-test > "/tmp/staging-test-logs/$name-int.log" 2>&1 '
         "    ) & "
         '    pids="$pids $!:$name"; '
+        "    ran=$((ran+1)); "
         "  else "
         '    echo "[skip] $name: missing ci-unit-test or ci-integration-test target"; '
         "  fi; "
         "done; "
+        'if [ "$ran" -eq 0 ]; then '
+        f'  echo "=== FAIL staging_test: 0 source repos eligible (no feat/{req_id} branch with ci-unit-test+ci-integration-test) — refusing to silent-pass ===" >&2; '
+        "  exit 1; "
+        "fi; "
         "for pid_name in $pids; do "
         "  pid=${pid_name%%:*}; "
         "  name=${pid_name##*:}; "

--- a/orchestrator/tests/test_checkers_empty_source_guard.py
+++ b/orchestrator/tests/test_checkers_empty_source_guard.py
@@ -1,8 +1,28 @@
-"""端到端 shell-level 测试：spec_lint / dev_cross_check / staging_test 的 cmd 模板
-在 /workspace/source 不存在或为空时**必须** exit 非 0，不能 silent-pass。
+"""Contract tests for REQ-checker-empty-source-1777113775.
 
-REQ-checker-empty-source-1777113775：previously 三个 checker 的 `for repo in /workspace/source/*/` 在
-源目录不存在或为空时会因为 bash 默认 glob fallback / 0 次循环走到 `[ $fail -eq 0 ]` 直接 PASS。
+Black-box behavioral contracts derived from:
+  openspec/changes/REQ-checker-empty-source-1777113775/specs/checker-empty-source-guard/spec.md
+  openspec/changes/REQ-checker-empty-source-1777113775/specs/checker-empty-source-guard/contract.spec.yaml
+
+Scenarios covered:
+  CESG-S1  spec_lint exits non-zero when /workspace/source is missing
+  CESG-S2  spec_lint exits non-zero when /workspace/source has zero subdirectories
+  CESG-S3  spec_lint exits non-zero when no repo has feat/<REQ> + openspec/changes/<REQ>/
+  CESG-S4  dev_cross_check exits non-zero when /workspace/source is missing
+  CESG-S5  dev_cross_check exits non-zero when /workspace/source is empty
+  CESG-S6  dev_cross_check exits non-zero when no repo has feat/<REQ> + ci-lint target
+  CESG-S7  staging_test exits non-zero when /workspace/source is missing
+  CESG-S8  staging_test exits non-zero when /workspace/source is empty
+  CESG-S9  staging_test exits non-zero when no repo has both ci-unit-test and ci-integration-test
+
+Testing strategy:
+  - S1, S2, S4, S5, S7, S8: Run the generated shell with a controlled tmpdir; guards A and B
+    fire before any git/docker work, so no external services needed.
+  - S3, S6, S9 (behavioral): Create a real git repo in tmpdir (no remote); git fetch origin
+    fails, triggering the skip path; ran stays 0; Guard C fires. Matches spec's "real git repo
+    that has no feat/<REQ> branch on origin" precondition.
+  - stderr_format: contract.spec.yaml requires the full literal pattern
+    '=== FAIL <stage>: <reason> — refusing to silent-pass ===' — asserted separately.
 """
 from __future__ import annotations
 
@@ -20,47 +40,149 @@ _BUILDERS = [
     pytest.param(build_staging_test_cmd, "staging_test", id="staging_test"),
 ]
 
+REQ_ID = "REQ-cesg-contract-test"
+
 
 def _patched_cmd(builder, fake_root: str) -> str:
-    """把 cmd 里所有 /workspace/source 替换成 tmp_path 下的假 root，方便本地跑。"""
-    return builder("REQ-X").replace("/workspace/source", fake_root)
+    """Replace /workspace/source with a controlled tmpdir path."""
+    return builder(REQ_ID).replace("/workspace/source", fake_root)
+
+
+def _run(script: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=15
+    )
+
+
+# ── Guard A: /workspace/source missing ────────────────────────────────────────
+# Scenarios CESG-S1, CESG-S4, CESG-S7
 
 
 @pytest.mark.parametrize("builder,name", _BUILDERS)
 def test_cmd_exits_nonzero_when_source_dir_missing(builder, name, tmp_path):
-    """fake_root 不存在 → 第一个 guard 命中，stderr 含 missing。"""
-    fake_root = str(tmp_path / "source")  # 故意不 mkdir
-    r = subprocess.run(
-        ["bash", "-c", _patched_cmd(builder, fake_root)],
-        capture_output=True, text=True, timeout=10,
+    """CESG-S1/S4/S7: exit 1 + stderr 'FAIL <stage>: ... missing' when /workspace/source absent."""
+    fake_root = str(tmp_path / "source")  # intentionally not created
+    r = _run(_patched_cmd(builder, fake_root))
+    assert r.returncode != 0, (
+        f"{name} should fail when source dir missing, got rc={r.returncode}"
     )
-    assert r.returncode != 0, f"{name} should fail when source dir missing, got rc={r.returncode}"
-    assert f"FAIL {name}" in r.stderr
-    assert "missing" in r.stderr
+    assert f"FAIL {name}" in r.stderr, (
+        f"{name}: expected 'FAIL {name}' in stderr.\nstderr: {r.stderr}"
+    )
+    assert "missing" in r.stderr, (
+        f"{name}: expected 'missing' in stderr.\nstderr: {r.stderr}"
+    )
+
+
+@pytest.mark.parametrize("builder,name", _BUILDERS)
+def test_guard_a_stderr_contains_refusing_to_silent_pass(builder, name, tmp_path):
+    """CESG-S1/S4/S7 (format): stderr MUST contain 'refusing to silent-pass' per contract.spec.yaml."""
+    fake_root = str(tmp_path / "source")
+    r = _run(_patched_cmd(builder, fake_root))
+    assert "refusing to silent-pass" in r.stderr, (
+        f"{name}: contract.spec.yaml requires stderr to contain 'refusing to silent-pass'.\n"
+        f"stderr: {r.stderr}"
+    )
+
+
+# ── Guard B: /workspace/source exists but zero subdirectories ─────────────────
+# Scenarios CESG-S2, CESG-S5, CESG-S8
 
 
 @pytest.mark.parametrize("builder,name", _BUILDERS)
 def test_cmd_exits_nonzero_when_source_dir_empty(builder, name, tmp_path):
-    """fake_root 存在但没有任何子目录 → 第二个 guard 命中，stderr 含 empty。"""
+    """CESG-S2/S5/S8: exit 1 + stderr 'FAIL <stage>: ... empty' when source has 0 subdirs."""
     fake_root = tmp_path / "source"
     fake_root.mkdir()
-    r = subprocess.run(
-        ["bash", "-c", _patched_cmd(builder, str(fake_root))],
-        capture_output=True, text=True, timeout=10,
+    r = _run(_patched_cmd(builder, str(fake_root)))
+    assert r.returncode != 0, (
+        f"{name} should fail when source dir empty, got rc={r.returncode}"
     )
-    assert r.returncode != 0, f"{name} should fail when source dir empty, got rc={r.returncode}"
-    assert f"FAIL {name}" in r.stderr
-    assert "empty" in r.stderr
+    assert f"FAIL {name}" in r.stderr, (
+        f"{name}: expected 'FAIL {name}' in stderr.\nstderr: {r.stderr}"
+    )
+    assert "empty" in r.stderr, (
+        f"{name}: expected 'empty' in stderr.\nstderr: {r.stderr}"
+    )
+
+
+@pytest.mark.parametrize("builder,name", _BUILDERS)
+def test_guard_b_stderr_contains_refusing_to_silent_pass(builder, name, tmp_path):
+    """CESG-S2/S5/S8 (format): stderr MUST contain 'refusing to silent-pass' per contract.spec.yaml."""
+    fake_root = tmp_path / "source"
+    fake_root.mkdir()
+    r = _run(_patched_cmd(builder, str(fake_root)))
+    assert "refusing to silent-pass" in r.stderr, (
+        f"{name}: contract.spec.yaml requires stderr to contain 'refusing to silent-pass'.\n"
+        f"stderr: {r.stderr}"
+    )
+
+
+@pytest.mark.parametrize("builder,name", _BUILDERS)
+def test_guard_b_source_dir_with_only_files_not_subdirs_is_empty(builder, name, tmp_path):
+    """Guard B must count only subdirectories; a source dir with only files counts as empty."""
+    fake_root = tmp_path / "source"
+    fake_root.mkdir()
+    (fake_root / "stale.lock").write_text("stale")  # file, not a subdir
+    r = _run(_patched_cmd(builder, str(fake_root)))
+    assert r.returncode != 0, (
+        f"{name} should treat source dir with only files as empty, got rc={r.returncode}"
+    )
+    assert "empty" in r.stderr, (
+        f"{name}: expected 'empty' in stderr (files-only dir).\nstderr: {r.stderr}"
+    )
+
+
+# ── Guard C: 0 eligible repos ─────────────────────────────────────────────────
+# Scenarios CESG-S3, CESG-S6, CESG-S9
 
 
 @pytest.mark.parametrize("builder,name", _BUILDERS)
 def test_cmd_exits_nonzero_when_no_repo_eligible(builder, name, tmp_path):
-    """fake_root 下有 1 个目录，但不是 git 仓 → fetch 失败 skip → ran=0 → 第三个 guard 命中。"""
+    """CESG-S3/S6/S9: exit 1 when a repo subdir exists but has no feat/<REQ> branch."""
     fake_root = tmp_path / "source"
     (fake_root / "repo-a").mkdir(parents=True)
-    r = subprocess.run(
-        ["bash", "-c", _patched_cmd(builder, str(fake_root))],
-        capture_output=True, text=True, timeout=10,
+    r = _run(_patched_cmd(builder, str(fake_root)))
+    assert r.returncode != 0, (
+        f"{name} should fail when 0 repos eligible, got rc={r.returncode}"
     )
-    assert r.returncode != 0, f"{name} should fail when 0 repos eligible, got rc={r.returncode}"
-    assert "0 source repos eligible" in r.stderr
+    assert "0 source repos eligible" in r.stderr, (
+        f"{name}: expected '0 source repos eligible' in stderr.\nstderr: {r.stderr}"
+    )
+
+
+@pytest.mark.parametrize("builder,name", _BUILDERS)
+def test_guard_c_real_git_repo_without_feat_branch(builder, name, tmp_path):
+    """CESG-S3/S6/S9 (real git): a real git repo with no remote → fetch fails → ran stays 0.
+
+    Spec precondition: '/workspace/source/repo-a exists (real git repo) but has no
+    feat/<REQ> branch on origin'. This test uses a git init'd repo without any remote
+    so that `git fetch origin feat/<REQ>` exits non-zero, triggering the skip path.
+    """
+    fake_root = tmp_path / "source"
+    repo_dir = fake_root / "repo-a"
+    repo_dir.mkdir(parents=True)
+    subprocess.run(
+        ["git", "init", str(repo_dir)],
+        capture_output=True, check=True,
+    )
+    r = _run(_patched_cmd(builder, str(fake_root)))
+    assert r.returncode != 0, (
+        f"{name}: real git repo with no remote should cause Guard C to fire.\n"
+        f"rc={r.returncode}\nstderr: {r.stderr}"
+    )
+    assert "0 source repos eligible" in r.stderr, (
+        f"{name}: expected '0 source repos eligible'.\nstderr: {r.stderr}"
+    )
+
+
+@pytest.mark.parametrize("builder,name", _BUILDERS)
+def test_guard_c_stderr_contains_refusing_to_silent_pass(builder, name, tmp_path):
+    """CESG-S3/S6/S9 (format): Guard C stderr MUST contain 'refusing to silent-pass'."""
+    fake_root = tmp_path / "source"
+    (fake_root / "repo-a").mkdir(parents=True)
+    r = _run(_patched_cmd(builder, str(fake_root)))
+    assert "refusing to silent-pass" in r.stderr, (
+        f"{name}: contract.spec.yaml requires 'refusing to silent-pass' in Guard C stderr.\n"
+        f"stderr: {r.stderr}"
+    )

--- a/orchestrator/tests/test_checkers_empty_source_guard.py
+++ b/orchestrator/tests/test_checkers_empty_source_guard.py
@@ -1,0 +1,66 @@
+"""端到端 shell-level 测试：spec_lint / dev_cross_check / staging_test 的 cmd 模板
+在 /workspace/source 不存在或为空时**必须** exit 非 0，不能 silent-pass。
+
+REQ-checker-empty-source-1777113775：previously 三个 checker 的 `for repo in /workspace/source/*/` 在
+源目录不存在或为空时会因为 bash 默认 glob fallback / 0 次循环走到 `[ $fail -eq 0 ]` 直接 PASS。
+"""
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from orchestrator.checkers.dev_cross_check import _build_cmd as build_dev_cross_check_cmd
+from orchestrator.checkers.spec_lint import _build_cmd as build_spec_lint_cmd
+from orchestrator.checkers.staging_test import _build_cmd as build_staging_test_cmd
+
+_BUILDERS = [
+    pytest.param(build_spec_lint_cmd, "spec_lint", id="spec_lint"),
+    pytest.param(build_dev_cross_check_cmd, "dev_cross_check", id="dev_cross_check"),
+    pytest.param(build_staging_test_cmd, "staging_test", id="staging_test"),
+]
+
+
+def _patched_cmd(builder, fake_root: str) -> str:
+    """把 cmd 里所有 /workspace/source 替换成 tmp_path 下的假 root，方便本地跑。"""
+    return builder("REQ-X").replace("/workspace/source", fake_root)
+
+
+@pytest.mark.parametrize("builder,name", _BUILDERS)
+def test_cmd_exits_nonzero_when_source_dir_missing(builder, name, tmp_path):
+    """fake_root 不存在 → 第一个 guard 命中，stderr 含 missing。"""
+    fake_root = str(tmp_path / "source")  # 故意不 mkdir
+    r = subprocess.run(
+        ["bash", "-c", _patched_cmd(builder, fake_root)],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert r.returncode != 0, f"{name} should fail when source dir missing, got rc={r.returncode}"
+    assert f"FAIL {name}" in r.stderr
+    assert "missing" in r.stderr
+
+
+@pytest.mark.parametrize("builder,name", _BUILDERS)
+def test_cmd_exits_nonzero_when_source_dir_empty(builder, name, tmp_path):
+    """fake_root 存在但没有任何子目录 → 第二个 guard 命中，stderr 含 empty。"""
+    fake_root = tmp_path / "source"
+    fake_root.mkdir()
+    r = subprocess.run(
+        ["bash", "-c", _patched_cmd(builder, str(fake_root))],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert r.returncode != 0, f"{name} should fail when source dir empty, got rc={r.returncode}"
+    assert f"FAIL {name}" in r.stderr
+    assert "empty" in r.stderr
+
+
+@pytest.mark.parametrize("builder,name", _BUILDERS)
+def test_cmd_exits_nonzero_when_no_repo_eligible(builder, name, tmp_path):
+    """fake_root 下有 1 个目录，但不是 git 仓 → fetch 失败 skip → ran=0 → 第三个 guard 命中。"""
+    fake_root = tmp_path / "source"
+    (fake_root / "repo-a").mkdir(parents=True)
+    r = subprocess.run(
+        ["bash", "-c", _patched_cmd(builder, str(fake_root))],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert r.returncode != 0, f"{name} should fail when 0 repos eligible, got rc={r.returncode}"
+    assert "0 source repos eligible" in r.stderr

--- a/orchestrator/tests/test_checkers_spec_lint.py
+++ b/orchestrator/tests/test_checkers_spec_lint.py
@@ -1,8 +1,5 @@
-"""checkers/dev_cross_check.py 单测：mock RunnerController，验 CheckResult 字段。
-
-ttpos-ci 契约统一后：cmd 遍历 /workspace/source/*，串行对每个含 `ci-lint` target 的仓
-跑 `BASE_REV=$(git merge-base HEAD origin/main) make ci-lint`。
-BASE_REV 缺失（fetch 不到 origin/main / develop / dev）则传空，ci-lint 退化为全量扫描。
+"""checkers/spec_lint.py 单测：mock RunnerController，验 CheckResult 字段 +
+empty-source guard（REQ-checker-empty-source-1777113775）的 cmd 形状。
 """
 from __future__ import annotations
 
@@ -11,7 +8,7 @@ import asyncio
 import pytest
 
 from orchestrator.checkers._types import CheckResult
-from orchestrator.checkers.dev_cross_check import _build_cmd, run_dev_cross_check
+from orchestrator.checkers.spec_lint import _build_cmd, run_spec_lint
 from orchestrator.k8s_runner import ExecResult
 
 
@@ -25,38 +22,31 @@ def make_fake_controller(exit_code: int, stdout: str = "", stderr: str = "", dur
 
 
 def _assert_for_each_repo_cmd(cmd: str) -> None:
-    """验证 cmd 是 for-each-repo 串行 shell 模板，跑 ci-lint + BASE_REV。"""
+    """验证 cmd 是 for-each-repo 模板，跑 openspec validate + scenario refs。"""
     assert "/workspace/source/*/" in cmd
-    assert "make ci-lint" in cmd
-    assert "ci-lint:" in cmd  # grep Makefile target 过滤
-    # BASE_REV 计算 + 注入
-    assert "BASE_REV=" in cmd
-    assert "git merge-base HEAD origin/main" in cmd
-    assert "git merge-base HEAD origin/develop" in cmd  # fallback
-    assert "git merge-base HEAD origin/dev" in cmd  # fallback
-    # 累加 fail 标志
+    assert "openspec validate" in cmd
+    assert "check-scenario-refs.sh" in cmd
     assert "fail=0" in cmd
     assert "fail=1" in cmd
-    assert "[ $fail -eq 0 ]" in cmd  # 不能用 `exit $fail`：orch 包装的 exit-marker echo 不再跑
+    assert "[ $fail -eq 0 ]" in cmd
 
 
 # ── pass ──────────────────────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_run_dev_cross_check_pass(monkeypatch):
-    FakeRC = make_fake_controller(exit_code=0, stdout="ok\n", stderr="", duration=1.5)
+async def test_run_spec_lint_pass(monkeypatch):
+    FakeRC = make_fake_controller(exit_code=0, stdout="ok\n", stderr="", duration=2.0)
     monkeypatch.setattr(
-        "orchestrator.checkers.dev_cross_check.k8s_runner.get_controller",
+        "orchestrator.checkers.spec_lint.k8s_runner.get_controller",
         lambda: FakeRC(),
     )
-    result = await run_dev_cross_check("REQ-1")
+    result = await run_spec_lint("REQ-1")
 
     assert isinstance(result, CheckResult)
     assert result.passed is True
     assert result.exit_code == 0
     assert result.stdout_tail == "ok\n"
-    assert result.stderr_tail == ""
     _assert_for_each_repo_cmd(result.cmd)
     assert FakeRC.last_cmd == result.cmd
 
@@ -65,54 +55,34 @@ async def test_run_dev_cross_check_pass(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_run_dev_cross_check_fail(monkeypatch):
+async def test_run_spec_lint_fail(monkeypatch):
     FakeRC = make_fake_controller(
-        exit_code=1, stdout="lint warnings...\n",
-        stderr="=== FAIL: ttpos-server-go ===\n", duration=8.2,
+        exit_code=1, stdout="",
+        stderr="=== FAIL: repo-a ===\n", duration=3.1,
     )
     monkeypatch.setattr(
-        "orchestrator.checkers.dev_cross_check.k8s_runner.get_controller",
+        "orchestrator.checkers.spec_lint.k8s_runner.get_controller",
         lambda: FakeRC(),
     )
-    result = await run_dev_cross_check("REQ-2")
+    result = await run_spec_lint("REQ-2")
 
     assert result.passed is False
     assert result.exit_code == 1
     assert "FAIL" in result.stderr_tail
 
 
-# ── stdout/stderr tail 截尾 ───────────────────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_run_dev_cross_check_truncates_tails(monkeypatch):
-    big_out = "x" * 5000
-    big_err = "e" * 4000
-    FakeRC = make_fake_controller(exit_code=0, stdout=big_out, stderr=big_err)
-    monkeypatch.setattr(
-        "orchestrator.checkers.dev_cross_check.k8s_runner.get_controller",
-        lambda: FakeRC(),
-    )
-    result = await run_dev_cross_check("REQ-3")
-
-    assert len(result.stdout_tail) == 2048
-    assert len(result.stderr_tail) == 2048
-    assert result.stdout_tail == big_out[-2048:]
-    assert result.stderr_tail == big_err[-2048:]
-
-
 # ── timeout ───────────────────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_run_dev_cross_check_timeout(monkeypatch):
+async def test_run_spec_lint_timeout(monkeypatch):
     class SlowRC:
         async def exec_in_runner(self, req_id, command, **kw):
             await asyncio.sleep(9999)
             return ExecResult(exit_code=0, stdout="", stderr="", duration_sec=0)
 
     monkeypatch.setattr(
-        "orchestrator.checkers.dev_cross_check.k8s_runner.get_controller",
+        "orchestrator.checkers.spec_lint.k8s_runner.get_controller",
         lambda: SlowRC(),
     )
 
@@ -124,10 +94,9 @@ async def test_run_dev_cross_check_timeout(monkeypatch):
         except asyncio.CancelledError:
             raise TimeoutError() from None
 
-    monkeypatch.setattr("orchestrator.checkers.dev_cross_check.asyncio.wait_for", fast_wait_for)
+    monkeypatch.setattr("orchestrator.checkers.spec_lint.asyncio.wait_for", fast_wait_for)
 
-    # timeout 走 internal CheckResult 返回（不抛异常）
-    result = await run_dev_cross_check("REQ-4", timeout_sec=1)
+    result = await run_spec_lint("REQ-3", timeout_sec=1)
     assert result.passed is False
     assert result.exit_code == -1
     assert "超时" in result.stderr_tail
@@ -137,22 +106,22 @@ async def test_run_dev_cross_check_timeout(monkeypatch):
 
 
 def test_build_cmd_emits_workspace_source_existence_guard():
-    """`/workspace/source` 不存在 → exit 1，不能 for 循环 0 次默认 pass。"""
+    """`/workspace/source` 不存在直接 exit 1，不能让 for 循环 0 次默认 pass。"""
     cmd = _build_cmd("REQ-X")
     assert "[ ! -d /workspace/source ]" in cmd
-    assert "FAIL dev_cross_check: /workspace/source missing" in cmd
+    assert "FAIL spec_lint: /workspace/source missing" in cmd
 
 
 def test_build_cmd_emits_repo_count_zero_guard():
-    """`/workspace/source` 空目录（0 cloned repo）→ exit 1。"""
+    """`/workspace/source` 是空目录（0 个 cloned repo）也直接 exit 1。"""
     cmd = _build_cmd("REQ-X")
     assert "find /workspace/source -mindepth 1 -maxdepth 1 -type d" in cmd
     assert '"$repo_count" -eq 0' in cmd
-    assert "FAIL dev_cross_check: /workspace/source empty" in cmd
+    assert "FAIL spec_lint: /workspace/source empty" in cmd
 
 
 def test_build_cmd_emits_zero_eligible_guard():
-    """所有仓都被 skip（无 feat 分支 / 无 ci-lint target）→ ran=0 → exit 1。"""
+    """所有仓都被 skip（feat 分支不存在 / 没 openspec/changes/<REQ>/）→ ran=0 → exit 1。"""
     cmd = _build_cmd("REQ-X")
     assert "ran=0" in cmd
     assert "ran=$((ran+1))" in cmd

--- a/orchestrator/tests/test_checkers_staging_test.py
+++ b/orchestrator/tests/test_checkers_staging_test.py
@@ -11,7 +11,7 @@ import asyncio
 import pytest
 
 from orchestrator.checkers._types import CheckResult
-from orchestrator.checkers.staging_test import run_staging_test
+from orchestrator.checkers.staging_test import _build_cmd, run_staging_test
 from orchestrator.k8s_runner import ExecResult
 
 
@@ -128,3 +128,30 @@ async def test_run_staging_test_timeout(monkeypatch):
 
     with pytest.raises(TimeoutError):
         await run_staging_test("REQ-4")
+
+
+# ── empty-source guard（REQ-checker-empty-source-1777113775）─────────────
+
+
+def test_build_cmd_emits_workspace_source_existence_guard():
+    """`/workspace/source` 不存在 → exit 1，不能 for 循环 0 次默认 pass。"""
+    cmd = _build_cmd("REQ-X")
+    assert "[ ! -d /workspace/source ]" in cmd
+    assert "FAIL staging_test: /workspace/source missing" in cmd
+
+
+def test_build_cmd_emits_repo_count_zero_guard():
+    """`/workspace/source` 空目录（0 cloned repo）→ exit 1。"""
+    cmd = _build_cmd("REQ-X")
+    assert "find /workspace/source -mindepth 1 -maxdepth 1 -type d" in cmd
+    assert '"$repo_count" -eq 0' in cmd
+    assert "FAIL staging_test: /workspace/source empty" in cmd
+
+
+def test_build_cmd_emits_zero_eligible_guard():
+    """所有仓都被 skip（无 feat 分支 / 缺 unit-or-integration target）→ ran=0 → exit 1。"""
+    cmd = _build_cmd("REQ-X")
+    assert "ran=0" in cmd
+    assert "ran=$((ran+1))" in cmd
+    assert '"$ran" -eq 0' in cmd
+    assert "0 source repos eligible" in cmd


### PR DESCRIPTION
## Summary

Three mechanical checkers (`spec_lint` / `dev_cross_check` / `staging_test`) emitted
a shell template that iterated `/workspace/source/*/`. When the directory was
missing, empty, or every cloned repo was skipped (no `feat/<REQ>` branch with the
required artifact), the for-loop iterated **zero times** and the trailing
`[ $fail -eq 0 ]` evaluated true — a **silent-pass** with zero work performed.

orchestrator then emitted `*_PASS`, the state machine advanced, and the failure
only surfaced at `pr_ci_watch` (or never) — corrupting the M7+M14e dashboards'
"checker accuracy" metric.

This PR adds three uniform guards to each `_build_cmd`:

- **Guard A**: `[ ! -d /workspace/source ]` → `exit 1` (PVC unmounted / clone helper never ran)
- **Guard B**: `find /workspace/source -mindepth 1 -maxdepth 1 -type d | wc -l == 0` → `exit 1` (dir exists, 0 cloned repos)
- **Guard C**: per-loop `ran` counter, incremented only inside the eligible branch; `ran -eq 0` after the loop → `exit 1` (e.g. agent reported done but never pushed `feat/<REQ>` / source repo lacks ttpos-ci Makefile targets)

All FAIL messages follow the literal pattern
`=== FAIL <stage>: <reason> — refusing to silent-pass ===` so verifier prompts
keep classifying via existing stderr-tail substring match.

## Eligibility predicates per stage

| stage | counts toward `ran` when |
|---|---|
| spec_lint | repo has `feat/<REQ>` branch fetchable + `openspec/changes/<REQ>/` dir |
| dev_cross_check | repo has `feat/<REQ>` branch fetchable + Makefile contains `^ci-lint:` |
| staging_test | repo has `feat/<REQ>` branch fetchable + Makefile contains `^ci-unit-test:` AND `^ci-integration-test:` |

## Test plan

- [x] `orchestrator/tests/test_checkers_spec_lint.py` (new) — covers spec_lint pass / fail / timeout / 3 guard shape assertions
- [x] `orchestrator/tests/test_checkers_empty_source_guard.py` (new) — runs the patched `_build_cmd` in a real `bash` subprocess against `tmp_path`; 3 guards × 3 checkers = 9 parametrized cases all exit non-zero with expected stderr substrings
- [x] existing `test_checkers_{dev_cross_check,staging_test}.py` — extended with the same 3 cmd-shape assertions
- [x] `openspec validate REQ-checker-empty-source-1777113775 --strict` passes
- [x] `check-scenario-refs.sh` passes (77 scenarios, all references resolved)
- [x] full orchestrator pytest run: 29 checker tests pass; pre-existing failures (`pytest-httpx` plugin missing in dev env, `make` binary missing in agent workspace) are unrelated to this change

## Notes

- `pr_ci_watch` is **not** affected — it talks to GitHub REST directly, no `/workspace/source/*` loop.
- Happy path (≥1 eligible repo) is identical to before; one extra `find | wc -l` (~10ms) plus three integer comparisons.
- POSIX-only constructs (`find`, `wc`, `[`, `$((..))`) — no `shopt`, no bashisms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)