### PR TITLE
test(self): pipeline-validation no-op marker (REQ-validate-fresh-pipeline-1777123726)

### DIFF
--- a/openspec/changes/REQ-validate-fresh-pipeline-1777123726/proposal.md
+++ b/openspec/changes/REQ-validate-fresh-pipeline-1777123726/proposal.md
@@ -1,0 +1,63 @@
+# REQ-validate-fresh-pipeline-1777123726: test(self): tiny no-op REQ to validate full sisyphus pipeline closes
+
+## 问题
+
+最近一连串自 dogfood REQ（`REQ-makefile-ci-targets-1777110320` / `REQ-self-accept-stage-1777121797` 等）
+落地后，sisyphus 的状态机已经具备从 `analyze → spec_lint → dev_cross_check → staging_test →
+pr_ci_watch → accept → archive → DONE` 走通**自己仓**的端到端能力。但每一条变更都带"实
+际功能"，多块改动叠在一起一旦中间 stage 红，很难判断红的是 **stage 机械层**还是
+**业务变更本身**。
+
+我们需要一条**确定性 no-op REQ**做脚手架冒烟（pipeline-validation smoke）：把 stage 与
+业务 payload 解耦——若它在 fresh pipeline 上跑 escalate / fail，几乎可以肯定问题
+出在 sisyphus 自己（router / checker / accept stack / archive），而不是业务代码。
+
+## 根因
+
+历史 self-dogfood REQ 同时携带行为变更（修 Makefile target、改 accept compose、改
+checker 等），所以"管道整体能不能闭合到 DONE"这件事**从未在零业务面积下被独立验证过**。
+没有这种校准，每次 pipeline 红都是双因素归因（stage 的锅 vs 变更的锅）。
+
+## 方案
+
+加一个**纯标识**模块作为本 REQ 的产物：
+
+### `orchestrator/src/orchestrator/_pipeline_marker.py`
+
+仅暴露一个模块级常量 `PIPELINE_VALIDATION_REQ`，其值为本 REQ id 字符串
+`"REQ-validate-fresh-pipeline-1777123726"`。
+
+- **不在生产路径被 import** —— `engine.py` / `router.py` / `actions/*` / `checkers/*` 都不引用
+- **不导出到 `__init__`** —— 仓 root 没 `__init__.py`，其他模块也不会触达
+- **没有 docstring 之外的副作用** —— 模块加载即定义一个 `str` 常量，无 IO / 无网络 / 无
+  全局状态
+- **future-proofing**：今后再来一次 fresh-pipeline smoke，只需新建一个新 REQ，把这个常
+  量改成新 REQ id（一行 patch），即可重复使用模块作为脚手架
+
+### contract 单测
+
+`orchestrator/tests/test_contract_pipeline_marker.py` 用**白盒** import 验证：
+
+1. 模块可被 import（不抛异常）
+2. `PIPELINE_VALIDATION_REQ` 是字符串
+3. 字符串值匹配 `^REQ-validate-fresh-pipeline-\d+$`（pattern 比硬编码值稳健，下次 smoke
+   只需改 module 不改 test）
+4. 模块没有副作用：`importlib.import_module` 后再 reload 仍得到同一个常量
+
+仅 unit 套件（`make ci-unit-test`），**不**带 `@pytest.mark.integration` —— 本 REQ 不
+碰 integration 集合。
+
+## 取舍
+
+- **为什么 `_` 前缀** —— 标记 "私有 / 不属于公共 API"，避免有人误以为这是 orchestrator
+  对外约定的元数据；纯内部 smoke fixture
+- **为什么不直接在 `pyproject.toml` 加 metadata** —— pyproject 改动会触发 build/wheel 路
+  径敏感的 staging_test / accept compose；我们要的是 "代码加一个 byte 都不影响业务路径"
+  的真 no-op，新增一个游离 .py 是面积最小的形式
+- **为什么不 reuse 历史 REQ 的 marker** —— 历史 REQ 都有自己的业务负载（Makefile / 状态
+  机变更 / accept stack），它们的 contract test 假设了那些负载存在；本 REQ 必须有一个
+  **自己**的 contract artifact，否则 spec_lint 会因为"openspec change 内 zero scenarios
+  ↔ test 引用"失败
+- **为什么 spec 写在 capability `pipeline-marker` 而不是 `pipeline-validation`** —— 该
+  capability 描述的就是一个 **marker 模块**的存在性契约；将来扩展 smoke fixture 也都
+  归到这个 capability 下，名字更贴近实物

