### PR TITLE
feat(admin): /req/{id}/resume to unblock REQ stuck on verifier escalate

### DIFF
--- a/openspec/changes/REQ-admin-resume-escalated-1777123726/design.md
+++ b/openspec/changes/REQ-admin-resume-escalated-1777123726/design.md
@@ -1,0 +1,179 @@
+# Design: admin /resume — state-level resume from ESCALATED
+
+## 状态机视角
+
+ESCALATED 是"等人决策的中转站"，已有 3 条出口 transition：
+
+```
+ESCALATED + VERIFY_PASS       → REVIEW_RUNNING (apply_verify_pass)
+                                  └→ apply_verify_pass 内 CAS 推到 stage_running
+                                  └→ 链式 emit 该 stage 的 done/pass 事件
+ESCALATED + VERIFY_FIX_NEEDED → FIXER_RUNNING (start_fixer)
+                                  └→ start_fixer 起新 BKD fixer-agent，跑完 emit FIXER_DONE
+ESCALATED + VERIFY_ESCALATE   → ESCALATED (None) [self-loop, no-op]
+```
+
+新 endpoint 不加 transition、不改状态机表，**仅作为派 Event 的入口**。
+
+```
+HTTP POST /admin/req/{id}/resume
+   └→ ResumeBody.action 映射成 Event
+       └→ engine.step(cur_state=ESCALATED, event=VERIFY_PASS|VERIFY_FIX_NEEDED)
+           └→ existing transition + action handler
+```
+
+## 与 verifier follow-up 路径并行
+
+```
+                       ┌── BKD verifier issue follow-up
+                       │     └─ wake agent → 写 decision JSON
+                       │         └─ webhook → derive_event → engine.step
+                       │             └─ same transitions
+                       │
+ESCALATED REQ ─────────┤
+                       │
+                       └── admin POST /resume
+                             └─ engine.step(VERIFY_PASS|FIX_NEEDED) directly
+```
+
+两条路径殊途同归，命中同一组 transition + action handler。verifier 路径走得通时
+（前提：有 verifier issue + agent 能跑）保留它给"agent 判"的能力；admin 路径是
+"人已经判完，不必绕 agent"的快捷键。
+
+## 路径冲突处理：rename runner-* prefix
+
+v0.2 引入 admin K8s runner ops（`405193f` commit）时占了 `/pause` `/resume`，
+没预留 state-level resume 的位置。本 REQ 加 `runner-` 前缀给 K8s 操作让出 `/resume`。
+
+| 之前 | 现在 |
+|---|---|
+| `POST /pause`              | `POST /runner-pause`              |
+| `POST /resume`             | `POST /runner-resume`             |
+| `POST /rebuild-workspace`  | `POST /rebuild-workspace`（不变，已有 workspace 字样足够）|
+| `GET  /runners`            | `GET  /runners`（不变）|
+| —                          | `POST /resume`（**新**，state-level）|
+
+`runner-` 前缀让 admin endpoint 自描述："runner-*"=K8s 资源、其它=state 操作。
+
+`runner-rebuild-workspace` 没必要 rename（已有 `workspace` 名词，跟 state 没语义冲突）。
+
+## ResumeBody schema 设计
+
+```python
+class ResumeBody(BaseModel):
+    action: Literal["pass", "fix-needed"]   # 必传，无默认
+    stage: str | None = None                # 覆盖 ctx.verifier_stage（pass 路由必需）
+    fixer: Literal["dev", "spec"] | None = None  # 覆盖 ctx.verifier_fixer（fix-needed 路由）
+    reason: str | None = None               # 写 ctx.resume_reason（审计）
+```
+
+为什么 action 不默认：让操作员的意图显式化（见 proposal "取舍"）。
+
+为什么 stage 可选：典型场景是上一轮 verifier 已经把 verifier_stage 写进 ctx，
+admin 不必重复传；但来自 pr_ci.timeout / accept-env-up.fail / intake.fail 这些
+**非 verifier 路径**的 ESCALATED ctx 没 verifier_stage，必须 body 带。
+
+为什么 fixer 可选：start_fixer 内部对 ctx.verifier_fixer 默认 "dev"。admin 想
+强制走 spec fixer 才需要 body 带。
+
+reason 完全可选：跟 `complete` 的 reason 同语义，仅审计用。
+
+## ctx 预置时机
+
+```
+1. _verify_token
+2. row = req_state.get
+3. assert row.state == ESCALATED  # 否则 409
+4. effective_stage = body.stage or row.context.get("verifier_stage")
+5. if action == "pass" and not effective_stage:
+       raise 400 "verifier_stage required for action=pass"
+6. ctx_patch = {
+       "resumed_by_admin": true,
+       "resume_action": body.action,
+   }
+   if body.stage:    ctx_patch["verifier_stage"] = body.stage
+   if body.fixer:    ctx_patch["verifier_fixer"] = body.fixer
+   if body.reason:   ctx_patch["resume_reason"] = body.reason
+7. await req_state.update_context(pool, req_id, ctx_patch)
+8. row = req_state.get（重读拿到 patched ctx）
+9. event = VERIFY_PASS if action=="pass" else VERIFY_FIX_NEEDED
+10. fake_body = _FakeBody(req_id, project_id)
+11. result = await engine.step(pool, body=fake_body, ..., event=event)
+12. return {"action": "resumed", "from_state": "escalated",
+            "event": event.value, "chained": result}
+```
+
+precondition_chain 顺序确保 401 ≠ 404 ≠ 409 ≠ 400 不互相覆盖。
+
+## 错误情形矩阵
+
+| 触发 | HTTP | body |
+|---|---|---|
+| 无 / 错 token | 401 | 同其它 admin endpoint |
+| REQ 不存在 | 404 | `{"detail": "req <id> not found"}` |
+| state != ESCALATED | 409 | `{"detail": "req <id> is in state <X>; expected escalated. Hint: POST /admin/req/<id>/escalate first to abort an in-flight REQ."}` |
+| body.action ∉ {pass, fix-needed} | 422 | pydantic ValidationError |
+| body.action="pass" + 缺 stage（ctx + body 都没）| 400 | `{"detail": "verifier_stage required for action=pass; provide body.stage or use BKD verifier follow-up"}` |
+| 成功（推 pass）| 200 | `{"action": "resumed", "event": "verify.pass", ...}` |
+| 成功（推 fix-needed）| 200 | `{"action": "resumed", "event": "verify.fix-needed", ...}` |
+| engine.step CAS 竞争失败（并发 BKD verifier follow-up 同时推 pass）| 200 | `{"action": "resumed", "chained": {"action": "skip", ...}}`（透传）|
+
+## 不变量
+
+### 不污染 transition table
+
+resume endpoint 不引入新 Event / 新 transition，所有路径都已经在
+`state.py TRANSITIONS` 里。状态机看 `(ESCALATED, VERIFY_PASS) → REVIEW_RUNNING`
+跟从 BKD verifier follow-up 来的 VERIFY_PASS 完全等价。
+
+### 不绕过 stage_runs / verifier_decisions
+
+走 engine.step 意味着：
+- engine `_record_stage_transitions` 会处理 stage_runs（apply_verify_pass 的
+  REVIEW_RUNNING → stage_running self-loop close 行为已写好）
+- 跟 BKD verifier follow-up 路径不同，admin 路径**不写 verifier_decisions**
+  （没真跑 verifier-agent，没 decision 可记）—— 这是预期行为，verifier_decisions
+  表只反映"verifier 真做的判断"。审计靠 ctx.resumed_by_admin / resume_action
+  / resume_reason 三个 ctx field 区分。
+
+### 跟 force_escalate / complete 不打架
+
+```
+in-flight → force_escalate → ESCALATED → resume(pass)    → 主链推下一 stage
+                                       → resume(fix-needed) → fixer agent
+                                       → complete         → DONE
+                                       → BKD verifier follow-up → 同 resume(pass/fix)
+```
+
+force_escalate 是 (any → escalated) 的入口，complete / resume 是 escalated → 出口。
+三个 endpoint 的 state 前置条件互斥（complete 要求 escalated；resume 要求 escalated；
+force_escalate 接受 any non-escalated），不会被误用打架。
+
+## 实现细节：runner endpoint rename
+
+仅改装饰器路径，函数名 `pause_runner` / `resume_runner` 不动（FastAPI 路径解析跟
+Python 函数名解耦；测试也按函数名 import 不受影响）。
+
+```python
+# 之前
+@admin.post("/req/{req_id}/pause")
+async def pause_runner(...):
+
+# 之后
+@admin.post("/req/{req_id}/runner-pause")
+async def pause_runner(...):
+```
+
+无 schema 改动 / 无 body 改动 / 无 response 改动 —— 纯路径迁移。
+
+## 测试覆盖
+
+7 个 case（tasks.md 详列），覆盖:
+- 401 / 404 / 409 / 400（缺 stage）/ 422（pydantic）四档错误
+- pass 成功（验证 emit VERIFY_PASS + ctx patch）
+- fix-needed 成功（验证 emit VERIFY_FIX_NEEDED）
+- 路径迁移（runner-pause / runner-resume 路径生效，旧路径 404）
+
+mock 走跟 test_admin.py 既有 `_FakePool` / `_FakeRow` 同一套，不引新 fixture。
+engine.step 整段 mock 掉，只验它被以正确参数调用一次（admin endpoint 责任仅"派 Event"，
+engine 行为已被 test_engine.py / test_state.py 覆盖）。

