### PR TITLE
feat(admin): add /req/{id}/complete endpoint to clean up stale escalated REQ

### DIFF
--- a/openspec/changes/REQ-admin-complete-endpoint-1777117709/proposal.md
+++ b/openspec/changes/REQ-admin-complete-endpoint-1777117709/proposal.md
@@ -1,0 +1,127 @@
+# REQ-admin-complete-endpoint-1777117709: feat(admin): add /req/<id>/complete endpoint to clean up stale escalated REQ
+
+## 问题
+
+ESCALATED 不是死终态——人在 BKD UI 给 verifier issue follow-up 还能续起来
+（`state.py` 的 ESCALATED + VERIFY_PASS / VERIFY_FIX_NEEDED 三条 transition）。
+为此 `runner_gc` 给 ESCALATED 留 `pvc_retain_on_escalate_days` 的保留期：
+
+```python
+# runner_gc.py L52-58
+if state == "escalated" and not ignore_retention:
+    updated_at = r["updated_at"]
+    if updated_at and (now - updated_at) < retention:
+        active.add(r["req_id"])
+```
+
+但**有些 escalated 不会续**：
+
+- 误开的 REQ（intent issue 写错被 user 直接放弃）
+- 上游需求被砍 / 被合并到别的 REQ
+- 老仓的 escalate（仓退役了，没人想再翻 PVC debug）
+- 流程跑到一半发现是 spike / 实验性 REQ
+
+这些 stale escalated 占的资源：
+
+- runner Pod 已经被 `_cleanup_runner_on_terminal(retain_pvc=True)` 清掉，**Pod 是 0**
+- 但 PVC 整段 retention 期都在挂磁盘（默认 1 天，prod 调到 7 天的 cluster 就更长）
+- `req_state` 行也一直在表里"working set"，metrics dashboard / `failure_mode` view 都
+  把它们当现役 escalate 计入 reason 频次（污染 Top-N）
+
+人现在能做的：
+
+1. **等 retention 过**——磁盘压力 / dashboard 污染 retention 期内挡不住
+2. **手动调 `runner_gc.gc_once(ignore_retention=True)`**——但那是磁盘紧急疏散开关，
+   会把所有 escalated 全清，**不能精确单点**
+3. **直接 `psql` 改 `req_state.state='done'`**——能跑但绕过审计、不触发 runner cleanup、
+   操作员需要 DB 凭证
+
+缺一条**精确、有审计、立即触发 runner cleanup** 的 admin path。
+
+## 方案
+
+加 `POST /admin/req/{req_id}/complete`，给 admin 一条明确"我看了，这个不会续，
+按 done 处理"的快捷键。
+
+### 行为契约
+
+```
+POST /admin/req/{req_id}/complete
+Authorization: Bearer <webhook_token>
+Body (optional): {"reason": "字符串，可选"}
+
+→ 200  {"action": "completed", "from_state": "escalated", "reason": "..."}
+→ 200  {"action": "noop", "state": "already done"}        # 幂等
+→ 404  REQ not found
+→ 409  REQ 不在 ESCALATED（防误用：in-flight REQ 想 force done 应当先 escalate
+        再 complete，两步走，避免一个 endpoint 把任意 stage 截断）
+```
+
+### 实现要点
+
+1. **state 转移**：直接 SQL `UPDATE req_state SET state='done', context = context || $2`
+   走（mirror 现有 `force_escalate` 的反向）。**不**走 `engine.step` / state machine
+   transition——admin override 不进 transition table，避免污染合法 transition 集合。
+2. **context 写入** `{"completed_reason": "admin", "completed_from_state": "escalated", ...}`
+   保留审计痕迹；如果 body 有 `reason` 字段也写进 ctx。
+3. **runner cleanup** 立即触发：fire-and-forget 调
+   `engine._cleanup_runner_on_terminal(req_id, ReqState.DONE)`，**不等 runner_gc 下一轮**。
+   这一步关键——光改 DB 不清 PVC 等于没省资源。注意 `retain_pvc=False`（done
+   语义就是不留）。
+4. **history 行**：CAS transition 那条 SQL 已经追加 history，但我们走直接 UPDATE 跳过了
+   `cas_transition` helper。**手工补一条** history entry（from=escalated, to=done,
+   event=admin.complete, action=null）以便 `req_summary` view 看得到这次操作。
+5. **拒绝 non-ESCALATED**：`state != ReqState.ESCALATED` → HTTPException(409)。设计取舍：
+   "complete 任意 state" 听起来更通用，但实际只在 escalated 后才有意义；放开 in-flight
+   REQ 的 complete 入口会让 admin 误把 ANALYZING 直接 done 而 runner 还在跑 prompt。
+   想要"任意 state → terminal"的人应当先 `escalate` 再 `complete`，两步操作意图明确。
+
+### 与现有 endpoints 的对比
+
+| endpoint | from_state | to_state | retain PVC | 主用例 |
+|---|---|---|---|---|
+| `force_escalate` | * | escalated | yes | 卡死 / 进度永远推不动 |
+| `complete` | escalated | done | no | 已经 escalated 但确认不会续，立即收资源 |
+| `pause` | * | (state 不动) | yes | 临时让出资源，准备 resume |
+
+**complete 不替代 escalate**——escalate 是"踢进死信队列"，complete 是"把死信队列里
+确认作废的最终清理"。配合 `force_escalate` 形成"escalate（保 PVC 等人）→ 人决定
+→ resume（VERIFY_PASS / VERIFY_FIX_NEEDED）或 complete（done + 清 PVC）"两叉。
+
+## 取舍
+
+- **为什么不直接砍 ESCALATED PVC retention** —— 保留期是给"人在 BKD UI 给 verifier
+  issue 续 follow-up"的窗口（`state.py` 那 3 条 ESCALATED → ... transition 用得着
+  workspace + git 状态）。砍掉 retention 等于砍掉续命路径。本 REQ 留 retention，加
+  显式"放弃续"按钮。
+- **为什么 409 不是 200 noop** —— 用 409 比 noop 更醒目；admin 误调 complete 的非
+  escalated REQ 应该看到错误，不该被静默忽略。但 already-done 是 200 noop（真·幂等）。
+- **为什么不接 BKD issue 标记** —— complete 只动 sisyphus state + runner 资源；BKD
+  issue 该不该归档是另一件事（`done_archive` agent 负责真·归档）。admin complete
+  是"宣告 REQ 不会续"，不是"REQ 完成了交付"——两者语义不一样。BKD intent issue
+  的状态由 admin 自己在 BKD UI 标，sisyphus 不代劳。
+- **为什么 fire-and-forget 而非 await 清完** —— mirror `engine._cleanup_runner_on_terminal`
+  用法：`asyncio.create_task` 让 endpoint 立即返回；cleanup 失败 runner_gc 兜底
+  （已经有日志 + retry 机制）。HTTP 调用方拿到 200 时表示"DB 改完了 + cleanup 已
+  排队"，不是"PVC 已删"。
+- **为什么 reason body 是 optional** —— 80% 调用是 stale 清扫批量做，写不出有意义的
+  reason；强制要求会让操作员胡填或者塞一坨重复的 "stale"。可选字段对真有 context
+  时（"REQ-X 被 REQ-Y 取代"）有用。
+
+## 影响面
+
+- 改 `orchestrator/src/orchestrator/admin.py`：加 `complete_req` endpoint + `CompleteBody`
+  pydantic model + 模块 docstring 增一行。
+- 改 `orchestrator/src/orchestrator/engine.py`：把 `_cleanup_runner_on_terminal`
+  从 module-private（前缀 `_`）改成 module-level 可导入（保持 `_` 名但 admin 直接
+  import；Python 没真"private"，admin 跨模块用是可接受的——或重命名去掉 `_`）。
+  **选用**：不改名，admin.py 里 `from .engine import _cleanup_runner_on_terminal`，
+  显式注释这是受管 cross-module import。
+- 测试：`orchestrator/tests/test_admin.py` 加 4 个 case：
+  - `test_complete_404_when_not_found`
+  - `test_complete_noop_when_already_done`
+  - `test_complete_409_when_not_escalated`（验证 in-flight 状态被拒）
+  - `test_complete_marks_done_and_triggers_cleanup`（验证 SQL UPDATE + cleanup task 起）
+- 不动 `state.py` / `engine.py` transition table / Postgres migrations.
+- 不动 BKD 集成层 / runner_gc（DB 层 done state 已经不在 keep set，gc 会顺手再扫一遍
+  作为兜底）。

