### PR TITLE
fix(_clone): multi-layer involved_repos fallback for direct analyze entry

### DIFF
--- a/openspec/changes/REQ-clone-fallback-direct-analyze-1777119520/proposal.md
+++ b/openspec/changes/REQ-clone-fallback-direct-analyze-1777119520/proposal.md
@@ -1,0 +1,102 @@
+# REQ-clone-fallback-direct-analyze-1777119520: fix(_clone): multi-layer involved_repos fallback for direct analyze entry
+
+## 问题
+
+REQ-clone-and-pr-ci-fallback-1777115925 让 `start_analyze` 在 dispatch
+analyze-agent 之前 server-side clone `ctx.intake_finalized_intent.involved_repos`
+（fallback `ctx.involved_repos`）到 `/workspace/source/<basename>/`。
+
+但 `start_analyze` 有**两条入口**：
+
+| 入口 | 触发 | ctx 内容 |
+|---|---|---|
+| **intake → analyze**  | `intent:intake` → 多轮 BKD chat → `INTAKE_PASS` → `start_analyze_with_finalized_intent` | webhook 解析 intake 最后一条 message 的 finalized intent JSON 写入 `ctx.intake_finalized_intent.involved_repos` |
+| **直接 analyze**     | `intent:analyze` 一步到位 → `start_analyze` | webhook 只写 `{intent_issue_id, intent_title}`，**没有 involved_repos** |
+
+直接 analyze 入口下 `_clone._resolve_repos` 一定返 `[]`，server-side clone 整段
+跳过，sisyphus 把 clone 完全甩给 `analyze.md.j2` Part A.3 的"agent 自跑 helper"
+fallback。本次（REQ-ups0uldr）就是这条路径，agent 必须自己 `kubectl exec
+runner -- /opt/sisyphus/scripts/sisyphus-clone-repos.sh phona/sisyphus`。
+
+后果（实证 2026-04-25 这个 session）：
+
+- 单仓 self-dogfood（sisyphus 改 sisyphus）也得每次手 clone，prompt 那段"多数情况
+  sisyphus 已替你跑"成了空头支票
+- agent 的"自跑 helper"是软约束 —— 走 prompt 文字描述，没办法机制约束 agent 真跑
+  （历史上有 analyze-agent 跳 Part A 直接 grep；REQ-checker-empty-source-1777113775
+  增加了 checker 兜底，但仍是事后裁决）
+- intent issue 上明明可以挂个 `repo:phona/sisyphus` tag 表明意图，**sisyphus 不读**
+- 单仓部署（如 sisyphus 自身 dogfood、ttpos-server-go single-repo lab）应当能在
+  ops 层配一次 default 仓 list，不该每次 intake
+
+## 方案
+
+把 `_clone._resolve_repos` 从 2 层升级到 4 层 fallback：
+
+| 层 | 来源 | 触发场景 |
+|---|---|---|
+| L1 | `ctx.intake_finalized_intent.involved_repos` | intake → analyze 主路径（**不变**） |
+| L2 | `ctx.involved_repos` | 老 caller / 测试夹具显式塞 ctx（**不变**） |
+| L3 | BKD intent issue tags 形如 `repo:<org>/<name>` | 用户在直接 analyze 入口显式打 tag |
+| L4 | `settings.default_involved_repos`（env `SISYPHUS_DEFAULT_INVOLVED_REPOS`） | 单仓 / 默认仓部署，ops 配一次 |
+
+`start_analyze` 跟 `start_analyze_with_finalized_intent` 都改成传
+`tags=tags, default_repos=settings.default_involved_repos` 给 helper；intake
+路径会沿用 L1 命中，不受影响；直接 analyze 入口现在有 L3 / L4 兜底。
+
+### 故意不做
+
+- **不**从 `intent_title` / BKD prompt 自由文本 fuzzy parse `org/repo` slug。
+  风险：路径串（`src/orchestrator`、`M14b/M14c`、`docs/integration-contracts.md`
+  里的 `phona/foo` 示例）极易误命中 → 拉错仓污染 `/workspace/source/`，下游
+  checker 行为不可预测。要文本声明就让用户显式打 `repo:` tag。
+- **不**改 `analyze.md.j2`。模板已经按 `cloned_repos` 真假分支显示"sisyphus
+  已替你 clone X"或"你必须自己 clone"，4 层全 miss 时仍 fall through 到原
+  prompt 路径，agent 行为兼容。
+- **不**给 L3 / L4 加 PR-CI 端的"discovery"。`pr_ci_watch` 已经从
+  `/workspace/source/*` 实地探测，不依赖 ctx —— 这个 REQ 只动 analyze
+  入口的 clone，pr_ci_watch 不动。
+
+## 取舍
+
+- **为什么 L3 是 `repo:` tag 而不是新 ctx 字段** —— BKD UI 没"自定义 ctx"
+  入口；用户能改的就是 issue title / tags / chat。tag 是机器可读，prefix
+  `repo:` 跟既有 `parent:` / `decision:` / `init:` / `target:` 几个 prefix
+  保持一致风格，router/webhook 已经熟。
+- **为什么 L4 default_factory 是 `[]` 而不是 `["phona/sisyphus"]`** —— 默认空，
+  opt-in。多仓部署不能强加默认；单仓部署（sisyphus self-dogfood）通过 helm
+  values `extraEnv: SISYPHUS_DEFAULT_INVOLVED_REPOS=phona/sisyphus` 显式配。
+- **为什么 4 层而不是 5 层加 prompt body 解析** —— 见上方 "故意不做"。
+- **为什么不用 AI 解析 intent_title 的 repo 提及** —— `_clone` 是机械 helper，
+  调 LLM 解析自由文本让它脱离"薄编排"哲学；agent 自己有 prompt Part A.3 fallback
+  路径，Last-resort 让 agent 决，比 sisyphus 假装智能强。
+- **slug regex 严格度** —— 强 require `[A-Za-z0-9][A-Za-z0-9-]{0,38}/[A-Za-z0-9][A-Za-z0-9._-]*`，
+  GitHub org / repo 命名规则的子集（org 最多 39 字符；repo 字符集允许 `._-`）。
+  非法 slug **不**静默丢弃，log warning 让 ops 看到 typo。
+
+## 影响面
+
+- `orchestrator/src/orchestrator/actions/_clone.py`：
+  - 重构 `_resolve_repos` → `resolve_repos`（公开 API，方便 unit + contract
+    test 直接调）+ 加 4 层逻辑 + 返回 `(repos, source_label)`
+  - 新增 helper `_extract_repo_tags(tags)` + `_REPO_SLUG_RE`
+  - `clone_involved_repos_into_runner` 加 keyword-only `tags` + `default_repos`
+    参数；旧签名 `(req_id, ctx)` 保持向后兼容（kwargs 可缺）
+  - log 增加 `source` 字段（来自哪一层）方便观测
+- `orchestrator/src/orchestrator/config.py`：加 `default_involved_repos: list[str] = Field(default_factory=list)`，env `SISYPHUS_DEFAULT_INVOLVED_REPOS`
+- `orchestrator/src/orchestrator/actions/start_analyze.py`：调 `clone_involved_repos_into_runner` 时传 `tags=tags, default_repos=settings.default_involved_repos`
+- `orchestrator/src/orchestrator/actions/start_analyze_with_finalized_intent.py`：同上（intake 路径正常用不上 L3/L4，但传进去保持调用形状一致 + 防 intake JSON 异常时降级到 L4）
+- `orchestrator/tests/test_actions_start_analyze.py`：补 8 个 case 覆盖 4 层 priority + tag 解析 + start_analyze 透传
+- `orchestrator/tests/test_contract_clone_fallback_direct_analyze.py`：新增。锁死
+  - layer priority order
+  - settings field 存在 + default `[]`
+  - `_clone.py` 不准 import `intent_title` / `get_issue` / `description`（自由文本解析 guard）
+  - start_analyze* 透传 `tags=tags` + `default_repos=settings.default_involved_repos`
+  - slug 校验严格度
+
+不动 / 不影响：
+
+- `state.py` / `engine.py` —— 状态机不变
+- `webhook.py` / `router.py` —— ctx 解析不变（webhook 仍只写 `intent_issue_id` + `intent_title`）
+- `pr_ci_watch.py` / `staging_test.py` —— checker 路径不动
+- `analyze.md.j2` —— 模板按 `cloned_repos` 真假分支已经处理两种情况，无需改

