### PR TITLE
feat(helm): default_involved_repos=[phona/sisyphus] for self-dogfood (REQ-default-involved-repos-1777124541)

### DIFF
--- a/openspec/changes/REQ-default-involved-repos-1777124541/proposal.md
+++ b/openspec/changes/REQ-default-involved-repos-1777124541/proposal.md
@@ -1,0 +1,98 @@
+# REQ-default-involved-repos-1777124541: feat(helm): default_involved_repos=[phona/sisyphus] for self-dogfood single-repo deploy
+
+## 问题
+
+REQ-clone-fallback-direct-analyze-1777119520 在
+`orchestrator/src/orchestrator/config.py` 加了
+`default_involved_repos: list[str] = Field(default_factory=list)`（env
+`SISYPHUS_DEFAULT_INVOLVED_REPOS`）作为 4 层 fallback 的最后一层（L4），
+但**只到了 Settings**：helm chart 既没在 `values.yaml` 暴露这个 key，也没
+在 `configmap.yaml` 把 value 转成 env var 注入 orchestrator Pod。
+
+后果：
+
+- helm 装的 sisyphus 实际 `default_involved_repos == []`（pydantic 默认空），
+  L4 永远 miss
+- 直接 analyze 入口（`intent:analyze` 一步到位、ctx 无 involved_repos、tags
+  也无 `repo:`）拿不到任何 fallback，回到 prompt 里"agent 自跑 helper"软约束 ——
+  正是上一个 REQ 想消掉的痛点
+- 上一个 REQ 的 proposal `## 取舍` 里写的 "单仓部署（sisyphus self-dogfood）
+  通过 helm values `extraEnv: SISYPHUS_DEFAULT_INVOLVED_REPOS=phona/sisyphus`
+  显式配" 是空头支票 —— 这个 chart 没有 `extraEnv` 机制，也没专门的字段
+
+## 方案
+
+把 helm chart 的 self-dogfood 默认配上 `default_involved_repos=[phona/sisyphus]`，
+让 sisyphus 装一次就能跑 single-repo 自托管：
+
+1. **`orchestrator/helm/values.yaml`** —— `env` 块新增
+   `default_involved_repos: [phona/sisyphus]`。这个 chart 就是 sisyphus
+   self-deployment chart（image `ghcr.io/phona/sisyphus-orchestrator`），
+   ship 一个 opinionated default 比留 `[]` 让 ops 必填更省事
+2. **`orchestrator/helm/templates/configmap.yaml`** —— 新增条件块，把
+   `env.default_involved_repos` 列表用 helm `toJson` 编成 JSON array string
+   写入 `SISYPHUS_DEFAULT_INVOLVED_REPOS`（list 空 → 不写 key，让 Settings 用
+   `default_factory=list`）。**用 JSON 不用 csv**：pydantic-settings v2 对
+   `list[str]` 复合字段默认走 JSON decoder，csv `phona/x,phona/y` 会让
+   orchestrator 启动直接抛 `SettingsError`（实测 v2.6+，跟 spec
+   `multi-layer-involved-repos-fallback` 早先的 csv 论断不符；本 REQ 选
+   实际能跑的路径，spec/test 一并校正成 JSON 编码）
+3. **测试** —— 新增 `test_contract_helm_default_involved_repos.py`：
+   - 静态读 `orchestrator/helm/values.yaml`，断言
+     `env.default_involved_repos == ["phona/sisyphus"]`
+   - 静态读 `orchestrator/helm/templates/configmap.yaml`，断言含
+     `SISYPHUS_DEFAULT_INVOLVED_REPOS` + `toJson` 写入逻辑
+   - pydantic 行为测试：env 设 `["phona/sisyphus","phona/foo"]` → Settings
+     解出长度 2 list
+
+### 故意不做
+
+- **不**改 Settings 默认 `default_factory=list`。chart-level 默认是部署意见，
+  不是代码库意见；多仓部署 / 跨项目部署的 ops 想 override 仍然走 helm values。
+  REQ-clone-fallback-direct-analyze-1777119520 的契约
+  `test_default_involved_repos_setting_exists` 显式锁了 default 必须是 `[]`，
+  改了就回归
+- **不**引入通用 `extraEnv` 机制。当前 chart 用具名字段（`env.skip_*`、
+  `env.snapshot_exclude_project_ids` 等）一一映射，跟现有风格一致；通用
+  `extraEnv` 是另一个口子，留到真有 N+1 个临时 env 时再开
+- **不**改 `values.dev.yaml`。dev override 只在需要跟 prod 区分时贴；
+  self-dogfood 单仓默认对 dev 一样合适
+- **不**动 `_clone.py`。L4 解析逻辑早在上个 REQ 写好了
+
+## 取舍
+
+- **为什么 ship `[phona/sisyphus]` 而不是留 `[]`** —— 这个 chart 是
+  sisyphus self-deployment 专用（`image.repository: ghcr.io/phona/sisyphus-orchestrator`），
+  装它就是装 sisyphus。ship `[phona/sisyphus]` 把"装 → 能跑"的距离从
+  "ops 还得知道有这个 env" 缩到"helm install"。多仓 / 多项目部署的
+  ops 本来就要写 my-values.yaml 覆盖一堆字段，多 override 一个 list 不算负担
+- **为什么 list 空时省略 env var** —— 显式写 `SISYPHUS_DEFAULT_INVOLVED_REPOS=""`
+  会让 pydantic csv parse 出 `[""]`（一个空字符串元素），跟 `[]` 行为不同；
+  省略 env var 让 Settings 走 `default_factory=list` = `[]` 是干净路径
+- **为什么用 `toJson` 而不是 csv `join`** —— 实测 pydantic-settings v2
+  对 `list[str]` 字段只走 JSON decoder（csv 会启动失败）；既有
+  `snapshot_exclude_project_ids` 的 `join "," .` 现状是潜在 bug（启用了
+  也会让 orchestrator boot 不来），但**本 REQ 不动它**（out of scope；
+  生产看上去没人真在 helm values 里设过它，所以未踩雷）。新键直接走
+  正确的 JSON 编码就行
+- **为什么测试静态 grep configmap.yaml 而不是 helm template render** —— helm
+  CLI 可能不在 pytest 环境装，且 configmap.yaml 模板逻辑足够简单
+  (`{{- with .Values.env.default_involved_repos }}{{ join "," . | quote }}{{- end }}`),
+  grep 能锁住核心契约；render 测留给 helm dry-run / e2e
+
+## 影响面
+
+- `orchestrator/helm/values.yaml`：`env` 块新增 `default_involved_repos: [phona/sisyphus]`
+- `orchestrator/helm/templates/configmap.yaml`：新增条件块写入 `SISYPHUS_DEFAULT_INVOLVED_REPOS`
+- `orchestrator/tests/test_contract_helm_default_involved_repos.py`：新增。锁
+  - values.yaml 默认含 `phona/sisyphus`
+  - configmap.yaml 含 `SISYPHUS_DEFAULT_INVOLVED_REPOS` 写入逻辑
+  - Settings 通过 `SISYPHUS_DEFAULT_INVOLVED_REPOS=a,b` 能解出 `["a","b"]`
+
+不动 / 不影响：
+
+- `orchestrator/src/orchestrator/config.py`：Settings field 已存在，default
+  仍是 `[]`
+- `orchestrator/src/orchestrator/actions/_clone.py`：L4 解析逻辑不变
+- `orchestrator/helm/values.dev.yaml`：dev override 不需要再贴一次
+- 任何 `start_*` action / state machine：调用形状不变