--- a/openspec/changes/REQ-admin-resume-escalated-1777123726/proposal.md
+++ b/openspec/changes/REQ-admin-resume-escalated-1777123726/proposal.md
@@ -1,0 +1,223 @@
+# REQ-admin-resume-escalated-1777123726: feat(admin): /req/{id}/resume endpoint to unblock business REQ stuck on verifier escalate
+
+## Why
+
+ESCALATED 不是死终态，但目前唯一的"续命"路径要绕 BKD verifier-agent（5–10s
+启动 + 重判 + 解 decision JSON），对操作员已确认是 infra flake / 已知误判的场景
+是浪费。`pr_ci.timeout` / `accept-env-up.fail` / `intake.fail` 这些**非 verifier
+路径**进 ESCALATED 的 REQ 甚至没 verifier issue 给人 follow-up，只能 raw `/emit`
+event 名手动派——绕审计、易出错。需要一条显式、参数受限、走合法 transition
+的 admin 出口，跟 `/escalate`（入口）`/complete`（作废出口）配齐。
+
+## What Changes
+
+- **新加** `POST /admin/req/{req_id}/resume`：state-level resume from ESCALATED。
+  body `{action: pass|fix-needed, stage?, fixer?, reason?}` → 派 VERIFY_PASS
+  / VERIFY_FIX_NEEDED Event 走 engine.step；复用现有 `apply_verify_pass`
+  / `start_fixer` action handler。**不引入新 Event / 新 transition**。
+- **重命名** v0.2 K8s runner endpoint:
+  `/admin/req/{id}/pause` → `/admin/req/{id}/runner-pause`,
+  `/admin/req/{id}/resume` → `/admin/req/{id}/runner-resume`。
+  让出 `/resume` 给新 state-level endpoint，行为不变，无 caller 影响。
+- **审计字段**：成功 resume 时把 `resumed_by_admin=true` / `resume_action`
+  / `resume_reason` 落 `req_state.context`，区别 BKD verifier 路径
+  （后者写 `verifier_decisions` 表）。
+
+## 问题
+
+ESCALATED 不是死终态——`state.py` 已经写了三条 transition 让人续命：
+
+```python
+# state.py L204-212
+(ReqState.ESCALATED, Event.VERIFY_PASS):
+    Transition(ReqState.ESCALATED, "apply_verify_pass", ...)
+(ReqState.ESCALATED, Event.VERIFY_FIX_NEEDED):
+    Transition(ReqState.FIXER_RUNNING, "start_fixer", ...)
+(ReqState.ESCALATED, Event.VERIFY_ESCALATE):
+    Transition(ReqState.ESCALATED, None, "...")
+```
+
+设计的"标准续命路径"是：用户在 BKD UI 给那条 escalate 的 verifier issue 写一条
+follow-up，BKD wake 同一个 verifier-agent 重写 decision JSON，session.completed
+→ webhook 解 decision → 派对应 Event → 命中上面的 transition。
+
+**但这条路径每次都要走 BKD verifier-agent**：
+
+- 起 BKD session（5–10s 启动 + 重读 prompt 上下文）
+- 让 agent 重判一遍（一次 prompt request + 模型推理 chain，吃 quota）
+- 解 decision JSON 派 Event
+
+**有些场景操作员已经知道答案**，跑 verifier 是浪费：
+
+- verifier 因为 `_HARD_REASONS={"fixer-round-cap"}` 强制 escalate，但操作员看了
+  确认 staging-test fail 是 GHA 网络抖动（基础设施 flaky），想直接 pass
+- pr_ci.timeout 走的 transition 直接进 ESCALATED（无 verifier 决策路径，没法续）：
+  `(PR_CI_RUNNING, PR_CI_TIMEOUT) → ESCALATED, "escalate"`
+- accept-env-up.fail 同样直接 ESCALATED：
+  `(ACCEPT_RUNNING, ACCEPT_ENV_UP_FAIL) → ESCALATED, "escalate"`
+- intake.fail 直接 ESCALATED：`(INTAKING, INTAKE_FAIL) → ESCALATED, "escalate"`
+- session.failed retry 用完 → ESCALATED；操作员排查后觉得 retry 一次能过
+
+这些场景下没有 verifier issue 给人 follow-up（pr_ci.timeout / accept-env-up.fail
+是机械路径），现状只能：
+
+1. **`/admin/req/{id}/emit` + body `{"event": "verify.pass"}`**——能用，但 emit
+   是底层调试 API，要操作员熟 Event 枚举名 + 知道 ESCALATED → VERIFY_PASS 的内部
+   transition 含义；操作员误打 `verify.escalate` 还会把 REQ 又自循环回 ESCALATED
+2. **手动伪造 verifier issue + decision JSON**——更复杂 + 污染 verifier_decisions 表
+3. **直接 `psql` 改 `req_state.state`**——绕审计、不带 stage 路由信息、apply_verify_pass
+   依赖的 ctx.verifier_stage 也不会被 set
+
+缺一条**显式、有审计、参数受限**的"resume from escalated" admin path。
+
+## 方案
+
+加 `POST /admin/req/{req_id}/resume`，把"决定下一步走 pass / fix"的语义化操作
+封装成一条 endpoint，复用现有 ESCALATED → VERIFY_PASS / VERIFY_FIX_NEEDED transition。
+
+**路径冲突解决**：现有 `/admin/req/{id}/pause` 和 `/resume` 是 v0.2 的 K8s runner
+pod 操作（删 pod / 重建 pod，不改 state），命名跟新的 state-level resume 撞车。
+本 REQ 同步把这两条 runner 操作 endpoint 重命名：
+
+| 旧路径 | 新路径 | 行为 |
+|---|---|---|
+| `/admin/req/{id}/pause` | `/admin/req/{id}/runner-pause` | 删 Pod 保 PVC（不变） |
+| `/admin/req/{id}/resume` | `/admin/req/{id}/runner-resume` | 重建 Pod（不变） |
+| —（新） | `/admin/req/{id}/resume` | state-level resume from ESCALATED |
+
+runner pause/resume 是 v0.2 引入的 admin 工具（V0.2-PLAN.md L27），目前只有人工 ops
+通过 Bearer token 用，无 CI / 自动化 caller（grep 全仓只有 docs 引用）；rename 影响面
+仅限 docs + 模块 docstring。
+
+### 行为契约
+
+```
+POST /admin/req/{req_id}/resume
+Authorization: Bearer <webhook_token>
+Body (required):
+{
+  "action": "pass" | "fix-needed",
+  "stage": "<verifier_stage>" | null,    # optional, 覆盖 ctx.verifier_stage
+  "fixer": "dev" | "spec" | null,        # optional, 覆盖 ctx.verifier_fixer (action=fix-needed)
+  "reason": "<audit string>" | null      # optional, 写到 ctx.resume_reason
+}
+
+→ 200  {"action": "resumed", "from_state": "escalated", "event": "verify.pass", "chained": {...}}
+→ 200  {"action": "resumed", "from_state": "escalated", "event": "verify.fix-needed", ...}
+→ 400  body.action invalid / "pass" 缺 stage（无 ctx.verifier_stage 兜底）
+→ 404  REQ not found
+→ 409  state != ESCALATED
+→ 401  bad / missing token
+```
+
+### 实现要点
+
+1. **复用现有 transition**：
+   - `action="pass"` → emit `Event.VERIFY_PASS` → `apply_verify_pass` 已支持
+     `src in (REVIEW_RUNNING, ESCALATED)` 的 CAS（`_verifier.py` L171-177）
+   - `action="fix-needed"` → emit `Event.VERIFY_FIX_NEEDED` → `(ESCALATED, VERIFY_FIX_NEEDED)
+     → FIXER_RUNNING, "start_fixer"` 主链已写
+
+2. **ctx 预置**：
+   - `ctx.verifier_stage` 由 `apply_verify_pass` / `start_fixer` 读用于路由；本 admin
+     调用的 ctx 可能：
+     - 仍含上一轮 verifier 写入的 verifier_stage / verifier_fixer / verifier_scope（典型）
+     - 或来自非 verifier 路径的 escalate（pr_ci.timeout / accept-env-up.fail / intake.fail），
+       ctx 没 verifier_stage（apply_verify_pass 会返 `unknown verifier_stage` 走死路）
+   - body.stage / body.fixer 覆盖 ctx，给操作员显式指定路由的能力
+   - body.reason 写 `ctx.resume_reason`；同时打 `ctx.resumed_by_admin=true`
+
+3. **走 engine.step 而非裸 SQL**：跟 `/escalate` `/complete` 不同，本 endpoint 走
+   合法 transition，所以走 `engine.step` 派 Event，让 `apply_verify_pass` /
+   `start_fixer` 跑（包括它们内部的 ensure_runner、stage_runs.close 等副作用）。
+   `_FakeBody`（已有，emit endpoint 复用）当 webhook body 喂 engine。
+
+4. **action="pass" 缺 stage 早 fail**：apply_verify_pass 拿不到 stage 会 emit
+   VERIFY_ESCALATE 把 REQ 又推回 ESCALATED，操作员回看是个静默"什么都没发生"——
+   admin endpoint 在 dispatch 前 validate ctx.verifier_stage（含 body 覆盖后），
+   缺则 400，给清晰错误。
+
+5. **审计**：history 行通过 cas_transition 走 engine.step 自动写
+   （from=escalated, to=review-running / fixer-running, event=verify.pass / verify.fix-needed,
+   action=apply_verify_pass / start_fixer）—— 不需要手动追加。
+   额外把 admin 标记落 ctx：`{"resumed_by_admin": true, "resume_action": "pass", "resume_reason": "..."}`。
+
+### 与现有 endpoints 的对比
+
+| endpoint | from_state | to_state | 走 transition? | 用例 |
+|---|---|---|---|---|
+| `force_escalate` | * | escalated | 否（裸 SQL） | 卡死 / 进度永远推不动 |
+| `complete` | escalated | done | 否（裸 SQL） | escalated 但确认作废 |
+| `resume`（新）| escalated | review-running / fixer-running | **是** | escalated 但操作员决定推 pass / fix |
+| `runner-pause` | (state 不动) | (state 不动) | 否（K8s only）| 临时让出资源 |
+| `runner-resume` | (state 不动) | (state 不动) | 否（K8s only）| 配 runner-pause |
+
+**resume 跟 complete 互不替代**——complete 是"宣告作废清资源"，resume 是"给一次
+机会推下一 stage"。两个 endpoint 配合 force_escalate 形成完整的 escalated 出口集：
+
+```
+in-flight REQ
+   ↓ force_escalate（卡死）
+ESCALATED ──→ resume(pass)         → REVIEW_RUNNING → 主链推 stage（apply_verify_pass）
+          ──→ resume(fix-needed)   → FIXER_RUNNING（start_fixer 起 fixer agent）
+          ──→ complete             → DONE（清 PVC）
+          ──→ BKD verifier follow-up（保留路径，不替代）
+```
+
+## 取舍
+
+- **为什么不做 `action="retry"`（重跑失败 stage）**——sisyphus 哲学是"escalate 后
+  flaky / infra 抖动直接归人决策"（CLAUDE.md "失败先验，再试错"），retry 这种
+  机械重试已经被 M14c 砍掉过。如果操作员要重跑 staging-test，应当用 `/emit`
+  body `{"event": "staging-test.fail"}` 这种 raw API；本 endpoint 只暴露
+  verifier 决策路径（pass / fix-needed），跟 verifier-agent 的语义对齐。
+
+- **为什么 body 必传 action 不默认 "pass"**——操作员用 admin 路径绕过 verifier
+  这件事本身要求 explicit。默认 pass 等于鼓励"我也不知道但先 pass 试试"——
+  这种语义应当走原本的 BKD verifier follow-up 让 agent 判，而不是 admin 兜底。
+
+- **为什么 rename runner-pause/resume 而不是给新 endpoint 取另一个名（unblock /
+  reactivate）**——`/resume` 在 escalate / complete / emit 已建立的"state 操作"
+  动词集合里语义最自然（"恢复执行"）。runner-pause/resume 当时 v0.2 命名漏想了
+  state /resume 的需求；现在补上 runner- 前缀，跟 runner ops 的 `runner-rebuild-workspace`
+  风格也更一致（rebuild-workspace 就是 runner 概念，没 state 含义）。
+
+  Rename 的 cost：admin docstring + V0.2-PLAN.md + sisyphus-integration.md 三处
+  docs；无脚本 / CI 调用方（grep 验证：`/admin/req/.*/(pause|resume)` 仅 4 处
+  匹配，全是文档）。Sisyphus pre-1.0，不发版本号兼容标签。
+
+- **为什么不在 resume 后加 `cleanup_runner` 反向操作**——apply_verify_pass 内部
+  已经会 `ensure_runner(req_id, wait_ready=True)`（_verifier.py L207），会把
+  escalate 时清的 pod 拉回来；start_fixer 通过原 transition 路径走的 BKD
+  fixer-agent 拉的也是同 pod。不需要 admin endpoint 自己管 runner。
+
+- **为什么 400 缺 verifier_stage 而不是 200 noop**——apply_verify_pass 缺 stage
+  的死路径（emit VERIFY_ESCALATE 自循环回 ESCALATED）对调用方完全静默，admin
+  会看到 200 带 chained={escalated} 回到原状态，操作员 confused。早 400 + 提示
+  "provide body.stage" 比让它走完一遍 transition 安全。
+
+- **为什么不做 `confirm: true` 二次确认**——admin endpoints 全靠 Bearer token
+  做权限隔离，已经是 ops-only 操作；force_escalate / complete 没二次确认本 endpoint
+  也跟齐。
+
+## 影响面
+
+### 改动文件
+
+- `orchestrator/src/orchestrator/admin.py`：
+  - 加 `ResumeBody(BaseModel)` pydantic schema
+  - 加 `@admin.post("/req/{req_id}/resume")` async def `resume_req`（新 state-level）
+  - 重命名 `@admin.post("/req/{req_id}/pause")` → `/runner-pause`
+  - 重命名 `@admin.post("/req/{req_id}/resume")` （runner，旧）→ `/runner-resume`
+  - 模块 docstring 更新（runner ops 段落 + 新 endpoint 列表）
+- `orchestrator/tests/test_admin.py`：5 个新 case 见 tasks.md
+- `orchestrator/docs/V0.2-PLAN.md`：admin 工具表更新 path
+- `orchestrator/docs/sisyphus-integration.md`：pause 引用更新 path
+
+### 不动
+
+- `state.py` / TRANSITIONS（已有 ESCALATED → VERIFY_PASS / VERIFY_FIX_NEEDED 三条 transition）
+- `engine.py` / `actions/_verifier.py`（apply_verify_pass / start_fixer 现状已支持 ESCALATED CAS source）
+- `escalate.py`（_HARD_REASONS / auto-resume 逻辑独立）
+- Postgres migrations（无新表）
+- BKD 集成层 / runner_gc / k8s_runner（runner 操作 endpoint 仅 path 改名，handler 函数不动）

