### PR TITLE
fix(runner_gc): demote disk_check_rbac_denied to INFO

### DIFF
--- a/openspec/changes/REQ-silence-runner-gc-rbac-1777123726/proposal.md
+++ b/openspec/changes/REQ-silence-runner-gc-rbac-1777123726/proposal.md
@@ -1,0 +1,82 @@
+# REQ-silence-runner-gc-rbac-1777123726: fix(runner_gc): truly silence repeated disk_check_rbac_denied warning
+
+## 问题
+
+REQ-orch-noise-cleanup-1777078500（PR #66）引入了进程级 flag `_DISK_CHECK_DISABLED`，
+意图是 runner_gc 第一次拿到 K8s 403（namespace-scoped Role 没 cluster 级 nodes:list）
+之后只 warn 一次，之后所有 GC tick 直接 short-circuit、不再 probe、不再 log。
+
+但生产里 `runner_gc.disk_check_rbac_denied` **仍然是 warn 级别**，alert 看板 / loki
+查询 `level=warning` 都会反复抓到它。原因不是 flag 失效（同进程内确实只发一次），
+而是 orchestrator pod 在日常迭代中频繁滚动（helm upgrade、livenessProbe 重启、
+deployment 配置变更），**每次新进程启动都会再 warn 一次**。从运维视角看就是：
+"WARNING runner_gc.disk_check_rbac_denied" 反复出现 —— 跟 PR #66 fix 之前的体感
+没差别。
+
+操作员实际诉求：
+
+- RBAC 缺 cluster 级 nodes:list 是 sisyphus 在 namespace-scoped Role 部署的**预期
+  配置**（chart 的 ClusterRole 是可选的），不是异常。
+- 这条 log 不该污染 warning 流，让真异常被淹没。
+- 同时**保留**信息可观测性 —— 运维偶尔需要确认 disk-pressure emergency purge 是否
+  被禁，以解释为什么磁盘吃紧时没触发紧急清理。
+
+## 根因
+
+之前的 fix 只在**单一进程生命周期**里去重；忽略了 pod 重启次数才是这条 log 的
+真正放大器。WARNING 级别假设了"这是值得告警关注的事件"，跟实际语义（一次性配置
+检测结果）不符。
+
+## 方案
+
+### 把 `runner_gc.disk_check_rbac_denied` 降级到 INFO
+
+`orchestrator/src/orchestrator/runner_gc.py:gc_once` 里 403 分支：
+
+```python
+log.warning("runner_gc.disk_check_rbac_denied", ...)   # 旧
+log.info("runner_gc.disk_check_rbac_denied", ...)      # 新
+```
+
+- INFO 级别下 alert 看板/loki 默认不报警，但 raw log 仍可 grep。
+- 现有 `_DISK_CHECK_DISABLED` flag 行为不变：同进程内仍然只发一次。
+- 跨进程重启的"看上去重复"问题：从 warning 流移除等价于"truly silenced"。
+
+### 不拆 helper / 不引新 setting
+
+考虑过的替代方案：
+
+1. **持久化 flag 到 DB / 文件**：跨进程去重，重新部署也只 log 一次。代价高
+   （引数据库依赖到 GC 路径），过度设计。
+2. **降到 DEBUG**：完全消失，operator 失去"我的 disk-pressure 是不是被禁了"的可见
+   性。
+3. **用环境变量声明 RBAC mode 主动跳过 probe**：要求 helm/operator 配置变更，门槛
+   太高，而且 sisyphus 自检比手配更可靠。
+
+INFO 是最低代价：单行改动，行为兼容，运维仍能在 raw log 中确认。
+
+### 同步更新合约和测试
+
+- `openspec/specs/orch-noise-cleanup` ORCHN-S4：requirement / scenario 把 "warning"
+  改为 "info"，措辞从 "MUST emit exactly one warning" 改为 "MUST emit at most
+  one info-level log per process" 强调"info 级别 + 进程级 dedup"。
+- `orchestrator/tests/test_contract_orch_noise_cleanup.py::test_orchn_s4_first_403_warns_and_disables`：
+  断言改成查 `log_level == "info"`；test 名字改成 `test_orchn_s4_first_403_logs_info_and_disables`。
+- `orchestrator/tests/test_runner_gc.py::test_disk_check_403_disables_after_first_warn`：
+  无需断 level（只查 event 名在 stdout 中），test 名字保留或顺手改成 `..._first_log_disables`，
+  不影响行为。
+
+## 影响
+
+- runtime: WARNING → INFO，不影响 GC 调度逻辑、不影响 disk-pressure emergency purge
+  路径、不影响 retention-only fallback。
+- alert 看板：少一条噪声 warning。
+- 文档/运维：这条 INFO 出现表示 namespace-scoped Role 没 nodes:list；不出现表示
+  RBAC 完整或 K8s 不可用。
+
+## 验证
+
+- `pytest orchestrator/tests/test_runner_gc.py orchestrator/tests/test_contract_orch_noise_cleanup.py -k disk` 全过。
+- `openspec validate openspec/changes/REQ-silence-runner-gc-rbac-1777123726` 通过。
+- 手动 staging：把 orchestrator ServiceAccount 的 ClusterRoleBinding 拔掉重启，确认
+  `runner_gc.disk_check_rbac_denied` 出现在 INFO 级别且后续 GC tick 没再 log。

