### PR TITLE
feat(observability): Q18 silent-pass detector for mechanical checkers

### DIFF
--- a/observability/queries/sisyphus/18-silent-pass-detector.sql
+++ b/observability/queries/sisyphus/18-silent-pass-detector.sql
@@ -1,0 +1,85 @@
+-- Q18: 机械 checker silent-pass 检测
+--
+-- 数据源：sisyphus 主库（orchestrator）→ 表 artifact_checks
+-- 用途：找最近 24h `passed=true` 但**疑似没真跑**的 checker 记录 —— 即"沉默通过"。
+--   spec_lint / dev_cross_check / staging_test / pr_ci_watch 各自源代码里写了
+--   "refusing to silent-pass" 的 guard（empty-source / ran=0 / no-gha-checks-ran），
+--   设计上零信号即 fail。本 query 是**事后兜底**：万一 guard 失效或被绕过，
+--   能从 metrics 层把"通过了但其实没干活"的样本捞出来人工 review。
+--
+-- 三类信号（CASE 优先级从严到松）：
+--   guard-leak  stdout/stderr 命中 "refusing to silent-pass" 但 passed=true
+--               → checker 内有逻辑 bug：guard 行打了但 exit code 仍是 0
+--   no-gha-pass pr_ci_watch 在 stdout 留下 "no-gha-checks-ran" 但 passed=true
+--               → _classify 返回 no-gha 走 fail 分支，passed=true 不可能；
+--                 出现说明分类逻辑被改坏或 stdout 串被复用
+--   too-fast    duration_sec < 0.2 × 同 stage 7d P50（passed=true 样本）
+--               → 跑得比中位数快 5×，大概率是脚本短路（grep 不到 → for 循环没跑 →
+--                 ran=0 guard 没正确生效）。和 Q2（慢异常）是对称的快异常
+--
+-- 推荐告警阈值：
+--   - 命中 1 行 silent_pass_kind ∈ ('guard-leak', 'no-gha-pass') → 立即介入
+--     这两类信号在 checker 源码里已经设计成不可达 path，出现就是有 bug
+--   - silent_pass_kind = 'too-fast' 单日 ≥ 3 条同 stage → 重算 P50 基线 / 查脚本短路
+--
+-- 列含义：
+--   req_id           疑似 silent-pass 的 REQ
+--   stage            sisyphus 阶段（spec_lint / dev_cross_check / staging_test / pr_ci_watch）
+--   silent_pass_kind 触发哪类信号（见上方 CASE）
+--   duration_sec     当次 check 实际耗时
+--   p50_sec          同 stage 7d passed=true 样本的中位数（基线）
+--   ratio            duration_sec / p50_sec（ < 0.2 视为异常）
+--   evidence         stdout_tail + stderr_tail 各取首段（300 字符），人工 triage 用
+--   cmd              具体命令
+--   checked_at       发生时间
+--
+-- 样本不足（同 stage 7d passed=true 样本 < 20）→ 跳过该 stage 的 too-fast 判断，
+-- 但 guard-leak / no-gha-pass 仍照常输出（绝对信号，不依赖基线）。
+
+WITH baseline AS (
+    SELECT
+        stage,
+        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY duration_sec) AS p50_sec
+    FROM artifact_checks
+    WHERE checked_at > now() - interval '7 days'
+      AND duration_sec IS NOT NULL
+      AND passed = true
+    GROUP BY stage
+    HAVING COUNT(*) >= 20
+)
+SELECT
+    c.req_id,
+    c.stage,
+    CASE
+        WHEN COALESCE(c.stdout_tail, '') || COALESCE(c.stderr_tail, '')
+             ILIKE '%refusing to silent-pass%'                THEN 'guard-leak'
+        WHEN COALESCE(c.stdout_tail, '') ILIKE '%no-gha-checks-ran%' THEN 'no-gha-pass'
+        WHEN c.duration_sec < b.p50_sec * 0.2                 THEN 'too-fast'
+    END                                                       AS silent_pass_kind,
+    ROUND(c.duration_sec::numeric, 2)                         AS duration_sec,
+    ROUND(b.p50_sec::numeric, 2)                              AS p50_sec,
+    ROUND((c.duration_sec / NULLIF(b.p50_sec, 0))::numeric, 2) AS ratio,
+    LEFT(
+        COALESCE(c.stdout_tail, '') || ' | ' || COALESCE(c.stderr_tail, ''),
+        300
+    )                                                          AS evidence,
+    c.cmd,
+    c.checked_at
+FROM artifact_checks c
+LEFT JOIN baseline b USING (stage)
+WHERE c.checked_at > now() - interval '24 hours'
+  AND c.passed = true
+  AND (
+        COALESCE(c.stdout_tail, '') || COALESCE(c.stderr_tail, '')
+            ILIKE '%refusing to silent-pass%'
+     OR COALESCE(c.stdout_tail, '') ILIKE '%no-gha-checks-ran%'
+     OR (b.p50_sec IS NOT NULL AND c.duration_sec < b.p50_sec * 0.2)
+  )
+ORDER BY
+    CASE
+        WHEN COALESCE(c.stdout_tail, '') || COALESCE(c.stderr_tail, '')
+             ILIKE '%refusing to silent-pass%' THEN 0
+        WHEN COALESCE(c.stdout_tail, '') ILIKE '%no-gha-checks-ran%' THEN 1
+        ELSE 2
+    END,
+    c.checked_at DESC;

