### PR TITLE
audit(read-only): ttpos-server-go + ttpos-flutter Makefile coverage of ttpos-ci contract

### DIFF
--- a/openspec/changes/REQ-audit-business-repo-makefile-1777125538/audit-report.md
+++ b/openspec/changes/REQ-audit-business-repo-makefile-1777125538/audit-report.md
@@ -1,0 +1,344 @@
+# ttpos-server-go + ttpos-flutter ↔ ttpos-ci 契约审计报告
+
+**REQ**: REQ-audit-business-repo-makefile-1777125538
+**审计日期**: 2026-04-25
+**审计范围**: 两个业务 repo 的 Makefile（含 include 链）覆盖 ttpos-ci 标准
+契约 + sisyphus 强约束的程度
+**审计方式**: 只读，通过 GitHub REST API 拉源文件，不修改任何仓
+
+## 1. 契约真值（合并后）
+
+ttpos-ci 契约由两份文档共同定义，本审计取并集：
+
+### 1.1 phona/ttpos-ci/README.md "业务仓库 CI 契约"
+
+| Target | 必需 | 环境变量 | 说明 |
+|---|---|---|---|
+| `ci-env` | ✅ | — | 输出 `KEY=VALUE` 到 stdout |
+| `ci-setup` | ✅ | — | 装依赖、备环境 |
+| `ci-lint` | ✅ | `BASE_REV` | 读环境变量；空则全量 |
+| `ci-unit-test` | ✅ | — | 覆盖率到 `coverage/` |
+| `ci-integration-test` | ✅ | `BUILD_ID` | 覆盖率到 `coverage/` |
+| `ci-build` | ✅ | `REF_NAME` | 构建产物 |
+
+`ci-env` 输出 key：`GO_VERSION` / `FLUTTER_VERSION` / `NEEDS_DOCKER` / `NEEDS_SUBMODULES`
+
+### 1.2 phona/sisyphus/docs/integration-contracts.md §2.1（机械 checker 子集）
+
+sisyphus 的 dev_cross_check / staging_test 只调三条：
+
+| Target | sisyphus 调用方 | 调用形态 |
+|---|---|---|
+| `ci-lint` | dev_cross_check (M15) | `cd /workspace/source/<repo> && BASE_REV=$(git merge-base HEAD origin/main) make ci-lint` |
+| `ci-unit-test` | staging_test (M1) | 同上 path，`make ci-unit-test` |
+| `ci-integration-test` | staging_test (M1) | 同上 path，`make ci-integration-test`（单仓内串行 unit→integration） |
+
+注：sisyphus 的 BASE_REV 计算 chain（来自 §2.2）是
+`origin/main → origin/develop → origin/dev → 空字符串`。
+
+### 1.3 phona/ttpos-ci/.github/workflows/ ci-go.yml + ci-flutter.yml 实际调用差异
+
+**ci-go.yml** 走完整链：`ci-env` → `ci-setup` → `ci-lint` (env `BASE_REV`) →
+`ci-unit-test` → `ci-integration-test BUILD_ID=...` → `ci-build` → SonarQube。
+
+**ci-flutter.yml** 只走 4 个：`ci-env` → `ci-setup` → `ci-lint BASE_REF="$BASE_REF"`
+→ `ci-unit-test` → SonarQube。**没有** `ci-integration-test`，**没有** `ci-build`。
+
+⚠️ ci-flutter.yml 里的 `BASE_REF=` 跟 README/Go 用的 `BASE_REV` 拼写不一致 ——
+见 §4.1。
+
+## 2. ttpos-server-go 审计
+
+仓 URL：`https://github.com/ZonEaseTech/ttpos-server-go` （**注**：integration-contracts.md
+里写的 `phona/ttpos-server-go` **不存在**，实际位置在 ZonEaseTech 组织下，私有）
+默认分支：`release`
+
+### 2.1 Makefile 结构
+
+```
+ttpos-server-go/
+├── Makefile                          # root；业务 install/build/run/migrate 等
+├── ttpos-scripts/
+│   ├── help.mk                       # included
+│   └── lint-ci-test.mk                # included；CI 标准 target 都在这里
+└── ...
+```
+
+root Makefile 顶部：
+
+```makefile
+include ./ttpos-scripts/help.mk
+include ./ttpos-scripts/lint-ci-test.mk
+```
+
+CI 标准 target 全在 `ttpos-scripts/lint-ci-test.mk` "CI 标准接口 — 供构建仓库调用"
+小节，`.PHONY: ci-env ci-setup ci-lint ci-unit-test ci-integration-test ci-build`。
+
+### 2.2 逐 target 对齐
+
+| Target | 状态 | 备注 |
+|---|---|---|
+| `ci-env` | ✅ PASS | 输出 `GO_VERSION=1.23` / `NEEDS_DOCKER=true` / `NEEDS_SUBMODULES=true`，全 ttpos-ci 标准 key 都覆盖 |
+| `ci-setup` | ✅ PASS | `cd main && go mod download` + `cd ttpos-bmp && go mod download` + 自动装 golangci-lint v1.62.2（按需） |
+| `ci-lint` | ✅ PASS | `cd main && go vet ./...` 并发 `cd main && golangci-lint run $${BASE_REV:+--new-from-rev=$$BASE_REV}` —— BASE_REV 空字符串 shell 不展开 flag，等价全量；非空则增量。**写法跟 sisyphus contract §2.2 推荐写法逐字符一致** |
+| `ci-unit-test` | ✅ PASS | Main + BMP 并发：`go test -short -v -count=1 -coverprofile=../coverage/unit.out` + bmp 同样。覆盖率到 `coverage/unit.out` + `coverage/bmp-unit.out`，对齐契约"输出到 coverage/" |
+| `ci-integration-test` | ✅ PASS | 用 `BUILD_ID`（缺省 `$(shell date +%s)`），并发跑 `test-main-local` + `test-bmp-local`，每路自己 docker compose 起 stack。失败传播：`fail=0; ... wait $$pid1 \|\| fail=1; ... exit $$fail` |
+| `ci-build` | ⚠️ STUB | 仅 `@echo "Building Docker images for $(REF_NAME)..."` + 注释 `# 复用现有的构建逻辑`。**没有真 docker build / push**。phona/ttpos-ci 的 `build.yml` 走这个 target —— 当前会"成功"但不产物 |
+
+### 2.3 sisyphus 强约束侧的额外检查
+
+| 检查项 | 状态 | 备注 |
+|---|---|---|
+| `ci-lint` 读 `BASE_REV` env | ✅ PASS | shell `$${BASE_REV:+...}` 形态完全对齐契约 §2.2 |
+| `ci-unit-test` 退码作为 sole signal | ✅ PASS | 两路 fail 任一 → exit 1 |
+| `ci-integration-test` 退码同上 | ✅ PASS | 同上模式 |
+| 单仓内 unit→integration 串行 OK | ✅ PASS | sisyphus 这边 staging_test 串行调，不依赖 Makefile 内部并发；Makefile 把 main+bmp 并发是仓内事 |
+| `feat/<REQ>` 分支 PR 能被 pr-ci-watch 找到 | ⚠️ WARN | 默认分支 `release`，不是 `main`。如果 PR base 是 release：pr-ci-watch 按 `gh pr list --head feat/REQ-x` 查能命中（不依赖 base），但 Makefile/CI 流的 `git merge-base HEAD origin/main` 会 fallthrough |
+| BASE_REV 计算成功 | ❌ GAP | 默认分支 `release`，sisyphus chain `main → develop → dev` 全 miss → BASE_REV=空 → ci-lint 全量扫（功能正确，性能问题；contract §2.2 没正式承认这个降级） |
+
+### 2.4 结论
+
+**ttpos-server-go 对 sisyphus 三大机械 checker 是 ready 状态**。dev_cross_check
++ staging_test 直接 `kubectl exec runner cd /workspace/source/ttpos-server-go &&
+make ci-lint` / `ci-unit-test` / `ci-integration-test` 都会跑起来。
+
+唯一要注意的是默认分支不是 main，BASE_REV 永远空 → ci-lint 全量。这不是 BUG，
+但应该在 contract 文档里注明（见 §4 doc 不一致）。
+
+`ci-build` stub 不阻塞 sisyphus，但**会让 phona/ttpos-ci 的 build.yml 当成成功
+但其实没产物**。建议独立 follow-up REQ 修。
+
+## 3. ttpos-flutter 审计
+
+仓 URL：`https://github.com/ZonEaseTech/ttpos-flutter` （同样 integration-contracts.md
+写的 `phona/ttpos-flutter` 不存在）
+默认分支：`release`
+
+### 3.1 Makefile 结构
+
+❌ **repo 根目录没有 Makefile 文件**。
+
+repo 根目录文件清单（在 `release` 分支）：
+
+```
+.agents.example      .claude/             .cursor/
+.cursorignore        .env.example         .fvmrc
+.github/             .gitignore           .husky/
+.mcp.json            .semgrep/            .semgrepignore
+.serena/             .vscode/             AGENTS.md
+CLAUDE.md            COMMAND_GUIDE.md     DOCKER_BUILD.md
+Dockerfile.build     Dockerfile.member    Dockerfile.menu
+Dockerfile.mobile    README.md            SECURITY_AUDIT_REPORT.md
+apps/                bun.lockb            cmd
+compax.keystore      docker-compose.dev.yml
+docker-compose.production.yml             docker-nginx.conf
+docker/              docs/                package.json
+packages/            pubspec.lock         pubspec.yaml
+scripts/
+```
+
+`scripts/` 下是一组 Dart 脚本（`build_android.dart` / `build_ios.dart` /
+`build_mac.dart` / `build_web.dart` / `pre_commit.dart` / `clean.dart` / 等），
+和一个独立 `cmd` 文件（2.4 KB，可能是 dispatcher）。
+
+构建链：
+
+- `pubspec.yaml`：melos workspace（含 `apps/pos`, `apps/assistant`, `apps/shop`,
+  `apps/kds`, `apps/member`, `apps/menu` 等 10 个 sub-app），dev_dependencies
+  包括 melos / husky / args / archive
+- `package.json`：仅 `ofetch` / `prisma` / `qs` 三个运行时依赖 + bun types。看
+  起来是给 prisma + Bun 跑 schema 工具
+
+→ flutter 这套用 melos + dart scripts + bun，**完全不走 Make**。
+
+### 3.2 逐 target 对齐
+
+ci-flutter.yml 实际只调 4 个 target，全部状态：
+
+| Target | 状态 | 备注 |
+|---|---|---|
+| `ci-env` | ❌ GAP | 无 Makefile → 无 target。ci-flutter.yml 用 `make ci-env > /dev/null 2>&1; if ...; then make ci-env >> $GITHUB_OUTPUT; fi` 兜底（见 init job），失败静默不阻塞，但 init outputs `flutter_version` / `needs_submodules` 都会是空。后续 step `subosito/flutter-action@v2` 收到空 `flutter-version` → 走 stable —— 行为模糊 |
+| `ci-setup` | ❌ GAP | 同上无 target。workflow `make ci-setup \|\| true` 兜底 |
+| `ci-lint` | ❌ GAP，**会真红** | 无兜底（workflow 写 `run: make ci-lint BASE_REF="$BASE_REF"` 直接调）→ `make: *** No rule to make target 'ci-lint'. Stop.` 退码 2 |
+| `ci-unit-test` | ❌ GAP，**会真红** | 同上无兜底（workflow 写 `run: make ci-unit-test`）→ make 报 no rule |
+
+ci-flutter.yml **不调** `ci-integration-test` / `ci-build`，所以这俩缺也不影响
+phona/ttpos-ci 走 ci-flutter 通路。**但 sisyphus 的 staging_test 一定调
+`ci-integration-test`** —— 对 sisyphus 是 GAP。
+
+### 3.3 sisyphus 强约束侧
+
+| 检查项 | 状态 |
+|---|---|
+| `ci-lint` 存在 | ❌ GAP |
+| `ci-unit-test` 存在 | ❌ GAP |
+| `ci-integration-test` 存在 | ❌ GAP |
+| `BASE_REV` env 处理 | ❌ N/A（target 不存在） |
+
+**所有 3 条 sisyphus 机械 checker 都会立即 `make: *** No rule` 红**。flutter
+这仓现在**完全不能进 sisyphus 的 involved_repos**。
+
+### 3.4 触发链 GAP
+
+phona/ttpos-ci 的 ci-flutter workflow 是 `repository_dispatch` 触发，需要业务仓
+有 `dispatch.yml` 发 `event_type: ci-flutter` 的 dispatch。
+
+ttpos-flutter `.github/workflows/` 下的 workflows：
+
+```
+claude-code-review.yml
+claude.yml
+commit-lint.yaml
+issue-router.yml
+project-automation.yml
+trigger-artifact-builds.yaml
+trigger-test-builds.yaml
+```
+
+❌ **没有 `dispatch.yml`**。ci-flutter pipeline 当前**根本无法被触发**。
+
+参考 ttpos-server-go 同位置有 `dispatch.yml`（确认通路是通的）。
+
+### 3.5 结论
+
+**ttpos-flutter 对 ttpos-ci + sisyphus 双重契约都 100% miss**。直接接 sisyphus
+会让 dev_cross_check / staging_test 立即红；接 ttpos-ci 也接不通（dispatch
+缺失）。
+
+修复路径有选择，不是 sisyphus 单方面拍：
+
+- **路径 A**: 在 flutter 仓加根 Makefile，把 melos / dart scripts 包成
+  ttpos-ci 标准 target（`ci-lint` 转 `melos run lint`、`ci-unit-test` 转
+  `melos test`、`ci-integration-test` 待定 / 可暂时空 OK）。最小侵入
+- **路径 B**: 在 ttpos-ci 加一份 `ci-flutter-melos.yml`，原生用 melos
+  commands，绕过 Makefile。需要业务 repo + ttpos-ci 双改
+
+`docs/integration-contracts.md` 当前没规定 melos-native repo 的 onboarding
+路径，需要先在 ttpos-ci 团队 + sisyphus 团队对齐再起 follow-up REQ。
+
+## 4. 文档不一致（顺手记录）
+
+### 4.1 BASE_REV vs BASE_REF 拼写不一致（phona/ttpos-ci）
+
+| 来源 | 写法 |
+|---|---|
+| `phona/ttpos-ci/README.md` "环境变量传递" 表格 | `BASE_REV` |
+| `phona/ttpos-ci/.github/workflows/ci-go.yml` | env `BASE_REV: ${{ ... }}` ✅ 对齐 README |
+| `phona/ttpos-ci/.github/workflows/ci-flutter.yml` | `make ci-lint BASE_REF="$BASE_REF"` ❌ 拼成 BASE_REF（少一个 V）+ 用 make-arg 而非 env |
+
+`BASE_REF` 是 GitHub Actions 内置的 ref 名（不是 SHA），跟 ttpos-ci 契约的
+"merge-base SHA"语义完全不同。即使 flutter 仓将来加了 `ci-lint` target 读
+`$$BASE_REV`，这条 workflow 也传不过去。
+
+修法：ci-flutter.yml lint job 改成
+
+```yaml
+- name: Compute merge base
+  ...  # 学 ci-go.yml 的 base 计算
+- name: Lint
+  env:
+    BASE_REV: ${{ needs.init.outputs.base_rev }}
+  run: make ci-lint
+```
+
+### 4.2 phona/sisyphus/docs/integration-contracts.md 例子组织错位
+
+§1 "两类 repo 角色" 表格：
+
+| 角色 | 例子 |
+|---|---|
+| source repo | `phona/ttpos-server-go`、`phona/ubox-crosser` |
+| integration repo | `phona/ttpos-arch-lab` |
+
+实测：
+
+- `phona/ttpos-server-go` → 404
+- `phona/ubox-crosser` → ✅ 存在（public）
+- `phona/ttpos-arch-lab` → 404
+- 实际位置：`ZonEaseTech/ttpos-server-go`（私有）+ `ZonEaseTech/ttpos-arch-lab`（私有）
+
+§7 排查清单 / §8 等下文还有 `phona/ttpos-server-go` 的引用。
+
+修法：要么改成 `ZonEaseTech/ttpos-server-go` 等真值（前提：sisyphus 团队读得到
+ZonEaseTech），要么改成中性占位 `<owner>/<repo>` + 一句"业务实际位置见
+sisyphus admin"。
+
+### 4.3 默认分支非 main 时 BASE_REV 行为未文档化
+
+`docs/integration-contracts.md` §2.2 BASE_REV 计算 chain：
+
+```bash
+base_rev=$(git merge-base HEAD origin/main 2>/dev/null \
+        || git merge-base HEAD origin/develop 2>/dev/null \
+        || git merge-base HEAD origin/dev 2>/dev/null \
+        || echo "")
+```
+
+ttpos-server-go / ttpos-flutter 默认 `release`，三条全 fall through → BASE_REV
+为空 → ci-lint 全量扫。这是预期行为（空 BASE_REV 等价全量），但文档没明说"非
+main/develop/dev 默认分支会自动降级全量"。
+
+修法：在 §2.2 加一句注：
+
+> 若 source repo default branch 既非 main / develop / dev，BASE_REV 会降级
+> 为空字符串，触发 ci-lint 全量扫描；功能正确，性能稍差，可接受。
+
+### 4.4 整体观察
+
+这三条 doc 不一致都是小修，但散在两个 repo 的不同文件里，建议合一个独立小型
+REQ 一次性收 —— 不混进任何业务仓的功能 PR。
+
+## 5. 审计结果概览（一表）
+
+| 维度 | ttpos-server-go | ttpos-flutter |
+|---|---|---|
+| Makefile 存在 | ✅ root + included `.mk` | ❌ 无 |
+| `ci-env` | ✅ | ❌ |
+| `ci-setup` | ✅ | ❌ |
+| `ci-lint`（含 BASE_REV） | ✅ | ❌ |
+| `ci-unit-test` | ✅ | ❌ |
+| `ci-integration-test` | ✅ | ❌ |
+| `ci-build` | ⚠️ stub | ❌ |
+| `dispatch.yml` 到 ttpos-ci | ✅ | ❌ |
+| 默认分支 == main | ❌（release） | ❌（release） |
+| BASE_REV merge-base 命中 | ❌（chain miss） | ❌（无 ci-lint） |
+| **sisyphus 三大机械 checker ready** | ✅ | ❌ |
+| **phona/ttpos-ci pipeline 通路** | ✅ | ❌ |
+
+## 6. 后续 REQ 候选（不在本 REQ 范围）
+
+按优先级排：
+
+1. **REQ-fix-integration-contracts-md-org-paths**（doc，最小，无依赖）—— 把
+   sisyphus docs 里 `phona/ttpos-*` 改 `ZonEaseTech/ttpos-*` 或占位
+2. **REQ-add-base-rev-doc-for-non-main-default-branch**（doc）—— §2.2 加非
+   主流默认分支的降级说明
+3. **REQ-fix-ci-flutter-base-rev-arg**（phona/ttpos-ci 仓）—— `BASE_REF=` 改
+   `BASE_REV:` env，对齐 ci-go 写法
+4. **REQ-ttpos-server-go-ci-build-real-impl**（业务仓 PR）—— 把 stub 换成
+   真 docker build/push（仅影响 phona/ttpos-ci build.yml，不影响 sisyphus）
+5. **REQ-ttpos-flutter-onboarding-strategy**（设计 REQ）—— 决定路径 A
+   （Makefile wrapper）vs 路径 B（ttpos-ci melos-native pipeline），出
+   spec
+6. **REQ-ttpos-flutter-onboarding-impl**（依赖 5）—— 落地选定方案
+7. **REQ-ttpos-server-go-default-branch-or-base-rev-fallback**（小，可拖）——
+   如果 release 分支决策长期保持，sisyphus BASE_REV chain 加 release
+   兜底；否则把 server-go default 改 main
+
+每条 REQ 都独立可起，互相不阻塞。
+
+## 7. 数据来源（reproducibility）
+
+所有原文件通过 GitHub REST API 读取（read-only），关键 endpoint：
+
+- `gh api repos/phona/ttpos-ci/contents/README.md`
+- `gh api repos/phona/ttpos-ci/contents/.github/workflows/ci-go.yml`
+- `gh api repos/phona/ttpos-ci/contents/.github/workflows/ci-flutter.yml`
+- `gh api repos/ZonEaseTech/ttpos-server-go/contents/Makefile`
+- `gh api repos/ZonEaseTech/ttpos-server-go/contents/ttpos-scripts/lint-ci-test.mk`
+- `gh api repos/ZonEaseTech/ttpos-server-go/contents/.github/workflows`
+- `gh api 'repos/ZonEaseTech/ttpos-flutter/contents?ref=release'`
+- `gh api 'repos/ZonEaseTech/ttpos-flutter/contents/scripts?ref=release'`
+- `gh api 'repos/ZonEaseTech/ttpos-flutter/contents/.github/workflows?ref=release'`
+
+复审时可重跑这一组 + diff 输出。