--- a/openspec/changes/REQ-admin-resume-escalated-1777123726/specs/admin-resume-endpoint/contract.spec.yaml
+++ b/openspec/changes/REQ-admin-resume-escalated-1777123726/specs/admin-resume-endpoint/contract.spec.yaml
@@ -1,0 +1,224 @@
+capability: admin-resume-endpoint
+version: "1.0"
+description: |
+  Admin endpoint POST /admin/req/{req_id}/resume: state-level resume from
+  ESCALATED. 把 verifier-agent 的 pass / fix-needed 决策语义封装成一条 admin
+  endpoint，复用现有 (ESCALATED, VERIFY_PASS) → REVIEW_RUNNING + (ESCALATED,
+  VERIFY_FIX_NEEDED) → FIXER_RUNNING transition。
+
+  跟 BKD verifier follow-up 路径并行：verifier 路径走 BKD agent 重判 + 写
+  decision JSON；admin 路径走人工直派 Event。两条路径殊途同归，命中同一组
+  transition + action handler。
+
+  附带：rename 旧 v0.2 K8s runner endpoint /pause /resume → /runner-pause
+  /runner-resume，让出 /resume 给 state-level resume。
+
+http:
+  - method: POST
+    path: /admin/req/{req_id}/resume
+    auth: Bearer <webhook_token>
+    handler: admin.resume_req                 # NEW (state-level)
+    request_body:
+      content_type: application/json
+      schema:
+        type: object
+        required: [action]
+        properties:
+          action:
+            type: string
+            enum: [pass, fix-needed]
+            description: |
+              "pass" → emit Event.VERIFY_PASS（推下一 stage）
+              "fix-needed" → emit Event.VERIFY_FIX_NEEDED（起 fixer agent）
+          stage:
+            type: ["string", "null"]
+            description: |
+              覆盖 ctx.verifier_stage（影响 apply_verify_pass 路由）。pass 路径
+              ctx 没 verifier_stage 时必传。
+          fixer:
+            type: ["string", "null"]
+            enum: [dev, spec, null]
+            description: 覆盖 ctx.verifier_fixer（fix-needed 路径用）。
+          reason:
+            type: ["string", "null"]
+            description: 写到 ctx.resume_reason，仅审计用。
+        additionalProperties: false
+    responses:
+      "200_pass":
+        condition: state was escalated, action=pass dispatched
+        body:
+          action: resumed
+          from_state: escalated
+          event: verify.pass
+          chained: "<engine.step result dict>"
+      "200_fix":
+        condition: state was escalated, action=fix-needed dispatched
+        body:
+          action: resumed
+          from_state: escalated
+          event: verify.fix-needed
+          chained: "<engine.step result dict>"
+      "400":
+        condition: action=pass with no resolvable verifier_stage
+        body:
+          detail: "verifier_stage required for action=pass; provide body.stage or use BKD verifier follow-up"
+      "404":
+        condition: no req_state row with req_id
+        body:
+          detail: "req <id> not found"
+      "409":
+        condition: state != escalated
+        body:
+          detail: "req <id> is in state <X>; expected escalated. Hint: POST /admin/req/<id>/escalate first to abort an in-flight REQ."
+      "422":
+        condition: pydantic validation fails (action ∉ {pass, fix-needed}, fixer ∉ {dev, spec})
+        body: pydantic standard error envelope
+      "401_or_403":
+        condition: missing / invalid Authorization header
+        handler: webhook._verify_token raises HTTPException
+
+  # rename 项（path 改，函数名 / 行为不变）
+  - method: POST
+    path: /admin/req/{req_id}/runner-pause     # was /pause
+    auth: Bearer <webhook_token>
+    handler: admin.pause_runner                # 函数名不变
+    behavior_unchanged: true                   # 行为：删 Pod 保 PVC
+  - method: POST
+    path: /admin/req/{req_id}/runner-resume    # was /resume
+    auth: Bearer <webhook_token>
+    handler: admin.resume_runner               # 函数名不变
+    behavior_unchanged: true                   # 行为：重建 Pod
+
+precondition_chain:
+  description: |
+    检查顺序固定（验证 → 取数 → 状态 → schema → ctx 路由），保证错误码不互相覆盖。
+  sequence:
+    - "1. _verify_token(authorization)                                # 401/403"
+    - "2. ResumeBody schema validation (pydantic)                     # 422"
+    - "3. row = await req_state.get(pool, req_id)"
+    - "4. if row is None: raise HTTPException(404)"
+    - "5. if row.state != ReqState.ESCALATED: raise HTTPException(409)"
+    - "6. effective_stage = body.stage or row.context.get('verifier_stage')"
+    - "7. if action == 'pass' and not effective_stage: raise HTTPException(400)"
+    - "8. ctx_patch = {resumed_by_admin: true, resume_action: action,"
+    - "                + (verifier_stage: body.stage if body.stage else omit),"
+    - "                + (verifier_fixer: body.fixer if body.fixer else omit),"
+    - "                + (resume_reason: body.reason if body.reason else omit)}"
+    - "9. await req_state.update_context(pool, req_id, ctx_patch)"
+    - "10. row = await req_state.get(pool, req_id)   # reload patched ctx"
+    - "11. event = VERIFY_PASS if action=='pass' else VERIFY_FIX_NEEDED"
+    - "12. fake_body = _FakeBody(req_id, project_id)"
+    - "13. result = await engine.step(pool, body=fake_body, ..., event=event)"
+    - "14. return {action: resumed, from_state: escalated, event: ..., chained: result}"
+
+state_change:
+  before: "req_state.state = 'escalated'"
+  after_pass:
+    - "context patched with resumed_by_admin / resume_action / optional resume_reason / stage"
+    - "state moves via engine.step → apply_verify_pass internally CAS to <stage>_running"
+    - "stage_runs row for verifier closed (handled by apply_verify_pass)"
+    - "ensure_runner re-pulls Pod (apply_verify_pass internal)"
+  after_fix_needed:
+    - "context patched"
+    - "state moves to FIXER_RUNNING via engine.step + start_fixer transition action"
+    - "start_fixer creates new BKD fixer issue + writes ctx.fixer_round"
+  context_patch_always:
+    resumed_by_admin: true
+    resume_action: <body.action>
+  context_patch_optional:
+    verifier_stage: <body.stage if provided>
+    verifier_fixer: <body.fixer if provided>
+    resume_reason: <body.reason if provided>
+
+invariants:
+  no_state_machine_pollution:
+    - "不在 state.py 加新 Event"
+    - "不在 TRANSITIONS 加 (ESCALATED, ?) 新 transition"
+    - "endpoint 仅是 Event 注入的入口；transition 表示已有的合法图"
+
+  reuse_existing_handlers:
+    - "apply_verify_pass 已支持 cas_transition 接 (REVIEW_RUNNING, ESCALATED) 双源"
+    - "start_fixer 已通过 (ESCALATED, VERIFY_FIX_NEEDED) → FIXER_RUNNING transition 接通"
+    - "本 endpoint 0 重复实现"
+
+  audit_distinguishable:
+    - "ctx.resumed_by_admin=true 跟 verifier_decisions 表行不冲突"
+    - "verifier_decisions 表只反映 BKD verifier-agent 真做的判断"
+    - "admin 路径不 insert verifier_decisions（没 verifier session）"
+    - "Metabase 看板想区分 admin resume vs verifier resume → 看 resumed_by_admin ctx flag"
+
+  path_disambiguation:
+    - "/resume 现在只语义化 state resume"
+    - "/runner-resume 处理 K8s pod 重建"
+    - "/runner-pause 处理 K8s pod 删除"
+    - "rename 不破坏任何 caller（grep 确认仅 docs 引用，无脚本 / 自动化）"
+
+interaction_with_verifier_followup:
+  description: |
+    用户用 BKD UI 在 verifier issue 续 follow-up 这条路径仍可用（state.py
+    transitions 不动），跟 admin /resume 并行存在。两者命中相同 transition；
+    区别仅在事件来源：BKD verifier 路径有 verifier_decisions 行 + verifier
+    re-decision；admin 路径靠 ctx.resumed_by_admin 标识。
+  use_admin_when:
+    - "已经知道答案（infra flake / agent 误判）—— 跑 verifier 浪费 quota + 时间"
+    - "ESCALATED 来自非 verifier 路径（pr_ci.timeout / accept-env-up.fail / intake.fail）—— 没 verifier issue 给人 follow-up"
+    - "verifier round cap 触顶 (_HARD_REASONS=fixer-round-cap) —— 操作员决定 hand-craft 一次跳过"
+  use_verifier_when:
+    - "想让 agent 重判（结果不确定）"
+    - "需要变更 fixer scope / reason 由 agent 重新捋"
+
+interaction_with_complete:
+  description: |
+    resume 跟 complete 都是 ESCALATED → 出口；语义对立：
+      resume: 给 REQ 一次机会推 stage / 重 fix
+      complete: 宣告 REQ 作废，进 done + 清 PVC
+    操作员看 admin /req/{id} 的 ctx 决定走哪条；endpoint 互不冲突
+    （precondition 都要求 state=escalated；并发时 SQL CAS 保串行）。
+
+interaction_with_force_escalate:
+  description: |
+    完整 escalated 出入口：
+      in-flight → force_escalate → ESCALATED
+      ESCALATED → resume(pass)        → next stage（推主链）
+      ESCALATED → resume(fix-needed)  → fixer-running
+      ESCALATED → complete            → done
+      ESCALATED → BKD verifier follow-up → 同 resume
+
+failure_modes:
+  cas_lost_to_concurrent_followup:
+    cause: |
+      操作员 POST /resume 同时另一边 BKD verifier follow-up 完成 webhook，两个
+      engine.step 同时尝试 CAS ESCALATED → REVIEW_RUNNING / FIXER_RUNNING。
+    handler: |
+      asyncpg / Postgres 行级 CAS 自带原子性。第二个调用 cas_transition 返
+      False，engine.step 返 {action: skip, reason: concurrent state change}，
+      被 admin endpoint 透传 chained 字段返给调用方。
+    state_outcome: 第一个胜出方推到 next state；第二个无副作用。
+    user_impact: 调用方拿 200 但 chained.action="skip"，应再读 /admin/req/{id} 确认 state。
+
+  ctx_verifier_stage_inconsistent:
+    cause: |
+      ctx.verifier_stage 跟实际 verifier issue 的 verify:<stage> tag 不一致
+      （多并发 verifier 把 ctx 覆盖过）。
+    handler: |
+      apply_verify_pass 优先读 tags（_verifier.py L144-152），admin 路径 tags
+      为 []（_FakeBody），fallback 到 ctx.verifier_stage —— body.stage 显式传
+      可彻底绕过该不一致。
+    user_impact: 操作员遇到 ctx 看着不对要传 body.stage 显式覆盖。
+
+  bad_stage_value:
+    cause: body.stage 传了一个不在 _PASS_ROUTING 里的值（如 "bogus"）
+    handler: |
+      apply_verify_pass 内部 _PASS_ROUTING.get(stage) 返 None → emit
+      VERIFY_ESCALATE 把 REQ 推回 ESCALATED 自循环。
+    detection: chained.result.emit == "verify.escalate"。
+    mitigation: 后续可以在 admin endpoint 增加 body.stage 校验白名单（暂不做，避免双份维护 _PASS_ROUTING）。
+
+  fix_needed_round_cap_already_hit:
+    cause: |
+      操作员对一个 fixer_round 已超 cap 的 REQ 调 resume(fix-needed)。
+      start_fixer 内部检测 fixer_round + 1 > settings.fixer_round_cap →
+      emit VERIFY_ESCALATE。
+    handler: 自然走 escalate.py，REQ 留 ESCALATED + ctx.escalated_reason="fixer-round-cap"。
+    user_impact: chained.result.emit == "verify.escalate"，REQ 没真起新 fixer。
+    mitigation: 操作员要么 reset ctx.fixer_round 后再 resume（手动 emit 无），要么走 complete 收尾。