--- a/openspec/changes/REQ-admin-complete-endpoint-1777117709/specs/admin-complete-endpoint/contract.spec.yaml
+++ b/openspec/changes/REQ-admin-complete-endpoint-1777117709/specs/admin-complete-endpoint/contract.spec.yaml
@@ -1,0 +1,133 @@
+capability: admin-complete-endpoint
+version: "1.0"
+description: |
+  Admin endpoint POST /admin/req/{req_id}/complete: 把"已 escalated 但确认不会续"
+  的 stale REQ 一键改 done + 立即触发 runner cleanup（PVC 不留），不绕 BKD、不绕
+  审计、不污染 transition table。
+
+  跟 force_escalate 配对：force_escalate 是"踢死信队列"，complete 是"清死信队列里
+  确认作废的"。两条独立的 admin override，通过状态前置条件互不交叉。
+
+http:
+  method: POST
+  path: /admin/req/{req_id}/complete
+  auth: Bearer <webhook_token>   # 同 webhook._verify_token；同所有其它 /admin/* endpoint
+  request_body:
+    content_type: application/json
+    schema:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: |
+            Optional human-written reason. Persisted to
+            req_state.context.completed_reason_detail when provided.
+      additionalProperties: false
+    optional: true   # 整个 body 可缺，等价于 {}
+  responses:
+    "200_completed":
+      condition: state was escalated, transition to done succeeded
+      body:
+        action: completed
+        from_state: escalated
+        reason: "<echoed reason or null>"
+    "200_noop":
+      condition: state already done (idempotent retry)
+      body:
+        action: noop
+        state: "already done"
+    "404":
+      condition: no req_state row with req_id
+      body:
+        detail: "req <id> not found"
+    "409":
+      condition: state ∉ {escalated, done}
+      body:
+        detail: "req <id> is in state <X>; expected escalated. Hint: POST /admin/req/<id>/escalate first if you want to abort an in-flight REQ."
+    "401_or_403":
+      condition: missing / invalid Authorization header
+      handler: webhook._verify_token raises HTTPException
+
+precondition_chain:
+  description: |
+    检查顺序固定（验证 → 取数 → 状态判断），保证 401 ≠ 404 ≠ 409 不互相覆盖。
+  sequence:
+    - "1. _verify_token(authorization)  # 401/403 if invalid"
+    - "2. row = await req_state.get(pool, req_id)"
+    - "3. if row is None: raise HTTPException(404)"
+    - "4. if row.state == ReqState.DONE: return noop  # 200 idempotent"
+    - "5. if row.state != ReqState.ESCALATED: raise HTTPException(409)"
+    - "6. SQL UPDATE state=done + history append + context patch"
+    - "7. asyncio.create_task(_cleanup_runner_on_terminal(req_id, ReqState.DONE))"
+    - "8. return {action: completed, from_state: escalated, ...}"
+
+state_change:
+  before: "req_state.state = 'escalated'"
+  after: "req_state.state = 'done'"
+  context_patch:
+    completed_reason: admin               # always set
+    completed_reason_detail: "<body.reason or absent>"
+    completed_from_state: escalated
+  history_append:
+    ts: "<now ISO8601>"
+    from: escalated
+    to: done
+    event: admin.complete
+    action: null
+
+runner_cleanup:
+  trigger_path: |
+    asyncio.create_task(engine._cleanup_runner_on_terminal(req_id, ReqState.DONE))
+  retain_pvc: false                        # done 不留 PVC，立即释放
+  fire_and_forget: true                    # endpoint 返回时 cleanup 还在跑；runner_gc 兜底失败
+  rationale: |
+    runner_gc 周期 = settings.runner_gc_interval_sec（默认 60s）。等下一轮
+    GC 才清等于 endpoint 没省资源。fire-and-forget 配合 runner_gc 兜底是
+    sisyphus 既有模式（engine.step 处理 terminal transition 也是这套）。
+
+invariants:
+  no_state_machine_pollution:
+    - "不在 state.py 加 admin.complete event"
+    - "不在 TRANSITIONS 加 (ESCALATED, ?) → DONE"
+    - "admin override 是状态机外的工具，不进 transition 表（保 transition 表只描述自动流转）"
+
+  no_short_circuit_inflight:
+    - "拒绝 non-ESCALATED state 是为了防止把跑中的 stage 截断"
+    - "操作员要先 escalate（终止当前 stage，runner Pod 已删，PVC 留 retention），
+       再 complete（确认作废，PVC 也删）"
+    - "两步走的设计意图：每一步操作意图明确，不能一个 endpoint 把任意 in-flight 推到 done"
+
+  history_audit:
+    - "history 行 event=admin.complete 是 marker，可被 metrics 查询识别"
+    - "context.completed_reason='admin' 跟 context.escalated_reason='admin'
+       同形（都是 admin override 的标识）"
+    - "BKD intent issue 状态由 admin 自己在 BKD UI 改；sisyphus 不代写"
+
+interaction_with_runner_gc:
+  description: |
+    DB 层 state=done 后，runner_gc 下一轮也会发现该 REQ 不在 active set，
+    会顺手再扫一次 → 即使 fire-and-forget cleanup 任务挂了，gc 兜底也能清。
+  redundancy: by design
+
+interaction_with_force_escalate:
+  description: |
+    force_escalate 是 in-flight → escalated 的"踢入死信队列"。
+    complete 是 escalated → done 的"清死信队列"。
+    两个 endpoint 独立，但常见使用是"先 force_escalate 再 complete"（两步操作
+    意图明确）。
+  example_sequence:
+    - "POST /admin/req/REQ-X/escalate     # state: analyzing → escalated, PVC 留"
+    - "POST /admin/req/REQ-X/complete     # state: escalated → done, PVC 删"
+
+failure_modes:
+  cleanup_task_exception:
+    cause: "K8s API 不通 / runner controller 挂了"
+    handler: "_cleanup_runner_on_terminal 内部 try/except，记 warning，runner_gc 兜底"
+    state_outcome: "DB state 仍是 done，下一轮 runner_gc 会扫到并重试清"
+    user_impact: "API 调用方仍拿 200（DB 已改），实际 PVC 释放可能延迟一个 GC 周期"
+
+  concurrent_complete:
+    cause: "两个 admin 同时 POST /complete 同一 REQ"
+    handler: "SQL UPDATE WHERE state='escalated' 自身有原子性；第二次 UPDATE 影响 0 行"
+    state_outcome: "第二个 endpoint 看到 state='done' 走 200 noop 路径"
+    detection: "history 行只追加一次（第一次 UPDATE 写的），不会有两条 admin.complete"

