### PR TITLE
docs(cookbook): ttpos-arch-lab accept-env-up/down (compose + emulator + APK + endpoint) (REQ-archlab-accept-env-cookbook-1777125697)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ sisyphus/
 | [observability/sisyphus-dashboard.md](observability/sisyphus-dashboard.md) | 13 张 Metabase 看板 + SQL（M7 + M14e） |
 | [docs/prompts.md](docs/prompts.md) | 各阶段 agent prompt 总览（按 role） |
 | [docs/api-tag-management-spec.md](docs/api-tag-management-spec.md) | BKD issue tag 命名规范（router 依赖） |
+| [docs/cookbook/](docs/cookbook/) | 按 lab 形态分给 `accept-env-up/down` 实现样板（mobile lab 见 `ttpos-arch-lab-accept-env.md`） |
 
 ## 开发规范
 

--- a/README.md
+++ b/README.md
@@ -133,3 +133,4 @@ kubectl logs -n sisyphus deploy/sisyphus-orchestrator -f
 | [observability/sisyphus-dashboard.md](observability/sisyphus-dashboard.md) | 13 张 Metabase 看板 + SQL（M7 + M14e） |
 | [docs/prompts.md](docs/prompts.md) | 各阶段 agent prompt 总览（按 role） |
 | [docs/api-tag-management-spec.md](docs/api-tag-management-spec.md) | BKD issue tag 命名规范（router 依赖） |
+| [docs/cookbook/](docs/cookbook/) | 按 lab 形态分别给 `accept-env-up/down` 实现样板（如 `ttpos-arch-lab-accept-env.md`：compose + emulator + APK + endpoint） |