--- a/openspec/changes/REQ-admin-resume-escalated-1777123726/specs/admin-resume-endpoint/spec.md
+++ b/openspec/changes/REQ-admin-resume-escalated-1777123726/specs/admin-resume-endpoint/spec.md
@@ -1,0 +1,187 @@
+# admin-resume-endpoint
+
+## ADDED Requirements
+
+### Requirement: /admin/req/{req_id}/resume dispatches VERIFY_PASS or VERIFY_FIX_NEEDED to unblock an escalated REQ
+
+The orchestrator SHALL expose a `POST /admin/req/{req_id}/resume` HTTP
+endpoint behind the same Bearer-token auth as the other `/admin/*` routes
+(`webhook._verify_token`). The endpoint MUST accept a JSON body with a
+required `action` field of value `"pass"` or `"fix-needed"`, and SHALL
+dispatch the corresponding state-machine event (`Event.VERIFY_PASS` or
+`Event.VERIFY_FIX_NEEDED`) through `engine.step` so that the existing
+`(ESCALATED, VERIFY_PASS) → REVIEW_RUNNING` and `(ESCALATED, VERIFY_FIX_NEEDED)
+→ FIXER_RUNNING` transitions execute their action handlers
+(`apply_verify_pass` / `start_fixer`). The endpoint MUST NOT introduce new
+events or transitions; it is purely an injection entry-point that mirrors
+the BKD verifier-agent follow-up path without requiring a verifier session.
+
+#### Scenario: ARE-S1 happy path: action=pass dispatches VERIFY_PASS
+
+- **GIVEN** a REQ row with `state='escalated'` and
+  `context.verifier_stage='staging_test'`
+- **WHEN** the client sends `POST /admin/req/REQ-X/resume` with body
+  `{"action": "pass"}` and a valid Bearer token
+- **THEN** the endpoint MUST call `engine.step` exactly once with
+  `event=Event.VERIFY_PASS` and `cur_state=ReqState.ESCALATED`
+- **AND** the response MUST be 200 with body containing
+  `action == "resumed"` and `event == "verify.pass"` and
+  `from_state == "escalated"`
+- **AND** prior to the dispatch the endpoint MUST patch
+  `req_state.context` to set `resumed_by_admin = true` and
+  `resume_action = "pass"`
+
+#### Scenario: ARE-S2 happy path: action=fix-needed dispatches VERIFY_FIX_NEEDED
+
+- **GIVEN** a REQ row with `state='escalated'` and
+  `context.verifier_stage='dev_cross_check'` and
+  `context.verifier_fixer='dev'`
+- **WHEN** the client sends `POST /admin/req/REQ-X/resume` with body
+  `{"action": "fix-needed"}`
+- **THEN** the endpoint MUST call `engine.step` exactly once with
+  `event=Event.VERIFY_FIX_NEEDED`
+- **AND** the response MUST be 200 with body containing
+  `action == "resumed"` and `event == "verify.fix-needed"`
+
+### Requirement: /admin/req/{req_id}/resume rejects non-ESCALATED states with HTTP 409
+
+The endpoint MUST return HTTP 409 Conflict when the REQ is in any state
+other than `escalated`. The error body MUST include the current state
+name and a hint pointing at `/admin/req/{req_id}/escalate` as the
+prerequisite step. This precondition prevents accidentally re-firing
+verifier events on an in-flight stage that already has a transition
+queued (e.g. ANALYZING during a running BKD analyze-agent session).
+
+#### Scenario: ARE-S3 calling resume on an in-flight REQ returns 409
+
+- **GIVEN** a REQ row with `state='analyzing'`
+- **WHEN** the client sends `POST /admin/req/REQ-X/resume` with body
+  `{"action": "pass"}`
+- **THEN** the response MUST be 409 with detail containing the literal
+  substring `analyzing`
+- **AND** `engine.step` MUST NOT be called
+- **AND** no SQL UPDATE on `req_state.context` MUST happen
+
+### Requirement: /admin/req/{req_id}/resume returns 404 when the REQ is unknown
+
+The endpoint MUST return HTTP 404 Not Found when no row matches the
+`req_id` path parameter, with the same error shape as the other
+`/admin/req/{req_id}/*` endpoints (`{"detail": "req <id> not found"}`).
+This MUST happen before any state-precondition check, so that "no such
+REQ" cannot be confused with "REQ in wrong state".
+
+#### Scenario: ARE-S4 unknown REQ returns 404
+
+- **GIVEN** no row in `req_state` with `req_id='REQ-DOES-NOT-EXIST'`
+- **WHEN** the client sends `POST /admin/req/REQ-DOES-NOT-EXIST/resume`
+  with any body
+- **THEN** the response MUST be 404 with detail containing the literal
+  substring `not found`
+
+### Requirement: /admin/req/{req_id}/resume rejects action=pass without resolvable verifier_stage
+
+The endpoint MUST return HTTP 400 Bad Request when `action == "pass"`
+and neither `body.stage` nor `req_state.context.verifier_stage` is set,
+because `apply_verify_pass` would otherwise emit `VERIFY_ESCALATE`
+(self-loop back to ESCALATED) silently. The error MUST instruct the
+operator to either pass `body.stage` explicitly or use the BKD verifier
+follow-up path. This is required because escalates from non-verifier
+paths (e.g. `pr_ci.timeout`, `accept-env-up.fail`, `intake.fail`) leave
+the context without `verifier_stage`.
+
+#### Scenario: ARE-S5 action=pass with no verifier_stage returns 400
+
+- **GIVEN** a REQ row with `state='escalated'` and
+  `context` containing no `verifier_stage` key (e.g. escalated via
+  `pr_ci.timeout`)
+- **WHEN** the client sends `POST /admin/req/REQ-X/resume` with body
+  `{"action": "pass"}` (no `stage` field)
+- **THEN** the response MUST be 400 with detail containing the literal
+  substring `verifier_stage`
+- **AND** `engine.step` MUST NOT be called
+
+### Requirement: /admin/req/{req_id}/resume body.stage and body.fixer override context fields before dispatch
+
+The endpoint SHALL accept optional `stage` and `fixer` fields in the
+request body. When provided, the values MUST be patched into
+`req_state.context` (writing keys `verifier_stage` and `verifier_fixer`
+respectively) before `engine.step` is invoked, so that
+`apply_verify_pass` / `start_fixer` route to the correct stage / fixer
+when the prior context did not record them or recorded a different one.
+The `fixer` value MUST be one of `{"dev", "spec"}`; any other value MUST
+yield HTTP 422 from pydantic schema validation.
+
+#### Scenario: ARE-S6 body.stage patches context.verifier_stage
+
+- **GIVEN** a REQ row with `state='escalated'` and `context.verifier_stage='staging_test'`
+- **WHEN** the client sends `POST /admin/req/REQ-X/resume` with body
+  `{"action": "pass", "stage": "pr_ci"}`
+- **THEN** before `engine.step` is called the endpoint MUST patch
+  `context.verifier_stage = "pr_ci"`
+
+### Requirement: /admin/req/{req_id}/resume body.reason is persisted to context for audit
+
+The endpoint SHALL accept an optional `reason` field in the request body.
+When provided, the value MUST be persisted in `req_state.context` under
+the key `resume_reason`. The flag `resumed_by_admin = true` and
+`resume_action = <body.action>` MUST always be patched into context
+regardless of whether `reason` is provided, so audit queries can
+distinguish admin-driven resumes from BKD-verifier-driven resumes (the
+latter writes `verifier_decisions` rows; the former writes only
+`req_state.history` + these context fields).
+
+#### Scenario: ARE-S7 body.reason persists to context.resume_reason
+
+- **GIVEN** a REQ row with `state='escalated'` and `context.verifier_stage='staging_test'`
+- **WHEN** the client sends `POST /admin/req/REQ-X/resume` with body
+  `{"action": "pass", "reason": "GHA infra flake confirmed"}`
+- **THEN** before `engine.step` is called the endpoint MUST patch
+  `context.resume_reason = "GHA infra flake confirmed"`,
+  `context.resumed_by_admin = true`, and `context.resume_action = "pass"`
+
+### Requirement: /admin/req/{req_id}/resume enforces Bearer auth as first step
+
+The endpoint MUST call `webhook._verify_token(authorization)` before any
+state read or context write, mirroring `force_escalate`, `complete_req`,
+and the runner-ops endpoints. A missing or invalid token MUST yield
+HTTP 401 / 403 (whichever `_verify_token` raises) and MUST NOT execute
+any DB query or `engine.step` call.
+
+#### Scenario: ARE-S8 missing Bearer token rejects before any state read
+
+- **GIVEN** any state of any REQ
+- **WHEN** the client sends `POST /admin/req/REQ-X/resume` without an
+  `Authorization` header
+- **THEN** `_verify_token` MUST be invoked and MUST raise an HTTPException
+- **AND** `req_state.get` MUST NOT be called
+- **AND** `engine.step` MUST NOT be called
+
+### Requirement: K8s runner pause/resume admin endpoints renamed with runner- prefix
+
+The orchestrator SHALL rename the pre-existing endpoints `POST /admin/req/{req_id}/pause`
+to `POST /admin/req/{req_id}/runner-pause`, and `POST /admin/req/{req_id}/resume`
+(the v0.2 runner-Pod recreate operation) to `POST /admin/req/{req_id}/runner-resume`.
+The renamed endpoints MUST preserve their existing behavior (delete-Pod-keep-PVC
+and recreate-Pod respectively), request body, response shape, and Bearer-token
+auth — only the URL path changes. The rename frees the bare `/resume` path for
+the new state-level endpoint defined above. Handler function names
+(`pause_runner`, `resume_runner`) MUST stay unchanged so existing tests
+that import them by name keep working.
+
+#### Scenario: ARE-S9 runner-pause path is registered and old /pause is gone
+
+- **GIVEN** the FastAPI admin router is initialized
+- **WHEN** the route table is inspected
+- **THEN** the route `POST /admin/req/{req_id}/runner-pause` MUST be
+  registered and bound to the `pause_runner` handler
+- **AND** no route `POST /admin/req/{req_id}/pause` MUST be registered
+
+#### Scenario: ARE-S10 runner-resume path is registered and bound to runner controller
+
+- **GIVEN** the FastAPI admin router is initialized
+- **WHEN** the route table is inspected
+- **THEN** the route `POST /admin/req/{req_id}/runner-resume` MUST be
+  registered and bound to the `resume_runner` handler (which calls
+  `RunnerController.resume`, NOT the new state-level resume)
+- **AND** the route `POST /admin/req/{req_id}/resume` MUST be bound to
+  the new state-level handler `resume_req`, NOT to `resume_runner`

