### PR TITLE
fix(start_analyze + pr_ci_watch): server-side clone + refuse stale env fallback

### DIFF
--- a/openspec/changes/REQ-clone-and-pr-ci-fallback-1777115925/proposal.md
+++ b/openspec/changes/REQ-clone-and-pr-ci-fallback-1777115925/proposal.md
@@ -1,0 +1,145 @@
+# REQ-clone-and-pr-ci-fallback-1777115925: fix(start_analyze + pr_ci_watch): server-side clone + refuse stale env fallback
+
+## 问题
+
+两条相互啮合的形状缺陷今天还撑着 sisyphus 的 happy path：
+
+### 缺陷 A：start_analyze 不做 server-side clone，agent 拿空 PVC 起跳
+
+`actions/start_analyze.py` 跟 `actions/start_analyze_with_finalized_intent.py`
+都只 `ensure_runner` 拉 Pod + PVC，然后立刻 follow-up `analyze.md.j2` prompt
+让 agent 自己 `kubectl exec ... /opt/sisyphus/scripts/sisyphus-clone-repos.sh ...`。
+prompt Part A.3 / A.4 把 clone 整套责任全压给 agent。
+
+后果：
+
+- intake 阶段已经在 `ctx.intake_finalized_intent.involved_repos` 落了
+  ground-truth 仓列表，sisyphus 拥有这条信号但**主动忽略**它。
+- 进 analyze stage 时 `/workspace/source/` 是空的（PVC 新挂或上一 REQ 被 GC）。
+  agent 必须先做 6 行 prompt 仪式才进入"实际写 spec / 写代码"——这 6 行
+  里随便错一行（kubectl exec 命令拼错 / 仓名打字 / shallow refspec 漏带）
+  整个 stage 都得回头修。
+- M15 之后 sisyphus 不再起 spec / dev 子 agent，analyze-agent 全责交付。
+  让全责 agent 仍要跑半段编排活，分工边界糊。
+- 真出过事故：agent kubectl exec clone 命令漏拼 `https://`、agent 误 clone
+  到 `/workspace/<repo>/` 而非 `/workspace/source/<repo>/`，
+  spec_lint / dev_cross_check 都因为找不到 `/workspace/source/*/` 直接
+  silent-pass（直到 REQ-checker-empty-source-1777113775 才硬关掉这条
+  silent-pass）。**根因是 clone 这步不该在 agent 里。**
+
+### 缺陷 B：pr_ci_watch checker 在缺仓时偷偷读 SISYPHUS_BUSINESS_REPO env
+
+`checkers/pr_ci_watch.py:86`：
+
+```python
+repo_list = repos or ([os.getenv("SISYPHUS_BUSINESS_REPO")] if os.getenv("SISYPHUS_BUSINESS_REPO") else [])
+```
+
+`actions/create_pr_ci_watch.py:78-81` 决定不了 repo 时（runner 文件系统空 +
+ctx 没 finalized intent + ctx 没 involved_repos）传 `repos=None` 给 checker，
+checker 静默 fallback 到全局 env var。
+
+`SISYPHUS_BUSINESS_REPO` 是 M15 之前的单仓 manifest 残骸，**全局共享**：
+
+- orchestrator deployment 启动时一次性设，所有 REQ 共用同一个值
+- 多仓 REQ 上下来时它只能指其中一个仓，剩下几个仓的 PR check-runs 一律
+  漏看
+- 旧单仓 REQ archive 之后这个 env 还在，新 REQ 被 fallback 到老仓 ——
+  pr_ci_watch 拿过期上下文判 PR check-runs，结果可能：
+  - 新 REQ 在仓 X，env 指仓 Y → 永远找不到 PR → exit 1（误 fail，触发
+    verifier-agent → fix-dev → fixer-agent 兜，浪费多轮）
+  - 新 REQ 在仓 Y（巧合命中 env）→ 看到的是真 PR，但只检了 1 个仓，多仓
+    REQ 的别的仓全跳过 → 假阳性 pass，状态机推到 accept 才被人肉 catch
+
+**stale env fallback 是 silent-pass 的同形错误**：在没收到 per-REQ 信号
+（runner 没 clone、ctx 没声明）时不该编一个，应当显式失败让 verifier 兜。
+
+## 方案
+
+A 改 push，B 改 refuse；两条独立但互补。
+
+### Fix A：start_analyze 接管 clone（server-side，不再委托 agent）
+
+`start_analyze` / `start_analyze_with_finalized_intent` 在 `ensure_runner`
+返 ready 后、`bkd.follow_up_issue(prompt)` 之前，**多一步 server-side
+clone**：
+
+1. 从 ctx 解出 repos（优先级：`ctx.intake_finalized_intent.involved_repos`
+   → `ctx.involved_repos`）
+2. 有 repos：通过 `k8s_runner.exec_in_runner` 跑
+   `/opt/sisyphus/scripts/sisyphus-clone-repos.sh <r1> <r2> ...`
+3. 退码非 0 → log + emit `VERIFY_ESCALATE`（不打 analyze-agent；clone 起跳
+   失败时 agent 也救不动）
+4. 退码 0 / 没 repos：继续往下 dispatch agent
+
+新 prompt 由 sisyphus 在 follow-up 里附一句 "/workspace/source/* 已经预
+clone 好"（analyze.md.j2 的 Part A.3 改成"如果 sisyphus 没替你 clone，再调
+helper"，agent 跳过 clone 直接进 spec / dev）。
+
+### Fix B：pr_ci_watch 拒绝 env fallback
+
+`checkers/pr_ci_watch.py:watch_pr_ci`：
+
+```python
+# 旧：repo_list = repos or [os.getenv("SISYPHUS_BUSINESS_REPO")] if env-set else []
+# 新：repo_list = list(repos or [])；空 → ValueError "no repos provided"
+```
+
+action layer `create_pr_ci_watch._run_checker` 的 source 序列保留：
+
+1. runner 文件系统 discovery（fix A 后 server-side clone 的 ground truth）
+2. `ctx.intake_finalized_intent.involved_repos`
+3. `ctx.involved_repos`
+
+三个都空 → `repos=None` 传给 checker → ValueError → action 把它当
+config error 翻译为 `PR_CI_TIMEOUT`（直接 ESCALATED，不进 verifier
+review）。
+
+`SISYPHUS_BUSINESS_REPO` 这个 env 名字本身**全删**：从配置层
+（`config.py`）和 helm values 里也清掉，避免后人再 fallback。
+
+### 配套：analyze.md.j2 prompt 调整
+
+Part A.3 (clone) 从 "agent 必须跑" 改成 "sisyphus 已替你跑；万一 ctx 没传
+repos sisyphus 跳过了，再手跑 helper"。Part A.2 (决定哪些仓) 在 intake
+路径上失效（intake 阶段已经声明），保留为直接 analyze 路径的 fallback。
+
+## 取舍
+
+- **为什么 server-side clone 出错就 ESCALATED 而非 retry 一次** —— clone
+  失败的根因有限：(i) GitHub 凭证过期 / 仓名打错（agent retry 也救不了），
+  (ii) 网络抖动（runner pod 重 schedule 后会重试一次，sisyphus 状态机
+  retry policy 兜底）。**配置错落** retry 没用，让人翻 escalate 队列才是
+  正确路径。
+- **为什么不改成"不传 repos = clone 全部 PR-CI-historic-repo"** —— 全局
+  默认仓集合就是 SISYPHUS_BUSINESS_REPO 的同形错误，再做一遍。直接路径
+  没 intake 时就让 user 在 BKD intent issue 里贴 finalized intent JSON
+  （或者补加一条 `intent:analyze:involved_repos:owner/repo` tag 给 router
+  拾），是清晰的扩展点。**本 REQ 不实现这条扩展**，只把 fallback 路径全删。
+- **删 env var 会破老单仓 REQ 么** —— `SISYPHUS_BUSINESS_REPO` 这个 env
+  在 sisyphus 仓里只被 `pr_ci_watch.py` 读。Helm values / dev 文档里出现
+  几处但都是注释 / docs；运行时只此一处。删干净。
+- **start_analyze 直接路径（无 intake）怎么办** —— ctx 里没
+  `intake_finalized_intent`，也没 `involved_repos`，sisyphus 跳过
+  server-side clone 那一步，**保留** agent 自己在 prompt 里 clone 的老
+  路径（Part A.3）。这是过渡；下一个 REQ 可以加直接路径的 repo 声明协议。
+- **agent prompt 同时介绍两套路径会乱么** —— 不会。prompt 改成"sisyphus
+  已经预 clone（多数情况 = intake 走完）；如果 `/workspace/source` 是空，
+  你自己 helper clone"。一个 `[ -d /workspace/source/*/ ] || /opt/sisyphus/scripts/sisyphus-clone-repos.sh ...`
+  guard 解决。
+
+## 影响面
+
+- 改 `actions/start_analyze.py` / `actions/start_analyze_with_finalized_intent.py`：
+  在 ensure_runner 之后加 server-side clone（条件触发）
+- 改 `checkers/pr_ci_watch.py`：删 env fallback，empty `repos=None` 直接 ValueError
+- 改 `actions/create_pr_ci_watch.py` 注释：删第 12 行的"3. SISYPHUS_BUSINESS_REPO env"档
+- 改 `prompts/analyze.md.j2`：Part A.3 从硬要求改成 fallback；强调 ctx 已 clone
+- 改 `prompts/_shared/runner_container.md.j2`（若提到 clone 则同步）
+- 测试：`test_checkers_pr_ci_watch.py` 现有 13 个 case 中 9 个用 env，改成
+  显式 `repos=` 参数；新增 `test_watch_pr_ci_ignores_env_var_when_repos_none`
+  验证 env 即使设了 repos=None 也 ValueError。
+- 新增 `test_actions_start_analyze.py`：覆盖 server-side clone 派发、
+  clone 失败 → VERIFY_ESCALATE、无 involved_repos → 跳过 clone。
+- 不动 `state.py` / `event_log` 表结构 / Postgres migrations。
+- `SISYPHUS_BUSINESS_REPO` env 从 helm values（如果有引用）和 README 里删。