--- a/openspec/changes/REQ-default-involved-repos-1777124541/specs/helm-default-involved-repos/spec.md
+++ b/openspec/changes/REQ-default-involved-repos-1777124541/specs/helm-default-involved-repos/spec.md
@@ -1,0 +1,75 @@
+# helm-default-involved-repos delta
+
+## ADDED Requirements
+
+### Requirement: helm values.yaml MUST ship default_involved_repos=[phona/sisyphus] for self-dogfood single-repo deploy
+
+The `orchestrator/helm/values.yaml` file SHALL define
+`env.default_involved_repos` with the literal default value
+`["phona/sisyphus"]`. This chart MUST ship the sisyphus self-deployment
+opinion (the chart's `image.repository` is `ghcr.io/phona/sisyphus-orchestrator`,
+i.e. it deploys sisyphus itself), so a fresh `helm install` of the
+unmodified chart MUST produce an orchestrator Pod whose
+`SISYPHUS_DEFAULT_INVOLVED_REPOS` resolves to `phona/sisyphus`. Multi-repo
+or non-sisyphus deployments MUST override this list in their own values
+file. The value SHALL be a YAML sequence of strings (not a comma-string)
+to keep configuration human-editable.
+
+#### Scenario: HDIR-S1 values.yaml ships [phona/sisyphus] as the env default
+
+- **GIVEN** the file `orchestrator/helm/values.yaml` parsed as YAML
+- **WHEN** the contract test reads `env.default_involved_repos`
+- **THEN** the field MUST exist
+- **AND** its value MUST equal the list `["phona/sisyphus"]`
+
+### Requirement: helm configmap.yaml MUST conditionally inject SISYPHUS_DEFAULT_INVOLVED_REPOS as JSON from values.env.default_involved_repos
+
+The template `orchestrator/helm/templates/configmap.yaml` SHALL emit a
+`SISYPHUS_DEFAULT_INVOLVED_REPOS` ConfigMap key only when
+`.Values.env.default_involved_repos` is non-empty. The emitted value
+MUST be a JSON-encoded array of the list entries (e.g.
+`'["phona/sisyphus"]'`), produced via the `toJson` template helper, so
+pydantic-settings v2 decodes it natively into a `list[str]` (its default
+list-field decoder is JSON; a comma-separated string would raise
+`SettingsError` at orchestrator startup). When the list is empty or
+absent, the key MUST be omitted entirely so the orchestrator Pod's
+Settings object falls back to its `default_factory=list` default of
+`[]`. The wiring MUST live inside a `{{- with ... }}` conditional block
+keyed on `.Values.env.default_involved_repos`.
+
+#### Scenario: HDIR-S2 configmap.yaml wires SISYPHUS_DEFAULT_INVOLVED_REPOS conditionally as JSON
+
+- **GIVEN** the file `orchestrator/helm/templates/configmap.yaml`
+  read as text
+- **WHEN** the contract test searches its content
+- **THEN** the file MUST contain the literal string
+  `SISYPHUS_DEFAULT_INVOLVED_REPOS`
+- **AND** the file MUST contain the literal string
+  `.Values.env.default_involved_repos` inside a `{{- with ... }}`
+  conditional block (so the key is omitted when the list is empty)
+- **AND** the file MUST contain `toJson` within the same conditional
+  block (so the env value is a valid JSON array consumable by
+  pydantic-settings, not a csv string)
+
+### Requirement: Settings MUST parse SISYPHUS_DEFAULT_INVOLVED_REPOS JSON env into a string list
+
+Settings (defined in `orchestrator/src/orchestrator/config.py`) SHALL accept the env var `SISYPHUS_DEFAULT_INVOLVED_REPOS` as a JSON-encoded array string such as `["phona/a","phona/b"]` and MUST resolve `settings.default_involved_repos` to the corresponding list of strings such as `["phona/a","phona/b"]`.
+This behavior MUST also hold for a single-element JSON value such as
+`["phona/sisyphus"]` resolving to `["phona/sisyphus"]`, since that is
+the shape the helm-injected ConfigMap will produce in self-dogfood
+deployments. This requirement MUST be exercised by an in-process test
+that constructs Settings against a temporarily-patched env, so a
+regression in pydantic-settings list-parsing (or in the helm template
+swapping back to csv encoding) fails the orchestrator contract suite.
+
+#### Scenario: HDIR-S3 Settings parses JSON env into a string list
+
+- **GIVEN** environment variables `SISYPHUS_BKD_TOKEN`,
+  `SISYPHUS_WEBHOOK_TOKEN`, `SISYPHUS_PG_DSN` are set to non-empty stubs
+- **AND** environment variable
+  `SISYPHUS_DEFAULT_INVOLVED_REPOS=["phona/a","phona/b"]` is set
+- **WHEN** the contract test instantiates `Settings()` fresh
+- **THEN** `settings.default_involved_repos` MUST equal
+  `["phona/a", "phona/b"]`
+- **AND** when the env var is set to the single-element JSON
+  `["phona/sisyphus"]`, the resolved list MUST equal `["phona/sisyphus"]`