--- a/openspec/changes/REQ-validate-fresh-pipeline-1777123726/specs/pipeline-marker/spec.md
+++ b/openspec/changes/REQ-validate-fresh-pipeline-1777123726/specs/pipeline-marker/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: 仓内 MUST 提供 pipeline validation marker 模块
+
+The repository SHALL provide a module at the path
+`orchestrator/src/orchestrator/_pipeline_marker.py` whose sole responsibility is
+to expose a module-level string constant identifying the REQ that is exercising
+the sisyphus pipeline as a smoke / no-op validation. The module MUST NOT be
+imported by any production code path (engine / router / actions / checkers /
+prompts / store) and MUST NOT register any side-effect at import time (no IO,
+no network, no global mutation, no logging emission). The module's value to the
+project is purely as a self-dogfood scaffolding artifact: it gives every
+"validate-fresh-pipeline" smoke REQ a tiny, deterministic, no-op delta to ship,
+so the pipeline can be re-validated end-to-end without entangling the result
+with real business changes.
+
+#### Scenario: PVR-S1 module imports cleanly with zero side effects
+
+- **GIVEN** a fresh Python interpreter with `orchestrator/src` on `sys.path`
+- **WHEN** the test calls `importlib.import_module("orchestrator._pipeline_marker")`
+- **THEN** the import returns a module object without raising, and no log line,
+  network call, or filesystem write is observable as a side effect of the import
+
+### Requirement: marker 常量 MUST 是字符串且匹配 REQ-validate-fresh-pipeline-<digits> 命名
+
+The module `orchestrator._pipeline_marker` SHALL define a module-level attribute
+named `PIPELINE_VALIDATION_REQ`. The attribute MUST be a `str` instance, and
+its value MUST match the regular expression
+`^REQ-validate-fresh-pipeline-\d+$`. This pattern, rather than a hard-coded
+literal, is the contract: future pipeline-validation smoke REQs are expected
+to bump only the trailing timestamp / counter while keeping the prefix stable,
+so contract tests written today continue to pass against future smoke REQs
+without per-REQ test edits.
+
+#### Scenario: PVR-S2 constant is str and matches REQ pattern
+
+- **GIVEN** the module `orchestrator._pipeline_marker` has been imported
+- **WHEN** the test reads attribute `PIPELINE_VALIDATION_REQ` from the module
+- **THEN** the attribute is an instance of `str` and its value matches the
+  regex `^REQ-validate-fresh-pipeline-\d+$`
+
+#### Scenario: PVR-S3 re-import returns the same constant value
+
+- **GIVEN** the module has been imported once and `PIPELINE_VALIDATION_REQ`
+  was captured into a local variable `first`
+- **WHEN** the test invokes `importlib.reload` on the module and re-reads
+  `PIPELINE_VALIDATION_REQ` into `second`
+- **THEN** `first == second` (the module is referentially stable across
+  reloads, confirming there is no import-time randomness or env-driven branch)
+
+### Requirement: marker 模块 MUST NOT 被 re-export 到 orchestrator 包命名空间
+
+The constant `PIPELINE_VALIDATION_REQ` MUST be accessible only via the explicit
+submodule path `orchestrator._pipeline_marker.PIPELINE_VALIDATION_REQ`. It MUST
+NOT be re-exported from `orchestrator/__init__.py` (which today does not exist
+and SHALL remain absent for this REQ), nor surfaced through any other
+production module's `__all__` or attribute. This keeps the marker invisible
+to anyone reading the package's public surface and prevents accidental
+production reliance on a smoke fixture.
+
+#### Scenario: PVR-S4 marker constant is not present on orchestrator package object
+
+- **GIVEN** `orchestrator` has been imported as a package
+- **WHEN** the test inspects `dir(orchestrator)` and `getattr(orchestrator, "PIPELINE_VALIDATION_REQ", None)`
+- **THEN** `PIPELINE_VALIDATION_REQ` is NOT in `dir(orchestrator)` and the
+  `getattr` call returns `None` (the constant is reachable only via the
+  fully-qualified submodule path)