--- a/docs/cookbook/ttpos-arch-lab-accept-env.md
+++ b/docs/cookbook/ttpos-arch-lab-accept-env.md
@@ -1,0 +1,360 @@
+# Cookbook: ttpos-arch-lab `accept-env-up` / `accept-env-down`
+
+> 给 **integration repo `phona/ttpos-arch-lab`**（以及任何形似的「mobile e2e lab」repo）
+> 一份能直接抄的 `make accept-env-up` / `make accept-env-down` 食谱：起后端
+> compose stack → 启 Android emulator（headless）→ 装 APK → emit endpoint JSON
+> → 让 sisyphus accept-agent 跑 FEATURE-A* scenarios。
+>
+> 适用场景：被测系统是 **「mobile App + 后端 stack」**，accept-agent 要同时面向
+> HTTP endpoint（验业务接口）和 emulator 上 App（验 UI 流程）。
+>
+> 契约权威是 [`docs/integration-contracts.md`](../integration-contracts.md) §2.3 / §3 / §5；
+> 本 cookbook 只是一份**实现样板**。冲突以契约文档为准。
+
+## 0. TL;DR — 这份 recipe 给你什么
+
+`make accept-env-up` 执行 5 步，**stdout 只在最后吐一行 JSON**（其余写 stderr）：
+
+1. 起 backend `docker compose up -d --wait`，等 healthcheck 转绿
+2. 启 Android emulator container（headless，软件渲染兜底）+ `adb` 等 boot 完成
+3. `flutter build apk --release` 出 APK（或拉 prebuilt）
+4. `adb install -r` 装到 emulator
+5. `printf '{"endpoint":"http://localhost:<port>","adb":"127.0.0.1:<adb-port>","namespace":"<ns>"}\n'`
+
+`make accept-env-down` 反向：`adb kill-server` → emulator container down → `docker compose down -v`，
+全部 best-effort（前缀 `-` 或 `|| true`）。
+
+## 1. repo 布局
+
+`ttpos-arch-lab` 是 sisyphus 契约里的 **integration repo**（不是 source repo），
+runner pod 把它 clone 到 `/workspace/integration/ttpos-arch-lab/`。整个 lab 自包含：
+backend stack + emulator wrapper + APK 来源声明 + Makefile，全在一个仓里。
+
+```
+ttpos-arch-lab/
+├── Makefile                              ← accept-env-up / accept-env-down
+├── docker-compose.accept.yml             ← backend stack（compose 项目名 = $SISYPHUS_NAMESPACE）
+├── emulator/
+│   ├── docker-compose.emulator.yml       ← Android emulator container（独立 compose）
+│   └── boot-wait.sh                      ← 等 emulator boot_completed 的辅助脚本
+├── apk/
+│   ├── source.txt                        ← APK 来源声明（git URL 或 GHCR artifact tag）
+│   └── build.sh                          ← 拉 source / 编 APK / 输出到 ./apk/dist/app.apk
+└── README.md                             ← 指回这份 cookbook
+```
+
+不强制目录细节，但 **Makefile + compose file + APK build script 三件套缺一不可**。
+
+## 2. backend compose stack：`docker-compose.accept.yml`
+
+骨架如下。要点：
+
+- 服务名留一个 `lab`（业务 backend 入口），exposing 8080 但**不写 host port** ——
+  让 docker 自动分配，避免并发 REQ 撞港。
+- 每个 service 必须有 `healthcheck`，否则 `docker compose up -d --wait` 不会真等就绪。
+- 同 compose 项目里可放 postgres / redis / mock 第三方等所有 backend 依赖。
+
+```yaml
+services:
+  lab:
+    image: ghcr.io/phona/ttpos-server-go:${TTPOS_SERVER_TAG:-main}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://ttpos:ttpos@postgres:5432/ttpos?sslmode=disable
+    ports:
+      - "8080"                  # docker 自分配 host port
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/healthz"]
+      interval: 5s
+      timeout: 2s
+      retries: 12
+      start_period: 5s
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ttpos
+      POSTGRES_PASSWORD: ttpos
+      POSTGRES_DB: ttpos
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ttpos -d ttpos"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+```
+
+> **为什么不直接用 helm chart 部 K3s lab？**
+> ttpos-arch-lab 历史上是 helm-based（见 `integration-contracts.md` §4.2）。但 emulator 在
+> K3s pod 里跑 KVM 通常没 `/dev/kvm` device，软件渲染又对 helm `--wait` 健康探针不友好；
+> 切到 docker compose + DinD 跑在 sisyphus-runner pod 里，**emulator container 跟
+> backend 共享 DinD daemon + 局域虚拟网络**，accept-agent 通过 host port 访问就行。
+
+## 3. Android emulator container：`emulator/docker-compose.emulator.yml`
+
+公共 emulator 镜像首选 `budtmo/docker-android` 或 `ghcr.io/cirruslabs/android-images`
+（runner 镜像基于 `cirruslabs/flutter:stable`，跟 cirruslabs 的 emulator 系列对齐）。
+
+```yaml
+services:
+  emulator:
+    image: ghcr.io/cirruslabs/android-images:api-34
+    privileged: true                       # KVM / binder 需要
+    devices:
+      - /dev/kvm                           # 有 KVM 走硬加速；无 KVM 走 -no-accel
+    environment:
+      EMULATOR_ARGS: "-no-window -no-audio -no-snapshot -gpu swiftshader_indirect"
+    ports:
+      - "5555"                             # adb daemon（host port docker 自分配）
+      - "5554"                             # emulator console（仅 debug 用）
+    healthcheck:
+      test: ["CMD-SHELL", "adb -s emulator-5554 shell getprop sys.boot_completed | grep -q 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 60                          # boot 慢，给足重试
+      start_period: 30s
+```
+
+**KVM fallback**：vm-node04 K3s sisyphus-runners namespace 没暴露 `/dev/kvm` 时，
+docker run 会报 `error gathering device information ... /dev/kvm: no such file`。
+两条路：
+
+1. **声明 `EMULATOR_ARGS: "-no-accel ..."`**：纯软件模拟，boot 时间从 ~30s 涨到 ~3min，
+   配套把 healthcheck `start_period` 调到 180s 即可。
+2. **加 device plugin / privileged passthrough**：让 sisyphus-runner pod 拿到 host
+   `/dev/kvm`。需要 host 上 `lsmod | grep kvm` 真有模块；vm-node04 是 KVM hypervisor 时
+   原生支持，否则不可得。
+
+> 软件模拟在 sisyphus accept 阶段是可接受的（accept stage timeout 1800s，缓 3min boot 没事）。
+> 优先走软件路径，不依赖宿主能力 = 整个 lab repo 在任何 K3s/runner 组合都能跑。
+
+### 3.1 `emulator/boot-wait.sh`
+
+把 healthcheck 写两遍（compose 一遍 + bash 一遍）的目的：compose `--wait` 会等
+healthcheck 第一次绿，但绿之后 `package manager`/`activity manager` 还可能没起完，
+直接 `adb install` 会偶发失败。这个脚本把 install 前置稳定性补全。
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ADB_HOST_PORT="${1:-5555}"
+ADB_TARGET="127.0.0.1:${ADB_HOST_PORT}"
+
+# 1. 让 host adb client 跟 emulator container 里的 adb daemon 握手
+for i in {1..30}; do
+  if adb connect "$ADB_TARGET" 2>/dev/null | grep -q "connected\|already"; then
+    break
+  fi
+  sleep 2
+done
+
+# 2. 等 sys.boot_completed=1
+adb -s "$ADB_TARGET" wait-for-device
+for i in {1..60}; do
+  if [ "$(adb -s "$ADB_TARGET" shell getprop sys.boot_completed | tr -d '\r')" = "1" ]; then
+    break
+  fi
+  sleep 3
+done
+
+# 3. 再额外等 package manager 就绪（pm list packages 可调用）
+for i in {1..30}; do
+  if adb -s "$ADB_TARGET" shell pm list packages -f >/dev/null 2>&1; then
+    echo "[boot-wait] emulator $ADB_TARGET ready" >&2
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "[boot-wait] emulator $ADB_TARGET never reached pm-ready state" >&2
+exit 1
+```
+
+## 4. APK 构建：`apk/build.sh`
+
+APK 来源有 3 种，cookbook 给最常见的 **「同 REQ 改 source repo + 当场编 APK」**：
+
+```bash
+#!/usr/bin/env bash
+# apk/build.sh — 编 APK 写到 ./apk/dist/app.apk
+#
+# 依赖：runner 镜像 cirruslabs/flutter:stable 已带 Flutter SDK + Android SDK + Java。
+set -euo pipefail
+
+DIST="$(cd "$(dirname "$0")" && pwd)/dist"
+mkdir -p "$DIST"
+
+# source repo 在 sisyphus 约定路径，单仓 REQ 当 ttpos-flutter-app 改了：
+SRC_REPO="${TTPOS_FLUTTER_REPO:-/workspace/source/ttpos-flutter-app}"
+
+if [[ ! -d "$SRC_REPO" ]]; then
+  echo "[apk/build] $SRC_REPO not found; falling back to GHCR prebuilt" >&2
+  # 兜底：从 GHCR 拉一个固定 tag 的 APK artifact（业务自己维护）
+  curl -fsSL \
+    -H "Authorization: Bearer $SISYPHUS_GHCR_TOKEN" \
+    "https://ghcr.io/v2/phona/ttpos-flutter-app/blobs/${TTPOS_APK_DIGEST:?missing}" \
+    -o "$DIST/app.apk"
+  exit 0
+fi
+
+cd "$SRC_REPO"
+flutter pub get
+flutter build apk --release \
+  --dart-define=API_BASE_URL="${TTPOS_API_BASE_URL:?must point to compose lab}"
+
+cp build/app/outputs/flutter-apk/app-release.apk "$DIST/app.apk"
+echo "[apk/build] APK -> $DIST/app.apk" >&2
+```
+
+要点：
+
+- **`--dart-define=API_BASE_URL`** 把 backend endpoint 编进 APK，让 emulator 内的 App
+  指向 compose stack。Makefile 在调 `build.sh` 前会把 `TTPOS_API_BASE_URL` 算好。
+- **prebuilt 兜底**：源仓没 clone 进 `/workspace/source/`（比如本 REQ 只改 backend、没改 App）
+  时，从 GHCR 拉固定 digest 的 APK 跑回归。digest 由 `apk/source.txt` 声明，业务团队维护。
+
+## 5. endpoint JSON 契约（多键扩展）
+
+`integration-contracts.md` §3 规定 stdout 末行 JSON **必须**有 `endpoint` 字段。
+mobile lab 在此基础上**再加两个非必需键**给 accept-agent 用：
+
+```json
+{
+  "endpoint": "http://localhost:34567",
+  "adb": "127.0.0.1:34568",
+  "apk_package": "com.phona.ttpos",
+  "namespace": "accept-req-xxx"
+}
+```
+
+| key | 必需 | 给谁用 |
+|---|---|---|
+| `endpoint` | ✅ | accept-agent 跑后端 HTTP scenarios（hit `lab` 服务） |
+| `adb` | （扩展） | accept-agent 跑 UI scenarios，先 `adb connect <addr>` 再 `adb shell input tap ...` 或 `am start` |
+| `apk_package` | （扩展） | accept-agent 启 App 用 `am start -n <package>/<activity>` |
+| `namespace` | （可选） | 跟 §3 一致，sisyphus 已通过 env 传一份；写一遍方便 debug |
+
+> **额外键由 accept-agent 自己读** —— sisyphus orchestrator 只解析 `endpoint`
+> 字段（`actions/create_accept.py` 里）。其他键透传给 accept-agent prompt context。
+> accept-agent prompt 模板 (`prompts/accept.md.j2`) 里能直接用 `ctx.lab.adb` /
+> `ctx.lab.apk_package`。
+
+## 6. 完整 Makefile 范本
+
+```makefile
+.PHONY: accept-env-up accept-env-down
+
+# sisyphus 注入；防御性兜底
+SISYPHUS_NAMESPACE ?= accept-default
+COMPOSE_PROJECT_NAME := $(SISYPHUS_NAMESPACE)
+BACKEND_COMPOSE_FILE  ?= docker-compose.accept.yml
+EMULATOR_COMPOSE_FILE ?= emulator/docker-compose.emulator.yml
+APK_PACKAGE ?= com.phona.ttpos
+
+accept-env-up:
+	@# 1. 起 backend stack
+	@echo "[arch-lab] up: backend stack ($(COMPOSE_PROJECT_NAME))" >&2
+	docker compose -p $(COMPOSE_PROJECT_NAME) -f $(BACKEND_COMPOSE_FILE) \
+	    up -d --wait --wait-timeout 180 >&2
+	@# 2. 算 backend host port（accept-agent 用 host 视角访问）
+	@backend_port=$$(docker compose -p $(COMPOSE_PROJECT_NAME) \
+	    -f $(BACKEND_COMPOSE_FILE) port lab 8080 | awk -F: 'END{print $$NF}'); \
+	if [ -z "$$backend_port" ]; then \
+	    echo "[arch-lab] FAIL: cannot resolve backend lab:8080 host port" >&2; \
+	    exit 2; \
+	fi; \
+	echo "$$backend_port" > .accept-backend-port
+	@# 3. 起 emulator container
+	@echo "[arch-lab] up: emulator" >&2
+	docker compose -p $(COMPOSE_PROJECT_NAME)-emu -f $(EMULATOR_COMPOSE_FILE) \
+	    up -d --wait --wait-timeout 600 >&2
+	@adb_port=$$(docker compose -p $(COMPOSE_PROJECT_NAME)-emu \
+	    -f $(EMULATOR_COMPOSE_FILE) port emulator 5555 | awk -F: 'END{print $$NF}'); \
+	if [ -z "$$adb_port" ]; then \
+	    echo "[arch-lab] FAIL: cannot resolve emulator 5555 host port" >&2; \
+	    exit 3; \
+	fi; \
+	echo "$$adb_port" > .accept-adb-port
+	@# 4. boot-wait + 编 APK + 装 APK
+	@adb_port=$$(cat .accept-adb-port); \
+	./emulator/boot-wait.sh "$$adb_port" >&2
+	@backend_port=$$(cat .accept-backend-port); \
+	TTPOS_API_BASE_URL="http://localhost:$$backend_port" ./apk/build.sh >&2
+	@adb_port=$$(cat .accept-adb-port); \
+	adb connect "127.0.0.1:$$adb_port" >&2; \
+	adb -s "127.0.0.1:$$adb_port" install -r ./apk/dist/app.apk >&2
+	@# 5. emit endpoint JSON（**stdout 末行**，前面所有日志写 stderr）
+	@backend_port=$$(cat .accept-backend-port); \
+	adb_port=$$(cat .accept-adb-port); \
+	printf '{"endpoint":"http://localhost:%s","adb":"127.0.0.1:%s","apk_package":"%s","namespace":"%s"}\n' \
+	    "$$backend_port" "$$adb_port" "$(APK_PACKAGE)" "$(SISYPHUS_NAMESPACE)"
+
+accept-env-down:
+	-@# best-effort：每一步独立失败不阻塞下一步
+	-adb kill-server 2>/dev/null || true
+	-docker compose -p $(COMPOSE_PROJECT_NAME)-emu -f $(EMULATOR_COMPOSE_FILE) \
+	    down --volumes --remove-orphans 2>&1 || true
+	-docker compose -p $(COMPOSE_PROJECT_NAME) -f $(BACKEND_COMPOSE_FILE) \
+	    down --volumes --remove-orphans 2>&1 || true
+	-rm -f .accept-backend-port .accept-adb-port 2>/dev/null || true
+```
+
+要点：
+
+- **stdout / stderr 严格分离**：`integration-contracts.md` §3 规定
+  `result.stdout.splitlines()` 反向取第一个非空行，前面任何日志混进 stdout 都会
+  让 sisyphus 错把 log 当 endpoint 解析。recipe 里 `>&2` / `@echo ... >&2` 全在 stderr。
+- **两个 compose 项目**：backend 用 `$(COMPOSE_PROJECT_NAME)`，emulator 用
+  `$(COMPOSE_PROJECT_NAME)-emu`，方便分开起 / 拆 / 排查；同 namespace 隔离 + 不互相干扰。
+- **port 落盘** `.accept-backend-port` / `.accept-adb-port`：env-up 多步要用，写文件
+  比 `$(shell ...)` 稳（make 函数在 recipe 间不能传值）；env-down 删掉。
+- **`accept-env-down` 全 `-` 前缀**：partial up 失败时（emulator 没起来，backend 起来了）
+  也要把 backend 拆掉，不能因为 adb / emulator 步骤报错就放弃 backend down。
+
+## 7. 跟 sisyphus accept-agent 的对接
+
+accept-agent prompt (`orchestrator/src/orchestrator/prompts/accept.md.j2`) 已经会
+读 `ctx.lab.endpoint`。多键扩展（`adb` / `apk_package`）要 accept-agent 自己用。
+推荐 prompt 段写：
+
+```text
+本 REQ 是 mobile App + 后端 stack 联合 e2e。lab 暴露：
+
+- HTTP endpoint：{{ ctx.lab.endpoint }}（hit 后端业务 API）
+- ADB：{{ ctx.lab.adb }}（emulator 已起 + APK {{ ctx.lab.apk_package }} 已装）
+
+跑 UI scenario 时：
+  adb connect {{ ctx.lab.adb }}
+  adb -s {{ ctx.lab.adb }} shell am start -n {{ ctx.lab.apk_package }}/.MainActivity
+  adb -s {{ ctx.lab.adb }} shell input tap <x> <y>
+  adb -s {{ ctx.lab.adb }} shell screencap -p > /tmp/screen.png
+
+跑 backend scenario 时：
+  curl -fsS {{ ctx.lab.endpoint }}/api/...
+```
+
+如果业务 prompt 没改 / `ctx.lab` 只读 `endpoint`：accept-agent 就只能跑 HTTP 部分，
+mobile UI scenarios 跳过 —— 这是**优雅降级**：endpoint 字段是契约，缺它 fail；
+adb 字段是扩展，缺它降级。
+
+## 8. 排查清单
+
+`make accept-env-up` 失败时按这个顺序看：
+
+| 症状 | 先看 |
+|---|---|
+| backend 起不来 | `docker compose -p $NS -f docker-compose.accept.yml logs --tail=80 lab` |
+| emulator 永远 boot 不完 | `docker compose -p $NS-emu logs emulator | grep -i "boot_completed\|kvm\|swiftshader"`；多半是 KVM 缺 + start_period 不够 |
+| `adb connect` 连不上 | `docker compose -p $NS-emu port emulator 5555` 看 host port 真分配没；`adb devices` 看有没有 `offline` |
+| APK 编译失败 | `apk/build.sh` 末尾的 stderr；`flutter doctor` 在 runner pod 里直接跑一次 |
+| `adb install` 报 `INSTALL_FAILED_INVALID_APK` | APK abi 跟 emulator 不一致，build.sh 加 `--target-platform android-x64` |
+| stdout 末行不是 JSON | recipe 哪一步把 log 输出到了 stdout（漏了 `>&2`）；`make accept-env-up 2>/dev/null \| tail -1` 看 |
+| sisyphus 解析不到 `endpoint` | endpoint URL 必须是 **runner pod 视角** reachable —— `localhost:<port>` 在 DinD 里走 host network 通；不要写 `http://lab:8080`（compose 内部 DNS 在 runner 视角下不通） |
+
+## 9. 跟现有契约 / 历史模板的关系
+
+- `docs/integration-contracts.md` §4.2 helm-based 模板：当 lab 部 K3s 时用，跟本 cookbook **互补不替代**。
+- `docs/integration-contracts.md` §4.2.2 docker-compose 通用模板：纯后端 stack 的简化版；mobile lab 在它上面加 emulator / APK，就是本 cookbook。
+- `docs/cookbook/` 后续可能再加 `flutter-mock-backend.md`（`REQ-flutter-accept-env-template-1777125538`）等：每份 cookbook 限定一种 lab 形态，互不重叠。