--- a/openspec/changes/REQ-admin-complete-endpoint-1777117709/specs/admin-complete-endpoint/spec.md
+++ b/openspec/changes/REQ-admin-complete-endpoint-1777117709/specs/admin-complete-endpoint/spec.md
@@ -1,0 +1,132 @@
+# admin-complete-endpoint
+
+## ADDED Requirements
+
+### Requirement: /admin/req/{req_id}/complete moves a stale escalated REQ to DONE and triggers immediate runner cleanup
+
+The orchestrator SHALL expose a `POST /admin/req/{req_id}/complete` HTTP
+endpoint behind the same Bearer-token auth as the other `/admin/*` routes
+(`webhook._verify_token`). The endpoint MUST move the named REQ from state
+`escalated` to state `done` via a direct SQL UPDATE on `req_state` (NOT
+through `engine.step` / the state-machine transition table — admin
+overrides do not pollute the legal transition set), and MUST schedule
+runner cleanup with `retain_pvc=False` so the PVC is released immediately
+rather than waiting for `runner_gc` to scan on its next interval. The
+endpoint SHALL append a history entry capturing the override
+(`{"event": "admin.complete", "from": "escalated", "to": "done"}`) so
+`req_summary` and audit queries can attribute the state change to the
+admin action.
+
+#### Scenario: ACE-S1 happy path: escalated REQ becomes done, cleanup task scheduled
+
+- **GIVEN** a REQ row with `state='escalated'` exists in `req_state` and
+  the K8s runner controller is initialized
+- **WHEN** the client sends `POST /admin/req/REQ-X/complete` with a valid
+  Bearer token and an empty body
+- **THEN** the endpoint MUST execute a SQL UPDATE setting `state='done'`
+  on the row keyed by `req_id='REQ-X'`
+- **AND** the response MUST be 200 with JSON body containing
+  `action == "completed"` and `from_state == "escalated"`
+- **AND** an `asyncio.Task` running `_cleanup_runner_on_terminal(req_id, ReqState.DONE)`
+  MUST be scheduled (fire-and-forget) before the endpoint returns
+- **AND** the SQL UPDATE MUST also append an entry to the `history` JSON
+  array containing the keys `from='escalated'`, `to='done'`,
+  `event='admin.complete'`
+
+### Requirement: /admin/req/{req_id}/complete is idempotent on already-done REQs
+
+The endpoint MUST return HTTP 200 with `action == "noop"` when invoked on
+a REQ already in state `done`. The handler MUST NOT execute any SQL
+UPDATE in this case (no spurious history entry, no spurious cleanup task)
+because a second cleanup is wasteful and a second history entry would
+corrupt the audit trail.
+
+#### Scenario: ACE-S2 second call on already-done REQ is a 200 noop
+
+- **GIVEN** a REQ row with `state='done'` exists
+- **WHEN** the client sends `POST /admin/req/REQ-X/complete`
+- **THEN** the response MUST be 200 with body containing
+  `action == "noop"` and `state == "already done"`
+- **AND** no SQL UPDATE on `req_state` MUST be executed
+- **AND** no cleanup task MUST be scheduled
+
+### Requirement: /admin/req/{req_id}/complete refuses non-ESCALATED states with HTTP 409
+
+The endpoint MUST return HTTP 409 Conflict when the REQ is in any state
+other than `escalated` or `done`. The error body MUST include the current
+state name and a hint pointing the operator at `/admin/req/{req_id}/escalate`
+as the prerequisite for moving an in-flight REQ toward terminal cleanup.
+This intentionally narrow precondition prevents an admin from
+short-circuiting an in-flight stage (e.g. ANALYZING with a running
+runner Pod) into DONE in a single call, which would race the action
+handler still touching the workspace and silently drop in-progress work.
+
+#### Scenario: ACE-S3 calling complete on an in-flight REQ returns 409
+
+- **GIVEN** a REQ row with `state='analyzing'` exists
+- **WHEN** the client sends `POST /admin/req/REQ-X/complete`
+- **THEN** the response MUST be 409 with detail containing the literal
+  substring `analyzing` and a hint mentioning `/admin/req/.../escalate`
+- **AND** no SQL UPDATE on `req_state` MUST be executed
+- **AND** no cleanup task MUST be scheduled
+
+### Requirement: /admin/req/{req_id}/complete returns 404 when the REQ is unknown
+
+The endpoint MUST return HTTP 404 Not Found when no row matches the
+`req_id` path parameter, with the same error shape as the other
+`/admin/req/{req_id}/*` endpoints (`{"detail": "req <id> not found"}`).
+This MUST happen before any state-precondition check so that "no such
+REQ" cannot be confused with "REQ in wrong state".
+
+#### Scenario: ACE-S4 unknown REQ returns 404
+
+- **GIVEN** no row in `req_state` with `req_id='REQ-DOES-NOT-EXIST'`
+- **WHEN** the client sends `POST /admin/req/REQ-DOES-NOT-EXIST/complete`
+- **THEN** the response MUST be 404 with detail containing the literal
+  substring `not found`
+
+### Requirement: /admin/req/{req_id}/complete optionally accepts a reason in body and persists it in context
+
+The endpoint SHALL accept an optional JSON body `{"reason": "<string>"}`.
+When provided, the `reason` MUST be persisted in `req_state.context`
+under the key `completed_reason_detail` so audit queries can recover the
+operator's intent. When omitted, the context MUST still record
+`completed_reason='admin'` (a fixed marker indicating the source of the
+override). The body itself remains optional — POST with no body or
+`{}` MUST succeed identically to the no-body path.
+
+#### Scenario: ACE-S5 reason in body is persisted to context
+
+- **GIVEN** a REQ row with `state='escalated'` exists
+- **WHEN** the client sends `POST /admin/req/REQ-X/complete` with body
+  `{"reason": "superseded by REQ-Y"}`
+- **THEN** the SQL UPDATE MUST patch `context` so that
+  `context.completed_reason == 'admin'` AND
+  `context.completed_reason_detail == 'superseded by REQ-Y'`
+
+#### Scenario: ACE-S6 missing body still works with default reason marker
+
+- **GIVEN** a REQ row with `state='escalated'` exists
+- **WHEN** the client sends `POST /admin/req/REQ-X/complete` with empty body
+- **THEN** the response MUST be 200 with `action == "completed"`
+- **AND** the SQL UPDATE MUST patch `context.completed_reason = 'admin'`
+- **AND** `context` MUST NOT have a `completed_reason_detail` key (no
+  spurious null-string field)
+
+### Requirement: /admin/req/{req_id}/complete enforces the same Bearer auth as other admin endpoints
+
+The endpoint MUST call `webhook._verify_token(authorization)` as the
+first action before reading any state, mirroring `force_escalate`,
+`emit_event`, and the v0.2 runner-ops endpoints. A missing or invalid
+token MUST yield HTTP 401 / 403 (whichever `_verify_token` raises) and
+MUST NOT execute any SQL UPDATE or cleanup task.
+
+#### Scenario: ACE-S7 missing Bearer token rejects before any state read
+
+- **GIVEN** any state of any REQ
+- **WHEN** the client sends `POST /admin/req/REQ-X/complete` without an
+  `Authorization` header
+- **THEN** `_verify_token` MUST be invoked and MUST raise the same
+  HTTPException as the other admin endpoints
+- **AND** `req_state.get` MUST NOT be called
+- **AND** no SQL UPDATE on `req_state` MUST be executed