--- a/observability/sisyphus-dashboard.md
+++ b/observability/sisyphus-dashboard.md
@@ -176,6 +176,30 @@ M7 原 5 条（Q1–Q5）基于 `artifact_checks`。M14e 追加 8 条（Q6–Q13
   - `test_changes > src_changes` 且 `test_changes ≥ 5` → fixer 改测试比改代码还多，可疑
   - `spec_changes` 持续增长 → fixer 在改 spec 迎合实现，spec-drift 告警
 
+## 机械 checker silent-pass（Q18）
+
+`spec_lint` / `dev_cross_check` / `staging_test` / `pr_ci_watch` 各自源代码里都有
+`refusing to silent-pass` guard（empty source / `ran=0` / `no-gha-checks-ran`），
+设计上"零信号即 fail"。Q18 是**事后兜底**：从 `artifact_checks` 已落表的样本里
+反查"通过了但其实没干活"的记录，万一 guard 失效或脚本被改坏可以从指标层捞回来。
+
+跟 Q14–Q16 的 fixer audit（agent 主观作弊）正交：那套针对 agent 的修复是否合规；
+本节针对**机械层**自身的"假阳性 pass"，互不重叠。
+
+### Q18. Silent-pass detector（机械 checker 沉默通过）
+
+- **SQL**：[queries/sisyphus/18-silent-pass-detector.sql](queries/sisyphus/18-silent-pass-detector.sql)
+- **Visualization**：Table（列顺序：`req_id, stage, silent_pass_kind, duration_sec, p50_sec, ratio, evidence, cmd, checked_at`），按 `silent_pass_kind` 升序 + `checked_at` 降序排
+  - 条件格式：`silent_pass_kind ∈ ('guard-leak', 'no-gha-pass')` 整行标红
+- **三类信号**：
+  - `guard-leak` —— stdout/stderr 命中 `refusing to silent-pass` 但 `passed=true`：checker 内部 guard 触发了告警 line 但 exit code 还是 0，**checker 实现 bug**
+  - `no-gha-pass` —— pr_ci_watch 留了 `no-gha-checks-ran` 但 `passed=true`：`_classify` 返回 `no-gha` 时本应 fail，出现说明分类逻辑被改坏
+  - `too-fast` —— `duration_sec < 0.2 × 同 stage 7d P50（passed=true 样本）`：跑得比中位数快 5×，多半是脚本短路（`for ... in /workspace/source/*` 循环没进 body），和 Q2（慢异常）对称
+- **人工介入阈值**：
+  - 任意 `guard-leak` 或 `no-gha-pass` 行 → 立即介入，检查 checker 源码
+  - `too-fast` 单日 ≥ 3 条同 stage → 重算 P50 基线 / 查脚本短路（per-repo for 循环 / git fetch 静默失败）
+- **基线说明**：P50 用同 stage 7d `passed=true` 样本，`HAVING COUNT(*) ≥ 20` 跳过样本不足的 stage（避免 too-fast 误报）。`guard-leak` / `no-gha-pass` 不依赖基线，无样本要求。
+
 ## 看板布局
 
 推荐两列布局（Metabase Dashboard，gridsize 18×? 自适应）：
@@ -226,6 +250,15 @@ Q12/Q13 是"此刻在出事吗"，放最上；Q6/Q8 是周度趋势；Q9/Q11 是
 └─────────────────────────────────────────────────────────────┘
 ```
 
+**机械 checker silent-pass 看板（建议挂 M7 看板底部，跟 Q1 同一界面方便对照）**：
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Q18. Silent-pass detector（机械 checker 沉默通过）           │
+│  (table 全宽，guard-leak / no-gha-pass 行标红)                │
+└─────────────────────────────────────────────────────────────┘
+```
+
 ## 刷新频率
 
 M7 看板：