--- a/docs/integration-contracts.md
+++ b/docs/integration-contracts.md
@@ -183,6 +183,11 @@ accept-env-down:
 按下面这份模板抄。约定跟 helm 那份一样：`accept-env-up` 起 stack 并在 stdout
 **最后一行**吐 endpoint JSON；`accept-env-down` 幂等清理。
 
+> 想看完整的 **「mobile App + 后端 stack」端到端 lab** 食谱（compose 起 backend +
+> headless Android emulator + 编 APK + 装到 emulator + 多键 endpoint JSON），
+> 看 [`docs/cookbook/ttpos-arch-lab-accept-env.md`](cookbook/ttpos-arch-lab-accept-env.md)。
+> 这里的 §4.2.2 只是纯后端 stack 的最小骨架。
+
 ```makefile
 .PHONY: accept-env-up accept-env-down
 

--- a/openspec/changes/REQ-archlab-accept-env-cookbook-1777125697/design.md
+++ b/openspec/changes/REQ-archlab-accept-env-cookbook-1777125697/design.md
@@ -1,0 +1,86 @@
+# Design: ttpos-arch-lab accept-env cookbook
+
+## 设计目标
+
+给「mobile App + 后端 stack」型 integration repo 一份能直接抄的
+`accept-env-up` / `accept-env-down` 实现样板，**不动**
+`docs/integration-contracts.md` 契约本身。
+
+## 关键决策
+
+### D1：cookbook 单开目录 `docs/cookbook/`，不塞契约文档
+
+| 选项 | 优 | 缺 |
+|---|---|---|
+| A. 塞 `integration-contracts.md` §4.2.3 | 单文件，导航简单 | §4 一节膨胀；契约（短而精）跟样板（长而具体）混层 |
+| B. **新开 `docs/cookbook/` 目录** ✅ | 契约 / 样板分层；后续多种 lab 形态各自一文件 | 多一个目录 + 跨链 |
+
+选 B：将来 `flutter-mock-backend.md`（REQ-flutter-accept-env-template）/ `go-pure-http.md`
+等可以共享同一目录，契约文档保持轻。
+
+### D2：KVM 默认走软件模拟兜底
+
+| 选项 | 优 | 缺 |
+|---|---|---|
+| A. 强制宿主暴露 `/dev/kvm` | emulator boot ~30s | vm-node04 K3s sisyphus-runners ns 没配；新接入要先动基础设施 |
+| B. **默认软件模拟，KVM 可选优化** ✅ | 任何 K3s pod 都能跑 | boot ~3min，需要把 healthcheck `start_period` 调大 |
+
+选 B：cookbook 应「**自包含**」—— 拿到样板 + runner 镜像就能跑，不依赖 host 能力。
+KVM 是「锦上添花」，文档里给如何加但默认禁用。
+
+### D3：endpoint JSON 多键扩展，保留 `endpoint` 为单一契约必需键
+
+`docs/integration-contracts.md` §3 规定 stdout 末行 JSON `endpoint` 字段必需。
+mobile lab 多了一个 ADB 资源，三种处理方式：
+
+| 选项 | 优 | 缺 |
+|---|---|---|
+| A. 把 ADB 塞进 `endpoint` URL 查询参数 (`?adb=...`) | 单键不破坏契约 | 解析复杂；`endpoint` 语义不再是 HTTP base |
+| B. 改契约成 `endpoints: {http: ..., adb: ...}` 多键对象 | 表达力强 | 破坏 §3 + 所有现有 lab；要联动 `actions/create_accept.py` |
+| C. **保留 `endpoint` HTTP base + 加扩展键 `adb` / `apk_package`** ✅ | 不动契约；老 lab 兼容；accept-agent 按需消费 | 文档要明确「扩展键非必需，缺它降级」 |
+
+选 C：sisyphus orchestrator (`actions/create_accept.py`) 只解析 `endpoint`，多余字段
+透传给 accept-agent prompt context，accept-agent 自己拍板用不用。
+
+### D4：APK 来源声明用 `apk/source.txt` + `apk/build.sh` 双层
+
+| 选项 | 优 | 缺 |
+|---|---|---|
+| A. 直接在 Makefile 里写 `flutter build apk ...` | 一目了然 | 来源切换（GHCR prebuilt vs 当场编）逻辑写 Makefile 太丑 |
+| B. **`apk/source.txt` 声明 + `apk/build.sh` 抽象** ✅ | 来源策略可演化（git / GHCR / S3 等）；Makefile 干净 | 多两个文件 |
+
+选 B：APK 来源是业务团队选型变量（开发期编译、稳定期 prebuilt 加速），抽到独立脚本
+让 Makefile 只关心「调 build.sh + 装到 emulator」。
+
+### D5：两个 compose 项目（backend / emulator）分开起
+
+| 选项 | 优 | 缺 |
+|---|---|---|
+| A. 同一份 compose file 起 backend + emulator | 单 `up -d --wait` 同时等 | emulator boot 慢拖累 backend 探针 timeout；compose 不允许混不同优先级 healthcheck |
+| B. **两个 compose 项目（`$NS` + `$NS-emu`）** ✅ | 分别 `--wait`，timeout 各自调；故障定位清晰 | Makefile 多两条 docker compose 调用 |
+
+选 B：backend `--wait-timeout 180`，emulator `--wait-timeout 600`，分别匹配实际启动时间。
+
+### D6：stdout / stderr 严格分流是 cookbook 必须强调的点
+
+`docs/integration-contracts.md` §3 + §4.2.2 / §3 都提到 stdout 末行约定，但实际写
+Makefile 时新手很容易把 `@echo "step done"` 漏成 stdout，让 sisyphus 把 log 当
+endpoint 解析。cookbook 把这点提到第 6 节（完整 Makefile 范本）的「要点」首条 +
+第 8 节排查清单第 6 条，提高可发现性。
+
+## 风险
+
+- **emulator 镜像更新 / API level 升级**：cookbook 钉死 `cirruslabs/android-images:api-34`，
+  业务升级时要改这个 tag。可接受 —— cookbook 是样板不是固化产物。
+- **DinD 内嵌套 docker compose 的资源压力**：backend stack + emulator container 跑在
+  sisyphus-runner pod 的 DinD 里，pod 默认 8 GiB cgroup 上限可能在大 stack 下吃紧。
+  排查清单第 1/2 条提了 `docker compose logs`，发现资源压力的入口够用；后续如果常态
+  OOM，可考虑给 mobile lab REQ 加 pod 资源 hint。
+
+## 不在本 REQ scope
+
+- 不写 ttpos-arch-lab 实际仓代码（cookbook 是 sisyphus 仓的文档，ttpos-arch-lab 仓
+  自己照样板改是另一个 REQ）
+- 不改 sisyphus orchestrator / accept-agent prompt（多键 endpoint 是文档约定，
+  accept-agent 在 prompt 段读 ctx.lab.adb 时业务团队自己更新 prompt）
+- 不补 `dev_cross_check` / `staging_test` 对 cookbook 内容的 lint（无 verifiable 校验项）

--- a/openspec/changes/REQ-archlab-accept-env-cookbook-1777125697/proposal.md
+++ b/openspec/changes/REQ-archlab-accept-env-cookbook-1777125697/proposal.md
@@ -1,0 +1,101 @@
+# REQ-archlab-accept-env-cookbook-1777125697: docs(cookbook): ttpos-arch-lab accept-env-up/down (compose + emulator + APK + endpoint)
+
+## 问题
+
+`docs/integration-contracts.md` 把 integration repo 的 lab 起 / 拆契约定到了
+**「目标名 + stdout JSON 形状 + env 变量列表」**，并给了两份 Makefile 模板：
+
+- §4.2 helm-based（K3s）
+- §4.2.2 docker-compose-based（纯后端 stack）
+
+但 sisyphus 实际典型的 integration repo —— `phona/ttpos-arch-lab` —— 是一类
+**「mobile App + 后端 stack」端到端 lab**，需要在 `accept-env-up` 一条命令里同时：
+
+1. 起 backend `docker compose` stack（业务 API + DB + 第三方 mock）
+2. 起 Android emulator container（headless，KVM 不可用时降软件渲染）
+3. 编 APK（`flutter build apk --release` + `--dart-define=API_BASE_URL=...` 把 backend
+   endpoint 编进 App）或拉 GHCR prebuilt
+4. `adb install -r` 装 APK 到 emulator
+5. emit 多键 endpoint JSON（`endpoint` HTTP + `adb` ADB 地址 + `apk_package`），
+   accept-agent 同时跑 backend HTTP scenarios 跟 mobile UI scenarios
+
+§4.2 / §4.2.2 任何一个都没覆盖这套组合：helm 那份不带 emulator、compose 那份不带
+APK build / install / 多键 endpoint。整 lab 团队无样板可抄，每个新接入的 mobile lab
+要自己摸一遍坑（KVM fallback / port 自分配 / boot_completed 检测 / stdout 严格分流）。
+
+## 根因
+
+历史上 sisyphus 的 accept stage 长期 `skip_accept: true`（`ttpos-arch-lab` 没真接），
+所以 mobile lab 的样板需求没暴露在文档欠账里。直到 self-dogfood
+（REQ-self-accept-stage-1777121797）把 accept 跑通后，`docs/integration-contracts.md`
+§4.2.2 docker-compose 模板才补齐 —— 但那是给纯后端 lab 用的，mobile lab 这一类
+跟它的差异（emulator + APK + 多键 endpoint）足够大，硬塞进 §4.2.2 一个表会让契约文档
+失去「一份契约 + 多份样板」的清晰分层。
+
+## 方案
+
+**新开 cookbook 目录 `docs/cookbook/`，第一份是 ttpos-arch-lab 这类 mobile lab 的食谱。**
+不改契约，不改 Python 代码 —— `integration-contracts.md` 仍然是契约权威，cookbook
+只是契约下的实现样板。
+
+### Step 1：新增 `docs/cookbook/ttpos-arch-lab-accept-env.md`
+
+完整 cookbook，包含 9 节：
+
+| § | 内容 |
+|---|---|
+| 0 | TL;DR — 5 步 recipe 概览 |
+| 1 | repo 布局（`docker-compose.accept.yml` / `emulator/` / `apk/` 三件套） |
+| 2 | backend compose 骨架（lab + postgres，host port 自分配，healthcheck 必备） |
+| 3 | Android emulator container（cirruslabs api-34；KVM fallback 软件模拟；`boot-wait.sh`） |
+| 4 | APK 构建（`flutter build apk` + `--dart-define`；GHCR prebuilt 兜底） |
+| 5 | endpoint JSON 多键扩展契约（`endpoint` 必需；`adb` / `apk_package` 扩展） |
+| 6 | 完整 Makefile 范本（5 步 recipe；stderr / stdout 严格分离） |
+| 7 | accept-agent prompt 段如何用多键 endpoint |
+| 8 | 排查清单 |
+| 9 | 跟 §4.2 helm / §4.2.2 compose 模板的关系 |
+
+### Step 2：从 `integration-contracts.md` §4.2.2 加 cross-link
+
+§4.2.2 是纯后端 stack 模板，紧挨着插一段「想看完整 mobile App + 后端 lab 食谱看 cookbook」
+的引用，让读者按需跳。
+
+### Step 3：从 `README.md` 文档索引追一行 cookbook 入口
+
+新接入的业务团队第一眼能找到 cookbook 目录。
+
+### Step 4：从 `CLAUDE.md` 文档索引追一行 cookbook 入口
+
+repo 进 Claude session 时也能看到这份资源。
+
+### Step 5：验证
+
+无业务行为变化，无单元测试新增。靠：
+
+- `openspec validate openspec/changes/REQ-archlab-accept-env-cookbook-1777125697 --strict` 通过
+- `check-scenario-refs.sh` 全 scenario ID 引用解析（task / spec 之间互通）
+- `make ci-lint && make ci-unit-test && make ci-integration-test` 全过
+  （docs-only diff，BASE_REV scope 后无 *.py 变更 → ci-lint 立 pass；pytest 套不动）
+- 文件存在 + 关键 section 标题匹配 grep
+
+## 取舍
+
+- **为什么单开 `docs/cookbook/` 目录而不是塞 `integration-contracts.md` §4.2.3** —— mobile lab
+  cookbook 长（~250 行 + 多份代码块），塞契约文档会让 §4 节臃肿；契约（target 名 / JSON
+  形状 / env 列表）要短而精，样板（实现步骤 / 容错 / 排查）可以长。两者分层。
+- **为什么 cookbook 直接给 Makefile 范本而不是抽象 step 描述** —— sisyphus 的契约消费者
+  是「想接入的 lab 团队」，他们要的是能 `cp -r` 进自己仓的可跑代码，不是抽象指引。
+- **为什么 KVM fallback 默认走软件模拟而不是要求 host `/dev/kvm`** —— vm-node04 K3s
+  sisyphus-runners namespace 当前没暴露 `/dev/kvm` device，cookbook 不能要求 host
+  能力。软件模拟 boot 慢但 accept stage 1800s timeout 内绰绰有余，**默认能跑**比
+  「快但要 host 配合」更符合自包含 lab 的设计。
+- **为什么 endpoint JSON 要多键而不是只 `endpoint`** —— mobile lab 的 endpoint 含两个
+  正交资源（HTTP + ADB），强塞一个 URL 字段（如 `http://localhost:1234?adb=...`）
+  反而复杂。`endpoint` 仍是契约必需键 + 优雅降级（accept-agent 不读 `adb` 时只跑
+  HTTP 部分），新接入只需读 README 就懂。
+- **为什么不写 sibling REQ-flutter-accept-env-template 的 Flutter 模拟 backend cookbook** ——
+  那是另一种 lab 形态（pure Flutter widget tests + mock backend，不真起 emulator），
+  scope 不同；cookbook 目录设计就是「一形态一文件」，留给那个 REQ 自己写。
+- **为什么不强制 ttpos-arch-lab 团队按这份 cookbook 重构他们仓** —— cookbook 是
+  *推荐样板*不是*契约*；他们当前仓如果 Makefile 已经满足 §2.3 + §3 契约，就没问题。
+  cookbook 是给新接入团队 + ttpos-arch-lab 后续改造时的参考。