--- a/openspec/changes/REQ-admin-complete-endpoint-1777117709/tasks.md
+++ b/openspec/changes/REQ-admin-complete-endpoint-1777117709/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: REQ-admin-complete-endpoint-1777117709
+
+## Stage: spec
+
+- [x] `openspec/changes/REQ-admin-complete-endpoint-1777117709/proposal.md`
+- [x] `openspec/changes/REQ-admin-complete-endpoint-1777117709/tasks.md`
+- [x] `openspec/changes/REQ-admin-complete-endpoint-1777117709/specs/admin-complete-endpoint/spec.md`
+- [x] `openspec/changes/REQ-admin-complete-endpoint-1777117709/specs/admin-complete-endpoint/contract.spec.yaml`
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/admin.py`：
+  - 加 `CompleteBody(BaseModel)` 含 optional `reason: str | None = None`
+  - 加 `@admin.post("/req/{req_id}/complete")` async def `complete_req`
+  - import `_cleanup_runner_on_terminal` from engine
+  - 模块 docstring 列表加 `POST /req/{req_id}/complete`
+
+- [x] `orchestrator/src/orchestrator/engine.py`：
+  - 不改名，但加一行注释说明 `_cleanup_runner_on_terminal` 被 admin.py 复用
+  - （非必需，确认 export 可达即可）
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_admin.py`：
+  - `test_complete_404_when_not_found`：req_state.get 返回 None → 404
+  - `test_complete_noop_when_already_done`：state=done → 200 noop
+  - `test_complete_409_when_not_escalated`：state=analyzing → 409
+  - `test_complete_marks_done_and_triggers_cleanup`：state=escalated →
+    SQL UPDATE 被调一次 + `_cleanup_runner_on_terminal` 被 schedule 一次
+  - `test_complete_writes_reason_in_context`：body.reason="x" 时 ctx patch 含 reason
+
+## Stage: PR
+
+- [x] git push feat/REQ-admin-complete-endpoint-1777117709
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/admin.py
+++ b/orchestrator/src/orchestrator/admin.py
@@ -5,6 +5,7 @@
 基础（已有）：
   POST /admin/req/{req_id}/emit       body: {"event": "..."}
   POST /admin/req/{req_id}/escalate