@@ -238,7 +271,10 @@ M14e 质量看板：
 - Q6 / Q8 / Q9 / Q11：每 1 小时（趋势类，不频繁）
 - Q7 / Q10：每 1 小时
 
-Metabase Question 设置 `Results cache TTL`：Q5/Q1 设 30s，Q2/Q3/Q4/Q12/Q13 设 120s，其余设 1800s。
+机械 checker silent-pass 看板：
+- Q18：每 5 分钟（和 Q2 同一节奏；guard-leak / no-gha-pass 出现等于"checker 实现有 bug"，越早发现越好）
+
+Metabase Question 设置 `Results cache TTL`：Q5/Q1 设 30s，Q2/Q3/Q4/Q12/Q13/Q18 设 120s，其余设 1800s。
 
 ## 告警（后续 issue，不在 M7 范围）
 
@@ -247,6 +283,7 @@ Metabase Question 设置 `Results cache TTL`：Q5/Q1 设 30s，Q2/Q3/Q4/Q12/Q13 
 - Q1：`row count > 0 AND max(fail_count) ≥ 5` → Lark
 - Q5：`row count > 0` WHERE `stuck_min > 30 AND last_passed = false` → Lark
 - Q3：新建 Question "任何 stage pass_rate_pct < 50%" → Lark
+- Q18：`row count > 0` WHERE `silent_pass_kind IN ('guard-leak','no-gha-pass')` → Lark（这两类是 checker 实现 bug，应当永远没行）
 
 阈值都可在 Metabase UI 里直接改，不用动 SQL。
 