--- a/openspec/changes/REQ-admin-resume-escalated-1777123726/tasks.md
+++ b/openspec/changes/REQ-admin-resume-escalated-1777123726/tasks.md
@@ -1,0 +1,43 @@
+# Tasks: REQ-admin-resume-escalated-1777123726
+
+## Stage: spec
+
+- [x] `openspec/changes/REQ-admin-resume-escalated-1777123726/proposal.md`
+- [x] `openspec/changes/REQ-admin-resume-escalated-1777123726/design.md`
+- [x] `openspec/changes/REQ-admin-resume-escalated-1777123726/tasks.md`
+- [x] `openspec/changes/REQ-admin-resume-escalated-1777123726/specs/admin-resume-endpoint/spec.md`
+- [x] `openspec/changes/REQ-admin-resume-escalated-1777123726/specs/admin-resume-endpoint/contract.spec.yaml`
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/admin.py`：
+  - 重命名 `@admin.post("/req/{req_id}/pause")` → `/req/{req_id}/runner-pause`（函数名 `pause_runner` 不变）
+  - 重命名 `@admin.post("/req/{req_id}/resume")` → `/req/{req_id}/runner-resume`（函数名 `resume_runner` 不变）
+  - 加 `class ResumeBody(BaseModel)`：action / stage / fixer / reason 四字段
+  - 加 `@admin.post("/req/{req_id}/resume")` async def `resume_req`（state-level）
+  - 模块 docstring 更新：runner ops 段重命名 + 新加 state-level resume 一行
+
+- [x] `orchestrator/docs/V0.2-PLAN.md`：admin 工具表把 pause/resume 改成 runner-pause/runner-resume
+
+- [x] `orchestrator/docs/sisyphus-integration.md`：`POST /admin/req/REQ-N/pause` 引用改成 `runner-pause`
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_admin.py`，新增 case：
+
+  - `test_resume_404_when_not_found`：req_state.get 返 None → 404
+  - `test_resume_409_when_not_escalated`：state=analyzing → 409 提示 hint
+  - `test_resume_400_when_pass_missing_stage`：action=pass + ctx 没 verifier_stage + body 没 stage → 400
+  - `test_resume_pass_dispatches_verify_pass_event`：state=escalated, ctx.verifier_stage=staging_test, action=pass → engine.step 被调一次 with event=VERIFY_PASS
+  - `test_resume_pass_with_body_stage_overrides_ctx`：body.stage="pr_ci" → ctx 被 patch + engine.step 收到正确 event
+  - `test_resume_fix_needed_dispatches_verify_fix_needed_event`：action=fix-needed → engine.step with event=VERIFY_FIX_NEEDED
+  - `test_resume_writes_audit_to_context`：body.reason="rerun infra flake" → ctx.resume_reason / resumed_by_admin 被 patch
+  - `test_resume_invalid_action_422`：body.action="bogus" → pydantic ValidationError
+  - `test_resume_auth_check_before_db`：bad token → 401，没 req_state.get
+  - `test_runner_pause_path_renamed`：函数 `pause_runner` 装饰器路径是 `/req/{req_id}/runner-pause`
+  - `test_runner_resume_path_renamed`：函数 `resume_runner` 装饰器路径是 `/req/{req_id}/runner-resume`
+
+## Stage: PR
+
+- [x] git push feat/REQ-admin-resume-escalated-1777123726
+- [x] gh pr create