--- a/openspec/changes/REQ-clone-fallback-direct-analyze-1777119520/specs/multi-layer-involved-repos-fallback/contract.spec.yaml
+++ b/openspec/changes/REQ-clone-fallback-direct-analyze-1777119520/specs/multi-layer-involved-repos-fallback/contract.spec.yaml
@@ -1,0 +1,92 @@
+capability: multi-layer-involved-repos-fallback
+version: "1.0"
+description: |
+  4-layer fallback for resolving the involved_repos list that the
+  server-side clone helper passes to /opt/sisyphus/scripts/sisyphus-clone-repos.sh
+  inside the per-REQ runner pod. Adds two new layers (BKD `repo:<org>/<name>`
+  tags and a settings-level default) on top of the original two ctx-based
+  layers, fixing the direct-analyze entry path where ctx is empty (no intake).
+
+api:
+  module: orchestrator.actions._clone
+
+  resolve_repos:
+    signature: |
+      resolve_repos(
+          ctx: dict | None,
+          *,
+          tags: Iterable[str] | None = None,
+          default_repos: Iterable[str] | None = None,
+      ) -> tuple[list[str], str]
+    returns:
+      repos: ordered, deduplicated list of `org/repo` slugs
+      source_label: one of
+        - "ctx.intake_finalized_intent.involved_repos"
+        - "ctx.involved_repos"
+        - "tags.repo"
+        - "settings.default_involved_repos"
+        - "none"  # all layers empty
+    layer_priority:
+      - L1: ctx["intake_finalized_intent"]["involved_repos"]
+      - L2: ctx["involved_repos"]
+      - L3: tags filtered by prefix `repo:` + slug regex
+      - L4: default_repos (typically settings.default_involved_repos)
+
+  _extract_repo_tags:
+    signature: |
+      _extract_repo_tags(tags: Iterable[str] | None) -> list[str]
+    behavior:
+      - drop tags whose first 5 chars != "repo:"
+      - validate the slug after `repo:` against
+        ^[A-Za-z0-9][A-Za-z0-9-]{0,38}/[A-Za-z0-9][A-Za-z0-9._-]*$
+      - log "clone.invalid_repo_tag" for `repo:` tags that fail the regex
+      - tolerate non-string entries in the iterable without raising
+      - dedup preserving first-occurrence order
+
+  clone_involved_repos_into_runner:
+    signature: |
+      async clone_involved_repos_into_runner(
+          req_id: str,
+          ctx: dict | None,
+          *,
+          tags: Iterable[str] | None = None,
+          default_repos: Iterable[str] | None = None,
+      ) -> tuple[list[str] | None, int | None]
+    return_modes:
+      "(None, None)":
+        - all 4 layers yield empty (no repos to clone)
+        - OR k8s_runner.get_controller() raised RuntimeError (dev env)
+      "(repos, None)":
+        helper exit_code == 0 (success)
+      "(repos, exit_code)":
+        helper exit_code != 0 (caller MUST emit VERIFY_ESCALATE)
+    log_fields:
+      - source: which layer matched (added in this REQ — observability)
+
+config:
+  setting:
+    name: default_involved_repos
+    type: list[str]
+    default: []
+    env: SISYPHUS_DEFAULT_INVOLVED_REPOS
+    pydantic_field: Field(default_factory=list)
+    parse_forms:
+      - csv: "phona/foo,phona/bar"
+      - json: '["phona/foo","phona/bar"]'
+    purpose: |
+      Last-resort fallback (L4) for resolve_repos. Default empty so
+      multi-repo deployments are not silently forced onto a wrong default;
+      single-repo deployments (sisyphus self-dogfood, single-repo lab) opt in.
+
+callers:
+  - module: orchestrator.actions.start_analyze
+    function: start_analyze
+    must_pass: ["tags=tags", "default_repos=settings.default_involved_repos"]
+  - module: orchestrator.actions.start_analyze_with_finalized_intent
+    function: start_analyze_with_finalized_intent
+    must_pass: ["tags=tags", "default_repos=settings.default_involved_repos"]
+
+invariants:
+  - _clone.py source MUST NOT contain the literals `intent_title`, `get_issue`, `description` (no free-text inference of repo slugs; enforced by contract test)
+  - resolve_repos is a pure function (no I/O); only clone_involved_repos_into_runner does the kubectl exec
+  - existing 2-layer behavior (intake / explicit ctx) is preserved bit-for-bit; new layers extend, never replace