--- a/openspec/changes/REQ-silence-runner-gc-rbac-1777123726/specs/orch-noise-cleanup/contract.spec.yaml
+++ b/openspec/changes/REQ-silence-runner-gc-rbac-1777123726/specs/orch-noise-cleanup/contract.spec.yaml
@@ -1,0 +1,65 @@
+capability: orch-noise-cleanup
+version: "1.1"
+description: |
+  Delta over orch-noise-cleanup v1.0 (PR #66 / REQ-orch-noise-cleanup-1777078500).
+
+  PR #66 added a process-level `_DISK_CHECK_DISABLED` flag that suppresses the
+  `runner_gc.disk_check_rbac_denied` log after the first 403 within a single
+  orchestrator process. This delta keeps that flag behavior intact and only
+  changes the log level for the first emission from WARNING to INFO so that
+  alert dashboards (loki / Grafana / pagerduty filters keyed on level=warning)
+  no longer receive a repeated entry across orchestrator pod restarts (helm
+  upgrade, livenessProbe restart, deployment rollout).
+
+  No other behavior changes:
+    - retention-based GC fallback unchanged
+    - disk-pressure emergency purge path unchanged
+    - non-403 ApiException still logged at debug
+    - exit short-circuit on subsequent ticks unchanged
+
+log_levels:
+  runner_gc_disk_check_rbac_denied:
+    module: orchestrator.runner_gc
+    function: gc_once
+    previous: warning            # PR #66 contract
+    current: info                # this delta
+    rationale: |
+      RBAC missing cluster-scoped nodes:list is an expected configuration on
+      namespace-scoped Role deployments of sisyphus. Repeating a warning every
+      orchestrator pod restart is alert noise; INFO preserves grep-ability for
+      operators without polluting warning streams.
+    dedup_semantics: |
+      Within a single process, the log line is emitted at most once. The
+      `_DISK_CHECK_DISABLED` module-level flag short-circuits subsequent
+      gc_once ticks before the K8s API call.
+
+  runner_gc_disk_check_failed:
+    module: orchestrator.runner_gc
+    function: gc_once
+    level: debug
+    unchanged: true
+
+  runner_gc_disk_pressure:
+    module: orchestrator.runner_gc
+    function: gc_once
+    level: warning
+    unchanged: true
+    rationale: |
+      Real disk-pressure detection (ratio > threshold) is an actionable signal
+      and stays at WARNING.
+
+state_invariants:
+  process_flag:
+    name: _DISK_CHECK_DISABLED
+    module: orchestrator.runner_gc
+    type: bool
+    initial: false
+    transitions:
+      - "false → true on first ApiException(status=403) raised by node_disk_usage_ratio"
+    persistence: "in-memory only; reset on process restart (intended)"
+
+unchanged_from_v1_0:
+  - snapshot_exclude_project_ids setting and ORCHN-S1..S3 scenarios
+  - non-403 ApiException debug-level handling
+  - disk-pressure emergency purge happy path (ratio > threshold)
+  - retention-only fallback when disk-check is disabled

--- a/openspec/changes/REQ-silence-runner-gc-rbac-1777123726/specs/orch-noise-cleanup/spec.md
+++ b/openspec/changes/REQ-silence-runner-gc-rbac-1777123726/specs/orch-noise-cleanup/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: runner_gc 在 nodes:list 缺权限时优雅降级
+
+The system SHALL detect Kubernetes API 403 (Forbidden) responses on the
+`nodes:list` call inside `runner_gc.gc_once` and treat them as a permanent
+RBAC denial for the orchestrator's ServiceAccount. On the first occurrence of
+a 403 within a process lifetime, the system MUST emit **at most one**
+`runner_gc.disk_check_rbac_denied` log line at **INFO** level (not WARNING) —
+this MUST NOT be raised at WARNING level so that operator alert dashboards
+filtering for warnings stop receiving repeated noise across orchestrator pod
+restarts. On all subsequent GC ticks within the same process, the system MUST
+skip the disk-pressure check entirely without issuing the underlying
+`list_node` API call and without emitting any further log line for the
+disabled probe. The skip MUST be equivalent to `disk_pressure=False`, so
+retention-based GC behavior is preserved. Other (non-403) exceptions raised
+by `node_disk_usage_ratio` MUST continue to be logged at debug level
+(`runner_gc.disk_check_failed`) without disabling future probes.
+
+#### Scenario: ORCHN-S4 首次 403 时 info 一次并禁用后续 disk-check
+
+- **GIVEN** orchestrator 进程刚启动，`_DISK_CHECK_DISABLED` 为 False
+- **AND** `core_v1.list_node` 抛出 `ApiException(status=403)`
+- **WHEN** `gc_once()` 被调用
+- **THEN** 恰好一条 `runner_gc.disk_check_rbac_denied` 日志被记录，**level=info**（**不是 warning**）
+- **AND** 进程级 `_DISK_CHECK_DISABLED` 被置为 True
+- **AND** 返回结果 `disk_pressure=False`
+
+#### Scenario: ORCHN-S5 disk-check 已禁用后 gc_once 不再调 list_node
+
+- **GIVEN** 上一轮 GC 已把 `_DISK_CHECK_DISABLED` 置为 True
+- **WHEN** `gc_once()` 再次被调用
+- **THEN** `node_disk_usage_ratio` 不被调用
+- **AND** 没有任何 `runner_gc.disk_check_*` 日志被记录（INFO/WARNING/DEBUG 任一级别都不打）
+- **AND** 返回结果 `disk_pressure=False`
+
+#### Scenario: ORCHN-S6 非 403 异常仍走 debug 不禁用
+
+- **GIVEN** `node_disk_usage_ratio` 抛出 `ApiException(status=500)`
+- **WHEN** `gc_once()` 被调用
+- **THEN** `log.debug("runner_gc.disk_check_failed", ...)` 被记录
+- **AND** `_DISK_CHECK_DISABLED` 保持 False（下一轮仍会再尝试）
+- **AND** 不发出任何 `runner_gc.disk_check_rbac_denied` info 或 warning 日志
+
+#### Scenario: ORCHN-S7 disk-check 正常 ratio > threshold 时仍能触发紧急清理
+
+- **GIVEN** RBAC 健全（list_node 200 OK），`ratio=0.9`，threshold=0.8
+- **WHEN** `gc_once()` 被调用
+- **THEN** `runner_gc.disk_pressure` warning 被记录
+- **AND** 返回结果 `disk_pressure=True`
+
+#### Scenario: ORCHN-S8 alert 看板按 level=warning 过滤时看不到 rbac_denied
+
+- **GIVEN** 一次或多次 orchestrator 进程启动 + RBAC 缺 nodes:list
+- **WHEN** alert / loki 等观测系统按 `level=warning` 查询
+- **THEN** `runner_gc.disk_check_rbac_denied` 不出现在结果中（因为它现在是 info 级别）

--- a/openspec/changes/REQ-silence-runner-gc-rbac-1777123726/tasks.md
+++ b/openspec/changes/REQ-silence-runner-gc-rbac-1777123726/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: REQ-silence-runner-gc-rbac-1777123726
+
+## Stage: contract / spec
+
+- [x] author `specs/orch-noise-cleanup/contract.spec.yaml` (capability delta —
+      log_level for `runner_gc.disk_check_rbac_denied`)
+- [x] author `specs/orch-noise-cleanup/spec.md` MODIFIED Requirements / Scenarios
+      replacing ORCHN-S4 wording (warning → info)
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/runner_gc.py:gc_once`: change
+      `log.warning("runner_gc.disk_check_rbac_denied", ...)` to
+      `log.info("runner_gc.disk_check_rbac_denied", ...)`; keep the
+      `_DISK_CHECK_DISABLED = True` short-circuit unchanged
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_runner_gc.py::test_disk_check_403_disables_after_first_warn`
+      — rename to `..._first_log_disables`, assertion still works (event name
+      in stdout)
+- [x] `orchestrator/tests/test_contract_orch_noise_cleanup.py::test_orchn_s4_first_403_warns_and_disables`
+      — rename to `test_orchn_s4_first_403_logs_info_and_disables`; switch
+      `log_level == "warning"` assertion to `log_level == "info"`; update the
+      docstring to match the new behavior
+
+## Stage: PR
+
+- [x] `git push origin feat/REQ-silence-runner-gc-rbac-1777123726`
+- [x] `gh pr create` with proposal summary + verification plan
+
+owner: analyze-agent

--- a/orchestrator/src/orchestrator/runner_gc.py
+++ b/orchestrator/src/orchestrator/runner_gc.py
@@ -83,11 +83,13 @@ async def gc_once() -> dict:
         except ApiException as e:
             if e.status == 403:
                 # RBAC 没给 nodes:list（orchestrator Role 是 ns-scoped），
-                # 永久降级：之后不再探测，留 retention-only 路径
+                # 永久降级：之后不再探测，留 retention-only 路径。
+                # INFO 不是 WARNING：namespace-scoped Role 是预期部署形态，
+                # 这条 log 不应每次 pod 重启就污染 warning 流。
                 _DISK_CHECK_DISABLED = True
-                log.warning("runner_gc.disk_check_rbac_denied",
-                            hint="ServiceAccount lacks cluster-scoped nodes:list; "
-                                 "disk-pressure emergency purge disabled until restart")
+                log.info("runner_gc.disk_check_rbac_denied",
+                         hint="ServiceAccount lacks cluster-scoped nodes:list; "
+                              "disk-pressure emergency purge disabled until restart")
             else:
                 log.debug("runner_gc.disk_check_failed", error=str(e), status=e.status)
         except Exception as e:

--- a/orchestrator/tests/test_contract_orch_noise_cleanup.py
+++ b/orchestrator/tests/test_contract_orch_noise_cleanup.py
@@ -7,10 +7,11 @@ Scenarios covered:
   ORCHN-S1  排除单个项目时跳过 BKD 调用
   ORCHN-S2  排除清单为空时保持原行为
   ORCHN-S3  全部 project_id 都被排除时短路返回 0
-  ORCHN-S4  首次 403 时 warn 一次并禁用后续 disk-check
+  ORCHN-S4  首次 403 时 info 一次并禁用后续 disk-check
   ORCHN-S5  disk-check 已禁用后 gc_once 不再调 list_node
   ORCHN-S6  非 403 异常仍走 debug 不禁用
   ORCHN-S7  disk-check 正常 ratio > threshold 时仍能触发紧急清理
+  ORCHN-S8  alert 看板按 level=warning 过滤时看不到 rbac_denied
 """
 from __future__ import annotations
 
@@ -176,13 +177,14 @@ async def test_orchn_s3_all_excluded_returns_zero(monkeypatch):
     )
 
 
-# ─── ORCHN-S4: 首次 403 时 warn 一次并禁用后续 disk-check ────────────────────
+# ─── ORCHN-S4: 首次 403 时 info 一次并禁用后续 disk-check ─────────────────────
 
 
-async def test_orchn_s4_first_403_warns_and_disables(monkeypatch):
+async def test_orchn_s4_first_403_logs_info_and_disables(monkeypatch):
     """
     ORCHN-S4: gc_once 在 node_disk_usage_ratio 抛出 ApiException(status=403) 时：
-    - 必须发出一条包含 'runner_gc.disk_check_rbac_denied' 的 WARNING 日志
+    - 必须发出恰好一条 'runner_gc.disk_check_rbac_denied' 的 **INFO** 日志
+      （不是 WARNING —— alert dashboards 按 level=warning 过滤时看不到）
     - 必须把进程级 _DISK_CHECK_DISABLED flag 置为 True
     - 返回结果 disk_pressure=False
     """
@@ -209,11 +211,27 @@ async def test_orchn_s4_first_403_warns_and_disables(monkeypatch):
         "ORCHN-S4: _DISK_CHECK_DISABLED must be True after first 403"
     )
 
-    # exactly one warning with the required key
+    # exactly one INFO record with the required event name
+    rbac_denied_records = [
+        r for r in log_records
+        if "runner_gc.disk_check_rbac_denied" in r.get("event", "")
+    ]
+    assert len(rbac_denied_records) == 1, (
+        f"ORCHN-S4: must log exactly one 'runner_gc.disk_check_rbac_denied'; "
+        f"got {len(rbac_denied_records)}: {rbac_denied_records}"
+    )
+    assert rbac_denied_records[0].get("log_level") == "info", (
+        f"ORCHN-S4: 'runner_gc.disk_check_rbac_denied' must be at INFO level "
+        f"(not WARNING) so alert dashboards stop receiving repeated entries "
+        f"across orchestrator pod restarts; got level "
+        f"{rbac_denied_records[0].get('log_level')!r}"
+    )
+
+    # must NOT emit at warning level (regression guard against PR #66 contract)
     warning_events = [r["event"] for r in log_records if r.get("log_level") == "warning"]
-    assert any("runner_gc.disk_check_rbac_denied" in e for e in warning_events), (
-        f"ORCHN-S4: must log warning 'runner_gc.disk_check_rbac_denied'; "
-        f"actual warnings: {warning_events}"
+    assert not any("runner_gc.disk_check_rbac_denied" in e for e in warning_events), (
+        f"ORCHN-S4: 'runner_gc.disk_check_rbac_denied' MUST NOT appear at "
+        f"WARNING level; warnings: {warning_events}"
     )
 
     # disk_pressure must be False
@@ -359,4 +377,46 @@ async def test_orchn_s7_high_ratio_triggers_disk_pressure(monkeypatch):
     disk_pressure = result.get("disk_pressure") if isinstance(result, dict) else getattr(result, "disk_pressure", None)
     assert disk_pressure is True, (
         f"ORCHN-S7: result disk_pressure must be True when ratio > threshold; got {result!r}"
+    )
+
+
+# ─── ORCHN-S8: alert 看板按 level=warning 过滤时看不到 rbac_denied ────────────
+
+
+async def test_orchn_s8_warning_filter_excludes_rbac_denied(monkeypatch):
+    """
+    ORCHN-S8: 多次 gc_once 在 RBAC 缺 nodes:list 的场景下都不能让
+    'runner_gc.disk_check_rbac_denied' 出现在 warning 流（哪怕第一次也不行）。
+    模拟 alert dashboard / loki 按 log_level == "warning" 过滤的查询。
+    """
+    from kubernetes.client.exceptions import ApiException
+
+    import orchestrator.runner_gc as gc_mod
+
+    monkeypatch.setattr(gc_mod, "_DISK_CHECK_DISABLED", False)
+
+    class _FakeController:
+        async def node_disk_usage_ratio(self):
+            raise ApiException(status=403)
+        async def gc_orphans(self, keep):
+            return []
+
+    monkeypatch.setattr(gc_mod.k8s_runner, "get_controller", lambda: _FakeController())
+    monkeypatch.setattr(gc_mod.db, "get_pool", lambda: _FakePool())
+
+    with structlog.testing.capture_logs() as log_records:
+        # 第一次 tick：触发 403 → log info → set flag
+        await gc_mod.gc_once()
+        # 模拟后续 N 次 tick（flag 已 True，应一律 short-circuit）
+        for _ in range(5):
+            await gc_mod.gc_once()
+
+    warning_records = [
+        r for r in log_records
+        if r.get("log_level") == "warning"
+        and "runner_gc.disk_check_rbac_denied" in r.get("event", "")
+    ]
+    assert warning_records == [], (
+        f"ORCHN-S8: alert filter (level=warning) MUST NOT see "
+        f"'runner_gc.disk_check_rbac_denied'; got: {warning_records}"
     )

--- a/orchestrator/tests/test_runner_gc.py
+++ b/orchestrator/tests/test_runner_gc.py
@@ -128,8 +128,8 @@ async def test_skips_when_no_controller(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_disk_check_403_disables_after_first_warn(monkeypatch, mock_controller, capsys):
-    """ApiException(403) → 进程级 flag 置 True；warn 一次，disk_pressure=False。"""
+async def test_disk_check_403_disables_after_first_log(monkeypatch, mock_controller, capsys):
+    """ApiException(403) → 进程级 flag 置 True；INFO log 一次，disk_pressure=False。"""
     pool = _FakePool([_row("REQ-1", "analyzing")])
     monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
     mock_controller.node_disk_usage_ratio = AsyncMock(


### PR DESCRIPTION
## Summary

PR #66 added a process-level `_DISK_CHECK_DISABLED` flag so that
`runner_gc.disk_check_rbac_denied` only logs once per orchestrator process when
the ServiceAccount lacks cluster-scoped `nodes:list`. That fix didn't fully
silence the noise: every helm upgrade / livenessProbe / deployment rollout
spawns a fresh process and the WARNING fires again. To operators filtering
alert dashboards on `level=warning`, it still looks like a repeating warning.

The condition (namespace-scoped Role on a single-node K3s) is the **expected**
sisyphus deployment shape — not an exceptional event. Demote the line from
WARNING to INFO so warning streams stay clean while raw logs remain grep-able.
Behavior is otherwise unchanged: still emitted at most once per process, still
short-circuits subsequent GC ticks via `_DISK_CHECK_DISABLED`,
disk-pressure emergency purge happy path and retention-only fallback both
preserved.

## Changes

- `orchestrator/src/orchestrator/runner_gc.py`: `log.warning(...)` →
  `log.info(...)` on the 403 branch (single-line change + comment).
- `orchestrator/tests/test_runner_gc.py`: rename
  `test_disk_check_403_disables_after_first_warn` →
  `..._first_log_disables` (existing assertion only checks event name, still
  valid).
- `orchestrator/tests/test_contract_orch_noise_cleanup.py`:
  - Update ORCHN-S4 to assert `log_level == "info"` exactly (and **NOT**
    warning) — regression guard.
  - Add ORCHN-S8: simulate alert dashboard filter (`level=warning` query) and
    assert `runner_gc.disk_check_rbac_denied` is absent across multiple
    gc_once ticks.
- `openspec/changes/REQ-silence-runner-gc-rbac-1777123726/`: MODIFIED
  Requirements delta over `orch-noise-cleanup` capability with new
  ORCHN-S4 / ORCHN-S8 wording and a contract.spec.yaml v1.1 noting the
  log-level transition (warning → info).

## Test plan

- [x] `uv run pytest tests/test_runner_gc.py tests/test_contract_orch_noise_cleanup.py tests/test_snapshot.py` — 25 passed
- [x] `uv run --extra dev ruff check src/orchestrator/runner_gc.py tests/test_runner_gc.py tests/test_contract_orch_noise_cleanup.py` — clean
- [x] `openspec validate REQ-silence-runner-gc-rbac-1777123726 --strict` — passes
- [x] `scripts/check-scenario-refs.sh --specs-search-path .` — passes (128 scenarios)
- [ ] Staging: drop the orchestrator ServiceAccount's ClusterRoleBinding, restart pod, confirm `runner_gc.disk_check_rbac_denied` appears at INFO level exactly once and is absent from `level=warning` queries on subsequent ticks.

REQ-silence-runner-gc-rbac-1777123726

🤖 Generated with [Claude Code](https://claude.com/claude-code)