--- a/openspec/changes/REQ-audit-business-repo-makefile-1777125538/proposal.md
+++ b/openspec/changes/REQ-audit-business-repo-makefile-1777125538/proposal.md
@@ -1,0 +1,143 @@
+# REQ-audit-business-repo-makefile-1777125538: audit(read-only) — ttpos-server-go + ttpos-flutter Makefile coverage of ttpos-ci contract
+
+## Why
+
+sisyphus 没有任何预飞行合规 check —— 一个新 source repo 进 `involved_repos` 后，
+dev_cross_check 第一次跑才会发现 target 缺，错误形态是
+`make: *** No rule to make target 'ci-lint'`，verifier-agent 得人工识别成
+"基础设施缺失"而非业务 bug。REQ-default-involved-repos-1777124541 起 sisyphus
+默认带 `[phona/sisyphus]` 自托管单仓跑通了；下一步要把 ttpos 业务双仓
+（ttpos-server-go / ttpos-flutter）加进 involved_repos 之前，先把现状摸一遍：
+哪些 repo 已经合规、哪些缺、缺哪几条。本 REQ 是只读审计，**不改业务 repo 任何
+文件**，也不改 sisyphus 行为代码；交付物只有 `audit-report.md` + 一份可复用
+onboarding checklist spec。修复缺口由独立 follow-up REQ 承接。
+
+## What Changes
+
+- 新增 capability `business-repo-onboarding-audit` 沉淀本次审计的核对项（5 条
+  ADDED Requirements），未来再加 source repo 时直接拿这份 checklist 跑一遍
+- 新增审计交付文档 `openspec/changes/REQ-audit-business-repo-makefile-1777125538/audit-report.md`
+- 不改业务 repo（ZonEaseTech/ttpos-server-go / ZonEaseTech/ttpos-flutter）任何文件
+- 不改 sisyphus orchestrator 行为代码
+- 不修任何 GAP（修复留给独立 follow-up REQ；候选清单见 audit-report §6）
+
+## 任务性质
+
+**只读审计**。本 REQ 不改业务 repo（ttpos-server-go / ttpos-flutter）任何文件，
+也不改 sisyphus 行为代码。交付物只有两件：
+
+1. `audit-report.md` —— 把 ttpos-ci 契约 vs 两个业务 repo 的 Makefile 现状逐条对齐，
+   列出 **PASS / GAP / DOCS-MISMATCH**
+2. `specs/business-repo-onboarding-audit/spec.md` —— 把这次审计沉淀成一份**可复用
+   onboarding checklist**，未来再加 source repo 时直接拿这份去过一遍
+
+修复缺口（GAP）由独立 follow-up REQ 承接（本 REQ 不背负实现职责）。
+
+## 为什么要做这次审计
+
+`docs/integration-contracts.md` 的硬约束是：source repo 必须实现 `ci-lint` /
+`ci-unit-test` / `ci-integration-test` 三个 ttpos-ci 标准 target，sisyphus
+的机械 checker（dev_cross_check / staging_test）按这个契约直接 `kubectl exec
+runner cd /workspace/source/<repo> && make ...`。
+
+但 sisyphus 没有任何 **预飞行合规 check**：
+
+- 一个新 repo 进 `involved_repos` 列表后，dev_cross_check 第一次跑才会发现 target
+  缺，错误形态是 `make: *** No rule to make target 'ci-lint'`，verifier-agent
+  得人工识别成"基础设施缺失"而非业务 bug
+- 两类返回（target 缺 vs 业务红）都退码 ≠ 0，sisyphus 没法在 stage 层区分；只能
+  靠 staging_test stderr 文本做启发式（实际目前没做）
+
+REQ-default-involved-repos-1777124541 起 `default_involved_repos=[phona/sisyphus]`
+让 sisyphus 自托管单仓跑通了。**下一步要把 ttpos 业务双仓加进去**之前，先把
+现状摸一遍：哪些 repo 已经合规、哪些缺、缺哪几条。
+
+## 摘要（详见 audit-report.md）
+
+**ttpos-server-go**（实际位置 `ZonEaseTech/ttpos-server-go`，默认分支 `release`）：
+
+- ✅ 全 6 个 ttpos-ci 标准 target 都在（含 `BASE_REV` 增量 lint 写法对齐
+  contract `golangci-lint run $${BASE_REV:+--new-from-rev=$$BASE_REV}`）
+- ⚠️ `ci-build` 是 stub —— 只 `@echo`，注释说 "复用现有的构建逻辑"，没真跑（不影响
+  sisyphus 三个机械 checker，但 ttpos-ci 的 build.yml 走这个 target）
+- ⚠️ 默认分支 `release` 而非 `main`：sisyphus runner pod 计算 BASE_REV 的 chain
+  是 `origin/main → origin/develop → origin/dev → empty`，**全部 miss** →
+  BASE_REV=空 → ci-lint 全量扫（功能正确，只是慢）
+- ✅ 有 `.github/workflows/dispatch.yml`，到 `phona/ttpos-ci` 的 `ci-go` 通路通
+
+**ttpos-flutter**（实际位置 `ZonEaseTech/ttpos-flutter`，默认分支 `release`）：
+
+- ❌ **repo 根目录没有 Makefile**。`apps/` 下 10 个 Flutter app 也没。构建走 melos
+  + `scripts/*.dart`（Bun + Dart 自定义脚本链），跟 ttpos-ci Makefile 契约完全
+  没对接
+- ❌ ci-flutter.yml 调用的 `ci-env` / `ci-setup` / `ci-lint` / `ci-unit-test` **全部
+  缺失**。其中 ci-env / ci-setup 在 workflow 里有 `|| true` 兜底；`ci-lint` /
+  `ci-unit-test` **没有**兜底 —— 真要触发会立刻 `make: *** No rule` 红
+- ❌ 仓内**没有 dispatch workflow**（只有 `commit-lint.yaml` /
+  `trigger-artifact-builds.yaml` / `trigger-test-builds.yaml` 等），所以 ttpos-ci
+  的 `ci-flutter` 现在根本**触发不到**。这意味着即便把 Makefile 写出来，PR 也不会
+  跑 phona/ttpos-ci 那条 lint/unit-test pipeline
+- 默认分支 `release`：sisyphus BASE_REV chain 同样 miss
+
+**契约文档自身的不一致（可以顺手记下）**：
+
+1. `phona/ttpos-ci/README.md` 标准说 ci-lint 读 **`BASE_REV` 环境变量**。
+   但 `phona/ttpos-ci/.github/workflows/ci-flutter.yml` 实际写法是
+   `make ci-lint BASE_REF="$BASE_REF"` —— 拼错成 `BASE_REF`（少一个 V）+ 用
+   make-arg 而非 env。`ci-go.yml` 写对了（`env: BASE_REV: ${{ ... }}`）。
+   单字符之差能让 flutter 那条永远全量 lint
+2. `docs/integration-contracts.md` §1 "两类 repo 角色" 表格用
+   `phona/ttpos-server-go` / `phona/ttpos-arch-lab` 做例子，但实际两个 repo
+   都在 `ZonEaseTech/` 下。analyze-agent 看 doc 自己拼仓路径会 404
+3. `docs/integration-contracts.md` §6 默认 dev-agent 的 `feat/REQ-id` 分支以
+   `main` 为基（`gh pr list --head feat/REQ-29 --repo ...`）；两个业务 repo 实际
+   default branch `release`。pr-ci-watch 的查询不依赖 base，但 BASE_REV
+   merge-base 计算依赖
+
+## 取舍
+
+**为什么不直接顺手把 GAP 修了**（仓里加 Makefile / dispatch.yml 等）：
+
+- 审计是分析层活；改业务 repo Makefile 是它仓的 PR + 它仓 owner 决策。从
+  sisyphus 这边强推 Makefile 模板会越界（参考 CLAUDE.md "不抢 AI 决定权"，扩
+  展到"不抢业务 repo owner 决定权"）
+- ttpos-flutter 用 melos + dart scripts 这套自有体系，把它硬塞进 ttpos-ci
+  Makefile 契约可能不是它团队最优解 —— 也许更好的路径是 ttpos-ci 加一个
+  flutter melos-aware 的 dispatch path，或单独一份 `flutter-ci.yml`
+  调 melos commands。这种方案选型应该在 onboarding REQ 阶段拍，不是审计 REQ
+  顺手做
+- ci-build stub 不影响 sisyphus 的三个机械 checker —— 是 ttpos-ci build.yml 才用
+  到。修它不阻塞 sisyphus 跑这俩 repo
+
+**为什么沉淀成 spec 而不只是 docs**：
+
+`specs/business-repo-onboarding-audit/spec.md` 把这次审计的 5 条核对项变成
+可复用 requirements。下次再有人提"接 phona/zplan 进 sisyphus"这样的 REQ，
+analyze-agent 看这个 spec 就能直接拿 checklist 跑一遍 + 同样的 audit-report
+形态产出。
+
+## 后续 REQ 候选（不在本 REQ 范围）
+
+1. `REQ-ttpos-server-go-default-branch-or-base-rev-fallback`：要么把
+   server-go default branch 改 `main`，要么改 sisyphus BASE_REV 计算 chain
+   加 `release` 兜底
+2. `REQ-ttpos-flutter-make-or-melos-bridge`：在 flutter 仓加最小 Makefile
+   wrapper，或在 phona/ttpos-ci 加 melos-native flutter pipeline
+3. `REQ-ttpos-flutter-dispatch-yml`：补 dispatch.yml 让 ttpos-ci ci-flutter 真能跑
+4. `REQ-fix-ci-flutter-base-rev-arg`：phona/ttpos-ci/.github/workflows/ci-flutter.yml
+   把 `BASE_REF=` 改成 env `BASE_REV:`，拼写对齐 README
+5. `REQ-fix-integration-contracts-md-org-paths`：docs 里 `phona/ttpos-*` 例子
+   改 `ZonEaseTech/ttpos-*` 或改成纯占位 `<owner>/<repo>`
+6. `REQ-add-base-rev-doc-for-non-main-default-branch`：integration-contracts.md
+   §2.2 写明 "若仓 default branch 既非 main 也非 develop/dev，BASE_REV 会
+   降级为全量；此为预期行为"
+
+每个候选独立小型 REQ，都不依赖其他先做。
+
+## 范围内做的事
+
+- [x] 读 phona/ttpos-ci/README.md + ci-go.yml + ci-flutter.yml 三份做契约真值
+- [x] 通过 GitHub REST API 拉两个业务 repo 的 Makefile + workflow 内容
+- [x] 逐条对齐契约 vs 现状，写入 `audit-report.md`
+- [x] 把审计核对项沉淀成 `specs/business-repo-onboarding-audit/spec.md` 复用
+- [x] 列出 GAP 候选 follow-up REQ