--- a/openspec/changes/REQ-metabase-silent-pass-detector-1777123726/proposal.md
+++ b/openspec/changes/REQ-metabase-silent-pass-detector-1777123726/proposal.md
@@ -1,0 +1,97 @@
+# REQ-metabase-silent-pass-detector-1777123726: feat(observability): Q18 silent-pass detector for mechanical checkers
+
+## 问题
+
+`spec_lint` / `dev_cross_check` / `staging_test` / `pr_ci_watch` 各自源代码里都
+显式写了 `refusing to silent-pass` guard：
+
+- `orchestrator/src/orchestrator/checkers/spec_lint.py:42-78` — `/workspace/source` 不存在 / 没子目录 / `ran=0` 都直接 `exit 1`
+- `orchestrator/src/orchestrator/checkers/dev_cross_check.py:38-75` — 同结构
+- `orchestrator/src/orchestrator/checkers/staging_test.py:48-87` — 同结构
+- `orchestrator/src/orchestrator/checkers/pr_ci_watch.py:329-365` — `_classify` 在全绿但 0 条 GHA check-run 时返 `no-gha`，调度方按 fail 分支处理（`no-gha-checks-ran` 上 stdout）
+
+设计上"零信号即 fail"，但**只有源码层**这一道防线。一旦：
+
+1. checker 脚本里某行 `[ "$ran" -eq 0 ]` guard 被改坏（或 `[` 语法手误，bash 退出码不是 1 而是 0）
+2. `_classify` 里被加进新 conclusion 但忘了归到 fail 分支
+3. for 循环静默吃掉错误（如 `git fetch ...; ...; (cd $repo && ... ) || true` 之类的修改）
+
+→ checker 报 `passed=true`（`exit_code=0`）但**实际啥也没跑**。这种"沉默通过"
+状态机会以为本仓全绿继续推下一 stage，最坏情况合掉一个根本没过测试的 PR。
+
+`artifact_checks` 表里其实**有**这种 silent-pass 的痕迹：
+
+- 一旦 guard 被绕过但 `=== FAIL spec_lint: ... refusing to silent-pass ===` 这种 stderr 留在了 `stderr_tail` 里 → 痕迹
+- pr_ci_watch 在 stdout_tail 留 `no-gha-checks-ran` 但 passed=true → 痕迹
+- duration_sec 异常短（远低于同 stage P50）= 脚本短路 → 痕迹
+
+但当前看板（Q1–Q16）**没有任何一条 SQL** 把这类样本捞出来 —— Q1 看 fail_count，
+Q2 看慢异常，Q3 看通过率，都是 `passed=true` 直接信任的；Q14–Q16 看 fixer audit
+（agent 主观作弊），不是机械层 silent-pass。
+
+## 根因
+
+机械 checker 的 silent-pass 现在是"靠源码 review 兜底"，没有 metrics 层
+defense-in-depth。文档 [docs/integration-contracts.md](../../../docs/integration-contracts.md)
+和 [docs/architecture.md](../../../docs/architecture.md) 反复强调"零信号即 fail" 是
+sisyphus 哲学之一，但没有看板帮人**反查源码是否还在这条哲学之内**。
+
+## 方案
+
+补一条 SQL（Q18）+ 一段 [observability/sisyphus-dashboard.md](../../../observability/sisyphus-dashboard.md)
+说明，从 `artifact_checks` 已落表样本反查"通过了但其实没干活"的记录。
+
+不动 checker 源码，不加新表 / 列，不改 schema / migration。**纯观测增量**。
+
+### 三类信号（CASE 优先级从严到松）
+
+| 信号 | 触发条件（passed=true 前提下） | 含义 |
+|---|---|---|
+| `guard-leak` | `stdout_tail`+`stderr_tail` 命中 `refusing to silent-pass` | guard 行打了但 exit code 还是 0 → checker 实现 bug |
+| `no-gha-pass` | `stdout_tail` 命中 `no-gha-checks-ran` | `_classify` 走到 no-gha 分支但 passed=true → pr_ci_watch 分类逻辑被改坏 |
+| `too-fast` | `duration_sec < 0.2 × 同 stage 7d P50（passed=true 样本）` | 跑得比中位数快 5×，多半是 for 循环没进 body |
+
+`guard-leak` / `no-gha-pass` 是绝对信号（不依赖基线），任意命中即立即介入。
+`too-fast` 是统计异常，需要同 stage 7d passed=true 样本 ≥ 20 才计算（避免小样本噪声，
+和 Q2 慢异常一致）。
+
+### 文件落点
+
+- 新增 `observability/queries/sisyphus/18-silent-pass-detector.sql`
+- 在 `observability/sisyphus-dashboard.md` 加一节"机械 checker silent-pass（Q18）"，
+  跟"Fixer Audit（Q14–Q16）"并列，说明三类信号 + Visualization + 阈值
+- 看板布局 + 刷新频率 + 告警章节同步追加 Q18 行
+
+### Verify
+
+- `openspec validate openspec/changes/REQ-metabase-silent-pass-detector-1777123726 --strict` 通过
+- `psql -d sisyphus -f observability/queries/sisyphus/18-silent-pass-detector.sql` 在干净库上 SQL 解析通过（语法 / 列名 / 类型）
+- 在生产 metabase 接入 Postgres 数据源后**手动**跑一次 SQL → 应当 0 行（生产没 silent-pass）
+- `make ci-lint && make ci-unit-test` 在 self-dogfood 下不打破（零 Python 改动只须不引入 lint）
+
+## 取舍
+
+- **为什么 Q 编号是 18 不是 14（REQ 名里的标签）** —— Q14 已经被
+  [Fixer audit verdict trend](../../../observability/queries/sisyphus/14-fixer-audit-verdict-trend.sql)
+  占了（migration 0006 之后引入），后续 Q15 / Q16 / Q17 也都已存在文件。
+  REQ 命名时 user 不知道这个冲突，实际下一个可用槽是 Q18。改 REQ 名会动 BKD issue
+  和 git ref，不值得；只在 proposal / dashboard md 里清楚说明 "REQ 名里的 Q14
+  对应实际 Q18"即可。文件名（`18-silent-pass-detector.sql`）跟 dashboard md 章节
+  标题（"Q18. Silent-pass detector"）保持一致。
+- **为什么不在 checker 源码里加机械防御** —— 已经有 `[ "$ran" -eq 0 ] && exit 1`
+  + `set -o pipefail` 这套；本 REQ 是 metrics 层兜底，跟源码层 guard 是 defense-in-depth
+  的**两道**而不是替代。改源码再加一层意义不大，反而 metrics 兜底能 catch "源码本身被改坏"
+  的场景（最危险的那种）。
+- **为什么不针对 `stage_runs` 也写一份** —— `stage_runs` 是 agent 侧（埋点尚未全覆盖），
+  本 REQ 只关注**机械 checker** 的 silent-pass（artifact_checks 已是稳态全覆盖）。
+  agent 侧 silent-pass（agent 报 pass 但没真做事）由 verifier audit Q15 已经覆盖。
+- **为什么 too-fast 阈值用 P50 × 0.2 而不是 P50 × 0.1 或绝对秒数** —— 0.2 给 5 倍的
+  容差区，足够 catch "for 循环没进 body" 这种数量级偏差，又不会被同 stage 自然 variance
+  误报。绝对秒数无法兼容 spec_lint（基线 1–3s）和 staging_test（基线 几分钟）两种
+  数量级。和 Q2（慢异常）的 `× 2` 是对称设计。
+- **为什么 too-fast 要求样本 ≥ 20** —— 同 Q2，小样本 P50 噪声大，stage 刚开始用没历史
+  时直接 silent-pass-kind=NULL 跳过比误报安全。`guard-leak` / `no-gha-pass` 不依赖
+  基线，无样本要求。
+- **为什么不同时落 Metabase Question JSON / dashboard JSON** —— 跟 Q1–Q17 一致，本 repo
+  只维护 SQL + md；Metabase Question 由人工导入（dashboard.md §"数据源"段已说明）。
+  导出 JSON 增加 schema 维护负担，目前 sisyphus 没自动化 metabase migration。