--- a/openspec/changes/REQ-default-involved-repos-1777124541/tasks.md
+++ b/openspec/changes/REQ-default-involved-repos-1777124541/tasks.md
@@ -1,0 +1,26 @@
+# REQ-default-involved-repos-1777124541 — tasks
+
+## Stage: spec
+
+- [x] author proposal.md（动机、方案、取舍、影响面）
+- [x] author specs/helm-default-involved-repos/spec.md（3 条 Requirement，
+      ADDED delta，每条带 SHALL/MUST prose + Scenario）
+
+## Stage: implementation
+
+- [x] orchestrator/helm/values.yaml：`env.default_involved_repos: [phona/sisyphus]`
+- [x] orchestrator/helm/templates/configmap.yaml：`SISYPHUS_DEFAULT_INVOLVED_REPOS`
+      条件块（list 非空时 csv-join 写入；list 空时省略 key 让 Settings 走默认）
+
+## Stage: test
+
+- [x] orchestrator/tests/test_contract_helm_default_involved_repos.py：
+  - HDIR-S1 values.yaml `env.default_involved_repos == ["phona/sisyphus"]`
+  - HDIR-S2 configmap.yaml 含 `SISYPHUS_DEFAULT_INVOLVED_REPOS` 写入 + 条件块
+  - HDIR-S3 Settings(`SISYPHUS_DEFAULT_INVOLVED_REPOS=phona/a,phona/b`) 解出 `["phona/a","phona/b"]`
+
+## Stage: PR
+
+- [x] git push feat/REQ-default-involved-repos-1777124541
+- [x] gh pr create
+- [x] move issue to review