--- a/openspec/changes/REQ-audit-business-repo-makefile-1777125538/specs/business-repo-onboarding-audit/spec.md
+++ b/openspec/changes/REQ-audit-business-repo-makefile-1777125538/specs/business-repo-onboarding-audit/spec.md
@@ -1,0 +1,140 @@
+# business-repo-onboarding-audit Specification
+
+## ADDED Requirements
+
+### Requirement: source repo onboarding audit MUST verify all six ttpos-ci targets exist
+
+The onboarding audit SHALL verify that a candidate source repo's `Makefile` (or include chain) defines all six ttpos-ci standard targets before that repo joins `involved_repos`. A source repo joining sisyphus's `involved_repos` (whether via `default_involved_repos` or per-REQ explicit declaration) MUST pass this audit before its first analyze REQ. The audit MUST cover all six standard targets:
+`ci-env`, `ci-setup`, `ci-lint`, `ci-unit-test`, `ci-integration-test`, and
+`ci-build`. A repo missing any target MUST be flagged GAP in the audit output and
+MUST NOT be added to involved_repos until the gap is closed by a separate
+follow-up REQ. This is a documentation-checklist requirement enforced manually
+by the analyze-agent at onboarding time, not a runtime sisyphus check.
+
+#### Scenario: AUDIT-S1 audit passes when all six targets resolve via root Makefile or include chain
+
+- **GIVEN** a candidate source repo whose root `Makefile` defines or includes
+  rules for `ci-env`, `ci-setup`, `ci-lint`, `ci-unit-test`, `ci-integration-test`,
+  `ci-build` (any of them MAY come from an `include` directive)
+- **WHEN** the auditor runs `make -n ci-env ci-setup ci-lint ci-unit-test ci-integration-test ci-build` against a fresh clone
+- **THEN** make resolves a recipe for every target and exits 0; the audit output
+  records PASS for the "all six targets" check
+
+#### Scenario: AUDIT-S2 audit flags GAP when any target is missing from include chain
+
+- **GIVEN** a candidate source repo whose Makefile (and its includes) defines
+  only `ci-lint`, `ci-unit-test`, and `ci-integration-test` but not `ci-env`,
+  `ci-setup`, or `ci-build`
+- **WHEN** the auditor runs `make -n ci-env`
+- **THEN** make exits non-zero with `No rule to make target` and the audit output
+  records GAP for the missing targets
+
+#### Scenario: AUDIT-S3 audit flags GAP when repo has no Makefile at all
+
+- **GIVEN** a candidate source repo with no `Makefile` at the repo root
+- **WHEN** the auditor lists the repo root via `gh api repos/<owner>/<repo>/contents`
+- **THEN** the audit output records GAP "no Makefile" and the candidate
+  IS NOT eligible for involved_repos until a Makefile is added
+
+### Requirement: onboarding audit MUST verify ci-lint honors BASE_REV environment variable
+
+The audit SHALL verify the repo's `ci-lint` recipe reads the `BASE_REV` environment
+variable for incremental scoping, MUST treat empty `BASE_REV` as full-scan
+fallback, and MUST exit zero on lint pass / non-zero on lint fail. The audit MAY
+satisfy this by reading the recipe and confirming the shell expansion idiom
+`$${BASE_REV:+--new-from-rev=$$BASE_REV}` (or an equivalent BASE_REV-checking
+construct) is present in the recipe body.
+
+#### Scenario: AUDIT-S4 ci-lint with BASE_REV expansion present
+
+- **GIVEN** the candidate's `ci-lint` recipe contains a shell expansion
+  `golangci-lint run $${BASE_REV:+--new-from-rev=$$BASE_REV}` (the canonical
+  ttpos-ci form documented in sisyphus integration-contracts.md §2.2)
+- **WHEN** the auditor greps the recipe text
+- **THEN** the audit records PASS for "ci-lint honors BASE_REV"
+
+#### Scenario: AUDIT-S5 ci-lint hardcodes branch reference instead of BASE_REV
+
+- **GIVEN** the candidate's `ci-lint` recipe hardcodes `golangci-lint run --new-from-rev=origin/main`
+  with no `BASE_REV` reference
+- **WHEN** the auditor greps the recipe
+- **THEN** the audit records GAP "ci-lint does not honor BASE_REV; will refuse
+  empty input or pin to wrong base" and the candidate IS NOT eligible until fixed
+
+### Requirement: onboarding audit MUST verify dispatch.yml routes to phona/ttpos-ci
+
+The onboarding audit SHALL verify, for any candidate source repo that intends to drive the phona/ttpos-ci pipeline (GitHub Actions side, the lint→unit-test→sonarqube path), that the candidate has a `.github/workflows/dispatch.yml` (or equivalent
+`repository_dispatch` sender) that fires `event_type` matching the ttpos-ci
+target workflow (`ci-go` or `ci-flutter`). Repos that do not need ttpos-ci
+GHA (sisyphus-only path) MAY skip this check; the audit MUST record N/A and
+note that pr-ci-watch will then have nothing to watch (which is a separate
+admission decision).
+
+#### Scenario: AUDIT-S6 candidate has dispatch.yml firing ci-go
+
+- **GIVEN** the candidate source repo has `.github/workflows/dispatch.yml`
+  containing `event_type: ci-go` (or ci-flutter for Flutter repos)
+- **WHEN** the auditor reads the workflow file
+- **THEN** the audit records PASS for "ttpos-ci dispatch wired"
+
+#### Scenario: AUDIT-S7 candidate has no dispatch.yml
+
+- **GIVEN** the candidate's `.github/workflows/` listing contains no `dispatch.yml`
+  (or any other workflow firing repository_dispatch into phona/ttpos-ci)
+- **WHEN** the auditor lists the directory
+- **THEN** the audit records GAP "no dispatch to ttpos-ci"; sisyphus pr-ci-watch
+  will see zero check-runs on the feat branch's PR and time out (1800s default)
+
+### Requirement: onboarding audit MUST record candidate repo's default branch
+
+The audit SHALL record the candidate's GitHub default branch and flag a WARN
+if it is not in the set `{main, develop, dev}`. WARN does not block onboarding
+but signals that sisyphus's `BASE_REV` calculation chain
+(`origin/main → origin/develop → origin/dev → empty`) will fall through to
+empty BASE_REV, causing `ci-lint` to run as full scan rather than incremental.
+The audit output MUST cite this as a known performance trade-off, not a
+correctness issue.
+
+#### Scenario: AUDIT-S8 default branch is main
+
+- **GIVEN** the candidate's `gh api repos/<owner>/<repo>` returns `"default_branch": "main"`
+- **WHEN** the auditor reads it
+- **THEN** the audit records PASS and notes BASE_REV computation will succeed
+  on the first chain step
+
+#### Scenario: AUDIT-S9 default branch is release
+
+- **GIVEN** the candidate's default_branch is `release` (or any other
+  non-main/develop/dev value)
+- **WHEN** the auditor reads it
+- **THEN** the audit records WARN "BASE_REV chain will fall through to empty;
+  ci-lint runs full scan" and flags this in the report's per-repo summary table.
+  Onboarding MAY proceed; performance impact is acceptable
+
+### Requirement: audit output MUST include a per-target pass/gap matrix and follow-up REQ candidate list
+
+The audit deliverable SHALL include a single-table summary of every audited
+target × every audited repo with cell values in the set
+`{✅ PASS, ⚠️ WARN, ⚠️ STUB, ❌ GAP, N/A}`. The deliverable MUST also list
+candidate follow-up REQs to close each GAP, with each candidate carrying a
+proposed REQ id stem and a one-line rationale. The audit itself MUST NOT
+attempt to close any GAP — closing is the responsibility of independently
+filed follow-up REQs so business-repo owners retain decision authority over
+their own Makefile / workflow shape.
+
+#### Scenario: AUDIT-S10 audit report contains the matrix
+
+- **GIVEN** an audit report markdown produced by the analyze-agent
+- **WHEN** a reviewer reads it
+- **THEN** there is a heading-level section containing a matrix table whose
+  rows are audited targets and whose columns are audited repos, with each cell
+  marked using one of the five status labels above
+
+#### Scenario: AUDIT-S11 audit report lists follow-up REQ candidates
+
+- **GIVEN** the audit identified at least one GAP or DOC-MISMATCH
+- **WHEN** the reviewer reads the report's "后续 REQ 候选" / "follow-up REQ
+  candidates" section
+- **THEN** every GAP and every DOC-MISMATCH has a corresponding numbered REQ
+  candidate with proposed id stem and one-line rationale. The audit deliverable
+  MUST NOT itself implement any of those follow-ups