--- a/openspec/changes/REQ-archlab-accept-env-cookbook-1777125697/specs/archlab-accept-env-cookbook/spec.md
+++ b/openspec/changes/REQ-archlab-accept-env-cookbook-1777125697/specs/archlab-accept-env-cookbook/spec.md
@@ -1,0 +1,154 @@
+# archlab-accept-env-cookbook Specification
+
+## ADDED Requirements
+
+### Requirement: 仓 MUST 提供 docs/cookbook/ttpos-arch-lab-accept-env.md cookbook 文件
+
+The sisyphus repo SHALL ship a cookbook document at the canonical path
+`docs/cookbook/ttpos-arch-lab-accept-env.md`. The file MUST exist on the
+`feat/REQ-archlab-accept-env-cookbook-1777125697` branch and serve as the
+copy-pasteable implementation recipe for any integration repo whose accept
+env combines a backend `docker compose` stack, a headless Android emulator
+container, an APK build / install step, and a multi-key endpoint JSON line.
+This cookbook MUST live alongside the canonical contract document
+`docs/integration-contracts.md` (not inline) so that the contract stays short
+and the recipe can grow without bloating the contract.
+
+#### Scenario: ARCHLAB-S1 cookbook file exists at docs/cookbook/ttpos-arch-lab-accept-env.md
+
+- **GIVEN** the working tree at the head of `feat/REQ-archlab-accept-env-cookbook-1777125697`
+- **WHEN** `test -f docs/cookbook/ttpos-arch-lab-accept-env.md` runs
+- **THEN** the command exits 0 (file is present) and the file's first non-empty
+  line is a level-1 heading containing the words `Cookbook` and `ttpos-arch-lab`
+
+### Requirement: cookbook MUST 覆盖 5 步 recipe + 9 节结构
+
+The cookbook `docs/cookbook/ttpos-arch-lab-accept-env.md` SHALL document a
+five-step `accept-env-up` recipe (1. backend compose up; 2. Android emulator
+container up; 3. APK build; 4. APK install via adb; 5. emit endpoint JSON on
+the last stdout line) and MUST organize the content into nine sections so that
+readers can navigate by topic: §0 TL;DR, §1 repo layout, §2 backend compose,
+§3 Android emulator container, §4 APK build, §5 endpoint JSON contract, §6
+complete Makefile sample, §7 accept-agent prompt integration, §8 troubleshooting
+checklist, §9 relationship to existing helm / compose templates. Each section
+MUST be discoverable as a level-2 markdown heading.
+
+#### Scenario: ARCHLAB-S2 nine top-level sections present in cookbook
+
+- **GIVEN** the cookbook file `docs/cookbook/ttpos-arch-lab-accept-env.md`
+- **WHEN** `grep -E '^## ' docs/cookbook/ttpos-arch-lab-accept-env.md` runs
+- **THEN** the output contains at least nine `## ` level-2 headings whose
+  numbering covers `## 0`, `## 1`, ..., `## 9` (or equivalent numeric prefixes
+  that map to the nine sections enumerated in this requirement)
+
+#### Scenario: ARCHLAB-S3 TL;DR section enumerates the five recipe steps
+
+- **GIVEN** the cookbook §0 TL;DR section
+- **WHEN** the section body is read
+- **THEN** the prose lists the five env-up steps in order: backend compose up,
+  emulator container up, APK build, APK install via adb, emit endpoint JSON;
+  AND the section explicitly names that the JSON is on the **last** stdout line
+
+### Requirement: cookbook §3 MUST 提供 KVM-fallback 软件模拟方案
+
+The cookbook §3 (Android emulator container) section MUST provide a
+software-rendering fallback for environments where `/dev/kvm` is not available
+(the default state of the K3s `sisyphus-runners` namespace on vm-node04).
+The fallback SHALL take the form of an `EMULATOR_ARGS` declaration that
+includes the literal flags `-no-accel` and `-gpu swiftshader_indirect`, and
+the section MUST explicitly call out that the emulator container's healthcheck
+`start_period` SHALL be increased (roughly 180 s order-of-magnitude) when
+running without KVM, so that boot can finish before compose `--wait` declares
+failure. Without this fallback, every new mobile-lab integration repo would
+need to negotiate KVM passthrough with infra before any accept-env recipe can
+run, which contradicts the cookbook's self-contained design goal.
+
+#### Scenario: ARCHLAB-S4 §3 names -no-accel and swiftshader_indirect as fallback
+
+- **GIVEN** the cookbook §3 emulator container section
+- **WHEN** the section body is scanned
+- **THEN** the body contains both the literal token `-no-accel` and the literal
+  token `swiftshader_indirect`, AND the body explicitly mentions adjusting
+  `start_period` (or healthcheck timing) for the software-rendering path
+
+### Requirement: cookbook §5 MUST 描述 endpoint JSON 多键扩展（endpoint 必需 + adb / apk_package 扩展）
+
+The cookbook §5 (endpoint JSON contract) section MUST document a multi-key
+endpoint JSON shape where the field `endpoint` remains the single required
+key (preserving the `docs/integration-contracts.md` §3 contract that sisyphus
+orchestrator parses) and where `adb` and `apk_package` are documented as
+optional extension keys consumed by the accept-agent prompt context (not by
+the orchestrator). The section SHALL state that absence of an extension key
+MUST cause graceful degradation of the relevant scenario class (e.g. UI
+scenarios skipped when `adb` is missing) but MUST NOT cause the orchestrator
+to fail accept env-up, so that this cookbook remains backward-compatible with
+existing integration repos that emit only `endpoint`.
+
+#### Scenario: ARCHLAB-S5 §5 declares endpoint required and adb / apk_package optional
+
+- **GIVEN** the cookbook §5 endpoint JSON contract section
+- **WHEN** the section body is read
+- **THEN** the body contains all three literal keys: `"endpoint"`, `"adb"`,
+  `"apk_package"`, AND the body labels `endpoint` as required (with a marker
+  like ✅ or the word "必需" / "required") and `adb` / `apk_package` as
+  optional extensions (with a marker like "扩展" / "optional" / "extension")
+
+### Requirement: cookbook §6 Makefile 范本 MUST 严格分流 stderr / stdout
+
+The cookbook §6 (complete Makefile sample) section MUST provide a
+copy-pasteable Makefile block that contains both `accept-env-up` and
+`accept-env-down` recipes, AND the `accept-env-up` recipe SHALL route
+every progress / log line to stderr (via `>&2` redirection or `@echo ... >&2`)
+and reserve stdout for the final `printf` of the endpoint JSON only. The
+recipe's terminating `printf` MUST emit a JSON object whose keys cover at
+minimum `endpoint`, `adb`, `apk_package`, `namespace`, with a trailing `\n`
+so that `result.stdout.splitlines()` reverse-iteration in
+`actions/create_accept.py` resolves the JSON line. The `accept-env-down`
+recipe MUST be best-effort idempotent: every teardown command SHALL be
+prefixed with the make `-` ignore-error sigil OR appended with `|| true`, so
+re-running after a partial failure exits 0.
+
+#### Scenario: ARCHLAB-S6 §6 Makefile up emits endpoint JSON on stdout last line
+
+- **GIVEN** the cookbook §6 Makefile sample
+- **WHEN** the `accept-env-up` recipe body is parsed
+- **THEN** the recipe's last command is a `printf` (or `@printf`) call whose
+  format string contains the literals `"endpoint"`, `"adb"`, `"apk_package"`,
+  `"namespace"`, AND the format string ends with `\n`
+
+#### Scenario: ARCHLAB-S7 §6 Makefile down is best-effort idempotent
+
+- **GIVEN** the cookbook §6 Makefile sample
+- **WHEN** the `accept-env-down` recipe body is parsed
+- **THEN** every primary teardown command (compose down for backend, compose
+  down for emulator, adb kill-server, port-file rm) is either prefixed with
+  `-` (make ignore-error) or appended with `|| true`, so a missing prior stack
+  does not propagate non-zero exit
+
+### Requirement: cookbook MUST 被 integration-contracts.md / README.md / CLAUDE.md 索引交叉链接
+
+`docs/integration-contracts.md` SHALL link to the cookbook from §4.2.2
+(docker-compose template) so that integrators reading the contract document
+discover the mobile-lab recipe at the relevant decision point.
+`README.md` and `CLAUDE.md` SHALL each add an entry to their respective
+"文档索引" tables pointing at `docs/cookbook/` (the directory entry) so that
+both human onboarding and AI session bootstrap surfaces expose the cookbook
+without requiring readers to grep. The system MUST NOT publish the cookbook
+file in isolation: an unlinked cookbook is invisible to the population that
+needs it most (lab teams onboarding for the first time).
+
+#### Scenario: ARCHLAB-S8 integration-contracts.md §4.2.2 links to cookbook
+
+- **GIVEN** `docs/integration-contracts.md`
+- **WHEN** the §4.2.2 section's body is scanned
+- **THEN** the section contains a markdown link whose target resolves to
+  `cookbook/ttpos-arch-lab-accept-env.md` (relative path from `docs/`) or
+  `docs/cookbook/ttpos-arch-lab-accept-env.md` (absolute from repo root)
+
+#### Scenario: ARCHLAB-S9 README.md 文档索引 lists docs/cookbook/
+
+- **GIVEN** `README.md`
+- **WHEN** the "文档索引" table is parsed
+- **THEN** at least one row's first column links to `docs/cookbook/` (the
+  directory) AND the row's second column mentions `accept-env-up` or
+  `accept-env` to disambiguate it from unrelated cookbook content