--- a/orchestrator/docs/V0.2-PLAN.md
+++ b/orchestrator/docs/V0.2-PLAN.md
@@ -24,7 +24,7 @@ v0.2 是从 "docker run runner + 单 repo 假设 + 硬编码 lab + sonarqube 绕
 | accept lab | 硬编码 ttpos-arch-lab | 通用：Makefile `ci-accept-env-up`/`down` + sisyphus 注入 env var |
 | image tag | dev-agent 假贴 | GHA `image-publish` job 产出，写到 commit status description |
 | bug 分类 | 笼统 `diagnosis:xxx` | 正交维度：**阶段标签** `bug:pre-release`/`ci`/`post-release` + `diagnosis:xxx` |
-| pause/resume | 无 | `/admin/req/{id}/pause` & `/resume`（删 Pod 保 PVC / 重建 Pod）|
+| pause/resume runner | 无 | `/admin/req/{id}/runner-pause` & `/runner-resume`（删 Pod 保 PVC / 重建 Pod；旧路径 `/pause` `/resume` 已迁移让出 `/resume` 给 state-level resume）|
 | rebuild workspace | 无 | `/admin/req/{id}/rebuild-workspace` |
 | runner GC | 无 | 启动 + 1h 周期扫 → 清 done/escalated 过保留期 |
 | agent 数量 | 9 | 12（+staging-test + pr-ci-watch + teardown 是 sisyphus 内，不是 agent）|
@@ -224,7 +224,7 @@ sisyphus **做**的事：
 - 每 REQ 拉一个 K8s Pod + PVC 做调试环境
 - 注入环境变量（REQ_ID / IMAGE_TAGS / KUBECONFIG 等）
 - 编排状态机 + 分发 BKD agent 任务
-- 提供 admin 运维 endpoints（pause/resume/rebuild/emit/escalate）
+- 提供 admin 运维 endpoints（runner-pause/runner-resume/rebuild-workspace/emit/escalate/complete/resume）
 - GC 清过保留期的 PVC
 
 sisyphus **不做**的事：

--- a/orchestrator/docs/sisyphus-integration.md
+++ b/orchestrator/docs/sisyphus-integration.md
@@ -208,5 +208,6 @@ ci-build:
 | REQ 卡住 | `curl /admin/req/REQ-N` 看 state + history + ctx.manifest_snapshot |
 | manifest 格式错 | `kubectl exec runner-<req> -- validate-manifest.py` |
 | workspace 丢 / 容器异常 | `POST /admin/req/REQ-N/rebuild-workspace`（S5 提供）|
-| 资源紧想让路 | `POST /admin/req/REQ-N/pause`（S5 提供）|
+| 资源紧想让路 | `POST /admin/req/REQ-N/runner-pause`（S5 提供）|
+| ESCALATED REQ 想推下一 stage / 重起 fixer | `POST /admin/req/REQ-N/resume` body `{"action": "pass"\|"fix-needed", "stage"?: "...", "reason"?: "..."}` |
 | bug 积累分析 | `gh issue list --label sisyphus:pre-release-bug` / `ci-bug` / `post-release-bug` |

--- a/orchestrator/src/orchestrator/admin.py
+++ b/orchestrator/src/orchestrator/admin.py
@@ -2,24 +2,28 @@
 
 需要同样的 Authorization: Bearer <webhook_token> 头。
 
-基础（已有）：
+State 操作：
   POST /admin/req/{req_id}/emit       body: {"event": "..."}
   POST /admin/req/{req_id}/escalate
   POST /admin/req/{req_id}/complete   body: {"reason": "..."} (optional)
+  POST /admin/req/{req_id}/resume     body: {"action": "pass"|"fix-needed", "stage"?, "fixer"?, "reason"?}
+                                       → state-level resume from ESCALATED
+                                       （派 VERIFY_PASS / VERIFY_FIX_NEEDED 走合法 transition）
   GET  /admin/metrics
   GET  /admin/req/{req_id}
 
-v0.2 runner 运维（新）：
-  POST /admin/req/{req_id}/pause      → 删 Pod，PVC 保留
-  POST /admin/req/{req_id}/resume     → 重建 Pod
+v0.2 K8s runner 运维：
+  POST /admin/req/{req_id}/runner-pause       → 删 Pod，PVC 保留
+  POST /admin/req/{req_id}/runner-resume      → 重建 Pod
   POST /admin/req/{req_id}/rebuild-workspace  → 强拉代码重建 workspace（需 PVC 存在）
-  GET  /admin/runners                  → 列所有 runner pod / pvc 状态
+  GET  /admin/runners                          → 列所有 runner pod / pvc 状态
 """
 from __future__ import annotations
 
 import asyncio
 import json
 from datetime import UTC, datetime
+from typing import Literal
 
 import structlog
 from fastapi import APIRouter, Header, HTTPException
@@ -219,6 +223,111 @@ async def complete_req(
     }
 
 
+class ResumeBody(BaseModel):
+    """state-level resume from ESCALATED 的 body schema。
+
+    action 必传，无默认 —— 走 admin override 绕过 verifier-agent 的语义要求 explicit。
+    其余可选：stage / fixer 覆盖 ctx 路由字段；reason 仅审计。
+    """
+    action: Literal["pass", "fix-needed"]
+    stage: str | None = None
+    fixer: Literal["dev", "spec"] | None = None
+    reason: str | None = None
+
+
+@admin.post("/req/{req_id}/resume")
+async def resume_req(
+    req_id: str,
+    body: ResumeBody,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    """从 ESCALATED 派 verifier 决策 Event，走合法 transition 推进状态机。
+
+    跟 BKD verifier follow-up 路径并行：两条路径都最终命中
+    `(ESCALATED, VERIFY_PASS) → REVIEW_RUNNING (apply_verify_pass)` 或
+    `(ESCALATED, VERIFY_FIX_NEEDED) → FIXER_RUNNING (start_fixer)`，
+    区别仅在事件来源（BKD verifier 路径有 verifier_decisions 行；admin
+    路径靠 ctx.resumed_by_admin 标识）。
+
+    适用：
+    - 已经知道答案（infra flake / agent 误判），跑 verifier 浪费 quota
+    - ESCALATED 来自非 verifier 路径（pr_ci.timeout / accept-env-up.fail
+      / intake.fail），没 verifier issue 给人 follow-up
+    """
+    _verify_token(authorization)
+
+    pool = db.get_pool()
+    row = await req_state.get(pool, req_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"req {req_id} not found")
+
+    if row.state != ReqState.ESCALATED:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"req {req_id} is in state {row.state.value}; expected escalated. "
+                f"Hint: POST /admin/req/{req_id}/escalate first to abort an "
+                f"in-flight REQ."
+            ),
+        )
+
+    # action=pass 必须有可路由的 verifier_stage（apply_verify_pass 拿不到会
+    # emit VERIFY_ESCALATE 走自循环，对调用方静默 —— 早 fail 给清晰错误）。
+    effective_stage = body.stage or (row.context or {}).get("verifier_stage")
+    if body.action == "pass" and not effective_stage:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "verifier_stage required for action=pass; "
+                "provide body.stage or use BKD verifier follow-up"
+            ),
+        )
+
+    # ctx 预置：admin 标记 + 可选覆盖
+    ctx_patch: dict = {
+        "resumed_by_admin": True,
+        "resume_action": body.action,
+    }
+    if body.stage:
+        ctx_patch["verifier_stage"] = body.stage
+    if body.fixer:
+        ctx_patch["verifier_fixer"] = body.fixer
+    if body.reason:
+        ctx_patch["resume_reason"] = body.reason
+    await req_state.update_context(pool, req_id, ctx_patch)
+
+    # 重读 ctx，让 engine.step 收到 patched 后的版本
+    row = await req_state.get(pool, req_id)
+    if row is None:  # 极小概率：admin 调用前并发删 row
+        raise HTTPException(status_code=404, detail=f"req {req_id} not found")
+
+    event = (
+        Event.VERIFY_PASS if body.action == "pass" else Event.VERIFY_FIX_NEEDED
+    )
+    fake = _FakeBody(req_id, row.project_id)
+    log.warning(
+        "admin.resume",
+        req_id=req_id, action=body.action, stage=effective_stage,
+        fixer=body.fixer, reason=body.reason,
+    )
+    chained = await engine.step(
+        pool,
+        body=fake,
+        req_id=req_id,
+        project_id=row.project_id,
+        tags=[],
+        cur_state=row.state,
+        ctx=row.context,
+        event=event,
+    )
+    return {
+        "action": "resumed",
+        "from_state": ReqState.ESCALATED.value,
+        "event": event.value,
+        "chained": chained,
+    }
+
+
 @admin.get("/metrics")
 async def metrics(
     authorization: str | None = Header(default=None),
@@ -342,14 +451,17 @@ def _require_controller() -> k8s_runner.RunnerController:
         ) from None
 
 
-@admin.post("/req/{req_id}/pause")
+@admin.post("/req/{req_id}/runner-pause")
 async def pause_runner(
     req_id: str,
     authorization: str | None = Header(default=None),
 ) -> dict:
     """删 Pod（PVC 保留），释放 docker daemon / 节点内存资源；workspace 保留。
 