--- a/openspec/changes/REQ-audit-business-repo-makefile-1777125538/tasks.md
+++ b/openspec/changes/REQ-audit-business-repo-makefile-1777125538/tasks.md
@@ -1,0 +1,41 @@
+# Tasks: REQ-audit-business-repo-makefile-1777125538
+
+只读审计 REQ。所有任务都是审计执行 + 沉淀，**不改业务 repo**。
+
+## Stage: contract / spec
+
+- [x] 读 phona/ttpos-ci/README.md "业务仓库 CI 契约" 段确定契约真值
+- [x] 读 phona/ttpos-ci/.github/workflows/{ci-go.yml, ci-flutter.yml} 看实际调用差异
+- [x] 读 phona/sisyphus/docs/integration-contracts.md §2.1 + §2.2 看 sisyphus 强约束子集
+- [x] 把审计核对项写成 `specs/business-repo-onboarding-audit/spec.md` 复用 spec
+      （ADDED Requirements；onboarding 时新仓必须过这一遍）
+
+## Stage: audit execution
+
+- [x] 通过 `gh api` 拉 ZonEaseTech/ttpos-server-go 的 Makefile + ttpos-scripts/lint-ci-test.mk
+- [x] 通过 `gh api` 拉 ZonEaseTech/ttpos-flutter 的根目录清单（release branch）+ scripts/ + .github/workflows
+- [x] 验证两仓的 default branch（确认不是 main）
+- [x] 查 ttpos-server-go 是否有 dispatch.yml（结果：有）
+- [x] 查 ttpos-flutter 是否有 dispatch.yml（结果：无）
+- [x] 找 phona/ttpos-server-go vs ZonEaseTech/ttpos-server-go 命名错位
+
+## Stage: report
+
+- [x] 写 `audit-report.md`，逐 target × 逐仓打 PASS / GAP / WARN / STUB
+- [x] 写 `proposal.md` 摘要 + 取舍 + 后续 REQ 候选
+- [x] 标出契约文档自身不一致（BASE_REV vs BASE_REF；phona/ vs ZonEaseTech/；非主流默认分支 BASE_REV 行为未文档化）
+
+## Stage: PR
+
+- [x] git push feat/REQ-audit-business-repo-makefile-1777125538
+- [x] gh pr create（标题 + body 写清楚是只读审计 REQ）
+
+## 不做的事（明确边界）
+
+- [ ] ~~改 ttpos-server-go 的 ci-build stub~~ —— 业务仓 owner 决策；本 REQ 范围外
+- [ ] ~~给 ttpos-flutter 加 Makefile~~ —— 路径 A vs 路径 B 没拍板，需要先有设计 REQ
+- [ ] ~~修 phona/ttpos-ci 的 ci-flutter.yml BASE_REF 拼写~~ —— 独立 doc/CI fix REQ
+- [ ] ~~改 docs/integration-contracts.md 里 phona/ttpos-* 错位~~ —— 独立 doc fix REQ
+- [ ] ~~把 ttpos-server-go 默认分支改 main~~ —— 业务仓 owner 决策
+
+这些 GAP / 不一致已在 audit-report.md §6 列成后续 REQ 候选，等业务方决策再独立起。