--- a/openspec/changes/REQ-validate-fresh-pipeline-1777123726/tasks.md
+++ b/openspec/changes/REQ-validate-fresh-pipeline-1777123726/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: REQ-validate-fresh-pipeline-1777123726
+
+## Stage: spec
+
+- [x] `openspec/changes/REQ-validate-fresh-pipeline-1777123726/proposal.md`
+- [x] `openspec/changes/REQ-validate-fresh-pipeline-1777123726/tasks.md`
+- [x] `openspec/changes/REQ-validate-fresh-pipeline-1777123726/specs/pipeline-marker/spec.md`
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/_pipeline_marker.py`：定义模块级常量
+  `PIPELINE_VALIDATION_REQ = "REQ-validate-fresh-pipeline-1777123726"`，无副作用，
+  不被生产模块引用
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_contract_pipeline_marker.py`：黑/白盒混合 contract test
+  - `test_pvr_s1_module_imports_cleanly` —— `importlib.import_module` 不抛
+  - `test_pvr_s2_constant_is_str_and_matches_req_pattern` —— 值匹配
+    `^REQ-validate-fresh-pipeline-\d+$`
+  - `test_pvr_s3_module_has_no_side_effects_on_reimport` —— 二次 import 同对象
+  - `test_pvr_s4_constant_is_not_re_exported_from_package` —— 仓 root 没
+    `__init__.py`，常量不出现在 `orchestrator` 命名空间
+
+## Stage: PR
+
+- [x] git push feat/REQ-validate-fresh-pipeline-1777123726
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/_pipeline_marker.py
+++ b/orchestrator/src/orchestrator/_pipeline_marker.py
@@ -1,0 +1,13 @@
+"""Pipeline-validation smoke marker (REQ-validate-fresh-pipeline-1777123726).
+
+Self-dogfood scaffolding: this module exists solely to give every
+"validate-fresh-pipeline" smoke REQ a tiny, deterministic, no-op delta. No
+production module imports it; the orchestrator's runtime behavior is unchanged
+whether this file is present or absent.
+
+See `openspec/changes/REQ-validate-fresh-pipeline-1777123726/proposal.md` for
+the rationale.
+"""
+from __future__ import annotations
+
+PIPELINE_VALIDATION_REQ: str = "REQ-validate-fresh-pipeline-1777123726"

--- a/orchestrator/tests/test_contract_pipeline_marker.py
+++ b/orchestrator/tests/test_contract_pipeline_marker.py
@@ -1,0 +1,48 @@
+"""Contract tests for REQ-validate-fresh-pipeline-1777123726.
+
+Black/white-box behavioral contracts derived from:
+  openspec/changes/REQ-validate-fresh-pipeline-1777123726/specs/pipeline-marker/spec.md
+
+Scenarios covered:
+  PVR-S1   module imports cleanly with zero observable side effects
+  PVR-S2   PIPELINE_VALIDATION_REQ is a str matching ^REQ-validate-fresh-pipeline-\\d+$
+  PVR-S3   importlib.reload returns the same constant value
+  PVR-S4   constant is not re-exported from the orchestrator package
+"""
+from __future__ import annotations
+
+import importlib
+import re
+
+PVR_PATTERN = re.compile(r"^REQ-validate-fresh-pipeline-\d+$")
+
+
+def test_pvr_s1_module_imports_cleanly() -> None:
+    mod = importlib.import_module("orchestrator._pipeline_marker")
+    assert mod is not None
+    assert mod.__name__ == "orchestrator._pipeline_marker"
+
+
+def test_pvr_s2_constant_is_str_and_matches_req_pattern() -> None:
+    from orchestrator import _pipeline_marker
+
+    value = _pipeline_marker.PIPELINE_VALIDATION_REQ
+    assert isinstance(value, str)
+    assert PVR_PATTERN.match(value), (
+        f"PIPELINE_VALIDATION_REQ={value!r} does not match {PVR_PATTERN.pattern}"
+    )
+
+
+def test_pvr_s3_module_has_no_side_effects_on_reimport() -> None:
+    mod = importlib.import_module("orchestrator._pipeline_marker")
+    first = mod.PIPELINE_VALIDATION_REQ
+    reloaded = importlib.reload(mod)
+    second = reloaded.PIPELINE_VALIDATION_REQ
+    assert first == second
+
+
+def test_pvr_s4_constant_is_not_re_exported_from_package() -> None:
+    import orchestrator
+
+    assert "PIPELINE_VALIDATION_REQ" not in dir(orchestrator)
+    assert getattr(orchestrator, "PIPELINE_VALIDATION_REQ", None) is None