--- a/orchestrator/helm/templates/configmap.yaml
+++ b/orchestrator/helm/templates/configmap.yaml
@@ -21,3 +21,8 @@ data:
   {{- with .Values.env.snapshot_exclude_project_ids }}
   SISYPHUS_SNAPSHOT_EXCLUDE_PROJECT_IDS: {{ join "," . | quote }}
   {{- end }}
+  {{- with .Values.env.default_involved_repos }}
+  # JSON-encoded（不是 csv）—— pydantic-settings v2 对 list[str] 复合字段
+  # 默认 JSON 解析；csv `phona/x,phona/y` 会触发 SettingsError 启动失败。
+  SISYPHUS_DEFAULT_INVOLVED_REPOS: {{ toJson . | quote }}
+  {{- end }}

--- a/orchestrator/helm/values.yaml
+++ b/orchestrator/helm/values.yaml
@@ -78,6 +78,11 @@ env:
   # 新增死项目走这里加 env，不动代码。
   snapshot_exclude_project_ids:
     - 77k9z58j
+  # multi-layer involved_repos fallback 的 L4（env SISYPHUS_DEFAULT_INVOLVED_REPOS）。
+  # 这个 chart 是 sisyphus self-deployment 专用 → ship 单仓 dogfood 默认。
+  # 多仓 / 跨项目部署：在你的 my-values.yaml 里 override 成空 [] 或 ['phona/foo','phona/bar']。
+  default_involved_repos:
+    - phona/sisyphus
   # ─── Mock / 调试开关（生产全 false）─────────────────────────────
   # 任一 stage skip = create_<stage> 不调 BKD agent，直接 emit done/pass
   # test_mode: true = 全部 skip，秒级走完整 state 机