--- a/openspec/changes/REQ-clone-and-pr-ci-fallback-1777115925/specs/server-side-clone-and-no-env-fallback/contract.spec.yaml
+++ b/openspec/changes/REQ-clone-and-pr-ci-fallback-1777115925/specs/server-side-clone-and-no-env-fallback/contract.spec.yaml
@@ -1,0 +1,115 @@
+capability: server-side-clone-and-no-env-fallback
+version: "1.0"
+description: |
+  Two互补的形状契约：
+
+  (A) `start_analyze` 在 ensure_runner 后 server-side clone
+      `intake_finalized_intent.involved_repos` 到 runner pod 的
+      `/workspace/source/<basename>/`（调 `/opt/sisyphus/scripts/sisyphus-clone-repos.sh`），
+      失败 → emit VERIFY_ESCALATE，不打 analyze-agent。
+
+  (B) `pr_ci_watch.watch_pr_ci` 拒绝从 `SISYPHUS_BUSINESS_REPO` env 偷读
+      fallback repo —— `repos=None` 直接 ValueError；`create_pr_ci_watch`
+      把 ValueError 翻译为 `PR_CI_TIMEOUT`（直接 ESCALATED 不进 verifier）。
+
+  两个加在一起把 sisyphus 对 per-REQ 仓集合的处理收成一条线：
+    intake → `ctx.involved_repos` → server-side clone → runner pod 文件系统
+    → pr_ci_watch runner discovery → GitHub PR check-runs。
+
+  没有第二条隐式路径：环境变量 / 全局配置 / agent prompt 任意 clone 都
+  不当 fallback。
+
+source_of_truth_chain:
+  intake_to_clone:
+    description: |
+      ctx.intake_finalized_intent.involved_repos 是真理的源头。
+      webhook.py 在 INTAKE_PASS 时已落到 ctx；start_analyze 系列 action 直接读。
+    fields:
+      - "ctx.intake_finalized_intent.involved_repos: list[str]   # primary"
+      - "ctx.involved_repos: list[str]                            # fallback (alt providers)"
+    consumer: |
+      orchestrator/src/orchestrator/actions/_clone.py::clone_involved_repos_into_runner
+
+  clone_to_pr_ci_watch_discovery:
+    description: |
+      server-side clone 把 repos 落到 runner pod 的
+      /workspace/source/<basename>/.git，create_pr_ci_watch._discover_repos_from_runner
+      用 `git remote get-url origin` 反查 owner/repo 名字。
+    runner_command: |
+      for d in /workspace/source/*/; do
+        [ -d "$d/.git" ] && git -C "$d" remote get-url origin 2>/dev/null;
+      done
+
+  pr_ci_watch_caller_contract:
+    description: |
+      create_pr_ci_watch._run_checker 决定不了 repos 时传 repos=None；
+      checker 直接 ValueError；caller catch 翻译 PR_CI_TIMEOUT。
+    sequence:
+      - "discover = await _discover_repos_from_runner(req_id)"
+      - "repos = discover or finalized.involved_repos or ctx.involved_repos"
+      - "try: result = await checker.watch_pr_ci(req_id, branch, repos=repos)"
+      - "except ValueError as e: return {'emit': PR_CI_TIMEOUT, 'reason': f'config error: {e}'}"
+
+server_side_clone_helper:
+  helper_path: /opt/sisyphus/scripts/sisyphus-clone-repos.sh
+  invocation: |
+    repos_quoted=$(printf '%q ' "$REPO_1" "$REPO_2" ...)
+    /opt/sisyphus/scripts/sisyphus-clone-repos.sh $repos_quoted
+  guarantees:
+    - "clone target = /workspace/source/<basename>/ (sisyphus 强约定路径)"
+    - "auth = pod 内已注入的 GH_TOKEN secret"
+    - "idempotent: 已存在则 fetch + checkout main，不重 clone"
+  failure_mode: |
+    任何 repo clone 失败 → helper exit ≠ 0；caller 把 ExecResult.exit_code
+    打包进 reason 字符串："clone failed (rc=N): <stderr-tail>"
+
+env_var_removal:
+  retired: SISYPHUS_BUSINESS_REPO
+  reason: |
+    Process-global env var 在多 REQ / 多仓 / 周转的真实场景下注定 stale。
+    REQ-X 跑在仓 A，env 指仓 B；orchestrator restart 之间 env 不变，REQ 切了
+    仓但 env 没切。fallback 命中时，要么找错 PR（false fail），要么漏看仓
+    （false pass）。
+  scrub_locations:
+    - "orchestrator/src/orchestrator/checkers/pr_ci_watch.py (line 86, the os.getenv fallback)"
+    - "orchestrator/src/orchestrator/checkers/pr_ci_watch.py docstring (line 4, the 'repos 列表来自 caller fallback 到 SISYPHUS_BUSINESS_REPO' phrasing)"
+    - "orchestrator/src/orchestrator/actions/create_pr_ci_watch.py docstring (line 11-12, the third tier description)"
+  permitted_remaining_references:
+    - "orchestrator/tests/test_checkers_pr_ci_watch.py — only inside the SCNF-S5 regression test that asserts the env is ignored"
+
+failure_paths:
+  clone_failure:
+    cause: "sisyphus-clone-repos.sh exits non-zero (auth / typo / network)"
+    handler: "start_analyze* return {'emit': VERIFY_ESCALATE, 'reason': 'clone failed ...'}"
+    state_outcome: "engine routes to ESCALATED via VERIFY_ESCALATE event"
+    rationale: |
+      Clone 配置错（仓名打错、token 失效）retry 没用；agent 在空 PVC 里也
+      做不了 spec / dev。直接 ESCALATED 让人在 BKD 看板修。
+
+  pr_ci_watch_no_repos:
+    cause: "create_pr_ci_watch._run_checker passes repos=None (no source of truth)"
+    handler: "watch_pr_ci raises ValueError → caller emit PR_CI_TIMEOUT"
+    state_outcome: "engine routes to ESCALATED via PR_CI_TIMEOUT event (NOT through verifier)"
+    rationale: |
+      verifier-agent 不能"修"缺失的 per-REQ 仓声明 —— 这是 intake / 上游配置
+      的活。跳过 verifier 直 ESCALATED 省一轮人力。
+
+invariants:
+  no_silent_pass_under_misconfig:
+    - "clone failure → VERIFY_ESCALATE (not silent dispatch on empty workspace)"
+    - "no repos → ValueError → PR_CI_TIMEOUT (not silent fallback to env)"
+    - "either condition skips verifier and directly escalates"
+
+  one_canonical_repo_source:
+    - "per-REQ ctx is the only authoritative source of involved_repos"
+    - "runner-pod /workspace/source/* is the materialized form (fed by server-side clone)"
+    - "GLOBAL env vars / config files / hardcoded defaults SHALL NOT supplement"
+
+  symmetric_with_REQ-checker-empty-source:
+    description: |
+      REQ-checker-empty-source-1777113775 已经把"`/workspace/source` 空 →
+      silent-pass" 在 mechanical checker 那一层关掉。本 REQ 把
+      "ctx 没 repos → 偷读全局 env" 在 watch-pr-ci 这层关掉，并把"agent
+      自己 clone 才有 source" 在 start_analyze 那层补上。三条加起来：
+      no source dir / no repos / no clone = 三种 misconfig 都显式失败而不
+      是 silent-pass。

--- a/openspec/changes/REQ-clone-and-pr-ci-fallback-1777115925/specs/server-side-clone-and-no-env-fallback/spec.md
+++ b/openspec/changes/REQ-clone-and-pr-ci-fallback-1777115925/specs/server-side-clone-and-no-env-fallback/spec.md
@@ -1,0 +1,152 @@
+## ADDED Requirements
+
+### Requirement: start_analyze MUST server-side clone involved_repos before dispatching analyze-agent
+
+The orchestrator SHALL own the clone of every repo listed in
+`ctx.intake_finalized_intent.involved_repos` (falling back to
+`ctx.involved_repos`) into the runner pod's `/workspace/source/<basename>/`,
+and MUST do so server-side from `actions/start_analyze.py::start_analyze`
+and `actions/start_analyze_with_finalized_intent.py::start_analyze_with_finalized_intent`
+after `k8s_runner.ensure_runner(req_id, wait_ready=True)` returns and
+BEFORE the BKD `follow_up_issue(prompt)` call dispatches the
+analyze-agent. The clone MUST be performed by invoking
+`/opt/sisyphus/scripts/sisyphus-clone-repos.sh <repo1> <repo2> ...` inside
+the runner pod via `k8s_runner.exec_in_runner`. The analyze-agent MUST
+NOT be the only path that places source code under
+`/workspace/source/<basename>/`.
+
+When the runner controller is unavailable (`k8s_runner.get_controller()`
+raises `RuntimeError`, e.g. dev environment without K8s), the orchestrator
+MUST log a warning and skip server-side clone gracefully, allowing the
+agent to fall back to its prompt-driven clone path.
+
+#### Scenario: SCNF-S1 server-side clone runs sisyphus-clone-repos.sh with intake involved_repos
+
+- **GIVEN** `start_analyze_with_finalized_intent` is invoked with
+  `ctx={"intake_finalized_intent": {"involved_repos": ["phona/repo-a", "ZonEaseTech/ttpos-server-go"]}}`
+- **WHEN** `k8s_runner.ensure_runner` returns Pod ready
+- **THEN** `k8s_runner.exec_in_runner` MUST be called with a command that
+  invokes `/opt/sisyphus/scripts/sisyphus-clone-repos.sh` and contains both
+  `phona/repo-a` and `ZonEaseTech/ttpos-server-go` as positional arguments
+- **AND** the call MUST happen before `BKDClient.follow_up_issue`
+
+#### Scenario: SCNF-S2 server-side clone is skipped when no involved_repos in ctx
+
+- **GIVEN** `start_analyze` is invoked on the direct-analyze path with
+  `ctx={"intent_title": "..."}` (no `intake_finalized_intent`, no
+  `involved_repos`)
+- **WHEN** the action runs
+- **THEN** `k8s_runner.exec_in_runner` MUST NOT be called
+- **AND** the action MUST still dispatch the analyze-agent via
+  `BKDClient.follow_up_issue` (preserving the direct-analyze fallback path
+  where the agent clones manually per `analyze.md.j2` Part A.3)
+
+### Requirement: start_analyze MUST emit VERIFY_ESCALATE when server-side clone fails
+
+The `start_analyze` / `start_analyze_with_finalized_intent` action SHALL
+NOT proceed to dispatch the analyze-agent when the server-side clone
+helper exits with a non-zero exit code (e.g., GitHub auth failure, repo
+name typo, persistent network error); it MUST instead return a mapping
+containing `emit: VERIFY_ESCALATE` and a `reason` string that includes
+the literal substring `clone failed` plus the failing helper exit code,
+so the engine routes the REQ directly to ESCALATED rather than hand a
+broken workspace to the agent.
+
+#### Scenario: SCNF-S3 clone helper exit code 5 → emit VERIFY_ESCALATE
+
+- **GIVEN** `ctx.intake_finalized_intent.involved_repos = ["phona/typo-repo"]`
+  and `k8s_runner.exec_in_runner` returns `ExecResult(exit_code=5, stderr="...")`
+- **WHEN** `start_analyze_with_finalized_intent` runs
+- **THEN** the return value MUST contain `emit == "VERIFY_ESCALATE"` and
+  `reason` MUST contain the substring `clone failed` and the literal
+  `5` (the helper exit code)
+- **AND** `BKDClient.follow_up_issue` MUST NOT have been called (no agent
+  dispatched on a broken workspace)
+
+### Requirement: pr_ci_watch MUST raise ValueError when caller passes no repos
+
+`watch_pr_ci` MUST raise `ValueError("no repos provided ...")` immediately
+when its `repos` argument is empty / `None`, treating the missing argument
+as a configuration error;
+`checkers/pr_ci_watch.py::watch_pr_ci(req_id, branch, ..., repos=None)`
+SHALL treat an empty / `None` `repos` argument as a configuration error.
+The function MUST NOT consult any environment variable (in particular
+MUST NOT read `SISYPHUS_BUSINESS_REPO` or any other global env) to
+synthesize a fallback repo list. The decision of which repos to monitor
+SHALL be made entirely by the caller
+(`actions/create_pr_ci_watch.py::_run_checker`) based on per-REQ context
+(runner-pod filesystem discovery and / or
+`ctx.intake_finalized_intent.involved_repos`).
+
+The deletion of the env-var fallback is intentional: a process-global env
+var inevitably gets stale across REQs (the env points at a single repo set
+at orchestrator startup, while real REQs span multiple repos and rotate
+weekly). The previous fallback caused two failure modes — (i) wrong-repo
+PR lookup when the env did not match the current REQ, (ii) silent loss of
+non-env-listed repos in multi-repo REQs — both of which appeared as
+either spurious PR-CI failures (verifier-fix-dev waste) or false-positive
+passes (review-only-bot misclassification on the unwatched repo).
+
+#### Scenario: SCNF-S4 watch_pr_ci raises ValueError when repos=None and no env consulted
+
+- **GIVEN** `SISYPHUS_BUSINESS_REPO` env var is unset
+- **WHEN** `watch_pr_ci("REQ-X", "feat/REQ-X")` is awaited (no `repos`
+  argument)
+- **THEN** `ValueError` MUST be raised with message containing
+  `no repos provided`
+
+#### Scenario: SCNF-S5 watch_pr_ci ignores SISYPHUS_BUSINESS_REPO env even when set
+
+- **GIVEN** `SISYPHUS_BUSINESS_REPO=phona/legacy-repo` is set in the
+  process environment AND the caller passes `repos=None` (e.g., runner
+  discovery returned empty list and ctx had no involved_repos)
+- **WHEN** `watch_pr_ci("REQ-X", "feat/REQ-X", repos=None)` is awaited
+- **THEN** `ValueError` MUST be raised exactly as in SCNF-S4 — the env
+  var MUST NOT be read, MUST NOT be used to synthesize `repos=["phona/legacy-repo"]`,
+  MUST NOT log "falling back to env"
+- **AND** no GitHub API call MUST be issued (no PR lookup, no check-run
+  fetch — the function MUST short-circuit before any HTTP I/O)
+
+### Requirement: create_pr_ci_watch MUST translate ValueError from checker to PR_CI_TIMEOUT
+
+The `actions/create_pr_ci_watch.py::_run_checker` function SHALL catch
+`ValueError` raised by `pr_ci_watch.watch_pr_ci` (the only ValueError now
+being the "no repos provided" config error) and translate it to
+`emit: PR_CI_TIMEOUT` with a `reason` string that contains the literal
+substring `config error`. This MUST route the REQ directly to ESCALATED
+through the existing PR_CI_TIMEOUT transition, NOT through PR_CI_FAIL +
+verifier (because verifier-agent cannot fix the missing per-REQ
+configuration — only the human or the upstream intake can).
+
+#### Scenario: SCNF-S6 create_pr_ci_watch returns PR_CI_TIMEOUT when repos cannot be resolved
+
+- **GIVEN** runner-pod discovery returns `[]` (workspace empty),
+  `ctx.intake_finalized_intent` is `None`, and `ctx.involved_repos` is also
+  `None`
+- **WHEN** `create_pr_ci_watch._run_checker(req_id, ctx)` is awaited
+- **THEN** the return value MUST be `{"emit": "PR_CI_TIMEOUT", "reason": "config error: no repos provided ...", "exit_code": -1}`
+- **AND** `pr_ci_watch.watch_pr_ci` MUST have been called once with
+  `repos=None` (not silently skipped — the action MUST defer the
+  configuration check to the checker so the rule lives in one place)
+
+### Requirement: SISYPHUS_BUSINESS_REPO env var MUST NOT be referenced in production code paths
+
+The string literal `SISYPHUS_BUSINESS_REPO` SHALL NOT appear in the
+production-path source files of `orchestrator/src/orchestrator/` (excluding
+test fixtures). Specifically the deletion includes
+`orchestrator/src/orchestrator/checkers/pr_ci_watch.py:86` and any other
+reference under `orchestrator/src/orchestrator/`. The contract test
+`tests/test_contract_clone_and_pr_ci_fallback.py` MUST grep the source
+tree to assert this invariant, so future copy-paste reintroduction is
+caught by CI rather than by a stale-env-fallback bug at 3am.
+
+The string MAY remain in test files under `orchestrator/tests/` only when
+a test explicitly verifies that the env var is ignored (the SCNF-S5
+regression guard). Production code references MUST be exactly zero.
+
+#### Scenario: SCNF-S7 grep finds zero SISYPHUS_BUSINESS_REPO references in production source
+
+- **GIVEN** the orchestrator source tree at `orchestrator/src/orchestrator/`
+- **WHEN** the contract test runs `grep -rn "SISYPHUS_BUSINESS_REPO" orchestrator/src/orchestrator/`
+- **THEN** the result MUST be empty (zero matches) — no Python source file
+  under the production path SHALL contain the string `SISYPHUS_BUSINESS_REPO`

--- a/openspec/changes/REQ-clone-and-pr-ci-fallback-1777115925/tasks.md
+++ b/openspec/changes/REQ-clone-and-pr-ci-fallback-1777115925/tasks.md
@@ -1,0 +1,68 @@
+# Tasks: REQ-clone-and-pr-ci-fallback-1777115925
+
+## Stage: spec
+
+- [x] `openspec/changes/REQ-clone-and-pr-ci-fallback-1777115925/proposal.md`
+- [x] `openspec/changes/REQ-clone-and-pr-ci-fallback-1777115925/tasks.md`
+- [x] `openspec/changes/REQ-clone-and-pr-ci-fallback-1777115925/specs/server-side-clone-and-no-env-fallback/spec.md`
+- [x] `openspec/changes/REQ-clone-and-pr-ci-fallback-1777115925/specs/server-side-clone-and-no-env-fallback/contract.spec.yaml`
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/actions/_clone.py` (new)：
+  共用 helper `clone_involved_repos_into_runner(req_id, ctx)`：
+  解析 ctx 拿 involved_repos，调 `k8s_runner.exec_in_runner` 跑
+  `/opt/sisyphus/scripts/sisyphus-clone-repos.sh`；返回 `(cloned_repos, ok)`
+  以便 caller 决定 emit。
+
+- [x] `orchestrator/src/orchestrator/actions/start_analyze.py`：
+  在 `ensure_runner` 之后、`bkd.follow_up_issue` 之前，调用
+  `clone_involved_repos_into_runner`；clone 失败 → emit `VERIFY_ESCALATE`；
+  没 involved_repos → 跳过 clone 但继续 dispatch（直接路径兼容）。
+
+- [x] `orchestrator/src/orchestrator/actions/start_analyze_with_finalized_intent.py`：
+  同样接入 server-side clone（这条路径必然有 `intake_finalized_intent`，
+  clone 失败 → `VERIFY_ESCALATE`）。
+
+- [x] `orchestrator/src/orchestrator/checkers/pr_ci_watch.py::watch_pr_ci`：
+  删 `SISYPHUS_BUSINESS_REPO` env fallback（line 86）；空 repos 直接
+  `raise ValueError("no repos provided ...")`。更新 module docstring 第 4
+  行 + watch_pr_ci docstring 第 84 行去掉 env 提及。
+
+- [x] `orchestrator/src/orchestrator/actions/create_pr_ci_watch.py`：
+  更新 module docstring（第 8-12 行）：repo 来源序列只剩两档
+  （runner 文件系统 discovery > intake `involved_repos`），删第 3 档
+  env fallback 描述。
+
+- [x] `orchestrator/src/orchestrator/prompts/analyze.md.j2`：
+  Part A.3 (clone) 从"agent 必须跑"改成"sisyphus 已替你预 clone；
+  `/workspace/source` 是空再自己跑 helper"。提示 agent 优先把
+  involved_repos 在 intake 阶段 finalize 到 ctx。
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_checkers_pr_ci_watch.py`：
+  - `patch_pr_lookup` 不再 setenv，签名改回返回 repo 名给调用方做参数
+  - 现有 9 个依赖 env 的 case 改用 `repos=["phona/ubox-crosser"]` 参数
+  - 新增 `test_watch_pr_ci_raises_value_error_even_if_env_set_when_repos_none`
+    验证 env 设了 + repos=None 也直接 ValueError（确保 env fallback 真的删了）
+
+- [x] `orchestrator/tests/test_actions_start_analyze.py` (new)：
+  - `test_start_analyze_server_side_clones_when_involved_repos_present`：
+    ctx 含 `involved_repos` → exec_in_runner 跑 sisyphus-clone-repos.sh
+    + bkd.follow_up_issue 收到 prompt
+  - `test_start_analyze_skips_clone_when_no_involved_repos`：
+    ctx 空 → 不调 exec_in_runner（直接路径兼容）
+  - `test_start_analyze_clone_failure_emits_verify_escalate`：
+    exec_in_runner 退码非 0 → return 含 `emit: VERIFY_ESCALATE`
+  - `test_start_analyze_with_finalized_intent_clone_uses_involved_repos`：
+    ctx.intake_finalized_intent.involved_repos 三仓 → helper 收到三仓参数
+
+- [x] `orchestrator/tests/test_contract_clone_and_pr_ci_fallback.py` (new)：
+  契约层兜底：grep 源码确认 `SISYPHUS_BUSINESS_REPO` 在 checker /
+  config / actions 里被删干净（防回归）。
+
+## Stage: PR
+
+- [x] git push feat/REQ-clone-and-pr-ci-fallback-1777115925
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/actions/_clone.py
+++ b/orchestrator/src/orchestrator/actions/_clone.py
@@ -1,0 +1,71 @@
+"""server-side clone helper：start_analyze 系列 action 用，把 ctx 里的
+involved_repos 落到 runner pod 的 /workspace/source/<basename>/。
+
+入口：`clone_involved_repos_into_runner(req_id, ctx)`，三种返回：
+- (None, None)：runner controller 没就绪 / ctx 没 involved_repos 都返这个
+  —— caller 跳过 clone 直接 dispatch agent（直接 analyze 路径兼容）
+- (repos, None)：clone 成功，repos 是真跑过 helper 的列表
+- (repos, exit_code)：clone 失败，exit_code 是 helper 退码（caller 应
+  emit VERIFY_ESCALATE，不打 agent 进空 PVC）
+"""
+from __future__ import annotations
+
+import shlex
+
+import structlog
+
+from .. import k8s_runner
+
+log = structlog.get_logger(__name__)
+
+_CLONE_HELPER = "/opt/sisyphus/scripts/sisyphus-clone-repos.sh"
+_CLONE_TIMEOUT_SEC = 600
+
+
+def _resolve_repos(ctx: dict | None) -> list[str]:
+    """优先级 ctx.intake_finalized_intent.involved_repos > ctx.involved_repos。"""
+    if not ctx:
+        return []
+    finalized = ctx.get("intake_finalized_intent") or {}
+    repos = finalized.get("involved_repos") or ctx.get("involved_repos") or []
+    return [r for r in repos if isinstance(r, str) and r]
+
+
+async def clone_involved_repos_into_runner(
+    req_id: str, ctx: dict | None,
+) -> tuple[list[str] | None, int | None]:
+    """在 runner pod 里跑 sisyphus-clone-repos.sh。
+
+    返回 (repos, exit_code)：
+    - (None, None)：跳过（无 controller 或无 repos），caller 继续 dispatch agent
+    - (repos, None)：成功（helper exit 0）
+    - (repos, exit_code)：失败（helper 非 0），caller 应 escalate
+    """
+    repos = _resolve_repos(ctx)
+    if not repos:
+        log.info("clone.skip_no_repos", req_id=req_id)
+        return None, None
+
+    try:
+        rc = k8s_runner.get_controller()
+    except RuntimeError as e:
+        # dev 环境无 K8s：跳过 server-side clone，agent 自己 clone
+        log.warning("clone.no_runner_controller", req_id=req_id, error=str(e))
+        return None, None
+
+    args = " ".join(shlex.quote(r) for r in repos)
+    cmd = f"{_CLONE_HELPER} {args}"
+    log.info("clone.exec", req_id=req_id, repos=repos)
+    result = await rc.exec_in_runner(req_id, cmd, timeout_sec=_CLONE_TIMEOUT_SEC)
+
+    if result.exit_code != 0:
+        log.error(
+            "clone.failed", req_id=req_id, repos=repos,
+            exit_code=result.exit_code,
+            stderr_tail=result.stderr[-512:] if result.stderr else "",
+        )
+        return repos, result.exit_code
+
+    log.info("clone.done", req_id=req_id, repos=repos,
+             duration_sec=round(result.duration_sec, 1))
+    return repos, None

--- a/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
@@ -6,10 +6,16 @@ feature flag checker_pr_ci_watch_enabled:
   True: sisyphus 自己调 GitHub REST API 轮询 check-runs，emit PR_CI_PASS/FAIL/TIMEOUT
 
 repo 列表来源（M15 哲学：runner 是真理，不维护额外 metadata）：
-  1. runner pod `/workspace/source/*/` discovery（analyze-agent 已 clone 好，跟其它
-     checker 走同一条契约 —— staging_test / dev_cross_check 都遍历这个目录）
-  2. ctx.intake_finalized_intent.involved_repos（intake 阶段 runner 还没起来时的预声明）
-  3. SISYPHUS_BUSINESS_REPO env（M15 manifest 残骸，老单仓 REQ 兼容，建议下线）
+  1. runner pod `/workspace/source/*/` discovery（start_analyze 已 server-side
+     clone 好，跟其它 checker 走同一条契约 —— staging_test / dev_cross_check
+     都遍历这个目录）
+  2. ctx.intake_finalized_intent.involved_repos / ctx.involved_repos
+     （intake 阶段已知 / 直接 analyze 路径透传）
+
+REQ-clone-and-pr-ci-fallback-1777115925 把第三档 process-global env fallback
+删了 —— stale 全局值在多 REQ / 多仓场景下注定指错仓。两个 source 都空时
+_run_checker 把 repos=None 透传给 watch_pr_ci，由 checker 抛 ValueError，本
+action 翻译成 PR_CI_TIMEOUT（直接 ESCALATED 不进 verifier）。
 """
 from __future__ import annotations
 
@@ -74,7 +80,8 @@ async def _run_checker(*, req_id: str, ctx: dict) -> dict:
     log.info("create_pr_ci_watch.checker_path", req_id=req_id)
     branch = ctx.get("branch") or f"feat/{req_id}"
 
-    # repo 来源优先级：runner 文件系统（M15 真理）> intake finalized > env fallback
+    # repo 来源优先级：runner 文件系统（M15 真理）> ctx involved_repos
+    # （process-global env fallback 已删，REQ-clone-and-pr-ci-fallback-1777115925）
     repos = await _discover_repos_from_runner(req_id)
     if not repos:
         finalized = ctx.get("intake_finalized_intent") or {}

--- a/orchestrator/src/orchestrator/actions/start_analyze.py
+++ b/orchestrator/src/orchestrator/actions/start_analyze.py
@@ -3,11 +3,18 @@
 v0.2 变化：agent 跑前先 ensure_runner 拉起 K8s Pod + PVC，保证 analyze-agent
 kubectl exec 进去能立刻用。Pod 生命周期绑本 REQ 直到 done/escalate。
 
+REQ-clone-and-pr-ci-fallback-1777115925：在 ensure_runner 之后、follow-up
+prompt 之前，把 ctx 里的 involved_repos 替 agent server-side clone 进
+/workspace/source/<basename>/。clone 失败 → 直接 emit VERIFY_ESCALATE，不
+让 agent 进空 PVC 干活。直接 analyze 路径（无 intake，ctx 没 involved_repos）
+保留 fallback：跳过 server-side clone，agent 按 prompt Part A.3 自己跑 helper。
+
 行为：
 1. ensure_runner（K8s：建 PVC + Pod，等 Ready）
-2. update-issue 把 intent issue 改名 [REQ-xxx] [ANALYZE] — <title> + tags=[analyze, REQ-xxx]
-3. follow-up-issue 发 analyze prompt
-4. update-issue statusId=working 触发 agent
+2. server-side clone involved_repos（如果 ctx 有；失败 → VERIFY_ESCALATE）
+3. update-issue 把 intent issue 改名 [REQ-xxx] [ANALYZE] — <title> + tags=[analyze, REQ-xxx]
+4. follow-up-issue 发 analyze prompt
+5. update-issue statusId=working 触发 agent
 """
 from __future__ import annotations
 
@@ -19,6 +26,7 @@ from ..config import settings
 from ..prompts import render
 from ..state import Event
 from . import register, short_title
+from ._clone import clone_involved_repos_into_runner
 from ._skip import skip_if_enabled
 
 log = structlog.get_logger(__name__)
@@ -41,7 +49,16 @@ async def start_analyze(*, body, req_id, tags, ctx):
         pod_name = await rc.ensure_runner(req_id, wait_ready=True)
         log.info("start_analyze.runner_ready", req_id=req_id, pod=pod_name)
 
-    # 2-4. BKD 调度 analyze-agent
+    # 2. server-side clone（ctx 有 involved_repos 时；直接 analyze 路径无声跳过）
+    cloned_repos, clone_rc = await clone_involved_repos_into_runner(req_id, ctx)
+    if clone_rc is not None:
+        # helper 跑过但失败 → 不 dispatch agent，直接 escalate
+        return {
+            "emit": Event.VERIFY_ESCALATE.value,
+            "reason": f"clone failed (rc={clone_rc}) for repos={cloned_repos}"[:200],
+        }
+
+    # 3-5. BKD 调度 analyze-agent
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         await bkd.update_issue(
             project_id=proj,
@@ -56,9 +73,11 @@ async def start_analyze(*, body, req_id, tags, ctx):
             project_id=proj,
             project_alias=proj,   # BKD REST 接 id 也接 alias，二者等价
             issue_id=issue_id,
+            cloned_repos=cloned_repos,
         )
         await bkd.follow_up_issue(project_id=proj, issue_id=issue_id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue_id, status_id="working")
 
-    log.info("start_analyze.done", req_id=req_id, issue_id=issue_id)
-    return {"issue_id": issue_id, "req_id": req_id}
+    log.info("start_analyze.done", req_id=req_id, issue_id=issue_id,
+             cloned_repos=cloned_repos)
+    return {"issue_id": issue_id, "req_id": req_id, "cloned_repos": cloned_repos}

--- a/orchestrator/src/orchestrator/actions/start_analyze_with_finalized_intent.py
+++ b/orchestrator/src/orchestrator/actions/start_analyze_with_finalized_intent.py
@@ -3,12 +3,18 @@
 intake-agent 写完 finalized intent JSON（落 ctx.intake_finalized_intent）后，
 这里创建新 BKD issue（不复用 intake issue），把 finalized intent 嵌入 analyze prompt。
 
+REQ-clone-and-pr-ci-fallback-1777115925：在 ensure_runner 之后、create
+analyze issue 之前，按 ctx.intake_finalized_intent.involved_repos
+server-side clone 业务仓到 /workspace/source/<basename>/。clone 失败 →
+emit VERIFY_ESCALATE，不打 agent 进空 PVC。
+
 行为：
 1. 检查 ctx.intake_finalized_intent 是否存在（缺失 → emit VERIFY_ESCALATE 不阻断）
 2. ensure_runner（analyze-agent 要 clone 仓写代码）
-3. create 新 BKD issue（title=[REQ-xxx] [ANALYZE]）
-4. follow-up 发 analyze prompt（带 intake_summary）
-5. update statusId=working 触发 agent
+3. server-side clone involved_repos（失败 → emit VERIFY_ESCALATE）
+4. create 新 BKD issue（title=[REQ-xxx] [ANALYZE]）
+5. follow-up 发 analyze prompt（带 intake_summary）
+6. update statusId=working 触发 agent
 """
 from __future__ import annotations
 
@@ -20,6 +26,7 @@ from ..config import settings
 from ..prompts import render
 from ..state import Event
 from . import register, short_title
+from ._clone import clone_involved_repos_into_runner
 
 log = structlog.get_logger(__name__)
 
@@ -46,7 +53,15 @@ async def start_analyze_with_finalized_intent(*, body, req_id, tags, ctx):
         pod_name = await rc.ensure_runner(req_id, wait_ready=True)
         log.info("start_analyze_with_finalized_intent.runner_ready", req_id=req_id, pod=pod_name)
 
-    # 2-4. 创建新 BKD analyze issue（不复用 intake issue）
+    # 2. server-side clone（intake 路径必有 involved_repos；失败 → escalate）
+    cloned_repos, clone_rc = await clone_involved_repos_into_runner(req_id, ctx)
+    if clone_rc is not None:
+        return {
+            "emit": Event.VERIFY_ESCALATE.value,
+            "reason": f"clone failed (rc={clone_rc}) for repos={cloned_repos}"[:200],
+        }
+
+    # 3-5. 创建新 BKD analyze issue（不复用 intake issue）
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         issue = await bkd.create_issue(
             project_id=proj,
@@ -64,9 +79,11 @@ async def start_analyze_with_finalized_intent(*, body, req_id, tags, ctx):
             project_alias=proj,
             issue_id=issue.id,
             intake_summary=finalized,
+            cloned_repos=cloned_repos,
         )
         await bkd.follow_up_issue(project_id=proj, issue_id=issue.id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue.id, status_id="working")
 
-    log.info("start_analyze_with_finalized_intent.done", req_id=req_id, analyze_issue_id=issue.id)
-    return {"analyze_issue_id": issue.id}
+    log.info("start_analyze_with_finalized_intent.done", req_id=req_id,
+             analyze_issue_id=issue.id, cloned_repos=cloned_repos)
+    return {"analyze_issue_id": issue.id, "cloned_repos": cloned_repos}

--- a/orchestrator/src/orchestrator/checkers/pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/checkers/pr_ci_watch.py
@@ -1,8 +1,10 @@
 """pr-ci-watch 自检（M2）：sisyphus 直接调 GitHub REST API 轮询 PR check-runs。
 
 M15：repo / pr_number 用 gh api 实时查，不读 manifest。
-repos 列表优先来自 caller（per-REQ involved_repos），fallback 到全局环境变量
-SISYPHUS_BUSINESS_REPO（兼容旧单仓 REQ）。
+REQ-clone-and-pr-ci-fallback-1777115925：repos 列表**只**来自 caller
+（per-REQ involved_repos / runner discovery）。空 → ValueError，**不**fallback
+到任何全局环境变量 —— stale env 在多 REQ / 多仓场景下注定指错仓，silent-pass
+或 false-fail，跟 sisyphus "无信号即失败" 哲学冲突。
 
 dev agent 只需 push branch + 创 PR，不用回写任何东西。
 
@@ -34,7 +36,6 @@ GH API:
 from __future__ import annotations
 
 import asyncio
-import os
 import time
 from dataclasses import dataclass
 
@@ -81,14 +82,15 @@ async def watch_pr_ci(
 
     每 tick 重新拉 head SHA：force-push 自动切新 SHA；超过 _MAX_SHA_FLIPS 次翻转 → fail。
     merged → pass；closed without merge → fail；refetch 失败 → retry 到 deadline。
-    repos 优先于 SISYPHUS_BUSINESS_REPO 环境变量（per-REQ involved_repos 优先于全局）。
+    repos 必须由 caller 显式传入（per-REQ involved_repos）；空 / None 直接
+    ValueError —— 没 fallback 到任何 process-global env，跟 sisyphus "无信号
+    即失败" 哲学一致。
     """
-    repo_list = repos or ([os.getenv("SISYPHUS_BUSINESS_REPO")] if os.getenv("SISYPHUS_BUSINESS_REPO") else [])
-    repo_list = [r for r in repo_list if r]
+    repo_list = [r for r in (repos or []) if r]
     if not repo_list:
         raise ValueError(
-            "no repos provided to watch_pr_ci (caller didn't pass repos and "
-            "SISYPHUS_BUSINESS_REPO env var not set)"
+            "no repos provided to watch_pr_ci (caller must pass per-REQ "
+            "involved_repos; no global env fallback)"
         )
 
     headers = {

--- a/orchestrator/src/orchestrator/prompts/analyze.md.j2
+++ b/orchestrator/src/orchestrator/prompts/analyze.md.j2
@@ -85,7 +85,18 @@ session 结束 + move review 时，每个被改的 source repo 的 `feat/{{ req_
 - spec_lint / dev_cross_check / staging_test 会**遍历 `/workspace/source/*`** 跑工具
 - **没有 leader / feature 主从**
 
-### A.3 clone 到约定结构（**调 sisyphus helper**）
+### A.3 clone 到约定结构（多数情况 **sisyphus 已替你跑**）
+
+REQ-clone-and-pr-ci-fallback-1777115925 起，`start_analyze` 在 dispatch
+你之前会 server-side 调 `/opt/sisyphus/scripts/sisyphus-clone-repos.sh`，
+把 ctx 里 `intake_finalized_intent.involved_repos` / `involved_repos`
+列的所有仓 clone 进 `/workspace/source/<basename>/`。
+{% if cloned_repos %}
+本次 sisyphus 已经预 clone 过：{{ cloned_repos | join(", ") }}。
+你直接进 spec / dev 即可，不用再跑 helper。
+{% else %}
+本次 ctx 没声明 involved_repos（直接 analyze 路径，无 intake），
+sisyphus 没替你 clone。**你必须自己跑 helper**：
 
 ```bash
 POD=runner-{{ req_id | lower }}
@@ -96,6 +107,8 @@ kubectl -n $NS exec $POD -- /opt/sisyphus/scripts/sisyphus-clone-repos.sh \
 ```
 
 helper 把每个仓 clone 到 `/workspace/source/<basename>/`，搞定 token、shallow、refspec。
+**今后建议在 BKD intake 阶段 finalize involved_repos**，下回 sisyphus 自己接管。
+{% endif %}
 
 ### A.4 检查 + 初始化 openspec project（每个 source repo）
 

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -72,7 +72,9 @@ async def test_start_analyze(monkeypatch):
     patch_bkd(monkeypatch, "start_analyze", fake)
     body = make_body(issue_id="intent-1", title="加个登录")
     out = await mod.start_analyze(body=body, req_id="REQ-9", tags=["intent:analyze"], ctx={})
-    assert out == {"issue_id": "intent-1", "req_id": "REQ-9"}
+    # cloned_repos=None: 直接 analyze 路径无 involved_repos，跳过 server-side clone
+    # （REQ-clone-and-pr-ci-fallback-1777115925）
+    assert out == {"issue_id": "intent-1", "req_id": "REQ-9", "cloned_repos": None}
     # 改 title + tags + 发 prompt + 推 working
     assert fake.update_issue.await_count == 2  # title/tags + working
     assert fake.follow_up_issue.await_count == 1

--- a/orchestrator/tests/test_actions_start_analyze.py
+++ b/orchestrator/tests/test_actions_start_analyze.py
@@ -1,0 +1,263 @@
+"""actions/start_analyze.py + start_analyze_with_finalized_intent.py 单测：
+
+REQ-clone-and-pr-ci-fallback-1777115925：验 server-side clone 派发与失败传播。
+
+不测 BKD REST 主体（在 test_bkd_rest.py），不测 ensure_runner 主体
+（在 test_k8s_runner.py），只测 _clone helper 跟 action 串起来的契约。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from orchestrator.actions import _clone, start_analyze, start_analyze_with_finalized_intent
+from orchestrator.state import Event
+
+
+@dataclass
+class FakeExec:
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
+    duration_sec: float = 0.1
+
+
+def _make_body(*, project_id: str = "nnvxh8wj", issue_id: str = "issue-X"):
+    return SimpleNamespace(projectId=project_id, issueId=issue_id, title="t")
+
+
+def _patch_runner(monkeypatch, *, exec_fn: AsyncMock, ensure_ready_fn: AsyncMock | None = None):
+    """同时 patch _clone 跟 start_analyze* 路径上的 k8s_runner.get_controller。"""
+    if ensure_ready_fn is None:
+        ensure_ready_fn = AsyncMock(return_value="runner-pod-x")
+
+    class FakeRC:
+        def __init__(self):
+            self.exec_in_runner = exec_fn
+            self.ensure_runner = ensure_ready_fn
+
+    fake_rc = FakeRC()
+    # _clone helper 调 k8s_runner.get_controller()
+    monkeypatch.setattr(_clone.k8s_runner, "get_controller", lambda: fake_rc)
+    # start_analyze.py 同样的 namespace
+    monkeypatch.setattr(start_analyze.k8s_runner, "get_controller", lambda: fake_rc)
+    monkeypatch.setattr(
+        start_analyze_with_finalized_intent.k8s_runner, "get_controller",
+        lambda: fake_rc,
+    )
+    return fake_rc
+
+
+def _patch_bkd_client(monkeypatch, *, target_module, follow_up: AsyncMock | None = None,
+                     update_issue: AsyncMock | None = None,
+                     create_issue: AsyncMock | None = None):
+    """patch target module 的 BKDClient，捕获 follow_up_issue / update_issue / create_issue 调用。"""
+    follow_up = follow_up or AsyncMock(return_value=None)
+    update_issue = update_issue or AsyncMock(return_value=None)
+    create_issue = create_issue or AsyncMock(
+        return_value=SimpleNamespace(id="created-issue-X"),
+    )
+
+    bkd_instance = MagicMock()
+    bkd_instance.follow_up_issue = follow_up
+    bkd_instance.update_issue = update_issue
+    bkd_instance.create_issue = create_issue
+    bkd_instance.__aenter__ = AsyncMock(return_value=bkd_instance)
+    bkd_instance.__aexit__ = AsyncMock(return_value=None)
+
+    monkeypatch.setattr(target_module, "BKDClient", lambda *a, **kw: bkd_instance)
+    return follow_up, update_issue, create_issue
+
+
+# ── start_analyze: server-side clone happy path ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_analyze_server_side_clones_when_involved_repos_present(monkeypatch):
+    """ctx 含 involved_repos → exec_in_runner 跑 sisyphus-clone-repos.sh，agent 收到 prompt。"""
+    exec_fn = AsyncMock(return_value=FakeExec(exit_code=0))
+    _patch_runner(monkeypatch, exec_fn=exec_fn)
+    follow_up, update_issue, _ = _patch_bkd_client(
+        monkeypatch, target_module=start_analyze,
+    )
+
+    ctx = {"involved_repos": ["phona/repo-a", "ZonEaseTech/ttpos-server-go"]}
+    rv = await start_analyze.start_analyze(
+        body=_make_body(), req_id="REQ-X", tags=[], ctx=ctx,
+    )
+
+    # 1) clone 跑过：cmd 含 helper 路径 + 两个仓
+    exec_fn.assert_awaited_once()
+    cmd = exec_fn.await_args.args[1]
+    assert "/opt/sisyphus/scripts/sisyphus-clone-repos.sh" in cmd
+    assert "phona/repo-a" in cmd
+    assert "ZonEaseTech/ttpos-server-go" in cmd
+
+    # 2) agent 收到 prompt（clone 之后）
+    follow_up.assert_awaited_once()
+    update_issue.assert_awaited()  # 至少 rename + status=working 两次
+
+    # 3) return 包含 cloned_repos
+    assert rv["cloned_repos"] == ["phona/repo-a", "ZonEaseTech/ttpos-server-go"]
+    assert "emit" not in rv  # 没 escalate
+
+
+@pytest.mark.asyncio
+async def test_start_analyze_skips_clone_when_no_involved_repos(monkeypatch):
+    """直接路径：ctx 没 involved_repos → 不调 exec_in_runner，agent 还是被 dispatch。"""
+    exec_fn = AsyncMock(return_value=FakeExec(exit_code=0))
+    _patch_runner(monkeypatch, exec_fn=exec_fn)
+    follow_up, _, _ = _patch_bkd_client(monkeypatch, target_module=start_analyze)
+
+    rv = await start_analyze.start_analyze(
+        body=_make_body(), req_id="REQ-X", tags=[],
+        ctx={"intent_title": "no involved_repos here"},
+    )
+
+    exec_fn.assert_not_awaited()  # 跳过 clone
+    follow_up.assert_awaited_once()  # 但仍 dispatch agent
+    assert rv["cloned_repos"] is None
+
+
+@pytest.mark.asyncio
+async def test_start_analyze_clone_failure_emits_verify_escalate(monkeypatch):
+    """clone helper exit 非 0 → return emit=VERIFY_ESCALATE，agent 不被 dispatch。"""
+    exec_fn = AsyncMock(return_value=FakeExec(exit_code=5, stderr="auth error"))
+    _patch_runner(monkeypatch, exec_fn=exec_fn)
+    follow_up, _, _ = _patch_bkd_client(monkeypatch, target_module=start_analyze)
+
+    ctx = {"intake_finalized_intent": {"involved_repos": ["phona/typo-repo"]}}
+    rv = await start_analyze.start_analyze(
+        body=_make_body(), req_id="REQ-X", tags=[], ctx=ctx,
+    )
+
+    exec_fn.assert_awaited_once()
+    follow_up.assert_not_awaited()  # 不打 agent 进空 PVC
+    assert rv["emit"] == Event.VERIFY_ESCALATE.value
+    assert "clone failed" in rv["reason"]
+    assert "5" in rv["reason"]  # exit code 出现在 reason
+
+
+# ── start_analyze_with_finalized_intent: intake 路径 ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_analyze_with_finalized_intent_clones_involved_repos(monkeypatch):
+    """intake 路径必有 finalized intent；server-side clone 拿 involved_repos。"""
+    exec_fn = AsyncMock(return_value=FakeExec(exit_code=0))
+    _patch_runner(monkeypatch, exec_fn=exec_fn)
+    follow_up, _, create_issue = _patch_bkd_client(
+        monkeypatch, target_module=start_analyze_with_finalized_intent,
+    )
+
+    ctx = {
+        "intake_finalized_intent": {
+            "involved_repos": ["phona/repo-a", "phona/repo-b", "phona/repo-c"],
+            "business_behavior": "x", "data_constraints": "y",
+            "edge_cases": "z", "do_not_touch": "w", "acceptance": "v",
+        },
+    }
+    rv = await start_analyze_with_finalized_intent.start_analyze_with_finalized_intent(
+        body=_make_body(), req_id="REQ-X", tags=[], ctx=ctx,
+    )
+
+    exec_fn.assert_awaited_once()
+    cmd = exec_fn.await_args.args[1]
+    for r in ("phona/repo-a", "phona/repo-b", "phona/repo-c"):
+        assert r in cmd
+
+    create_issue.assert_awaited_once()  # intake 路径要建新 analyze issue
+    follow_up.assert_awaited_once()
+    assert rv["cloned_repos"] == ["phona/repo-a", "phona/repo-b", "phona/repo-c"]
+    assert "emit" not in rv
+
+
+@pytest.mark.asyncio
+async def test_start_analyze_with_finalized_intent_clone_failure_escalates(monkeypatch):
+    """intake 路径 clone 失败 → VERIFY_ESCALATE，且不 create analyze issue。"""
+    exec_fn = AsyncMock(return_value=FakeExec(exit_code=2, stderr="repo not found"))
+    _patch_runner(monkeypatch, exec_fn=exec_fn)
+    follow_up, _, create_issue = _patch_bkd_client(
+        monkeypatch, target_module=start_analyze_with_finalized_intent,
+    )
+
+    ctx = {"intake_finalized_intent": {"involved_repos": ["phona/typo"]}}
+    rv = await start_analyze_with_finalized_intent.start_analyze_with_finalized_intent(
+        body=_make_body(), req_id="REQ-X", tags=[], ctx=ctx,
+    )
+
+    exec_fn.assert_awaited_once()
+    create_issue.assert_not_awaited()
+    follow_up.assert_not_awaited()
+    assert rv["emit"] == Event.VERIFY_ESCALATE.value
+    assert "clone failed" in rv["reason"]
+    assert "2" in rv["reason"]
+
+
+@pytest.mark.asyncio
+async def test_start_analyze_with_finalized_intent_missing_finalized_escalates(monkeypatch):
+    """intake_finalized_intent 缺失 → VERIFY_ESCALATE（保留旧契约）。"""
+    # 不 patch runner / bkd —— 该 case 在它们之前就 return
+    rv = await start_analyze_with_finalized_intent.start_analyze_with_finalized_intent(
+        body=_make_body(), req_id="REQ-X", tags=[], ctx={},
+    )
+    assert rv["emit"] == Event.VERIFY_ESCALATE.value
+    assert "intake_finalized_intent" in rv["reason"]
+
+
+# ── _clone helper 行为单测 ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_clone_helper_skips_when_no_controller(monkeypatch):
+    """k8s_runner.get_controller 抛 RuntimeError → 跳过 clone（dev 环境兼容）。"""
+    def raise_no_ctrl():
+        raise RuntimeError("controller not initialized")
+    monkeypatch.setattr(_clone.k8s_runner, "get_controller", raise_no_ctrl)
+
+    repos, rc = await _clone.clone_involved_repos_into_runner(
+        "REQ-X", {"involved_repos": ["phona/repo-a"]},
+    )
+    assert repos is None
+    assert rc is None
+
+
+@pytest.mark.asyncio
+async def test_clone_helper_finalized_intent_takes_priority(monkeypatch):
+    """ctx.intake_finalized_intent.involved_repos 优先于 ctx.involved_repos。"""
+    exec_fn = AsyncMock(return_value=FakeExec(exit_code=0))
+
+    class FakeRC:
+        exec_in_runner = exec_fn
+
+    monkeypatch.setattr(_clone.k8s_runner, "get_controller", lambda: FakeRC())
+
+    ctx = {
+        "intake_finalized_intent": {"involved_repos": ["finalized/wins"]},
+        "involved_repos": ["fallback/loses"],
+    }
+    repos, rc = await _clone.clone_involved_repos_into_runner("REQ-X", ctx)
+    assert repos == ["finalized/wins"]
+    assert rc is None
+    cmd = exec_fn.await_args.args[1]
+    assert "finalized/wins" in cmd
+    assert "fallback/loses" not in cmd
+
+
+@pytest.mark.asyncio
+async def test_clone_helper_filters_non_string_repos(monkeypatch):
+    """involved_repos 含非字符串项 → 过滤掉，不传给 helper。"""
+    exec_fn = AsyncMock(return_value=FakeExec(exit_code=0))
+
+    class FakeRC:
+        exec_in_runner = exec_fn
+
+    monkeypatch.setattr(_clone.k8s_runner, "get_controller", lambda: FakeRC())
+
+    ctx = {"involved_repos": ["phona/repo-a", None, "", 42, "phona/repo-b"]}
+    repos, rc = await _clone.clone_involved_repos_into_runner("REQ-X", ctx)
+    assert repos == ["phona/repo-a", "phona/repo-b"]
+    assert rc is None

--- a/orchestrator/tests/test_checkers_pr_ci_watch.py
+++ b/orchestrator/tests/test_checkers_pr_ci_watch.py
@@ -1,7 +1,11 @@
 """checkers/pr_ci_watch.py 单测：mock GitHub API，验全绿/任一失败/全失败/超时/SHA翻转/PR合并关闭。
 
-M15：watch_pr_ci(req_id, branch, ...)，repo 从 SISYPHUS_BUSINESS_REPO env 读，
+M15：watch_pr_ci(req_id, branch, ..., repos=...)，repos 必须由 caller 显式传入；
 pr_number + head.sha 用 GitHub REST API `head` 过滤器按 branch 查（这里 mock 掉），不再读 manifest。
+
+REQ-clone-and-pr-ci-fallback-1777115925：删 SISYPHUS_BUSINESS_REPO env fallback，
+所有 case 显式传 `repos=[...]` 给 watch_pr_ci；env 即使被设也必须被 ignore（regression
+guard 见 test_watch_pr_ci_ignores_env_var_when_repos_none）。
 
 SHA refresh（force-push 检测）：每 tick 重新拉 head SHA，SHA 变化时重置 check-runs 缓存。
 """
@@ -39,16 +43,19 @@ def _run(
     }
 
 
-def patch_pr_lookup(monkeypatch, *, repo: str = "phona/ubox-crosser", pr_number: int | None = 42):
-    """SISYPHUS_BUSINESS_REPO env + mock _get_pr_info 返指定 (number, sha, state)。"""
-    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", repo)
+def patch_pr_lookup(monkeypatch, *, repo: str = "phona/ubox-crosser", pr_number: int | None = 42) -> str:
+    """mock _get_pr_info 返指定 (number, sha, state)；返回 repo 名给 caller 传入 repos= 参数。
 
+    REQ-clone-and-pr-ci-fallback-1777115925：不再 setenv SISYPHUS_BUSINESS_REPO ——
+    caller 必须显式 `repos=[repo]` 传给 watch_pr_ci。
+    """
     async def fake_lookup(client, _repo: str, _branch: str) -> tuple[int, str, str]:
         if pr_number is None:
             raise ValueError("No open PR found")
         return pr_number, "deadbeef" * 5, "open"
 
     monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
+    return repo
 
 
 # ── 单轮直绿 ──────────────────────────────────────────────────────────────
@@ -56,14 +63,14 @@ def patch_pr_lookup(monkeypatch, *, repo: str = "phona/ubox-crosser", pr_number:
 @pytest.mark.asyncio
 async def test_watch_pr_ci_all_green(httpx_mock, monkeypatch):
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
-    patch_pr_lookup(monkeypatch)
+    repo = patch_pr_lookup(monkeypatch)
 
     httpx_mock.add_response(
         url="https://api.github.com/repos/phona/ubox-crosser/commits/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/check-runs?per_page=100",
         json=_runs_payload(_run("lint"), _run("unit"), _run("integration")),
     )
 
-    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9", poll_interval_sec=1, timeout_sec=60)
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9", poll_interval_sec=1, timeout_sec=60, repos=[repo])
 
     assert isinstance(result, CheckResult)
     assert result.passed is True
@@ -78,7 +85,7 @@ async def test_watch_pr_ci_all_green(httpx_mock, monkeypatch):
 @pytest.mark.asyncio
 async def test_watch_pr_ci_any_failed(httpx_mock, monkeypatch):
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
-    patch_pr_lookup(monkeypatch)
+    repo = patch_pr_lookup(monkeypatch)
 
     httpx_mock.add_response(
         url="https://api.github.com/repos/phona/ubox-crosser/commits/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/check-runs?per_page=100",
@@ -89,7 +96,7 @@ async def test_watch_pr_ci_any_failed(httpx_mock, monkeypatch):
         ),
     )
 
-    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9", poll_interval_sec=1, timeout_sec=60)
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9", poll_interval_sec=1, timeout_sec=60, repos=[repo])
 
     assert result.passed is False
     assert result.exit_code == 1
@@ -103,7 +110,7 @@ async def test_watch_pr_ci_any_failed(httpx_mock, monkeypatch):
 @pytest.mark.asyncio
 async def test_watch_pr_ci_all_failed(httpx_mock, monkeypatch):
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
-    patch_pr_lookup(monkeypatch)
+    repo = patch_pr_lookup(monkeypatch)
 
     httpx_mock.add_response(
         url="https://api.github.com/repos/phona/ubox-crosser/commits/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/check-runs?per_page=100",
@@ -113,7 +120,7 @@ async def test_watch_pr_ci_all_failed(httpx_mock, monkeypatch):
         ),
     )
 
-    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9", poll_interval_sec=1, timeout_sec=60)
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9", poll_interval_sec=1, timeout_sec=60, repos=[repo])
 
     assert result.passed is False
     assert result.exit_code == 1
@@ -127,7 +134,7 @@ async def test_watch_pr_ci_all_failed(httpx_mock, monkeypatch):
 async def test_watch_pr_ci_timeout(httpx_mock, monkeypatch):
     """所有 check-run 都还 in_progress，到 timeout 返 124。"""
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
-    patch_pr_lookup(monkeypatch)
+    repo = patch_pr_lookup(monkeypatch)
 
     # 让 sleep 立即返回，避免真等
     async def fast_sleep(_):
@@ -140,7 +147,7 @@ async def test_watch_pr_ci_timeout(httpx_mock, monkeypatch):
         is_reusable=True,
     )
 
-    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9", poll_interval_sec=0, timeout_sec=0)
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9", poll_interval_sec=0, timeout_sec=0, repos=[repo])
 
     assert result.passed is False
     assert result.exit_code == 124
@@ -154,7 +161,7 @@ async def test_watch_pr_ci_timeout(httpx_mock, monkeypatch):
 async def test_watch_pr_ci_pending_then_pass(httpx_mock, monkeypatch):
     """前一轮 pending，后一轮全绿。"""
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
-    patch_pr_lookup(monkeypatch)
+    repo = patch_pr_lookup(monkeypatch)
 
     async def fast_sleep(_):
         return None
@@ -171,7 +178,7 @@ async def test_watch_pr_ci_pending_then_pass(httpx_mock, monkeypatch):
         json=_runs_payload(_run("lint")),
     )
 
-    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9", poll_interval_sec=1, timeout_sec=60)
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9", poll_interval_sec=1, timeout_sec=60, repos=[repo])
 
     assert result.passed is True
     assert result.exit_code == 0
@@ -183,13 +190,15 @@ async def test_watch_pr_ci_pending_then_pass(httpx_mock, monkeypatch):
 async def test_watch_pr_ci_pr_lookup_http_error(monkeypatch):
     """_get_pr_info 抛 httpx.HTTPError → watch_pr_ci 捕获后返 exit_code=1。"""
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
-    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/ubox-crosser")
 
     async def fake_lookup_fail(client, _repo: str, _branch: str) -> tuple[int, str, str]:
         raise httpx.HTTPError("mocked API error")
     monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup_fail)
 
-    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9", poll_interval_sec=1, timeout_sec=60)
+    result = await pr_ci_watch.watch_pr_ci(
+        "REQ-9", "feat/REQ-9", poll_interval_sec=1, timeout_sec=60,
+        repos=["phona/ubox-crosser"],
+    )
 
     assert result.passed is False
     assert result.exit_code == 1
@@ -202,7 +211,7 @@ async def test_watch_pr_ci_pr_lookup_http_error(monkeypatch):
 async def test_watch_pr_ci_empty_runs_times_out(httpx_mock, monkeypatch):
     """PR 刚开 GHA 还没触发，check-runs 为空 → pending → 超时。"""
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
-    patch_pr_lookup(monkeypatch)
+    repo = patch_pr_lookup(monkeypatch)
 
     async def fast_sleep(_):
         return None
@@ -214,38 +223,60 @@ async def test_watch_pr_ci_empty_runs_times_out(httpx_mock, monkeypatch):
         is_reusable=True,
     )
 
-    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9", poll_interval_sec=0, timeout_sec=0)
+    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9", poll_interval_sec=0, timeout_sec=0, repos=[repo])
     assert result.exit_code == 124
 
 
-# ── env / branch 不全 → 抛 ValueError ────────────────────────────────────
+# ── repos 参数不全 → 抛 ValueError（无 env fallback）────────────────────────
 
 @pytest.mark.asyncio
 async def test_watch_pr_ci_raises_when_no_repos(monkeypatch):
-    """没传 repos 参数 + SISYPHUS_BUSINESS_REPO 没设 → 直接 ValueError。"""
+    """没传 repos 参数 → 直接 ValueError，不偷读任何 env。"""
     monkeypatch.delenv("SISYPHUS_BUSINESS_REPO", raising=False)
     with pytest.raises(ValueError, match="no repos provided"):
         await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9")
 
 
 @pytest.mark.asyncio
+async def test_watch_pr_ci_ignores_env_var_when_repos_none(monkeypatch):
+    """REQ-clone-and-pr-ci-fallback regression: env 设了 + repos=None 也必须 ValueError。
+
+    旧版 watch_pr_ci 在 repos 空时偷读 SISYPHUS_BUSINESS_REPO 当 fallback ——
+    process-global env 在多 REQ / 多仓场景下注定 stale，会查错仓 PR 或漏看仓。
+    本 case 守: env 设了也无效，empty repos 一定 ValueError。
+    """
+    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/legacy-repo")
+
+    async def fake_lookup_must_not_be_called(*args, **kwargs):
+        raise AssertionError("watch_pr_ci 不该接触 GitHub —— ValueError 应当先短路")
+    monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup_must_not_be_called)
+
+    with pytest.raises(ValueError, match="no repos provided"):
+        await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9")  # repos= 缺省 None
+
+    # 显式传 repos=[] 也一样
+    with pytest.raises(ValueError, match="no repos provided"):
+        await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9", repos=[])
+
+
+@pytest.mark.asyncio
 async def test_watch_pr_ci_returns_fail_when_no_pr(monkeypatch):
     """找不到对应 PR → 返 fail CheckResult（exit=1），不再抛 ValueError 让 caller 处理。"""
-    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/ubox-crosser")
-
     async def fake_lookup_none(client, _repo: str, _branch: str) -> tuple[int, str, str]:
         raise ValueError("No open PR found for branch")
     monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup_none)
 
-    result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9")
+    result = await pr_ci_watch.watch_pr_ci(
+        "REQ-9", "feat/REQ-9", repos=["phona/ubox-crosser"],
+    )
     assert result.passed is False
     assert result.exit_code == 1
     assert "No open PR found" in result.stderr_tail
 
 
 @pytest.mark.asyncio
-async def test_watch_pr_ci_per_req_repos_override_env(monkeypatch):
-    """传入 repos 参数应覆盖 SISYPHUS_BUSINESS_REPO env var（per-REQ 覆盖全局）。"""
+async def test_watch_pr_ci_uses_only_caller_passed_repos(monkeypatch):
+    """REQ-clone-and-pr-ci-fallback：caller 传 repos=[X]，env 即使指 Y 也不影响 —— 只用 X。"""
     monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/wrong-repo")
 
     looked_up: list[str] = []
@@ -350,10 +381,10 @@ async def test_watch_pr_ci_sha_flip_restarts_check_runs(monkeypatch):
     monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
     monkeypatch.setattr(pr_ci_watch, "_get_check_runs", fake_check_runs)
     monkeypatch.setattr(pr_ci_watch.asyncio, "sleep", fast_sleep)
-    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/repo")
 
     result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9",
-                                            poll_interval_sec=1, timeout_sec=60)
+                                            poll_interval_sec=1, timeout_sec=60,
+                                            repos=["phona/repo"])
 
     assert result.passed is True
     assert result.exit_code == 0
@@ -381,10 +412,10 @@ async def test_watch_pr_ci_too_many_sha_flips(monkeypatch):
     monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
     monkeypatch.setattr(pr_ci_watch, "_get_check_runs", fake_check_runs)
     monkeypatch.setattr(pr_ci_watch.asyncio, "sleep", fast_sleep)
-    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/repo")
 
     result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9",
-                                            poll_interval_sec=0, timeout_sec=60)
+                                            poll_interval_sec=0, timeout_sec=60,
+                                            repos=["phona/repo"])
 
     assert result.passed is False
     assert result.exit_code == 1
@@ -412,10 +443,10 @@ async def test_watch_pr_ci_pr_merged_returns_pass(monkeypatch):
 
     monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
     monkeypatch.setattr(pr_ci_watch, "_get_check_runs", fake_check_runs)
-    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/repo")
 
     result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9",
-                                            poll_interval_sec=0, timeout_sec=60)
+                                            poll_interval_sec=0, timeout_sec=60,
+                                            repos=["phona/repo"])
 
     assert result.passed is True
     assert result.exit_code == 0
@@ -439,10 +470,10 @@ async def test_watch_pr_ci_pr_closed_returns_fail(monkeypatch):
 
     monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
     monkeypatch.setattr(pr_ci_watch, "_get_check_runs", fake_check_runs)
-    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/repo")
 
     result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9",
-                                            poll_interval_sec=0, timeout_sec=60)
+                                            poll_interval_sec=0, timeout_sec=60,
+                                            repos=["phona/repo"])
 
     assert result.passed is False
     assert result.exit_code == 1
@@ -463,10 +494,10 @@ async def test_watch_pr_ci_initial_pr_already_merged(monkeypatch):
 
     monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
     monkeypatch.setattr(pr_ci_watch, "_get_check_runs", fake_check_runs)
-    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/repo")
 
     result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9",
-                                            poll_interval_sec=0, timeout_sec=60)
+                                            poll_interval_sec=0, timeout_sec=60,
+                                            repos=["phona/repo"])
 
     assert result.passed is True
     assert "merged" in result.stdout_tail
@@ -495,11 +526,11 @@ async def test_watch_pr_ci_pr_refetch_error_retries(monkeypatch):
     monkeypatch.setattr(pr_ci_watch, "_get_pr_info", fake_lookup)
     monkeypatch.setattr(pr_ci_watch, "_get_check_runs", fake_check_runs)
     monkeypatch.setattr(pr_ci_watch.asyncio, "sleep", fast_sleep)
-    monkeypatch.setenv("SISYPHUS_BUSINESS_REPO", "phona/repo")
 
     # tick 1: re-fetch 失败但 check-runs 用 cached SHA 成功 → pass
     result = await pr_ci_watch.watch_pr_ci("REQ-9", "feat/REQ-9",
-                                            poll_interval_sec=1, timeout_sec=60)
+                                            poll_interval_sec=1, timeout_sec=60,
+                                            repos=["phona/repo"])
 
     assert result.passed is True
 
@@ -581,7 +612,7 @@ async def test_watch_pr_ci_review_only_check_runs_treated_as_fail(
 ):
     """端到端：PR 只有 claude-review 报绿 → checker 返 passed=False reason=no-gha。"""
     monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
-    patch_pr_lookup(monkeypatch)
+    repo = patch_pr_lookup(monkeypatch)
 
     httpx_mock.add_response(
         url="https://api.github.com/repos/phona/ubox-crosser/commits/"
@@ -591,6 +622,7 @@ async def test_watch_pr_ci_review_only_check_runs_treated_as_fail(
 
     result = await pr_ci_watch.watch_pr_ci(
         "REQ-9", "feat/REQ-9", poll_interval_sec=1, timeout_sec=60,
+        repos=[repo],
     )
 
     assert result.passed is False

--- a/orchestrator/tests/test_contract_clone_and_pr_ci_fallback.py
+++ b/orchestrator/tests/test_contract_clone_and_pr_ci_fallback.py
@@ -1,0 +1,68 @@
+"""contract regression for REQ-clone-and-pr-ci-fallback-1777115925:
+
+死锁 SISYPHUS_BUSINESS_REPO env fallback 不被 reintroduced —— grep 整个
+production source tree 应当 0 命中。test fixture 里允许（regression guard
+本身需要 setenv 来验证 ignore 行为）。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_PRODUCTION_SOURCE = Path(__file__).resolve().parent.parent / "src" / "orchestrator"
+
+
+def test_no_sisyphus_business_repo_env_in_production_source():
+    """grep 'SISYPHUS_BUSINESS_REPO' under orchestrator/src/orchestrator/ → 0 命中。
+
+    任何重新引入这个 env 的 commit 必须先把这个 case 改回来 —— 让回归显式。
+    """
+    matches: list[str] = []
+    for py in _PRODUCTION_SOURCE.rglob("*.py"):
+        text = py.read_text(encoding="utf-8", errors="replace")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if "SISYPHUS_BUSINESS_REPO" in line:
+                matches.append(f"{py.relative_to(_PRODUCTION_SOURCE.parent.parent)}:{lineno}: {line.strip()}")
+    assert matches == [], (
+        "SISYPHUS_BUSINESS_REPO must not be referenced in production source "
+        "(REQ-clone-and-pr-ci-fallback-1777115925). Found:\n"
+        + "\n".join(matches)
+    )
+
+
+def test_no_os_getenv_repo_fallback_in_pr_ci_watch():
+    """checker pr_ci_watch.py 不应 import os —— 已经不读任何 env。"""
+    pr_ci_watch_path = _PRODUCTION_SOURCE / "checkers" / "pr_ci_watch.py"
+    text = pr_ci_watch_path.read_text(encoding="utf-8")
+    # `import os` 整行 / `os.getenv(` 都不该出现
+    bad_lines = [
+        f"line {i}: {line.rstrip()}"
+        for i, line in enumerate(text.splitlines(), 1)
+        if line.strip() in ("import os",) or "os.getenv(" in line
+    ]
+    assert bad_lines == [], (
+        "pr_ci_watch.py must not consult os.environ (REQ-clone-and-pr-ci-fallback-1777115925). "
+        "Found:\n" + "\n".join(bad_lines)
+    )
+
+
+def test_clone_helper_module_exists():
+    """server-side clone helper module 必须存在（合约层兜底）。"""
+    helper = _PRODUCTION_SOURCE / "actions" / "_clone.py"
+    assert helper.exists(), (
+        "actions/_clone.py is the canonical server-side clone helper "
+        "(REQ-clone-and-pr-ci-fallback-1777115925) and must remain importable."
+    )
+    text = helper.read_text(encoding="utf-8")
+    assert "clone_involved_repos_into_runner" in text
+    assert "/opt/sisyphus/scripts/sisyphus-clone-repos.sh" in text
+
+
+def test_start_analyze_actions_invoke_clone_helper():
+    """start_analyze + start_analyze_with_finalized_intent 必须 import + call _clone helper。"""
+    for action_filename in ("start_analyze.py", "start_analyze_with_finalized_intent.py"):
+        path = _PRODUCTION_SOURCE / "actions" / action_filename
+        text = path.read_text(encoding="utf-8")
+        assert "clone_involved_repos_into_runner" in text, (
+            f"{action_filename} must import + invoke clone_involved_repos_into_runner "
+            "(REQ-clone-and-pr-ci-fallback-1777115925)."
+        )


### PR DESCRIPTION
## Summary

REQ-clone-and-pr-ci-fallback-1777115925 把 sisyphus 对 per-REQ 仓集合的处理收成
一条线，删两条隐式 fallback：

- **A — `start_analyze` server-side clone**：`actions/start_analyze.py` /
  `actions/start_analyze_with_finalized_intent.py` 在 `ensure_runner` 后、
  `bkd.follow_up_issue` 前调用新 `actions/_clone.py::clone_involved_repos_into_runner`
  跑 `/opt/sisyphus/scripts/sisyphus-clone-repos.sh`，把
  `ctx.intake_finalized_intent.involved_repos` 里的仓 server-side clone 进
  `/workspace/source/<basename>/`。clone 失败 → `emit VERIFY_ESCALATE`，不让
  analyze-agent 进空 PVC 干活。直接 analyze 路径（无 intake）跳过 clone，
  agent 走 prompt fallback 自己 clone。

- **B — `pr_ci_watch` refuse stale env fallback**：`checkers/pr_ci_watch.py::watch_pr_ci`
  删 `SISYPHUS_BUSINESS_REPO` env fallback。process-global env 在多 REQ / 多
  仓场景下注定 stale —— 要么查错仓 PR (false fail) 要么漏看仓 (false pass)。
  空 `repos` 参数直接 `ValueError`，`create_pr_ci_watch._run_checker` 翻成
  `PR_CI_TIMEOUT`（直接 ESCALATED 不进 verifier — verifier 不能修缺失的
  per-REQ 仓声明）。

跟前几条 REQ 形状互补：
- REQ-checker-empty-source-1777113775 关掉了机械 checker 在 `/workspace/source`
  空时 silent-pass
- 本 REQ 关掉 watch_pr_ci 在 repos 缺时 silent fallback
- 本 REQ 加 server-side clone 把 \`/workspace/source\` 的存在性绑到
  ctx.involved_repos 上
三条加起来：no source dir / no repos / no clone 三种 misconfig 都显式失败而
不是默默继续。

`analyze.md.j2` Part A.3 从"agent 必须跑 clone"改成"sisyphus 已替你预
clone（多数情况）；ctx 没 repos 时再自己跑 helper"。

## Test plan

- [x] `uv run pytest`：567 unit tests pass（Makefile 测试因本环境无 \`make\` 跳过；
      它们在 CI 环境正常）
- [x] `openspec validate REQ-clone-and-pr-ci-fallback-1777115925`：valid
- [x] `bash scripts/check-scenario-refs.sh --specs-search-path .`：OK 84 scenarios
- [x] `uv tool run ruff check src/orchestrator/ tests/`：clean
- [x] 新 `tests/test_actions_start_analyze.py`：9 case 覆盖 clone 派发、跳过、
      失败 → escalate、_clone helper 边角
- [x] 新 `tests/test_contract_clone_and_pr_ci_fallback.py`：grep 守 0 命中
      `SISYPHUS_BUSINESS_REPO` + `pr_ci_watch.py` 不 import os + 两 start_analyze
      action 都 import `_clone` helper
- [x] `tests/test_checkers_pr_ci_watch.py`：现有 22 case 改成显式 `repos=[...]`
      参数；新 `test_watch_pr_ci_ignores_env_var_when_repos_none` regression guard

## Files changed

production:
- `orchestrator/src/orchestrator/actions/_clone.py` (new)
- `orchestrator/src/orchestrator/actions/start_analyze.py`
- `orchestrator/src/orchestrator/actions/start_analyze_with_finalized_intent.py`
- `orchestrator/src/orchestrator/actions/create_pr_ci_watch.py` (docstring only)
- `orchestrator/src/orchestrator/checkers/pr_ci_watch.py`
- `orchestrator/src/orchestrator/prompts/analyze.md.j2`

tests:
- `orchestrator/tests/test_actions_start_analyze.py` (new, 9 cases)
- `orchestrator/tests/test_contract_clone_and_pr_ci_fallback.py` (new, 4 cases)
- `orchestrator/tests/test_checkers_pr_ci_watch.py` (rewire 22 cases + 1 new)
- `orchestrator/tests/test_actions_smoke.py` (assert update for new return shape)

specs:
- `openspec/changes/REQ-clone-and-pr-ci-fallback-1777115925/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)