--- a/openspec/changes/REQ-archlab-accept-env-cookbook-1777125697/tasks.md
+++ b/openspec/changes/REQ-archlab-accept-env-cookbook-1777125697/tasks.md
@@ -1,0 +1,35 @@
+# Tasks — REQ-archlab-accept-env-cookbook-1777125697
+
+## Stage: contract / spec
+
+- [x] 立 `specs/archlab-accept-env-cookbook/spec.md`（openspec delta 格式 ADDED Requirements）
+- [x] 9 个 scenario：cookbook 文件存在 / 9 个 section 各自的内容约束 / 多键 endpoint JSON / Makefile 范本 stderr-stdout 分流 / cross-link 到 integration-contracts.md / README.md / CLAUDE.md
+- [x] scenario ID 用 `[ARCHLAB-S<N>]` 命名空间防撞
+
+## Stage: implementation
+
+- [x] `docs/cookbook/ttpos-arch-lab-accept-env.md` —— 完整 cookbook（§0 TL;DR / §1 repo 布局 / §2 backend compose / §3 emulator container / §4 APK build / §5 endpoint JSON 多键契约 / §6 完整 Makefile 范本 / §7 accept-agent prompt 段 / §8 排查清单 / §9 跟既有契约的关系）
+- [x] `docs/integration-contracts.md` §4.2.2 加 cross-link 引到 cookbook
+- [x] `README.md` 文档索引追一行 cookbook 入口
+- [x] `CLAUDE.md` 文档索引追一行 cookbook 入口
+
+## Stage: validation
+
+- [x] `openspec validate openspec/changes/REQ-archlab-accept-env-cookbook-1777125697 --strict` 通过
+- [x] `scripts/check-scenario-refs.sh` 全 ARCHLAB-S* scenario ID 引用解析
+- [x] `make ci-lint` 通过（docs-only diff，scope 后无 *.py 变更）
+- [x] `make ci-unit-test` 通过（pytest 套不动）
+- [x] `make ci-integration-test` 通过（exit 5 / 0 都接受）
+
+## Stage: PR
+
+- [x] `git push origin feat/REQ-archlab-accept-env-cookbook-1777125697`
+- [x] `gh pr create` —— title + body 写清楚动机 + 测试方案
+- [x] BKD issue tags 保留 `analyze` + `REQ-archlab-accept-env-cookbook-1777125697`
+- [x] BKD issue move review
+
+## 不在本 REQ scope（明确）
+
+- ❌ 改 ttpos-arch-lab 仓代码（cookbook 在 sisyphus 仓里描述，业务仓改造另开 REQ）
+- ❌ 改 sisyphus orchestrator / accept-agent prompt 模板（多键 endpoint 是文档约定）
+- ❌ 写 `tests/integration/`（M18 challenger-agent 的活；docs-only REQ 也无 test-able contract）