--- a/openspec/changes/REQ-metabase-silent-pass-detector-1777123726/specs/silent-pass-detector/spec.md
+++ b/openspec/changes/REQ-metabase-silent-pass-detector-1777123726/specs/silent-pass-detector/spec.md
@@ -1,0 +1,181 @@
+# silent-pass-detector Specification
+
+## ADDED Requirements
+
+### Requirement: Q18 SQL MUST detect three classes of silent-pass signals over the last 24h
+
+The system SHALL ship a SQL file at
+`observability/queries/sisyphus/18-silent-pass-detector.sql` that scans the
+`artifact_checks` table for rows whose `passed = true` AND `checked_at >
+now() - interval '24 hours'`, classifying each match into exactly one
+`silent_pass_kind` column out of `'guard-leak'`, `'no-gha-pass'`, or
+`'too-fast'`. The query MUST emit at minimum the columns `req_id`, `stage`,
+`silent_pass_kind`, `duration_sec`, `p50_sec`, `ratio`, `evidence`, `cmd`,
+and `checked_at`, so that an operator reading the Metabase table can
+attribute each suspicious row to a REQ + stage and inspect the captured
+checker output without re-querying.
+
+#### Scenario: Q18-S1 SQL file exists at the canonical path
+
+- **GIVEN** the working tree at the head of feat/REQ-metabase-silent-pass-detector-1777123726
+- **WHEN** `ls observability/queries/sisyphus/18-silent-pass-detector.sql` runs
+- **THEN** the file exists and is non-empty
+
+#### Scenario: Q18-S2 SQL filters to passed=true within 24h window
+
+- **GIVEN** the SQL file `18-silent-pass-detector.sql` is read
+- **WHEN** the WHERE clause is parsed
+- **THEN** it contains both `c.passed = true` AND `c.checked_at > now() - interval '24 hours'` (case-insensitive on identifiers)
+
+#### Scenario: Q18-S3 silent_pass_kind CASE branches cover the three signals
+
+- **GIVEN** the SQL file `18-silent-pass-detector.sql` is read
+- **WHEN** the SELECT-list `silent_pass_kind` CASE expression is parsed
+- **THEN** it produces literal string values `'guard-leak'`, `'no-gha-pass'`, AND `'too-fast'` in three distinct WHEN branches
+
+#### Scenario: Q18-S4 output columns include req_id / stage / kind / duration / baseline / ratio / evidence / cmd / checked_at
+
+- **GIVEN** the SQL file `18-silent-pass-detector.sql` is read
+- **WHEN** the top-level SELECT list is parsed
+- **THEN** it projects columns named (or aliased) `req_id`, `stage`, `silent_pass_kind`, `duration_sec`, `p50_sec`, `ratio`, `evidence`, `cmd`, `checked_at`
+
+### Requirement: guard-leak signal MUST mirror the literal "refusing to silent-pass" marker emitted by checker source
+
+The system SHALL classify an `artifact_checks` row as
+`silent_pass_kind = 'guard-leak'` when `passed = true` AND the concatenation
+of `stdout_tail` and `stderr_tail` matches the literal substring
+`refusing to silent-pass` (case-insensitive). This signal MUST take
+precedence over `no-gha-pass` and `too-fast` in the CASE evaluation order,
+because the marker is emitted directly by the
+`spec_lint` / `dev_cross_check` / `staging_test` checker scripts when
+their internal empty-source / `ran=0` guard fires — its presence alongside
+`passed=true` proves the guard fired but exit code stayed 0, which is a
+checker implementation bug that MUST surface immediately regardless of
+duration baselines.
+
+#### Scenario: Q18-S5 guard-leak literal "refusing to silent-pass" matches checker source
+
+- **GIVEN** `orchestrator/src/orchestrator/checkers/spec_lint.py`, `dev_cross_check.py`, and `staging_test.py` are scanned
+- **WHEN** `grep -c 'refusing to silent-pass'` runs across those three files
+- **THEN** each file has at least 2 hits (matches the literal the SQL pattern depends on, so spec ↔ source stays in sync)
+
+#### Scenario: Q18-S6 SQL ILIKE pattern uses literal substring "refusing to silent-pass"
+
+- **GIVEN** the SQL file `18-silent-pass-detector.sql` is read
+- **WHEN** the WHERE clause and the silent_pass_kind CASE are parsed
+- **THEN** both reference the literal string `refusing to silent-pass` via ILIKE pattern `%refusing to silent-pass%`
+
+#### Scenario: Q18-S7 guard-leak takes precedence over no-gha-pass and too-fast
+
+- **GIVEN** the SQL file `18-silent-pass-detector.sql` is read
+- **WHEN** the silent_pass_kind CASE expression is parsed
+- **THEN** the WHEN branch testing `refusing to silent-pass` appears textually before the WHEN branch testing `no-gha-checks-ran` AND before the WHEN branch testing the duration ratio
+
+### Requirement: no-gha-pass signal MUST mirror the literal "no-gha-checks-ran" marker emitted by pr_ci_watch source
+
+The system SHALL classify an `artifact_checks` row as
+`silent_pass_kind = 'no-gha-pass'` when `passed = true` AND `stdout_tail`
+matches the literal substring `no-gha-checks-ran` (case-insensitive). This
+signal MUST take precedence over `too-fast`, because
+`orchestrator/src/orchestrator/checkers/pr_ci_watch.py:_classify` returns
+`'no-gha'` for the all-green-but-zero-GHA-check-runs verdict and the caller
+treats that as fail — so an `artifact_checks` row carrying both `passed=true`
+AND that marker proves the classification logic was changed in a way that
+broke the fail path.
+
+#### Scenario: Q18-S8 SQL ILIKE pattern uses literal substring "no-gha-checks-ran"
+
+- **GIVEN** the SQL file `18-silent-pass-detector.sql` is read
+- **WHEN** the WHERE clause and the silent_pass_kind CASE are parsed
+- **THEN** both reference the literal string `no-gha-checks-ran` via ILIKE pattern `%no-gha-checks-ran%`
+
+#### Scenario: Q18-S9 no-gha-pass literal matches pr_ci_watch source
+
+- **GIVEN** `orchestrator/src/orchestrator/checkers/pr_ci_watch.py` is scanned
+- **WHEN** `grep -c 'no-gha-checks-ran'` runs
+- **THEN** the file has at least 1 hit (matches the literal the SQL depends on)
+
+### Requirement: too-fast signal MUST use a 7d per-stage P50 baseline of passed-true samples with a 20-sample minimum
+
+The system SHALL define a CTE named `baseline` that computes
+`PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY duration_sec)` per `stage` over
+`artifact_checks` rows where `checked_at > now() - interval '7 days'`,
+`duration_sec IS NOT NULL`, AND `passed = true`. The CTE MUST apply
+`HAVING COUNT(*) >= 20` to drop stages with insufficient samples. The
+top-level SELECT MUST then classify a row as
+`silent_pass_kind = 'too-fast'` only when the joined baseline `p50_sec`
+exists AND `c.duration_sec < b.p50_sec * 0.2`. Stages with insufficient
+samples MUST NOT emit `too-fast` rows (no false positives from small
+samples), but MUST still emit `guard-leak` / `no-gha-pass` rows because
+those signals are absolute and do not depend on the baseline.
+
+#### Scenario: Q18-S10 baseline CTE filters to passed=true samples over 7d
+
+- **GIVEN** the SQL file `18-silent-pass-detector.sql` is read
+- **WHEN** the `baseline` CTE body is parsed
+- **THEN** the WHERE clause contains `passed = true` AND `checked_at > now() - interval '7 days'` AND `duration_sec IS NOT NULL`
+
+#### Scenario: Q18-S11 baseline CTE uses PERCENTILE_CONT(0.5) per stage
+
+- **GIVEN** the SQL file `18-silent-pass-detector.sql` is read
+- **WHEN** the `baseline` CTE body is parsed
+- **THEN** the SELECT computes `PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY duration_sec)` AND the GROUP BY is on `stage`
+
+#### Scenario: Q18-S12 baseline CTE drops stages with fewer than 20 samples
+
+- **GIVEN** the SQL file `18-silent-pass-detector.sql` is read
+- **WHEN** the `baseline` CTE body is parsed
+- **THEN** it contains `HAVING COUNT(*) >= 20`
+
+#### Scenario: Q18-S13 too-fast threshold uses 0.2 × P50
+
+- **GIVEN** the SQL file `18-silent-pass-detector.sql` is read
+- **WHEN** the silent_pass_kind CASE and the WHERE clause are parsed
+- **THEN** both express the too-fast condition as `duration_sec < ... p50_sec * 0.2` (using whatever alias the CTE binds to p50_sec)
+
+#### Scenario: Q18-S14 stages without baseline still emit guard-leak / no-gha-pass rows
+
+- **GIVEN** the SQL file `18-silent-pass-detector.sql` is read
+- **WHEN** the JOIN between `artifact_checks` and `baseline` is parsed
+- **THEN** it is a LEFT JOIN (so rows survive when no baseline exists), AND the WHERE clause guards the duration check with `b.p50_sec IS NOT NULL` so absent-baseline rows can still match the absolute markers
+
+### Requirement: dashboard md MUST publish Q18 documentation with visualization, three signal kinds, layout, refresh, and alert rules
+
+The document `observability/sisyphus-dashboard.md` SHALL contain a section
+introducing Q18 that names all three `silent_pass_kind` values
+(`guard-leak`, `no-gha-pass`, `too-fast`) and links to
+`queries/sisyphus/18-silent-pass-detector.sql`. The section MUST specify
+the visualization (Table) and intervention thresholds. The dashboard
+layout, refresh-frequency, and alert sections MUST be amended in the same
+document so a reader who only consults the dashboard md can wire Q18 into
+Metabase without reading the SQL itself.
+
+#### Scenario: Q18-S15 dashboard md introduces Q18 section with the SQL link
+
+- **GIVEN** the file `observability/sisyphus-dashboard.md` is read
+- **WHEN** the heading `### Q18.` (or its body) is parsed
+- **THEN** it links to `queries/sisyphus/18-silent-pass-detector.sql` AND names all three values `guard-leak`, `no-gha-pass`, `too-fast`
+
+#### Scenario: Q18-S16 dashboard md publishes Visualization=Table for Q18
+
+- **GIVEN** the Q18 section of `observability/sisyphus-dashboard.md`
+- **WHEN** the Visualization line is read
+- **THEN** the visualization is `Table` AND the column order names `req_id`, `stage`, `silent_pass_kind`, `duration_sec`, `p50_sec`, `ratio`, `evidence`, `cmd`, `checked_at`
+
+#### Scenario: Q18-S17 dashboard layout section adds a Q18 frame
+
+- **GIVEN** `observability/sisyphus-dashboard.md` is read
+- **WHEN** the "看板布局" section is parsed
+- **THEN** it includes a frame mentioning `Q18` so Q18 has a designated dashboard slot
+
+#### Scenario: Q18-S18 dashboard refresh-frequency section names Q18
+
+- **GIVEN** `observability/sisyphus-dashboard.md` is read
+- **WHEN** the "刷新频率" section is parsed
+- **THEN** it names `Q18` with a refresh cadence (5 minute target, matching Q2)
+
+#### Scenario: Q18-S19 dashboard alert section adds Q18 trigger for guard-leak / no-gha-pass
+
+- **GIVEN** `observability/sisyphus-dashboard.md` is read
+- **WHEN** the "告警" section is parsed
+- **THEN** it lists `Q18` alongside an alert condition naming both `guard-leak` AND `no-gha-pass`