### PR DESCRIPTION
## Summary

Read-only audit of `ZonEaseTech/ttpos-server-go` + `ZonEaseTech/ttpos-flutter` against the ttpos-ci contract (defined by `phona/ttpos-ci/README.md` + `docs/integration-contracts.md`), to gate adding them into sisyphus's `involved_repos` after REQ-default-involved-repos-1777124541. **No business-repo files changed; no orchestrator behavior changed.**

### Headline findings

| | ttpos-server-go | ttpos-flutter |
|---|---|---|
| Makefile present | ✅ root + included `lint-ci-test.mk` | ❌ no Makefile |
| All 6 ttpos-ci standard targets | ✅ (ci-build is a stub) | ❌ all 4 ci-flutter.yml callees missing |
| `ci-lint` honors `BASE_REV` | ✅ canonical idiom | ❌ no recipe |
| `dispatch.yml` to phona/ttpos-ci | ✅ | ❌ |
| **sisyphus 3 mechanical checkers ready** | ✅ | ❌ |

### Documentation inconsistencies surfaced (separate fix REQs)

1. `phona/ttpos-ci/.github/workflows/ci-flutter.yml` passes `BASE_REF=` make-arg; README says `BASE_REV` env. Wrong both in name (1-char diff) and channel (arg vs env).
2. `phona/sisyphus/docs/integration-contracts.md` cites `phona/ttpos-server-go` / `phona/ttpos-arch-lab` — actual repos are `ZonEaseTech/...`.
3. `BASE_REV` chain (`main → develop → dev`) falls through to empty when default branch is `release`; both audited repos use `release`. Behavior is correct (full lint), but the contract doesn't acknowledge the degradation.