-    适合"让出资源给高优 REQ"的场景。resume 即恢复。
+    适合"让出资源给高优 REQ"的场景。runner-resume 即恢复 Pod。
+
+    路径加 `runner-` 前缀（曾经是 `/pause`），跟 state-level `/resume` 区分
+    （后者派 verifier 决策 Event，跟 K8s 资源无关）。
     """
     _verify_token(authorization)
     rc = _require_controller()
@@ -364,12 +476,16 @@ async def pause_runner(
     return {"action": "paused", "pod_deleted": deleted, "pvc_kept": True}
 
 
-@admin.post("/req/{req_id}/resume")
+@admin.post("/req/{req_id}/runner-resume")
 async def resume_runner(
     req_id: str,
     authorization: str | None = Header(default=None),
 ) -> dict:
-    """重建 Pod，PVC 自动重新挂载。"""
+    """重建 Pod，PVC 自动重新挂载。
+
+    路径加 `runner-` 前缀（曾经是 `/resume`），跟 state-level `/resume`
+    （从 ESCALATED 派 verifier 决策 Event）区分。
+    """
     _verify_token(authorization)
     rc = _require_controller()
 

--- a/orchestrator/tests/test_admin.py
+++ b/orchestrator/tests/test_admin.py
@@ -1,4 +1,4 @@
-"""admin endpoints 烟测：emit / escalate / complete / get-req。"""
+"""admin endpoints 烟测：emit / escalate / complete / resume / get-req."""
 from __future__ import annotations
 
 import asyncio
@@ -7,16 +7,19 @@ from datetime import UTC, datetime
 
 import pytest
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 from orchestrator.admin import (
     CompleteBody,
     EmitBody,
+    ResumeBody,
     _FakeBody,
     complete_req,
     force_escalate,
     get_req,
+    resume_req,
 )
-from orchestrator.state import ReqState
+from orchestrator.state import Event, ReqState
 
 
 def test_fakebody_shape():
@@ -348,3 +351,321 @@ def test_complete_body_optional_reason():
     """CompleteBody 的 reason 可省略."""
     assert CompleteBody().reason is None
     assert CompleteBody(reason="x").reason == "x"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# /admin/req/{req_id}/resume tests (REQ-admin-resume-escalated-1777123726)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _bypass_auth_pool_and_update(
+    monkeypatch,
+    pool: _FakePool,
+    row: _FakeRow | None,
+    second_row: _FakeRow | None = None,
+):
+    """resume_req 需要：_verify_token + db.get_pool + req_state.get（两次）+
+    req_state.update_context。第二次 get 默认返跟第一次同 row（覆盖原 ctx）。
+    """
+    from orchestrator import admin as admin_mod
+    monkeypatch.setattr(admin_mod, "_verify_token", lambda x: None)
+
+    calls = {"n": 0}
+    second = second_row if second_row is not None else row
+
+    async def _get(_pool, _req_id):
+        calls["n"] += 1
+        return row if calls["n"] == 1 else second
+
+    monkeypatch.setattr("orchestrator.admin.req_state.get", _get)
+    monkeypatch.setattr("orchestrator.admin.db.get_pool", lambda: pool)
+
+    update_calls: list = []
+
+    async def _update(_pool, _req_id, patch):
+        update_calls.append(patch)
+
+    monkeypatch.setattr("orchestrator.admin.req_state.update_context", _update)
+    return update_calls
+
+
+@pytest.mark.asyncio
+async def test_resume_404_when_not_found(monkeypatch):
+    """ARE-S4: REQ 不存在 → 404."""
+    pool = _FakePool()
+    _bypass_auth_pool_and_update(monkeypatch, pool, row=None)
+
+    with pytest.raises(HTTPException) as ei:
+        await resume_req(
+            "REQ-MISSING", body=ResumeBody(action="pass"),
+            authorization="Bearer x",
+        )
+    assert ei.value.status_code == 404
+    assert "not found" in ei.value.detail
+
+
+@pytest.mark.asyncio
+async def test_resume_409_when_not_escalated(monkeypatch):
+    """ARE-S3: state=analyzing → 409 with hint about /escalate first."""
+    pool = _FakePool()
+    row = _FakeRow(req_id="REQ-X", project_id="p", state=ReqState.ANALYZING)
+    _bypass_auth_pool_and_update(monkeypatch, pool, row=row)
+
+    step_calls: list = []
+
+    async def _step(*a, **kw):
+        step_calls.append((a, kw))
+
+    monkeypatch.setattr("orchestrator.admin.engine.step", _step)
+
+    with pytest.raises(HTTPException) as ei:
+        await resume_req(
+            "REQ-X", body=ResumeBody(action="pass"), authorization="Bearer x",
+        )
+    assert ei.value.status_code == 409
+    assert "analyzing" in ei.value.detail
+    assert "/escalate" in ei.value.detail
+    assert step_calls == []
+
+
+@pytest.mark.asyncio
+async def test_resume_400_when_pass_missing_stage(monkeypatch):
+    """ARE-S5: action=pass + ctx 没 verifier_stage + body 没 stage → 400."""
+    pool = _FakePool()
+    row = _FakeRow(
+        req_id="REQ-X", project_id="p", state=ReqState.ESCALATED,
+        context={},  # 没 verifier_stage
+    )
+    _bypass_auth_pool_and_update(monkeypatch, pool, row=row)
+
+    step_calls: list = []
+
+    async def _step(*a, **kw):
+        step_calls.append((a, kw))
+
+    monkeypatch.setattr("orchestrator.admin.engine.step", _step)
+
+    with pytest.raises(HTTPException) as ei:
+        await resume_req(
+            "REQ-X", body=ResumeBody(action="pass"), authorization="Bearer x",
+        )
+    assert ei.value.status_code == 400
+    assert "verifier_stage" in ei.value.detail
+    assert step_calls == []
+
+
+@pytest.mark.asyncio
+async def test_resume_pass_dispatches_verify_pass_event(monkeypatch):
+    """ARE-S1: state=escalated, ctx.verifier_stage=staging_test, action=pass →
+    engine.step 被调一次 with event=VERIFY_PASS."""
+    pool = _FakePool()
+    row = _FakeRow(
+        req_id="REQ-X", project_id="p", state=ReqState.ESCALATED,
+        context={"verifier_stage": "staging_test"},
+    )
+    update_calls = _bypass_auth_pool_and_update(monkeypatch, pool, row=row)
+
+    step_calls: list = []
+
+    async def _step(*a, **kw):
+        step_calls.append(kw)
+        return {"action": "no-op", "next_state": "review-running"}
+
+    monkeypatch.setattr("orchestrator.admin.engine.step", _step)
+
+    result = await resume_req(
+        "REQ-X", body=ResumeBody(action="pass"), authorization="Bearer x",
+    )
+
+    assert result["action"] == "resumed"
+    assert result["from_state"] == "escalated"
+    assert result["event"] == "verify.pass"
+    assert "chained" in result
+    # engine.step 被调一次，event 是 VERIFY_PASS
+    assert len(step_calls) == 1
+    assert step_calls[0]["event"] == Event.VERIFY_PASS
+    assert step_calls[0]["cur_state"] == ReqState.ESCALATED
+    assert step_calls[0]["req_id"] == "REQ-X"
+    # ctx 被 patch（resumed_by_admin + resume_action）
+    assert len(update_calls) == 1
+    assert update_calls[0]["resumed_by_admin"] is True
+    assert update_calls[0]["resume_action"] == "pass"
+    assert "verifier_stage" not in update_calls[0]  # 没传 body.stage 不应 patch
+
+
+@pytest.mark.asyncio
+async def test_resume_pass_with_body_stage_overrides_ctx(monkeypatch):
+    """ARE-S6: body.stage="pr_ci" → ctx 被 patch verifier_stage."""
+    pool = _FakePool()
+    row = _FakeRow(
+        req_id="REQ-X", project_id="p", state=ReqState.ESCALATED,
+        context={"verifier_stage": "staging_test"},  # 旧 stage
+    )
+    update_calls = _bypass_auth_pool_and_update(monkeypatch, pool, row=row)
+
+    async def _step(*a, **kw):
+        return {"action": "no-op"}
+
+    monkeypatch.setattr("orchestrator.admin.engine.step", _step)
+
+    body = ResumeBody(action="pass", stage="pr_ci")
+    await resume_req("REQ-X", body=body, authorization="Bearer x")
+
+    assert update_calls[0]["verifier_stage"] == "pr_ci"
+
+
+@pytest.mark.asyncio
+async def test_resume_fix_needed_dispatches_verify_fix_needed_event(monkeypatch):
+    """ARE-S2: action=fix-needed → engine.step with event=VERIFY_FIX_NEEDED."""
+    pool = _FakePool()
+    row = _FakeRow(
+        req_id="REQ-X", project_id="p", state=ReqState.ESCALATED,
+        context={
+            "verifier_stage": "dev_cross_check",
+            "verifier_fixer": "dev",
+        },
+    )
+    _bypass_auth_pool_and_update(monkeypatch, pool, row=row)
+
+    step_calls: list = []
+
+    async def _step(*a, **kw):
+        step_calls.append(kw)
+        return {"action": "start_fixer"}
+
+    monkeypatch.setattr("orchestrator.admin.engine.step", _step)
+
+    body = ResumeBody(action="fix-needed")
+    result = await resume_req("REQ-X", body=body, authorization="Bearer x")
+
+    assert result["event"] == "verify.fix-needed"
+    assert step_calls[0]["event"] == Event.VERIFY_FIX_NEEDED
+
+
+@pytest.mark.asyncio
+async def test_resume_writes_audit_to_context(monkeypatch):
+    """ARE-S7: body.reason="..." → ctx.resume_reason / resumed_by_admin patch."""
+    pool = _FakePool()
+    row = _FakeRow(
+        req_id="REQ-X", project_id="p", state=ReqState.ESCALATED,
+        context={"verifier_stage": "staging_test"},
+    )
+    update_calls = _bypass_auth_pool_and_update(monkeypatch, pool, row=row)
+
+    async def _step(*a, **kw):
+        return {}
+
+    monkeypatch.setattr("orchestrator.admin.engine.step", _step)
+
+    body = ResumeBody(action="pass", reason="GHA infra flake confirmed")
+    await resume_req("REQ-X", body=body, authorization="Bearer x")
+
+    patch = update_calls[0]
+    assert patch["resumed_by_admin"] is True
+    assert patch["resume_action"] == "pass"
+    assert patch["resume_reason"] == "GHA infra flake confirmed"
+
+
+@pytest.mark.asyncio
+async def test_resume_fixer_override_in_body(monkeypatch):
+    """body.fixer="spec" → ctx.verifier_fixer patched."""
+    pool = _FakePool()
+    row = _FakeRow(
+        req_id="REQ-X", project_id="p", state=ReqState.ESCALATED,
+        context={"verifier_stage": "spec_lint", "verifier_fixer": "dev"},
+    )
+    update_calls = _bypass_auth_pool_and_update(monkeypatch, pool, row=row)
+
+    async def _step(*a, **kw):
+        return {}
+
+    monkeypatch.setattr("orchestrator.admin.engine.step", _step)
+
+    body = ResumeBody(action="fix-needed", fixer="spec")
+    await resume_req("REQ-X", body=body, authorization="Bearer x")
+    assert update_calls[0]["verifier_fixer"] == "spec"
+
+
+def test_resume_body_invalid_action_raises():
+    """ResumeBody schema 拒绝 action ∉ {pass, fix-needed}."""
+    with pytest.raises(ValidationError):
+        ResumeBody(action="bogus")
+
+
+def test_resume_body_invalid_fixer_raises():
+    """ResumeBody schema 拒绝 fixer ∉ {dev, spec}."""
+    with pytest.raises(ValidationError):
+        ResumeBody(action="fix-needed", fixer="qa")
+
+
+def test_resume_body_action_required():
+    """ResumeBody.action 是必传，缺 → ValidationError."""
+    with pytest.raises(ValidationError):
+        ResumeBody()
+
+
+@pytest.mark.asyncio
+async def test_resume_auth_check_before_db(monkeypatch):
+    """ARE-S8: bad token → 401，没 req_state.get / engine.step."""
+    from orchestrator import admin as admin_mod
+
+    def _bad_token(_):
+        raise HTTPException(status_code=401, detail="bad token")
+
+    monkeypatch.setattr(admin_mod, "_verify_token", _bad_token)
+
+    get_called: list = []
+    step_called: list = []
+
+    async def _get(*a, **kw):
+        get_called.append(1)
+        return None
+
+    async def _step(*a, **kw):
+        step_called.append(1)
+
+    monkeypatch.setattr("orchestrator.admin.req_state.get", _get)
+    monkeypatch.setattr("orchestrator.admin.db.get_pool", lambda: _FakePool())
+    monkeypatch.setattr("orchestrator.admin.engine.step", _step)
+
+    with pytest.raises(HTTPException) as ei:
+        await resume_req(
+            "REQ-X", body=ResumeBody(action="pass"), authorization=None,
+        )
+    assert ei.value.status_code == 401
+    assert get_called == []
+    assert step_called == []
+
+
+# ─── runner endpoint rename：路径切到 /runner-pause / /runner-resume ─────
+
+
+def test_admin_route_table_runner_pause_renamed():
+    """ARE-S9: /admin/req/{req_id}/runner-pause 已注册，旧 /pause 不存在."""
+    from orchestrator.admin import admin as admin_router
+
+    paths = {
+        r.path
+        for r in admin_router.routes
+        if hasattr(r, "path") and "POST" in (getattr(r, "methods", set()) or set())
+    }
+    assert "/admin/req/{req_id}/runner-pause" in paths
+    assert "/admin/req/{req_id}/pause" not in paths
+
+
+def test_admin_route_table_runner_resume_renamed():
+    """ARE-S10: /admin/req/{req_id}/runner-resume 已注册，bare /resume 现在
+    指向新的 state-level resume_req（不是旧 resume_runner）."""
+    from orchestrator.admin import admin as admin_router
+    from orchestrator.admin import resume_req, resume_runner
+
+    paths_to_endpoint: dict = {
+        r.path: r.endpoint
+        for r in admin_router.routes
+        if hasattr(r, "path") and "POST" in (getattr(r, "methods", set()) or set())
+    }
+    # runner 路径绑 resume_runner
+    assert paths_to_endpoint.get("/admin/req/{req_id}/runner-resume") is resume_runner
+    # bare /resume 绑 state-level resume_req（不是 resume_runner）
+    assert paths_to_endpoint.get("/admin/req/{req_id}/resume") is resume_req
+    assert paths_to_endpoint.get("/admin/req/{req_id}/resume") is not resume_runner


### PR DESCRIPTION
## Summary

- Add `POST /admin/req/{req_id}/resume` — state-level resume from ESCALATED. Body `{action: pass|fix-needed, stage?, fixer?, reason?}` dispatches `VERIFY_PASS` / `VERIFY_FIX_NEEDED` through `engine.step`, reusing existing `(ESCALATED, …) → REVIEW_RUNNING/FIXER_RUNNING` transitions without booting a BKD verifier-agent session.
- Rename v0.2 K8s runner endpoints `/admin/req/{id}/pause` → `/runner-pause` and `/admin/req/{id}/resume` → `/runner-resume` (handlers / behavior unchanged) to free `/resume` for the new state-level endpoint and match the `runner-` prefix already used by `/rebuild-workspace` siblings.
- Audit: `resumed_by_admin`, `resume_action`, optional `resume_reason` are patched into `req_state.context`, distinguishing admin-driven resumes from BKD-verifier-driven ones (latter writes `verifier_decisions`).

## Why

ESCALATED is not a dead terminal — `state.py` already has three exits via `VERIFY_PASS` / `VERIFY_FIX_NEEDED` / `VERIFY_ESCALATE`. The intended resume path goes through a BKD verifier follow-up, which costs 5–10s session startup + an agent re-decision round-trip. For known infra flakes, agent misjudgements, or REQs that escalated via non-verifier paths (`pr_ci.timeout`, `accept-env-up.fail`, `intake.fail`), the operator already knows the answer and just needs a typed dispatch.

The only existing alternatives were `/admin/req/{id}/emit` with raw event names (low-level, easy to misuse) or direct `psql` (bypasses audit, doesn't pre-load `ctx.verifier_stage` for `apply_verify_pass`).

## Behavior

| In | Out |
|---|---|
| state ≠ escalated | 409 with hint pointing at `/escalate` |
| REQ not found | 404 |
| `action=pass` + no resolvable `verifier_stage` (ctx ∪ body) | 400 with hint |
| `action=pass` + ctx/body has stage | dispatch `VERIFY_PASS` → `apply_verify_pass` (CAS to `<stage>_running`, ensure_runner) |
| `action=fix-needed` | dispatch `VERIFY_FIX_NEEDED` → `start_fixer` |
| invalid `action` / `fixer` enum | 422 (pydantic) |
| missing token | 401 |

## Files

- `orchestrator/src/orchestrator/admin.py` — new endpoint + runner endpoint rename + module docstring
- `orchestrator/tests/test_admin.py` — 11 new test cases (ARE-S1..S10 + 1 schema check)
- `orchestrator/docs/V0.2-PLAN.md`, `orchestrator/docs/sisyphus-integration.md` — admin tools updated
- `openspec/changes/REQ-admin-resume-escalated-1777123726/` — proposal / design / tasks / spec / contract

## Test plan

- [ ] sisyphus pre-commit / lint passes (`make ci-lint` scoped to changed files)
- [ ] new admin tests pass (`pytest tests/test_admin.py`) — 29 passed locally
- [ ] adjacent suites stable (`tests/test_state.py tests/test_engine.py tests/test_verifier.py`) — 142 passed locally
- [ ] `openspec validate REQ-admin-resume-escalated-1777123726` clean
- [ ] `check-scenario-refs.sh` finds all ARE-S1..S10 scenario references
- [ ] manual smoke after deploy: `curl -X POST /admin/req/<escalated-req>/resume -d '{"action":"pass"}'` advances state, `curl /admin/req/<id>` shows `ctx.resumed_by_admin=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)