### PR DESCRIPTION
## Summary

- 新开 `docs/cookbook/` 目录；首份 `ttpos-arch-lab-accept-env.md` 给「mobile App +
  后端 stack」端到端 lab 一份能直接抄的 `accept-env-up` / `accept-env-down` 样板：
  起 backend compose → 启 Android emulator（headless）→ 编 APK → 装到 emulator →
  emit 多键 endpoint JSON。
- 不改 `docs/integration-contracts.md` 契约本身；§4.2.2 加 cross-link 引到 cookbook。
  `README.md` / `CLAUDE.md` 文档索引各追一行 cookbook 入口。
- base 在 origin/main（包含 #96 `ci-accept-env-up/down → accept-env-up/down` rename）
  之后，cookbook + spec 用不带 `ci-` 前缀的新 target 名。

## 动机

`docs/integration-contracts.md` §4.2 helm 和 §4.2.2 docker-compose 模板都不覆盖
mobile lab 这一类（emulator + APK build/install + 多键 endpoint）。每个新接入的
mobile lab 要自己摸 KVM fallback / port 自分配 / boot_completed 检测 / stdout
严格分流的坑。把样板抽成 cookbook，契约文档保持轻、样板可以长。

## 关键决策

- **cookbook 单开目录**而不是塞契约 §4.2.3 —— 契约（短）vs 样板（长）分层；后续
  Flutter mock backend / Go pure HTTP 等 cookbook 共享同一目录。