--- a/openspec/changes/REQ-metabase-silent-pass-detector-1777123726/tasks.md
+++ b/openspec/changes/REQ-metabase-silent-pass-detector-1777123726/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: REQ-metabase-silent-pass-detector-1777123726
+
+## Stage: spec
+
+- [x] `proposal.md` 详述根因 + 方案 + 三类信号定义 + 取舍
+- [x] `specs/silent-pass-detector/spec.md`（ADDED Requirements + Scenarios，覆盖三类信号 + 基线 + dashboard 说明）
+- [x] `tasks.md`（本文件，每个 checkbox 反映真实交付状态）
+
+## Stage: implementation
+
+- [x] 新增 `observability/queries/sisyphus/18-silent-pass-detector.sql` — 三类信号 CASE + 7d P50 baseline CTE + 24h 窗口
+- [x] `observability/sisyphus-dashboard.md` 加 "机械 checker silent-pass（Q18）" 节，含 Visualization / 三类信号说明 / 阈值
+- [x] `observability/sisyphus-dashboard.md` 看板布局段补 Q18 框图
+- [x] `observability/sisyphus-dashboard.md` 刷新频率段加 Q18 行（每 5 分钟，同 Q2 节奏）
+- [x] `observability/sisyphus-dashboard.md` 告警段加 Q18 alert 触发条件（`guard-leak` / `no-gha-pass` 行 → Lark）
+- [x] `observability/sisyphus-dashboard.md` cache TTL 行把 Q18 加入 120s 组（同 Q2/Q3/Q4/Q12/Q13）
+
+## Stage: verify
+
+- [x] `openspec validate openspec/changes/REQ-metabase-silent-pass-detector-1777123726 --strict` 通过
+- [x] `grep -n 'refusing to silent-pass\|no-gha-checks-ran' observability/queries/sisyphus/18-silent-pass-detector.sql` 命中 ≥ 2 处（信号字符串与 checker 源码字面对齐）
+- [x] `grep -n 'PERCENTILE_CONT(0.5)' observability/queries/sisyphus/18-silent-pass-detector.sql` 命中（baseline CTE 用 P50）
+- [x] `grep -nE 'COUNT\(\*\) >= 20' observability/queries/sisyphus/18-silent-pass-detector.sql` 命中（20 sample threshold）
+- [x] `grep -n 'Q18' observability/sisyphus-dashboard.md` ≥ 5 处命中（章节 + 布局 + 刷新 + 告警 + cache）
+- [x] `make ci-lint` 不报新 lint 错误（零 Python 改动只须不打破）
+
+## Stage: PR
+
+- [x] commit `feat(observability): Q18 silent-pass detector for mechanical checkers (REQ-metabase-silent-pass-detector-1777123726)`
+- [x] push origin feat/REQ-metabase-silent-pass-detector-1777123726
+- [x] gh pr create