### PR DESCRIPTION
## 动机

Self-dogfood scaffolding REQ — 落一条**确定性 no-op delta**，唯一目的是把 sisyphus
管道从头到尾跑一遍 (`analyze → spec_lint → dev_cross_check → staging_test →
pr_ci_watch → accept → archive → DONE`)，把 stage 机械层与业务 payload 解耦。
若管道在这条 PR 上跑红，几乎一定是 sisyphus 自己的问题（router / checker /
accept stack / archive），不是业务变更的问题。

## 改动

- `orchestrator/src/orchestrator/_pipeline_marker.py` (new, 13 lines): 暴露模块级
  `PIPELINE_VALIDATION_REQ: str = "REQ-validate-fresh-pipeline-1777123726"`。
  - 不被任何生产模块 import
  - 加载时无副作用（无 IO / 无网络 / 无全局状态）
  - 不出现在 `orchestrator` 包命名空间（仓 root 没 `__init__.py`，常量仅经
    `orchestrator._pipeline_marker.PIPELINE_VALIDATION_REQ` 可达）
- `orchestrator/tests/test_contract_pipeline_marker.py` (new, 4 tests): 覆盖 4 个
  scenario：
  - PVR-S1 模块 import 干净
  - PVR-S2 常量是 `str` 且匹配 `^REQ-validate-fresh-pipeline-\d+$`
  - PVR-S3 `importlib.reload` 后值不变
  - PVR-S4 常量未 re-export 到 `orchestrator` 包命名空间
- `openspec/changes/REQ-validate-fresh-pipeline-1777123726/`: proposal / tasks /
  specs（delta 格式，每 requirement body 含 SHALL/MUST，scenarios 用
  `#### Scenario: <ID>` 格式）

## 取舍

- **未来 reuse**：下一次 fresh-pipeline smoke 只需新建一个新 REQ，把常量字面量
  改成新 REQ id 即可；contract test 的正则与具体 timestamp 解耦，无需改。
- **为什么不直接改 pyproject.toml metadata**：pyproject 改动会触发 build / wheel
  路径敏感的 staging_test / accept compose；新增一个游离 `.py` 是面积最小的真
  no-op。
- **为什么 `_` 前缀**：标记"私有 / 不属公共 API"，避免被误用为 orchestrator 对外
  元数据。

## Test plan

- [x] `openspec validate REQ-validate-fresh-pipeline-1777123726` → valid
- [x] `scripts/check-scenario-refs.sh --specs-search-path . .` → 131 refs OK
- [x] `cd orchestrator && uv run ruff check src/ tests/` → All checks passed
- [x] `BASE_REV=$(git merge-base HEAD origin/main) make ci-lint` → scoped to 2
      files, all clean
- [x] `make ci-unit-test` → 633 passed (含 PVR-S1..S4 4 项新增)
- [x] `make ci-integration-test` → 0 collected (exit 5 → 视为 pass)
- [ ] sisyphus pipeline accept stage → 由 sisyphus 机械 checker 验
- [ ] 全管道闭合到 DONE → 本 REQ 的最终验收

REQ-id: `REQ-validate-fresh-pipeline-1777123726`