- **KVM 默认软件模拟兜底**（`-no-accel` + `-gpu swiftshader_indirect` + `start_period`
  调到 ~180 s）—— vm-node04 K3s sisyphus-runners ns 没暴露 `/dev/kvm`，cookbook 必须
  自包含。
- **多键 endpoint JSON 扩展**：`endpoint` 仍是 §3 契约必需键；`adb` / `apk_package`
  是 accept-agent prompt 消费的可选扩展，缺它优雅降级（UI scenarios skip）。
- **stderr / stdout 严格分流**写进 cookbook §6 + §8 排查清单 —— 这是新手最容易翻车
  的点。

## 文件改动

| 文件 | 性质 |
|---|---|
| `docs/cookbook/ttpos-arch-lab-accept-env.md` | 新增 cookbook（9 节 / 360 行 / 完整 Makefile 范本） |
| `docs/integration-contracts.md` §4.2.2 | 加 cross-link 引到 cookbook |
| `README.md` 文档索引 | 追一行 `docs/cookbook/` 入口 |
| `CLAUDE.md` 文档索引 | 追一行 `docs/cookbook/` 入口 |
| `openspec/changes/REQ-archlab-accept-env-cookbook-1777125697/` | proposal + design + tasks + specs/archlab-accept-env-cookbook/spec.md（6 个 ADDED requirements / 9 scenarios） |

无 Python / Makefile / 测试改动。

## Test plan

- [x] `openspec validate REQ-archlab-accept-env-cookbook-1777125697 --strict` 通过
- [x] `scripts/check-scenario-refs.sh .` 通过（179 个 scenario 定义）
- [x] `git diff --stat HEAD~1` 验证：8 文件 / +743 / -0（纯加法）
- [ ] dev_cross_check：docs-only diff，BASE_REV scope 后 0 个 *.py 变更 → `make ci-lint` 立 pass
- [ ] staging_test：sisyphus pytest 套不动；新 cookbook + spec 文件不参与 pytest collection
- [ ] pr_ci：GHA 在 PR 上跑（lint / unit / integration test）

🤖 Generated with [Claude Code](https://claude.com/claude-code)