### PR DESCRIPTION
## Summary

每个 sisyphus 机械 checker（`spec_lint` / `dev_cross_check` / `staging_test` / `pr_ci_watch`）源码里都显式写了 `refusing to silent-pass` guard，设计上"零信号即 fail"。但只有源码层这一道防线 —— 一旦 guard 被改坏 / for 循环静默吃错误，checker 会报 `passed=true` 但其实啥也没跑，状态机就推下一 stage，最坏情况合掉一个根本没过测试的 PR。

**Q18 是事后 metrics 兜底**：从 `artifact_checks` 已落表样本反查"通过了但其实没干活"的记录。

三类信号（CASE 优先级从严到松）：
- `guard-leak` —— `stdout/stderr` 命中 `refusing to silent-pass` 但 `passed=true` → checker 内 guard 行打了但 exit code 仍是 0
- `no-gha-pass` —— `pr_ci_watch` stdout 留 `no-gha-checks-ran` 但 `passed=true` → `_classify` 分类逻辑被改坏
- `too-fast` —— `duration_sec < 0.2 × 同 stage 7d P50（passed=true 样本）` → 脚本短路（和 Q2 慢异常对称）

`guard-leak` / `no-gha-pass` 是绝对信号（不依赖基线），任意命中即告警；`too-fast` 同 Q2 一样 `HAVING COUNT(*) >= 20` 防小样本噪声。