### What this PR adds

- `openspec/changes/REQ-audit-business-repo-makefile-1777125538/proposal.md` — exec summary + 后续 REQ candidate list
- `openspec/changes/REQ-audit-business-repo-makefile-1777125538/audit-report.md` — full per-target × per-repo gap matrix with reproducibility notes (every gh-api endpoint cited)
- `openspec/changes/REQ-audit-business-repo-makefile-1777125538/specs/business-repo-onboarding-audit/spec.md` — new capability codifying this audit as a reusable checklist (5 ADDED Requirements, 11 scenarios) so future onboarding REQs can run the same checks
- `openspec/changes/REQ-audit-business-repo-makefile-1777125538/tasks.md` — done-checkboxes for the audit work + explicit non-goals

### What this PR explicitly does NOT do

- Add a Makefile to ttpos-flutter (Path A vs Path B selection is a separate design REQ — owner of business repo decides)
- Replace ttpos-server-go's stubbed `ci-build` (only impacts ttpos-ci `build.yml`, not sisyphus)
- Fix `BASE_REF` typo in `phona/ttpos-ci/ci-flutter.yml`
- Update sisyphus's integration-contracts.md org-name examples
- Touch BASE_REV chain in sisyphus to fall through to `release`

Six independent follow-up REQ candidates listed in `audit-report.md §6`.

## Test plan

- [x] `openspec validate REQ-audit-business-repo-makefile-1777125538` passes
- [x] `scripts/check-scenario-refs.sh --specs-search-path . .` passes (all scenario refs resolve, 181 definitions globally)
- [ ] sisyphus spec_lint (mechanical) on this branch — runs server-side after move review
- [ ] Reviewer reads `audit-report.md` and confirms no GAP claim is misstated; spot-checks a couple gh-api citations in §7

🤖 Generated with [Claude Code](https://claude.com/claude-code)