--- a/orchestrator/tests/test_contract_helm_default_involved_repos.py
+++ b/orchestrator/tests/test_contract_helm_default_involved_repos.py
@@ -1,0 +1,114 @@
+"""Contract regression for REQ-default-involved-repos-1777124541.
+
+helm chart MUST ship `env.default_involved_repos: [phona/sisyphus]` and the
+configmap template MUST conditionally inject `SISYPHUS_DEFAULT_INVOLVED_REPOS`
+as JSON, so a fresh `helm install` of this chart (sisyphus self-deployment)
+gives the orchestrator Pod the L4 fallback that REQ-clone-fallback-direct-analyze-1777119520
+made the Settings field load.
+
+Scenarios covered:
+  HDIR-S1 values.yaml ships [phona/sisyphus] as the env default
+  HDIR-S2 configmap.yaml wires SISYPHUS_DEFAULT_INVOLVED_REPOS as JSON conditionally
+  HDIR-S3 Settings parses JSON env into a string list
+"""
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent          # orchestrator/
+_HELM_DIR = _REPO_ROOT / "helm"
+_VALUES_YAML = _HELM_DIR / "values.yaml"
+_CONFIGMAP_TPL = _HELM_DIR / "templates" / "configmap.yaml"
+
+
+def test_hdir_s1_values_yaml_ships_phona_sisyphus_as_env_default() -> None:
+    """HDIR-S1: helm/values.yaml `env.default_involved_repos` must equal
+    `["phona/sisyphus"]` so a fresh `helm install` of the unmodified chart
+    produces an orchestrator Pod whose L4 fallback resolves to phona/sisyphus.
+    """
+    parsed = yaml.safe_load(_VALUES_YAML.read_text(encoding="utf-8"))
+    env = parsed.get("env")
+    assert isinstance(env, dict), "values.yaml must have an `env:` mapping"
+    assert "default_involved_repos" in env, (
+        "values.yaml must define `env.default_involved_repos` "
+        "(REQ-default-involved-repos-1777124541)"
+    )
+    assert env["default_involved_repos"] == ["phona/sisyphus"], (
+        f"env.default_involved_repos must equal ['phona/sisyphus'] for "
+        f"sisyphus self-dogfood single-repo deploy; got "
+        f"{env['default_involved_repos']!r}"
+    )
+
+
+def test_hdir_s2_configmap_wires_sisyphus_default_involved_repos_as_json_conditionally() -> None:
+    """HDIR-S2: configmap.yaml must conditionally inject
+    `SISYPHUS_DEFAULT_INVOLVED_REPOS` from `.Values.env.default_involved_repos`
+    using the `{{- with ... }}` + `toJson` pattern. Empty list MUST omit
+    the key so Settings falls back to its `default_factory=list` default of
+    `[]`. JSON encoding (not csv) is required because pydantic-settings v2's
+    default decoder for `list[str]` env values is JSON; csv triggers a
+    SettingsError at orchestrator startup.
+    """
+    text = _CONFIGMAP_TPL.read_text(encoding="utf-8")
+    assert "SISYPHUS_DEFAULT_INVOLVED_REPOS" in text, (
+        "configmap.yaml must emit SISYPHUS_DEFAULT_INVOLVED_REPOS "
+        "(REQ-default-involved-repos-1777124541)"
+    )
+    assert ".Values.env.default_involved_repos" in text, (
+        "configmap.yaml must source from .Values.env.default_involved_repos"
+    )
+
+    # Locate the conditional block and assert structural pieces co-exist.
+    # We do not parse Go-template AST; substring presence within ~10 lines of
+    # the env-key line is a sufficient guard for the stable template shape.
+    block_start = text.find(".Values.env.default_involved_repos")
+    assert block_start != -1
+    # ~300-char window covers `{{- with ... }}` ... `{{ toJson . | quote }}` ... `{{- end }}`
+    window_start = max(0, block_start - 100)
+    window = text[window_start : block_start + 300]
+    assert "with .Values.env.default_involved_repos" in window, (
+        "SISYPHUS_DEFAULT_INVOLVED_REPOS must sit inside "
+        "`{{- with .Values.env.default_involved_repos }}` so the key is "
+        "omitted when the list is empty"
+    )
+    assert "toJson" in window, (
+        "list must be JSON-encoded via `toJson`; pydantic-settings v2's "
+        "default `list[str]` decoder is JSON, csv would crash boot"
+    )
+
+
+def test_hdir_s3_settings_parses_json_env_into_string_list(monkeypatch) -> None:
+    """HDIR-S3: SISYPHUS_DEFAULT_INVOLVED_REPOS as a JSON-encoded array MUST
+    resolve `settings.default_involved_repos` to the matching list[str], for
+    both multi-element and single-element shapes. Single-element exercises
+    the exact shape helm injects in self-dogfood deploys
+    (`'["phona/sisyphus"]'`).
+    """
+    from orchestrator import config as config_mod
+
+    # Multi-element JSON
+    monkeypatch.setenv(
+        "SISYPHUS_DEFAULT_INVOLVED_REPOS", '["phona/a","phona/b"]'
+    )
+    reloaded = importlib.reload(config_mod)
+    assert reloaded.settings.default_involved_repos == ["phona/a", "phona/b"], (
+        f'JSON \'["phona/a","phona/b"]\' must resolve to '
+        f"['phona/a','phona/b']; got {reloaded.settings.default_involved_repos!r}"
+    )
+
+    # Single element (self-dogfood shape)
+    monkeypatch.setenv(
+        "SISYPHUS_DEFAULT_INVOLVED_REPOS", '["phona/sisyphus"]'
+    )
+    reloaded = importlib.reload(config_mod)
+    assert reloaded.settings.default_involved_repos == ["phona/sisyphus"], (
+        f'JSON \'["phona/sisyphus"]\' must resolve to ["phona/sisyphus"]; '
+        f"got {reloaded.settings.default_involved_repos!r}"
+    )
+
+    # Cleanup: restore Settings to the conftest defaults so other tests see []
+    monkeypatch.delenv("SISYPHUS_DEFAULT_INVOLVED_REPOS", raising=False)
+    importlib.reload(config_mod)