## REQ
[REQ-metabase-silent-pass-detector-1777123726](https://github.com/phona/sisyphus/blob/main/openspec/changes/REQ-metabase-silent-pass-detector-1777123726/proposal.md)

> 为何 Q 编号是 **18** 不是 **14**（REQ 名里的标签）：Q14–Q17 已经被 Fixer Audit / dedup retry 占了，下一个可用槽是 Q18。proposal.md §"取舍"详细说明。

## Files

- `observability/queries/sisyphus/18-silent-pass-detector.sql` — 三类信号 CASE + 7d P50 baseline CTE + 24h 窗口
- `observability/sisyphus-dashboard.md` — 新增"机械 checker silent-pass（Q18）"节 + 看板布局 / 刷新频率 / 告警 / cache TTL 段落同步
- `openspec/changes/REQ-metabase-silent-pass-detector-1777123726/` — proposal / tasks / spec.md（19 scenarios）

无 Python / migration / Makefile 改动。

## Test plan

- [x] `openspec validate REQ-metabase-silent-pass-detector-1777123726 --strict` 通过
- [x] `scripts/check-scenario-refs.sh --specs-search-path . .` 通过（146 scenarios 定义全可见）
- [x] `BASE_REV=$(git merge-base HEAD origin/main) make ci-lint` 0 Python 文件变更，pass
- [x] sqlglot postgres dialect 解析 SQL 通过（语法 / 列名 / 类型）
- [ ] sisyphus 自家 `spec_lint` checker 跑 self-dogfood：`openspec validate openspec/changes/REQ-metabase-silent-pass-detector-1777123726`
- [ ] sisyphus 自家 `staging_test` checker 跑 self-dogfood：`make ci-unit-test && make ci-integration-test`
- [ ] 生产 metabase 接 Postgres 后手动跑 SQL，应返 0 行（生产应当没 silent-pass）

🤖 Generated with [Claude Code](https://claude.com/claude-code)