--- a/openspec/changes/REQ-clone-fallback-direct-analyze-1777119520/specs/multi-layer-involved-repos-fallback/spec.md
+++ b/openspec/changes/REQ-clone-fallback-direct-analyze-1777119520/specs/multi-layer-involved-repos-fallback/spec.md
@@ -1,0 +1,183 @@
+# multi-layer-involved-repos-fallback
+
+## ADDED Requirements
+
+### Requirement: _clone.resolve_repos MUST resolve involved_repos through a 4-layer fallback in fixed priority order
+
+The orchestrator's server-side clone helper SHALL resolve the list of
+repos to clone into the runner pod via a 4-layer ordered fallback. The
+helper MUST consult the layers in this exact priority and return the
+first layer whose normalized list is non-empty. The function MUST also
+return a `source_label` string identifying which layer matched (for
+observability and structured logging via `clone.exec` / `clone.done`):
+
+| order | source_label                                  | input                                                  |
+|-------|-----------------------------------------------|--------------------------------------------------------|
+| 1     | `ctx.intake_finalized_intent.involved_repos`  | intake-agent finalized intent JSON written by webhook  |
+| 2     | `ctx.involved_repos`                          | explicit ctx field set by upstream caller / fixture    |
+| 3     | `tags.repo`                                   | BKD intent issue tags shaped `repo:<org>/<name>`       |
+| 4     | `settings.default_involved_repos`             | env `SISYPHUS_DEFAULT_INVOLVED_REPOS` (csv or JSON)    |
+
+When all four layers yield an empty (or non-list / all-non-string)
+result, the helper MUST return `([], "none")` and the caller MUST skip
+the server-side clone (let the analyze-agent run its prompt-driven
+fallback per `analyze.md.j2` Part A.3).
+
+The helper MUST normalize each layer's input by filtering out
+non-string and empty entries while preserving original order and
+deduplicating repeated slugs.
+
+#### Scenario: MLIRF-S1 ctx.intake_finalized_intent wins over every other layer
+
+- **GIVEN** `resolve_repos` is called with
+  `ctx={"intake_finalized_intent": {"involved_repos": ["L1/x"]}, "involved_repos": ["L2/x"]}`,
+  `tags=["repo:L3/x"]`, `default_repos=["L4/x"]`
+- **WHEN** the function returns
+- **THEN** the result MUST be `(["L1/x"], "ctx.intake_finalized_intent.involved_repos")`
+
+#### Scenario: MLIRF-S2 layer fall-through to ctx.involved_repos when L1 missing
+
+- **GIVEN** `resolve_repos` is called with
+  `ctx={"involved_repos": ["L2/x"]}`, `tags=["repo:L3/x"]`,
+  `default_repos=["L4/x"]`
+- **WHEN** the function returns
+- **THEN** the result MUST be `(["L2/x"], "ctx.involved_repos")`
+
+#### Scenario: MLIRF-S3 layer fall-through to BKD `repo:` tags on direct analyze entry
+
+- **GIVEN** `resolve_repos` is called with `ctx={"intent_title": "..."}`
+  (no involved_repos), `tags=["analyze", "REQ-X", "repo:phona/sisyphus"]`,
+  `default_repos=["L4/x"]`
+- **WHEN** the function returns
+- **THEN** the result MUST be `(["phona/sisyphus"], "tags.repo")`
+
+#### Scenario: MLIRF-S4 layer fall-through to settings.default_involved_repos
+
+- **GIVEN** `resolve_repos` is called with empty `ctx`, no `repo:` tags,
+  `default_repos=["phona/sisyphus"]`
+- **WHEN** the function returns
+- **THEN** the result MUST be `(["phona/sisyphus"], "settings.default_involved_repos")`
+
+#### Scenario: MLIRF-S5 all four layers empty returns `([], "none")` and caller skips clone
+
+- **GIVEN** `resolve_repos` is called with empty `ctx`, empty `tags`,
+  empty `default_repos`
+- **WHEN** the function returns
+- **THEN** the result MUST be `([], "none")`
+- **AND** `clone_involved_repos_into_runner` calling this MUST return
+  `(None, None)` and MUST NOT invoke `exec_in_runner`
+
+### Requirement: _clone helper MUST extract `repo:<org>/<name>` tags with strict slug validation
+
+The helper SHALL extract the slug after the literal prefix `repo:` from
+each tag in the `tags` argument, MUST validate it against the regex
+`^[A-Za-z0-9][A-Za-z0-9-]{0,38}/[A-Za-z0-9][A-Za-z0-9._-]*$` (a strict
+subset of GitHub org / repo naming rules: org max 39 chars, repo allows
+`._-` and digits), MUST drop tags that do not start with `repo:` or
+whose slug fails validation, MUST log a `clone.invalid_repo_tag`
+warning when a `repo:` tag has an invalid slug (so operators can spot
+typos), MUST tolerate non-string entries in the `tags` iterable without
+raising, and MUST deduplicate repeated valid slugs while preserving
+first-occurrence order.
+
+#### Scenario: MLIRF-S6 valid slugs accepted, invalid slugs rejected, dedup preserves order
+
+- **GIVEN** `tags = ["analyze", "REQ-X", "repo:phona/sisyphus", "repo:Zone-Ease_Tech/foo", "repo:invalid org/name", "repo:/missing-org", "repo:no-slash-here", "repo:phona/sisyphus", "repo:phona/repo-with.dots_and-dash"]`
+- **WHEN** `_extract_repo_tags(tags)` returns
+- **THEN** the result MUST be exactly
+  `["phona/sisyphus", "phona/repo-with.dots_and-dash"]`
+  (note: `Zone-Ease_Tech/foo` is rejected because the org segment
+  contains an underscore, which is outside the allowed org charset
+  `[A-Za-z0-9-]`)
+
+#### Scenario: MLIRF-S7 None / non-string tags handled without raising
+
+- **GIVEN** `tags = ["repo:phona/x", 42, None, "repo:phona/y"]`
+- **WHEN** `_extract_repo_tags(tags)` returns
+- **THEN** the result MUST be `["phona/x", "phona/y"]` and no exception
+  MUST be raised
+
+### Requirement: settings.default_involved_repos MUST exist and default to empty list
+
+The `Settings` class SHALL declare a `default_involved_repos: list[str]`
+field with a `default_factory=list` (i.e. default empty). The env var
+binding MUST be `SISYPHUS_DEFAULT_INVOLVED_REPOS` (per the
+`SettingsConfigDict(env_prefix="SISYPHUS_")` convention). Pydantic
+SHALL accept both csv (`"phona/foo,phona/bar"`) and JSON array forms.
+The default MUST be empty so multi-repo deployments are not silently
+forced into a wrong default; single-repo deployments (sisyphus
+self-dogfood, single-repo lab) opt in via env.
+
+#### Scenario: MLIRF-S8 default_involved_repos field exists with empty default
+
+- **GIVEN** `Settings.model_fields["default_involved_repos"]`
+- **WHEN** the test inspects the field
+- **THEN** the field MUST exist
+- **AND** `default_factory()` MUST evaluate to `[]`
+
+### Requirement: start_analyze and start_analyze_with_finalized_intent MUST forward tags + settings.default_involved_repos to the clone helper
+
+Both `start_analyze` and `start_analyze_with_finalized_intent` SHALL
+invoke `clone_involved_repos_into_runner` with both keyword arguments
+`tags=tags` (the action's `tags` parameter) and
+`default_repos=settings.default_involved_repos`. This is the only path
+through which L3 (BKD `repo:` tags) and L4 (settings default) reach the
+helper. Forgetting either keyword on either entry point MUST be caught
+by the contract test (which greps the action source for the literal
+substrings `tags=tags` and `default_repos=settings.default_involved_repos`).
+
+#### Scenario: MLIRF-S9 direct-analyze entry with `repo:` tag clones via L3
+
+- **GIVEN** `start_analyze` is invoked with `tags=["intent:analyze", "repo:phona/sisyphus"]`
+  and `ctx={"intent_title": "..."}` (no `involved_repos`)
+- **WHEN** the action runs against a fake runner controller
+- **THEN** `exec_in_runner` MUST be called once with a command containing
+  `/opt/sisyphus/scripts/sisyphus-clone-repos.sh` and the literal
+  argument `phona/sisyphus`
+- **AND** the action's return value MUST contain
+  `cloned_repos == ["phona/sisyphus"]` and MUST NOT contain `emit`
+
+#### Scenario: MLIRF-S10 direct-analyze entry with no ctx, no tags, settings.default set → L4 clones
+
+- **GIVEN** `start_analyze` is invoked with `tags=["intent:analyze"]`,
+  `ctx={"intent_title": "single-repo dogfood"}`, and
+  `settings.default_involved_repos == ["phona/sisyphus"]`
+- **WHEN** the action runs against a fake runner controller
+- **THEN** `exec_in_runner` MUST be called once with `phona/sisyphus`
+  in the command
+- **AND** the action's return value MUST contain
+  `cloned_repos == ["phona/sisyphus"]`
+
+#### Scenario: MLIRF-S11 all four layers empty → no exec call, agent dispatched anyway
+
+- **GIVEN** `start_analyze` is invoked with `tags=["intent:analyze"]`,
+  `ctx={"intent_title": "no repos anywhere"}`, and
+  `settings.default_involved_repos == []`
+- **WHEN** the action runs
+- **THEN** `exec_in_runner` MUST NOT be called
+- **AND** the action MUST still call `BKDClient.follow_up_issue` (preserving
+  the agent-driven prompt fallback path from `analyze.md.j2` Part A.3)
+- **AND** the return value MUST contain `cloned_repos is None`
+
+### Requirement: _clone helper MUST NOT introspect free-text fields to infer repo slugs
+
+The `actions/_clone.py` module SHALL NOT consult `ctx.intent_title`, the
+BKD issue prompt body, or any other free-form text field to fuzzy-parse
+`org/repo` slugs. The forbidden source-text substrings `intent_title`,
+`get_issue`, and `description` MUST NOT appear anywhere in the file
+(neither in code nor in docstrings). This is enforced by a contract
+test that greps the file. Rationale: paths like
+`src/orchestrator`, `M14b/M14c`, or example slugs in surrounding markdown
+documentation are indistinguishable from real `org/repo` slugs at the
+regex layer; introducing fuzzy text parsing here trades a real ergonomic
+gain (`repo:` tag + settings default already cover that) for an
+unbounded false-positive surface that would corrupt
+`/workspace/source/`. Any future contributor wanting to add free-text
+parsing MUST first remove this guard with a follow-up REQ.
+
+#### Scenario: MLIRF-S12 _clone.py source contains no free-text introspection markers
+
+- **GIVEN** the file `orchestrator/src/orchestrator/actions/_clone.py`
+- **WHEN** the contract test reads it as text and searches for the
+  literals `intent_title`, `get_issue`, `description`
+- **THEN** the search MUST yield zero matches across all three literals

--- a/openspec/changes/REQ-clone-fallback-direct-analyze-1777119520/tasks.md
+++ b/openspec/changes/REQ-clone-fallback-direct-analyze-1777119520/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: REQ-clone-fallback-direct-analyze-1777119520
+
+## Stage: spec
+
+- [x] `openspec/changes/REQ-clone-fallback-direct-analyze-1777119520/proposal.md`
+- [x] `openspec/changes/REQ-clone-fallback-direct-analyze-1777119520/tasks.md`
+- [x] `openspec/changes/REQ-clone-fallback-direct-analyze-1777119520/specs/multi-layer-involved-repos-fallback/spec.md`
+- [x] `openspec/changes/REQ-clone-fallback-direct-analyze-1777119520/specs/multi-layer-involved-repos-fallback/contract.spec.yaml`
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/actions/_clone.py`：
+  - 重构 `_resolve_repos` → public `resolve_repos(ctx, *, tags, default_repos) -> (list, str)` 含 4 层逻辑
+  - 加 `_extract_repo_tags(tags)` + `_REPO_SLUG_RE`（`repo:<org>/<name>` 解析 + slug 校验）
+  - 加 `_normalize_repos(raw)`：list/tuple → list[str] + 顺序保留去重
+  - `clone_involved_repos_into_runner` 加 keyword-only `tags` + `default_repos`，向后兼容
+  - log `clone.exec` / `clone.done` / `clone.failed` 都带 `source` 字段（哪一层命中）
+
+- [x] `orchestrator/src/orchestrator/config.py`：
+  - 加 `default_involved_repos: list[str] = Field(default_factory=list)`
+  - env name: `SISYPHUS_DEFAULT_INVOLVED_REPOS`（含中文注释说明用法）
+
+- [x] `orchestrator/src/orchestrator/actions/start_analyze.py`：
+  - 调 `clone_involved_repos_into_runner` 时传 `tags=tags, default_repos=settings.default_involved_repos`
+  - 模块 docstring 增一段 REQ-clone-fallback-direct-analyze-1777119520 说明
+
+- [x] `orchestrator/src/orchestrator/actions/start_analyze_with_finalized_intent.py`：
+  - 同上传参（intake 路径正常 L1 命中，传参保持调用形状一致 + 兜底）
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_actions_start_analyze.py`：补 8 个 case
+  - `test_clone_helper_uses_repo_tags_when_ctx_empty`
+  - `test_clone_helper_uses_default_repos_when_ctx_and_tags_empty`
+  - `test_clone_helper_returns_none_when_all_layers_empty`
+  - `test_resolve_repos_priority_order`
+  - `test_resolve_repos_skips_empty_layers`
+  - `test_extract_repo_tags_validates_slug`
+  - `test_extract_repo_tags_handles_none_and_non_string`
+  - `test_start_analyze_passes_repo_tags_and_default_to_clone`
+  - `test_start_analyze_uses_settings_default_when_no_ctx_no_tags`
+  - `test_start_analyze_skip_remains_when_all_layers_empty`
+
+- [x] `orchestrator/tests/test_contract_clone_fallback_direct_analyze.py`：新增
+  - `test_resolve_repos_layer_priority`
+  - `test_default_involved_repos_setting_exists`
+  - `test_clone_helper_does_not_parse_intent_title_or_body`
+  - `test_start_analyze_actions_pass_tags_and_default_to_clone`
+  - `test_repo_tag_extraction_validates_slug`
+
+## Stage: PR
+
+- [x] git push feat/REQ-clone-fallback-direct-analyze-1777119520
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/actions/_clone.py
+++ b/orchestrator/src/orchestrator/actions/_clone.py
@@ -1,16 +1,33 @@
-"""server-side clone helper：start_analyze 系列 action 用，把 ctx 里的
-involved_repos 落到 runner pod 的 /workspace/source/<basename>/。
+"""server-side clone helper：start_analyze 系列 action 用，把 involved_repos 落到
+runner pod 的 /workspace/source/<basename>/。
 
-入口：`clone_involved_repos_into_runner(req_id, ctx)`，三种返回：
-- (None, None)：runner controller 没就绪 / ctx 没 involved_repos 都返这个
-  —— caller 跳过 clone 直接 dispatch agent（直接 analyze 路径兼容）
+入口：`clone_involved_repos_into_runner(req_id, ctx, *, tags, default_repos)`，
+三种返回：
+- (None, None)：runner controller 没就绪 / 所有 fallback 层都没拿到 repos →
+  caller 跳过 clone 直接 dispatch agent（直接 analyze 路径兼容）
 - (repos, None)：clone 成功，repos 是真跑过 helper 的列表
 - (repos, exit_code)：clone 失败，exit_code 是 helper 退码（caller 应
   emit VERIFY_ESCALATE，不打 agent 进空 PVC）
+
+REQ-clone-fallback-direct-analyze-1777119520：multi-layer fallback for direct
+analyze entry。原版只读 ctx，intake 跳过时 ctx 是空的，sisyphus 把 clone
+完全推给 agent prompt。新版按下列优先级解析：
+
+1. ctx.intake_finalized_intent.involved_repos —— intake 路径产物
+2. ctx.involved_repos —— 直接被 caller 写到 ctx 的 involved
+3. tags 里 `repo:<org>/<name>` 形式的 explicit opt-in
+4. settings.default_involved_repos —— 单仓部署的 last-resort
+
+L3/L4 都是显式信号：tag 是用户在 BKD intent issue 上挂的，env 是 operator
+在 sisyphus 部署时配的。**故意不**从 issue 标题 / prompt 自由文本解析
+slug —— 假阳性风险高（"src/orchestrator"、"M14b/M14c" 之类路径会误命中），
+不如等用户显式打 tag 或 ops 配 default。
 """
 from __future__ import annotations
 
+import re
 import shlex
+from collections.abc import Iterable
 
 import structlog
 
@@ -21,27 +38,87 @@ log = structlog.get_logger(__name__)
 _CLONE_HELPER = "/opt/sisyphus/scripts/sisyphus-clone-repos.sh"
 _CLONE_TIMEOUT_SEC = 600
 
+# `repo:<org>/<name>` BKD tag 形式。github org/repo slug 规则：
+# org 字母数字 + 连字符；repo 字母数字 + . _ -。
+_REPO_TAG_PREFIX = "repo:"
+_REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,38}/[A-Za-z0-9][A-Za-z0-9._-]*$")
 
-def _resolve_repos(ctx: dict | None) -> list[str]:
-    """优先级 ctx.intake_finalized_intent.involved_repos > ctx.involved_repos。"""
-    if not ctx:
+
+def _normalize_repos(raw: object) -> list[str]:
+    """把任意 iterable 过滤成 list[str]，丢非字符串 / 空串。顺序保留 + 去重。"""
+    if not isinstance(raw, (list, tuple)):
         return []
-    finalized = ctx.get("intake_finalized_intent") or {}
-    repos = finalized.get("involved_repos") or ctx.get("involved_repos") or []
-    return [r for r in repos if isinstance(r, str) and r]
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in raw:
+        if not isinstance(item, str):
+            continue
+        s = item.strip()
+        if not s or s in seen:
+            continue
+        seen.add(s)
+        out.append(s)
+    return out
+
+
+def _extract_repo_tags(tags: Iterable[str] | None) -> list[str]:
+    """从 BKD issue tags 抽 `repo:<org>/<name>` 并校验 slug 合法。"""
+    if not tags:
+        return []
+    out: list[str] = []
+    for t in tags:
+        if not isinstance(t, str) or not t.startswith(_REPO_TAG_PREFIX):
+            continue
+        slug = t[len(_REPO_TAG_PREFIX):].strip()
+        if _REPO_SLUG_RE.match(slug):
+            out.append(slug)
+        else:
+            log.warning("clone.invalid_repo_tag", tag=t)
+    # 去重保留顺序
+    seen: set[str] = set()
+    return [r for r in out if not (r in seen or seen.add(r))]
+
+
+def resolve_repos(
+    ctx: dict | None,
+    *,
+    tags: Iterable[str] | None = None,
+    default_repos: Iterable[str] | None = None,
+) -> tuple[list[str], str]:
+    """multi-layer fallback。返回 (repos, source_label)。
+
+    source_label 给 log / obs 用，标明 repos 是从哪一层取到的。
+    """
+    finalized = (ctx or {}).get("intake_finalized_intent") or {}
+    layers: list[tuple[str, object]] = [
+        ("ctx.intake_finalized_intent.involved_repos", finalized.get("involved_repos")),
+        ("ctx.involved_repos", (ctx or {}).get("involved_repos")),
+        ("tags.repo", _extract_repo_tags(tags)),
+        ("settings.default_involved_repos", list(default_repos or [])),
+    ]
+    for label, raw in layers:
+        repos = _normalize_repos(raw)
+        if repos:
+            return repos, label
+    return [], "none"
 
 
 async def clone_involved_repos_into_runner(
-    req_id: str, ctx: dict | None,
+    req_id: str,
+    ctx: dict | None,
+    *,
+    tags: Iterable[str] | None = None,
+    default_repos: Iterable[str] | None = None,
 ) -> tuple[list[str] | None, int | None]:
     """在 runner pod 里跑 sisyphus-clone-repos.sh。
 
     返回 (repos, exit_code)：
-    - (None, None)：跳过（无 controller 或无 repos），caller 继续 dispatch agent
+    - (None, None)：跳过（无 controller 或所有 fallback 都没 repos），
+      caller 继续 dispatch agent
     - (repos, None)：成功（helper exit 0）
     - (repos, exit_code)：失败（helper 非 0），caller 应 escalate
     """
-    repos = _resolve_repos(ctx)
+    repos, source = resolve_repos(ctx, tags=tags, default_repos=default_repos)
     if not repos:
         log.info("clone.skip_no_repos", req_id=req_id)
         return None, None
@@ -55,17 +132,17 @@ async def clone_involved_repos_into_runner(
 
     args = " ".join(shlex.quote(r) for r in repos)
     cmd = f"{_CLONE_HELPER} {args}"
-    log.info("clone.exec", req_id=req_id, repos=repos)
+    log.info("clone.exec", req_id=req_id, repos=repos, source=source)
     result = await rc.exec_in_runner(req_id, cmd, timeout_sec=_CLONE_TIMEOUT_SEC)
 
     if result.exit_code != 0:
         log.error(
-            "clone.failed", req_id=req_id, repos=repos,
+            "clone.failed", req_id=req_id, repos=repos, source=source,
             exit_code=result.exit_code,
             stderr_tail=result.stderr[-512:] if result.stderr else "",
         )
         return repos, result.exit_code
 
-    log.info("clone.done", req_id=req_id, repos=repos,
+    log.info("clone.done", req_id=req_id, repos=repos, source=source,
              duration_sec=round(result.duration_sec, 1))
     return repos, None

--- a/orchestrator/src/orchestrator/actions/start_analyze.py
+++ b/orchestrator/src/orchestrator/actions/start_analyze.py
@@ -6,8 +6,12 @@ kubectl exec 进去能立刻用。Pod 生命周期绑本 REQ 直到 done/escalat
 REQ-clone-and-pr-ci-fallback-1777115925：在 ensure_runner 之后、follow-up
 prompt 之前，把 ctx 里的 involved_repos 替 agent server-side clone 进
 /workspace/source/<basename>/。clone 失败 → 直接 emit VERIFY_ESCALATE，不
-让 agent 进空 PVC 干活。直接 analyze 路径（无 intake，ctx 没 involved_repos）
-保留 fallback：跳过 server-side clone，agent 按 prompt Part A.3 自己跑 helper。
+让 agent 进空 PVC 干活。
+
+REQ-clone-fallback-direct-analyze-1777119520：直接 analyze 路径（无 intake，
+ctx 没 involved_repos）也试 multi-layer fallback —— 把 BKD intent issue tags
+里的 `repo:<org>/<name>` 跟 settings.default_involved_repos 喂给 _clone helper。
+所有层都拿不到 → 才落到 agent prompt Part A.3 的"自跑 helper"路径。
 
 行为：
 1. ensure_runner（K8s：建 PVC + Pod，等 Ready）
@@ -49,8 +53,11 @@ async def start_analyze(*, body, req_id, tags, ctx):
         pod_name = await rc.ensure_runner(req_id, wait_ready=True)
         log.info("start_analyze.runner_ready", req_id=req_id, pod=pod_name)
 
-    # 2. server-side clone（ctx 有 involved_repos 时；直接 analyze 路径无声跳过）
-    cloned_repos, clone_rc = await clone_involved_repos_into_runner(req_id, ctx)
+    # 2. server-side clone（multi-layer fallback：ctx → tags → settings.default
+    # 都没拿到 → 无声跳过，让 agent 按 prompt Part A.3 自跑 helper）
+    cloned_repos, clone_rc = await clone_involved_repos_into_runner(
+        req_id, ctx, tags=tags, default_repos=settings.default_involved_repos,
+    )
     if clone_rc is not None:
         # helper 跑过但失败 → 不 dispatch agent，直接 escalate
         return {

--- a/orchestrator/src/orchestrator/actions/start_analyze_with_finalized_intent.py
+++ b/orchestrator/src/orchestrator/actions/start_analyze_with_finalized_intent.py
@@ -53,8 +53,12 @@ async def start_analyze_with_finalized_intent(*, body, req_id, tags, ctx):
         pod_name = await rc.ensure_runner(req_id, wait_ready=True)
         log.info("start_analyze_with_finalized_intent.runner_ready", req_id=req_id, pod=pod_name)
 
-    # 2. server-side clone（intake 路径必有 involved_repos；失败 → escalate）
-    cloned_repos, clone_rc = await clone_involved_repos_into_runner(req_id, ctx)
+    # 2. server-side clone（intake 路径必有 involved_repos；失败 → escalate）。
+    # tags + settings.default_involved_repos 是 REQ-clone-fallback-direct-analyze
+    # 的 multi-layer 兜底，intake 路径正常用不上但传进去保持调用形状一致。
+    cloned_repos, clone_rc = await clone_involved_repos_into_runner(
+        req_id, ctx, tags=tags, default_repos=settings.default_involved_repos,
+    )
     if clone_rc is not None:
         return {
             "emit": Event.VERIFY_ESCALATE.value,

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -129,6 +129,16 @@ class Settings(BaseSettings):
     # vm-node04 默认 id 见 runner_container.md.j2 的 fallback。helm values 可覆盖。
     aissh_server_id: str = "5b25f0cd-4fef-4a1f-a4c0-14ecf1395d84"
 
+    # ─── REQ-clone-fallback-direct-analyze-1777119520：multi-layer involved_repos
+    # 的 last-resort fallback 层（L4）。直接 analyze 路径（无 intake）+ ctx 没
+    # involved_repos + tags 也没 `repo:<org>/<name>` → 用这里的 default 喂 server-side
+    # clone helper。单仓部署（如 sisyphus 自 dogfood）配 `phona/sisyphus` 一条即可，
+    # 直接 analyze 入口就能 auto-clone；多仓 / 跨项目部署留空（Field default_factory），
+    # 强制用户走 intake 或在 intent issue 上挂 `repo:` tag 显式声明。
+    # env：`SISYPHUS_DEFAULT_INVOLVED_REPOS=phona/sisyphus,phona/foo`（逗号分隔）
+    # 或 JSON 数组 `["phona/sisyphus","phona/foo"]`。
+    default_involved_repos: list[str] = Field(default_factory=list)
+
     # ─── M14b/M14c：verifier-agent 框架 ─────────────────────────────────
     # 每个 stage transition（成功 or 失败）先起一个 verifier-agent 做主观判断
     # —— 3 路决策：pass / fix / escalate，再由 webhook 路由推进状态机。

--- a/orchestrator/tests/test_actions_start_analyze.py
+++ b/orchestrator/tests/test_actions_start_analyze.py
@@ -261,3 +261,214 @@ async def test_clone_helper_filters_non_string_repos(monkeypatch):
     repos, rc = await _clone.clone_involved_repos_into_runner("REQ-X", ctx)
     assert repos == ["phona/repo-a", "phona/repo-b"]
     assert rc is None
+
+
+# ── REQ-clone-fallback-direct-analyze-1777119520: multi-layer fallback ────
+
+@pytest.mark.asyncio
+async def test_clone_helper_uses_repo_tags_when_ctx_empty(monkeypatch):
+    """ctx 没 involved_repos，但 BKD tags 含 `repo:<org>/<name>` → 解析后 clone。"""
+    exec_fn = AsyncMock(return_value=FakeExec(exit_code=0))
+
+    class FakeRC:
+        exec_in_runner = exec_fn
+
+    monkeypatch.setattr(_clone.k8s_runner, "get_controller", lambda: FakeRC())
+
+    repos, rc = await _clone.clone_involved_repos_into_runner(
+        "REQ-X",
+        ctx={"intent_title": "direct analyze entry"},
+        tags=["analyze", "REQ-X", "repo:phona/foo", "repo:ZonEaseTech/bar"],
+    )
+    assert repos == ["phona/foo", "ZonEaseTech/bar"]
+    assert rc is None
+    cmd = exec_fn.await_args.args[1]
+    assert "phona/foo" in cmd
+    assert "ZonEaseTech/bar" in cmd
+
+
+@pytest.mark.asyncio
+async def test_clone_helper_uses_default_repos_when_ctx_and_tags_empty(monkeypatch):
+    """ctx + tags 都没 involved_repos → settings.default_involved_repos 兜底。"""
+    exec_fn = AsyncMock(return_value=FakeExec(exit_code=0))
+
+    class FakeRC:
+        exec_in_runner = exec_fn
+
+    monkeypatch.setattr(_clone.k8s_runner, "get_controller", lambda: FakeRC())
+
+    repos, rc = await _clone.clone_involved_repos_into_runner(
+        "REQ-X",
+        ctx={"intent_title": "direct analyze, no repo tag"},
+        tags=["analyze", "REQ-X"],
+        default_repos=["phona/sisyphus"],
+    )
+    assert repos == ["phona/sisyphus"]
+    assert rc is None
+
+
+@pytest.mark.asyncio
+async def test_clone_helper_returns_none_when_all_layers_empty(monkeypatch):
+    """ctx + tags + default_repos 全空 → (None, None)，caller 跳过。"""
+    exec_fn = AsyncMock(return_value=FakeExec(exit_code=0))
+
+    class FakeRC:
+        exec_in_runner = exec_fn
+
+    monkeypatch.setattr(_clone.k8s_runner, "get_controller", lambda: FakeRC())
+
+    repos, rc = await _clone.clone_involved_repos_into_runner(
+        "REQ-X", ctx={"intent_title": "no repos anywhere"},
+        tags=["analyze"], default_repos=[],
+    )
+    assert repos is None
+    assert rc is None
+    exec_fn.assert_not_awaited()
+
+
+def test_resolve_repos_priority_order():
+    """L1 ctx.intake_finalized_intent > L2 ctx.involved_repos > L3 tags.repo > L4 default。"""
+    # L1 wins
+    repos, src = _clone.resolve_repos(
+        {"intake_finalized_intent": {"involved_repos": ["L1/x"]},
+         "involved_repos": ["L2/x"]},
+        tags=["repo:L3/x"],
+        default_repos=["L4/x"],
+    )
+    assert repos == ["L1/x"]
+    assert src == "ctx.intake_finalized_intent.involved_repos"
+
+    # L1 missing → L2 wins
+    repos, src = _clone.resolve_repos(
+        {"involved_repos": ["L2/x"]},
+        tags=["repo:L3/x"],
+        default_repos=["L4/x"],
+    )
+    assert repos == ["L2/x"]
+    assert src == "ctx.involved_repos"
+
+    # L1+L2 missing → L3 (tags) wins
+    repos, src = _clone.resolve_repos(
+        {"intent_title": "no involved"},
+        tags=["repo:L3/x", "analyze"],
+        default_repos=["L4/x"],
+    )
+    assert repos == ["L3/x"]
+    assert src == "tags.repo"
+
+    # L1+L2+L3 missing → L4 (settings.default) wins
+    repos, src = _clone.resolve_repos(
+        {}, tags=["analyze"], default_repos=["L4/x", "L4/y"],
+    )
+    assert repos == ["L4/x", "L4/y"]
+    assert src == "settings.default_involved_repos"
+
+    # all empty → ([], "none")
+    repos, src = _clone.resolve_repos({}, tags=[], default_repos=[])
+    assert repos == []
+    assert src == "none"
+
+
+def test_resolve_repos_skips_empty_layers():
+    """空 list / 非 list / 含非字符串项的 layer 视作 miss，继续往下找。"""
+    # L1 是空 list → fall through to L2
+    repos, src = _clone.resolve_repos(
+        {"intake_finalized_intent": {"involved_repos": []},
+         "involved_repos": ["fallback/wins"]},
+    )
+    assert repos == ["fallback/wins"]
+    assert src == "ctx.involved_repos"
+
+    # L1 非 list（agent 写错 schema） → fall through
+    repos, src = _clone.resolve_repos(
+        {"intake_finalized_intent": {"involved_repos": "not-a-list"},
+         "involved_repos": ["fallback/wins"]},
+    )
+    assert repos == ["fallback/wins"]
+    assert src == "ctx.involved_repos"
+
+
+def test_extract_repo_tags_validates_slug():
+    """`repo:<org>/<name>` 形式合法的 tag 才算数；非法 slug + 非 repo: 前缀全过滤。"""
+    tags = [
+        "analyze", "REQ-X", "round-2",                # 不是 repo: 前缀
+        "repo:phona/sisyphus",                        # OK
+        "repo:Zone-Ease_Tech/foo",                    # OK（org/repo 字符集）
+        "repo:invalid org/name",                      # 非法 slug（含空格）
+        "repo:/missing-org",                          # 非法 slug
+        "repo:no-slash-here",                         # 非法 slug
+        "repo:phona/sisyphus",                        # 重复，去重
+        "repo:phona/repo-with.dots_and-dash",         # OK
+    ]
+    out = _clone._extract_repo_tags(tags)
+    assert out == [
+        "phona/sisyphus",
+        "phona/repo-with.dots_and-dash",
+    ]
+
+
+def test_extract_repo_tags_handles_none_and_non_string():
+    assert _clone._extract_repo_tags(None) == []
+    assert _clone._extract_repo_tags([]) == []
+    # 非字符串项跳过，不抛
+    assert _clone._extract_repo_tags(["repo:phona/x", 42, None, "repo:phona/y"]) == [
+        "phona/x", "phona/y",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_start_analyze_passes_repo_tags_and_default_to_clone(monkeypatch):
+    """直接 analyze 入口：ctx 没 involved，但 tags 带 `repo:`，sisyphus 替 clone。"""
+    exec_fn = AsyncMock(return_value=FakeExec(exit_code=0))
+    _patch_runner(monkeypatch, exec_fn=exec_fn)
+    follow_up, _, _ = _patch_bkd_client(monkeypatch, target_module=start_analyze)
+
+    rv = await start_analyze.start_analyze(
+        body=_make_body(), req_id="REQ-X",
+        tags=["intent:analyze", "repo:phona/sisyphus"],
+        ctx={"intent_title": "direct analyze entry"},
+    )
+    exec_fn.assert_awaited_once()
+    cmd = exec_fn.await_args.args[1]
+    assert "phona/sisyphus" in cmd
+    follow_up.assert_awaited_once()
+    assert rv["cloned_repos"] == ["phona/sisyphus"]
+    assert "emit" not in rv
+
+
+@pytest.mark.asyncio
+async def test_start_analyze_uses_settings_default_when_no_ctx_no_tags(monkeypatch):
+    """直接 analyze 入口：ctx 空 + tags 没 repo:，settings.default_involved_repos 兜底。"""
+    exec_fn = AsyncMock(return_value=FakeExec(exit_code=0))
+    _patch_runner(monkeypatch, exec_fn=exec_fn)
+    _patch_bkd_client(monkeypatch, target_module=start_analyze)
+    monkeypatch.setattr(start_analyze.settings, "default_involved_repos",
+                        ["phona/sisyphus"])
+
+    rv = await start_analyze.start_analyze(
+        body=_make_body(), req_id="REQ-X",
+        tags=["intent:analyze"],
+        ctx={"intent_title": "single-repo dogfood"},
+    )
+    exec_fn.assert_awaited_once()
+    cmd = exec_fn.await_args.args[1]
+    assert "phona/sisyphus" in cmd
+    assert rv["cloned_repos"] == ["phona/sisyphus"]
+
+
+@pytest.mark.asyncio
+async def test_start_analyze_skip_remains_when_all_layers_empty(monkeypatch):
+    """ctx + tags + settings.default 全空 → 沿用旧 fallback，不调 helper，agent 自己 clone。"""
+    exec_fn = AsyncMock(return_value=FakeExec(exit_code=0))
+    _patch_runner(monkeypatch, exec_fn=exec_fn)
+    follow_up, _, _ = _patch_bkd_client(monkeypatch, target_module=start_analyze)
+    monkeypatch.setattr(start_analyze.settings, "default_involved_repos", [])
+
+    rv = await start_analyze.start_analyze(
+        body=_make_body(), req_id="REQ-X",
+        tags=["intent:analyze"],
+        ctx={"intent_title": "no repos anywhere"},
+    )
+    exec_fn.assert_not_awaited()
+    follow_up.assert_awaited_once()
+    assert rv["cloned_repos"] is None

--- a/orchestrator/tests/test_contract_clone_fallback_direct_analyze.py
+++ b/orchestrator/tests/test_contract_clone_fallback_direct_analyze.py
@@ -1,0 +1,115 @@
+"""contract regression for REQ-clone-fallback-direct-analyze-1777119520:
+
+multi-layer involved_repos fallback for direct analyze entry。
+- _resolve_repos / resolve_repos 必须按 4-layer 顺序：ctx.intake → ctx.involved
+  → tags.repo → settings.default
+- _clone helper 不能从自由文本（intent_title / prompt body）反向推断 repos
+  （假阳性风险高，规则强制改用显式 tag 或 settings env）
+- start_analyze + start_analyze_with_finalized_intent 必须把 tags +
+  settings.default_involved_repos 透传给 clone helper
+- settings.default_involved_repos field 必须存在，env=SISYPHUS_DEFAULT_INVOLVED_REPOS
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from orchestrator.actions import _clone
+from orchestrator.config import Settings
+
+_PRODUCTION_SOURCE = Path(__file__).resolve().parent.parent / "src" / "orchestrator"
+
+
+def test_resolve_repos_layer_priority():
+    """priority: L1 > L2 > L3 > L4。"""
+    repos, src = _clone.resolve_repos(
+        {"intake_finalized_intent": {"involved_repos": ["L1/x"]},
+         "involved_repos": ["L2/x"]},
+        tags=["repo:L3/x"], default_repos=["L4/x"],
+    )
+    assert repos == ["L1/x"]
+    assert src == "ctx.intake_finalized_intent.involved_repos"
+
+    repos, src = _clone.resolve_repos(
+        {"involved_repos": ["L2/x"]},
+        tags=["repo:L3/x"], default_repos=["L4/x"],
+    )
+    assert (repos, src) == (["L2/x"], "ctx.involved_repos")
+
+    repos, src = _clone.resolve_repos(
+        {}, tags=["repo:L3/x"], default_repos=["L4/x"],
+    )
+    assert (repos, src) == (["L3/x"], "tags.repo")
+
+    repos, src = _clone.resolve_repos({}, tags=[], default_repos=["L4/x"])
+    assert (repos, src) == (["L4/x"], "settings.default_involved_repos")
+
+    repos, src = _clone.resolve_repos({}, tags=[], default_repos=[])
+    assert (repos, src) == ([], "none")
+
+
+def test_default_involved_repos_setting_exists():
+    """settings 必须有 default_involved_repos field（env=SISYPHUS_DEFAULT_INVOLVED_REPOS）。"""
+    fields = Settings.model_fields
+    assert "default_involved_repos" in fields, (
+        "Settings.default_involved_repos must exist for "
+        "REQ-clone-fallback-direct-analyze-1777119520 (L4 fallback)."
+    )
+    f = fields["default_involved_repos"]
+    # 默认空 list（多仓部署不强加默认；单仓部署用 env 显式设）
+    default = (
+        f.default_factory() if f.default_factory is not None else f.default
+    )
+    assert default == [], (
+        "default_involved_repos must default to empty list — opt-in only."
+    )
+
+
+def test_clone_helper_does_not_parse_intent_title_or_body():
+    """_clone.py 不准从 intent_title / 自由文本 fuzzy parse repo slug。
+
+    这条 guard 故意写得严格 —— 任何未来想引入 "title slug 解析" 的人必须先
+    把 REQ 当面拿来重新讨论假阳性风险（"src/orchestrator"、"M14b/M14c" 之类
+    路径会被误命中）。
+    """
+    src = (_PRODUCTION_SOURCE / "actions" / "_clone.py").read_text(encoding="utf-8")
+    forbidden_substrings = [
+        "intent_title",          # 不应读 ctx.intent_title
+        "get_issue",             # 不应主动 fetch BKD prompt body
+        "description",           # 不应解析 issue.description
+    ]
+    hits = [s for s in forbidden_substrings if s in src]
+    assert hits == [], (
+        f"_clone.py must NOT introspect free-text fields {hits} for repo slugs "
+        "(REQ-clone-fallback-direct-analyze-1777119520). Use explicit "
+        "`repo:<org>/<name>` tags or settings.default_involved_repos."
+    )
+
+
+def test_start_analyze_actions_pass_tags_and_default_to_clone():
+    """start_analyze + start_analyze_with_finalized_intent 必须透传 tags +
+    settings.default_involved_repos 给 _clone helper。"""
+    for action_filename in ("start_analyze.py", "start_analyze_with_finalized_intent.py"):
+        path = _PRODUCTION_SOURCE / "actions" / action_filename
+        text = path.read_text(encoding="utf-8")
+        assert "tags=tags" in text, (
+            f"{action_filename} must pass tags=tags to clone_involved_repos_into_runner "
+            "(REQ-clone-fallback-direct-analyze-1777119520)."
+        )
+        assert "default_repos=settings.default_involved_repos" in text, (
+            f"{action_filename} must pass default_repos=settings.default_involved_repos "
+            "to clone_involved_repos_into_runner "
+            "(REQ-clone-fallback-direct-analyze-1777119520)."
+        )
+
+
+def test_repo_tag_extraction_validates_slug():
+    """非法 slug 必须拒绝，不准把 `repo:invalid X` 当 repo 名扔给 helper。"""
+    out = _clone._extract_repo_tags([
+        "repo:phona/sisyphus",
+        "repo:bad slug",
+        "repo:no-slash",
+        "repo:/empty-org",
+        "repo:org/",
+        "repo:phona/repo-with.dots_and-dash",
+    ])
+    assert out == ["phona/sisyphus", "phona/repo-with.dots_and-dash"]


### PR DESCRIPTION
## Summary

REQ-clone-fallback-direct-analyze-1777119520

直接 analyze 入口（`intent:analyze` 一步到位，无 intake）现在 ctx 是空的
（webhook 只写 `{intent_issue_id, intent_title}`），`_clone._resolve_repos`
读两层 ctx 一定返 `[]`，server-side clone 整段跳过 → clone 完全甩给
`analyze.md.j2` Part A.3 的 agent prompt fallback。本 PR 把 `resolve_repos`
升 4 层 priority，新增两条显式 fallback：

| 层 | 来源 | 触发场景 |
|---|---|---|
| L1 | `ctx.intake_finalized_intent.involved_repos` | intake → analyze（**不变**） |
| L2 | `ctx.involved_repos` | 老 caller / 测试夹具（**不变**） |
| L3 | BKD intent issue tags `repo:<org>/<name>` | 直接 analyze 入口显式声明 |
| L4 | `settings.default_involved_repos` (env `SISYPHUS_DEFAULT_INVOLVED_REPOS`) | 单仓 / 默认仓部署 |

`start_analyze` + `start_analyze_with_finalized_intent` 都改成透传
`tags=tags, default_repos=settings.default_involved_repos`；intake 路径
正常 L1 命中不受影响。

## Why this matters

sisyphus self-dogfood（这个 REQ 自己就是个例子）走直接 analyze 入口时，
agent 必须自己 `kubectl exec runner -- /opt/sisyphus/scripts/sisyphus-clone-repos.sh phona/sisyphus`。
现在 ops 在 helm values 配一次 `SISYPHUS_DEFAULT_INVOLVED_REPOS=phona/sisyphus`
就能让 sisyphus 自动接管，agent 直接进 spec / dev。

## 故意不做

- **不**从 `intent_title` / BKD prompt body fuzzy parse `org/repo` slug —— 假阳性高
  （`src/orchestrator`、`M14b/M14c`、文档示例里的 `phona/foo` 都会误命中）。
  contract test `test_clone_helper_does_not_parse_intent_title_or_body` 锁死
  `_clone.py` 不准 import `intent_title` / `get_issue` / `description`。
- **不**改 `analyze.md.j2`。模板已按 `cloned_repos` 真假分支显示"sisyphus 已替你
  clone"或"自跑 helper"，4 层全 miss 时仍 fall through 到原 prompt fallback。
- **不**改 `pr_ci_watch` —— checker 已经从 `/workspace/source/*` 实地探测，
  本 REQ 只动 analyze 入口的 clone 决策。

## Test plan

- [x] `openspec validate REQ-clone-fallback-direct-analyze-1777119520` 通过
- [x] `scripts/check-scenario-refs.sh` 0 个 broken ref
- [x] `ruff check src/ tests/` 通过
- [x] 24 个新 / 改的 unit + contract test 全过（`tests/test_actions_start_analyze.py` + `tests/test_contract_clone_fallback_direct_analyze.py`）
- [x] 全 `pytest -m "not integration"` 套件 592 passed（12 个 makefile-related 失败是 Coder workspace 没装 `make`，跟本 PR 无关；sisyphus runner pod 里有 `make`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)