+  POST /admin/req/{req_id}/complete   body: {"reason": "..."} (optional)
   GET  /admin/metrics
   GET  /admin/req/{req_id}
 
@@ -15,6 +16,10 @@ v0.2 runner 运维（新）：
   GET  /admin/runners                  → 列所有 runner pod / pvc 状态
 """
 from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
 
 import structlog
 from fastapi import APIRouter, Header, HTTPException
@@ -106,6 +111,112 @@ async def force_escalate(
     )
     log.warning("admin.force_escalate", req_id=req_id, from_state=row.state.value)
     return {"action": "force_escalated", "from_state": row.state.value}
+
+
+class CompleteBody(BaseModel):
+    """complete 接受可选的 reason 字段。"""
+    reason: str | None = None
+
+
+# 持引用防 fire-and-forget cleanup task 被 GC（done_callback 自清）。
+# 跟 engine._cleanup_tasks 同模式但隔离作用域，便于测试 introspect 仅本 endpoint 起的 task。
+_complete_cleanup_tasks: set[asyncio.Task] = set()
+
+
+@admin.post("/req/{req_id}/complete")
+async def complete_req(
+    req_id: str,
+    body: CompleteBody | None = None,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    """把 stale escalated REQ 直接标 done + 立即触发 runner cleanup（PVC 不留）。
+
+    跟 force_escalate 配对：force_escalate 是"踢死信队列"，complete 是"清死信队列"。
+
+    前置条件：
+      - state == DONE: 200 noop（幂等）
+      - state == ESCALATED: 改 done + cleanup
+      - 其它 state: 409（防误把 in-flight stage 截断）
+    """
+    _verify_token(authorization)
+    params = body or CompleteBody()
+
+    pool = db.get_pool()
+    row = await req_state.get(pool, req_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"req {req_id} not found")
+
+    if row.state == ReqState.DONE:
+        return {"action": "noop", "state": "already done"}
+
+    if row.state != ReqState.ESCALATED:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"req {req_id} is in state {row.state.value}; expected escalated. "
+                f"Hint: POST /admin/req/{req_id}/escalate first if you want to "
+                f"abort an in-flight REQ."
+            ),
+        )
+
+    history_entry: dict = {
+        "ts": datetime.now(UTC).isoformat(),
+        "from": ReqState.ESCALATED.value,
+        "to": ReqState.DONE.value,
+        "event": "admin.complete",
+        "action": None,
+    }
+    ctx_patch: dict = {
+        "completed_reason": "admin",
+        "completed_from_state": ReqState.ESCALATED.value,
+    }
+    if params.reason:
+        ctx_patch["completed_reason_detail"] = params.reason
+
+    # 直接 SQL UPDATE（mirror force_escalate）；WHERE state='escalated' 防并发竞争。
+    result = await pool.execute(
+        "UPDATE req_state SET state='done', "
+        "history = history || $2::jsonb, "
+        "context = context || $3::jsonb, "
+        "updated_at = now() "
+        "WHERE req_id = $1 AND state = $4",
+        req_id,
+        json.dumps([history_entry]),
+        json.dumps(ctx_patch),
+        ReqState.ESCALATED.value,
+    )
+    # asyncpg 返 "UPDATE N" 字符串；N=0 表示并发已被另一 caller 改了
+    if not result.endswith(" 1"):
+        log.warning("admin.complete.cas_lost", req_id=req_id, result=result)
+        # 重读一次，按当前 state 决定回什么
+        row2 = await req_state.get(pool, req_id)
+        if row2 and row2.state == ReqState.DONE:
+            return {"action": "noop", "state": "already done"}
+        raise HTTPException(
+            status_code=409,
+            detail=f"req {req_id} state changed concurrently; retry",
+        )
+
+    # 立即触发 runner cleanup（不等 runner_gc 下一轮）；fire-and-forget。
+    # engine._cleanup_runner_on_terminal 是 cross-module import：admin override
+    # 复用同一套 cleanup 逻辑（log + try/except + retain_pvc 旗标），不复制。
+    task = asyncio.create_task(
+        engine._cleanup_runner_on_terminal(req_id, ReqState.DONE)
+    )
+    _complete_cleanup_tasks.add(task)
+    task.add_done_callback(_complete_cleanup_tasks.discard)
+
+    log.warning(
+        "admin.complete",
+        req_id=req_id,
+        from_state=ReqState.ESCALATED.value,
+        reason=params.reason,
+    )
+    return {
+        "action": "completed",
+        "from_state": ReqState.ESCALATED.value,
+        "reason": params.reason,
+    }
 
 
 @admin.get("/metrics")

--- a/orchestrator/tests/test_admin.py
+++ b/orchestrator/tests/test_admin.py
@@ -1,10 +1,22 @@
-"""admin endpoints 烟测：emit / escalate / get-req。"""
+"""admin endpoints 烟测：emit / escalate / complete / get-req。"""
 from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime
 
 import pytest
 from fastapi import HTTPException
 
-from orchestrator.admin import EmitBody, _FakeBody, force_escalate, get_req
+from orchestrator.admin import (
+    CompleteBody,
+    EmitBody,
+    _FakeBody,
+    complete_req,
+    force_escalate,
+    get_req,
+)
+from orchestrator.state import ReqState
 
 
 def test_fakebody_shape():
@@ -67,3 +79,272 @@ async def test_get_req_404(monkeypatch):
     with pytest.raises(HTTPException) as ei:
         await get_req("REQ-X", authorization="Bearer x")
     assert ei.value.status_code == 404
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# /admin/req/{req_id}/complete tests (REQ-admin-complete-endpoint-1777117709)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@dataclass
+class _FakeRow:
+    req_id: str
+    project_id: str
+    state: ReqState
+    history: list = None
+    context: dict = None
+    created_at: datetime = None
+    updated_at: datetime = None
+
+    def __post_init__(self):
+        if self.history is None:
+            self.history = []
+        if self.context is None:
+            self.context = {}
+        if self.created_at is None:
+            self.created_at = datetime.now(UTC)
+        if self.updated_at is None:
+            self.updated_at = datetime.now(UTC)
+
+
+class _FakePool:
+    """记录 execute 调用 + 返回 fake 'UPDATE 1' 默认。"""
+
+    def __init__(self, execute_return: str = "UPDATE 1"):
+        self.executed: list[tuple] = []
+        self._execute_return = execute_return
+
+    async def execute(self, sql: str, *args) -> str:
+        self.executed.append((sql, args))
+        return self._execute_return
+
+
+def _bypass_auth_and_pool(monkeypatch, pool: _FakePool, row: _FakeRow | None):
+    from orchestrator import admin as admin_mod
+    monkeypatch.setattr(admin_mod, "_verify_token", lambda x: None)
+
+    async def _get(_pool, _req_id):
+        return row
+    monkeypatch.setattr("orchestrator.admin.req_state.get", _get)
+    monkeypatch.setattr("orchestrator.admin.db.get_pool", lambda: pool)
+
+
+@pytest.mark.asyncio
+async def test_complete_404_when_not_found(monkeypatch):
+    """ACE-S4: REQ 不存在 → 404."""
+    pool = _FakePool()
+    _bypass_auth_and_pool(monkeypatch, pool, row=None)
+
+    with pytest.raises(HTTPException) as ei:
+        await complete_req("REQ-MISSING", body=None, authorization="Bearer x")
+    assert ei.value.status_code == 404
+    assert "not found" in ei.value.detail
+    assert pool.executed == []  # 没改 DB
+
+
+@pytest.mark.asyncio
+async def test_complete_noop_when_already_done(monkeypatch):
+    """ACE-S2: state=done → 200 noop, 没 SQL UPDATE 没 cleanup task."""
+    pool = _FakePool()
+    row = _FakeRow(req_id="REQ-X", project_id="p", state=ReqState.DONE)
+    _bypass_auth_and_pool(monkeypatch, pool, row=row)
+
+    cleanup_calls = []
+
+    async def _fake_cleanup(req_id, terminal_state):
+        cleanup_calls.append((req_id, terminal_state))
+
+    monkeypatch.setattr(
+        "orchestrator.admin.engine._cleanup_runner_on_terminal", _fake_cleanup,
+    )
+
+    result = await complete_req("REQ-X", body=None, authorization="Bearer x")
+    assert result == {"action": "noop", "state": "already done"}
+    assert pool.executed == []
+    # 让 event loop 跑一帧确认没起 task
+    await asyncio.sleep(0)
+    assert cleanup_calls == []
+
+
+@pytest.mark.asyncio
+async def test_complete_409_when_not_escalated(monkeypatch):
+    """ACE-S3: state=analyzing → 409 with hint about /escalate first."""
+    pool = _FakePool()
+    row = _FakeRow(req_id="REQ-X", project_id="p", state=ReqState.ANALYZING)
+    _bypass_auth_and_pool(monkeypatch, pool, row=row)
+
+    with pytest.raises(HTTPException) as ei:
+        await complete_req("REQ-X", body=None, authorization="Bearer x")
+    assert ei.value.status_code == 409
+    assert "analyzing" in ei.value.detail
+    assert "/escalate" in ei.value.detail
+    assert pool.executed == []
+
+
+@pytest.mark.asyncio
+async def test_complete_marks_done_and_triggers_cleanup(monkeypatch):
+    """ACE-S1: 成功路径——SQL UPDATE 写 done + cleanup task scheduled."""
+    pool = _FakePool(execute_return="UPDATE 1")
+    row = _FakeRow(req_id="REQ-X", project_id="p", state=ReqState.ESCALATED)
+    _bypass_auth_and_pool(monkeypatch, pool, row=row)
+
+    cleanup_calls = []
+
+    async def _fake_cleanup(req_id, terminal_state):
+        cleanup_calls.append((req_id, terminal_state))
+
+    monkeypatch.setattr(
+        "orchestrator.admin.engine._cleanup_runner_on_terminal", _fake_cleanup,
+    )
+
+    result = await complete_req("REQ-X", body=None, authorization="Bearer x")
+
+    assert result["action"] == "completed"
+    assert result["from_state"] == "escalated"
+    # SQL 调一次
+    assert len(pool.executed) == 1
+    sql, args = pool.executed[0]
+    assert "UPDATE req_state" in sql
+    assert "state='done'" in sql
+    assert "WHERE req_id = $1 AND state = $4" in sql
+    assert args[0] == "REQ-X"
+    assert args[3] == ReqState.ESCALATED.value
+    # cleanup task 已 schedule，跑一帧让它执行
+    await asyncio.sleep(0)
+    assert cleanup_calls == [("REQ-X", ReqState.DONE)]
+
+
+@pytest.mark.asyncio
+async def test_complete_writes_reason_in_context(monkeypatch):
+    """ACE-S5: body.reason → ctx 里写 completed_reason_detail."""
+    import json as _json
+
+    pool = _FakePool(execute_return="UPDATE 1")
+    row = _FakeRow(req_id="REQ-X", project_id="p", state=ReqState.ESCALATED)
+    _bypass_auth_and_pool(monkeypatch, pool, row=row)
+
+    async def _fake_cleanup(req_id, terminal_state):
+        pass
+
+    monkeypatch.setattr(
+        "orchestrator.admin.engine._cleanup_runner_on_terminal", _fake_cleanup,
+    )
+
+    body = CompleteBody(reason="superseded by REQ-Y")
+    result = await complete_req("REQ-X", body=body, authorization="Bearer x")
+
+    assert result["reason"] == "superseded by REQ-Y"
+    _sql, args = pool.executed[0]
+    # args[2] 是 ctx_patch JSON
+    ctx = _json.loads(args[2])
+    assert ctx["completed_reason"] == "admin"
+    assert ctx["completed_reason_detail"] == "superseded by REQ-Y"
+    assert ctx["completed_from_state"] == "escalated"
+
+
+@pytest.mark.asyncio
+async def test_complete_no_reason_omits_detail_field(monkeypatch):
+    """ACE-S6: 没 reason → ctx 不写 completed_reason_detail（不留 null 字段）."""
+    import json as _json
+
+    pool = _FakePool(execute_return="UPDATE 1")
+    row = _FakeRow(req_id="REQ-X", project_id="p", state=ReqState.ESCALATED)
+    _bypass_auth_and_pool(monkeypatch, pool, row=row)
+
+    async def _fake_cleanup(req_id, terminal_state):
+        pass
+
+    monkeypatch.setattr(
+        "orchestrator.admin.engine._cleanup_runner_on_terminal", _fake_cleanup,
+    )
+
+    await complete_req("REQ-X", body=None, authorization="Bearer x")
+    _sql, args = pool.executed[0]
+    ctx = _json.loads(args[2])
+    assert ctx["completed_reason"] == "admin"
+    assert "completed_reason_detail" not in ctx
+
+
+@pytest.mark.asyncio
+async def test_complete_history_entry_appended(monkeypatch):
+    """ACE-S1: history 行追加 admin.complete event marker."""
+    import json as _json
+
+    pool = _FakePool(execute_return="UPDATE 1")
+    row = _FakeRow(req_id="REQ-X", project_id="p", state=ReqState.ESCALATED)
+    _bypass_auth_and_pool(monkeypatch, pool, row=row)
+
+    async def _fake_cleanup(req_id, terminal_state):
+        pass
+
+    monkeypatch.setattr(
+        "orchestrator.admin.engine._cleanup_runner_on_terminal", _fake_cleanup,
+    )
+
+    await complete_req("REQ-X", body=None, authorization="Bearer x")
+    _sql, args = pool.executed[0]
+    history = _json.loads(args[1])
+    assert isinstance(history, list) and len(history) == 1
+    entry = history[0]
+    assert entry["from"] == "escalated"
+    assert entry["to"] == "done"
+    assert entry["event"] == "admin.complete"
+    assert entry["action"] is None
+    assert "ts" in entry
+
+
+@pytest.mark.asyncio
+async def test_complete_concurrent_update_lost_returns_409(monkeypatch):
+    """failure_modes.concurrent_complete: SQL UPDATE 影响 0 行（已被另一 caller 改） → 409 或 noop."""
+    pool = _FakePool(execute_return="UPDATE 0")
+    row = _FakeRow(req_id="REQ-X", project_id="p", state=ReqState.ESCALATED)
+
+    from orchestrator import admin as admin_mod
+    monkeypatch.setattr(admin_mod, "_verify_token", lambda x: None)
+
+    # 第一次 get 返 escalated（precondition pass），UPDATE 后 reload 返 done（被并发改了）
+    call_count = {"n": 0}
+
+    async def _get(_pool, _req_id):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return row
+        return _FakeRow(req_id="REQ-X", project_id="p", state=ReqState.DONE)
+
+    monkeypatch.setattr("orchestrator.admin.req_state.get", _get)
+    monkeypatch.setattr("orchestrator.admin.db.get_pool", lambda: pool)
+
+    # 并发对手已经把它推到 done → 我们应回 noop（200）
+    result = await complete_req("REQ-X", body=None, authorization="Bearer x")
+    assert result["action"] == "noop"
+
+
+@pytest.mark.asyncio
+async def test_complete_auth_check_before_db(monkeypatch):
+    """ACE-S7: _verify_token 是第一步，失败时不调 req_state.get / pool."""
+    from orchestrator import admin as admin_mod
+
+    def _bad_token(_):
+        raise HTTPException(status_code=401, detail="bad token")
+
+    monkeypatch.setattr(admin_mod, "_verify_token", _bad_token)
+
+    get_called = []
+
+    async def _get(*a, **kw):
+        get_called.append(1)
+        return None
+
+    monkeypatch.setattr("orchestrator.admin.req_state.get", _get)
+    monkeypatch.setattr("orchestrator.admin.db.get_pool", lambda: _FakePool())
+
+    with pytest.raises(HTTPException) as ei:
+        await complete_req("REQ-X", body=None, authorization=None)
+    assert ei.value.status_code == 401
+    assert get_called == []
+
+
+def test_complete_body_optional_reason():
+    """CompleteBody 的 reason 可省略."""
+    assert CompleteBody().reason is None
+    assert CompleteBody(reason="x").reason == "x"


### PR DESCRIPTION
## Summary

- Adds `POST /admin/req/{req_id}/complete` — moves a stale ESCALATED REQ to DONE and triggers immediate runner cleanup (PVC released).
- Pairs with `force_escalate`: escalate kicks an in-flight REQ into the dead-letter queue (PVC retained for human follow-up); complete clears confirmed-stale entries from that queue (PVC released).
- Optional `{"reason": "..."}` body persisted to `context.completed_reason_detail`; default marker `completed_reason='admin'`.
- Mirrors existing admin override style (direct SQL UPDATE, audit history entry tagged `event=admin.complete`, fire-and-forget cleanup task).

## Why

Stale escalated REQs (abandoned intent, retired repo, spike experiments) currently sit retaining PVC for the entire `pvc_retain_on_escalate_days` window (default 1d, prod up to 7d). The operator's existing options are all bad:

1. Wait for retention to expire — magnifies disk pressure during the wait.
2. Trigger `runner_gc.gc_once(ignore_retention=True)` — a disk-pressure emergency switch; cannot precisely target one REQ.
3. `psql` direct UPDATE — bypasses audit history and skips runner cleanup.

This endpoint is the missing precise + audited + cleanup-triggering path.

## Behavior contract

| Precondition | Response |
|---|---|
| Missing/invalid Bearer token | 401/403 (same `_verify_token` as other admin routes) |
| REQ not found | 404 |
| state == DONE | 200 `{"action": "noop", "state": "already done"}` (idempotent) |
| state == ESCALATED | 200 `{"action": "completed", "from_state": "escalated", "reason": ...}` + cleanup task |
| state in any other in-flight state | 409 with hint pointing at `/admin/req/.../escalate` first |

The 409 on in-flight states is intentional — preventing an admin from short-circuiting a running stage into DONE in one call (which would race the action handler still touching the workspace and silently drop in-progress work).

## Spec / proposal

`openspec/changes/REQ-admin-complete-endpoint-1777117709/`:
- `proposal.md` — problem statement, design tradeoffs
- `specs/admin-complete-endpoint/spec.md` — 7 ADDED Requirements (ACE-S1..S7) covering happy path, idempotency, 409 precondition, 404, optional reason body, default marker on missing reason, auth-first ordering
- `specs/admin-complete-endpoint/contract.spec.yaml` — precondition chain, state-change schema, runner-cleanup contract, invariants, failure modes (cleanup task exception fallthrough to runner_gc; concurrent-complete CAS via WHERE state='escalated')

## Test plan

- [x] `openspec validate REQ-admin-complete-endpoint-1777117709` — passes
- [x] `bash scripts/check-scenario-refs.sh ...` — passes (91 scenarios discovered)
- [x] `uv run --extra dev ruff check src/ tests/` — passes
- [x] `uv run --extra dev pytest -m "not integration"` (excluding `test_contract_makefile_ci_targets.py` which requires `make` binary not present in the agent's Coder env) — 577 passed, 2 skipped, 0 failed
- [x] 10 new test cases in `tests/test_admin.py` covering ACE-S1..S7 plus concurrent-update CAS and auth-first ordering
- [ ] Local smoke `curl -X POST http://localhost:8080/admin/req/REQ-X/complete -H 'Authorization: Bearer ...'` (deferred — orchestrator deployment via PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)