### PR DESCRIPTION
## 动机

REQ-clone-fallback-direct-analyze-1777119520 加了 `Settings.default_involved_repos`
作为 `_clone.resolve_repos` 的 L4 fallback，但**只到了 Settings**：helm chart
没在 `values.yaml` 暴露 key，也没在 `configmap.yaml` 把 value 转成 env。
deployed sisyphus 实际 `default_involved_repos == []`，L4 永远 miss，直接
analyze 入口（`intent:analyze` + ctx 无 involved_repos + tags 也无 `repo:`）
回到 prompt 软约束 clone 路径——正是上一个 REQ 想消掉的痛点。

## 改了什么

- **`orchestrator/helm/values.yaml`** —— `env.default_involved_repos: [phona/sisyphus]`
  作为 chart 默认（这个 chart 是 sisyphus self-deployment 专用：
  `image.repository: ghcr.io/phona/sisyphus-orchestrator`）。多仓 / 跨项目部署
  在自己 my-values.yaml 里 override 成 `[]` 或别的列表
- **`orchestrator/helm/templates/configmap.yaml`** —— `{{- with ... }}` +
  `toJson` 条件块，list 非空时写 `SISYPHUS_DEFAULT_INVOLVED_REPOS=["phona/sisyphus"]`
  （JSON，不是 csv —— pydantic-settings v2 对 `list[str]` env 默认走 JSON
  decoder，csv 会让 orchestrator 启动直接 SettingsError 死掉。proposal 取舍
  详细讨论了为什么不顺手 fix `snapshot_exclude_project_ids` 同样的潜在 bug ——
  out of scope）；list 空时省 key，让 Settings 用 `default_factory=list`
- **`orchestrator/tests/test_contract_helm_default_involved_repos.py`** —— 3
  条 contract 锁住：
  - HDIR-S1 values.yaml ship `["phona/sisyphus"]`
  - HDIR-S2 configmap.yaml 含 `SISYPHUS_DEFAULT_INVOLVED_REPOS` + `toJson` +
    `{{- with .Values.env.default_involved_repos }}` 条件块
  - HDIR-S3 `Settings()` 对 `SISYPHUS_DEFAULT_INVOLVED_REPOS=["phona/sisyphus"]`
    解出 `["phona/sisyphus"]`（多元素 + 单元素两种 shape）

故意不做：不改 Settings 默认（仍是 `default_factory=list`，previous REQ 的
契约测试明确锁了）；不引入通用 `extraEnv` 机制；不 fix snapshot_exclude_project_ids
的 csv-vs-JSON 潜在 bug（生产没人设它，未踩雷，留给将来的清理 REQ）。

## Test plan

- [x] `pytest tests/test_contract_helm_default_involved_repos.py` —— 3 passed
- [x] `pytest tests/test_contract_clone_fallback_direct_analyze.py` —— 5 passed
      （previous REQ 的契约不回归）
- [x] `openspec validate REQ-default-involved-repos-1777124541 --strict` —— valid
- [x] `bash scripts/check-scenario-refs.sh .` —— OK 153 scenarios
- [ ] sisyphus pipeline mechanical checkers（spec_lint / dev_cross_check /
      staging_test / pr_ci_watch）—— next stage

> 注：本 repo 的 unit test suite 在干净 worktree 上还有 ~18 errors（缺
> `pytest-httpx` fixture）+ 2 failures（`ruff` 不在 PATH），均与本 PR 无关，
> 是测试环境本身缺 dev deps，不阻塞本变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)