### PR TITLE
feat(config): default agent_model = claude-sonnet-4-6 (token cost reduction)

### DIFF
--- a/openspec/changes/REQ-default-agent-model-sonnet-1777131381/proposal.md
+++ b/openspec/changes/REQ-default-agent-model-sonnet-1777131381/proposal.md
@@ -1,0 +1,49 @@
+# REQ-default-agent-model-sonnet-1777131381: feat(config): default agent_model = claude-sonnet-4-6
+
+## 问题
+
+`orchestrator/src/orchestrator/config.py` 中 `agent_model: str | None = None`，
+`None` 表示用 BKD per-engine 默认，实际走 claude-opus-4 / opus-4-5（最贵模型）。
+
+sisyphus 起的所有子 agent（verifier / fixer / accept / pr_ci_watch /
+done_archive / staging_test）都走这个默认，**每次 REQ 流转都是 opus 成本**。
+而这些 agent 做的是有固定结构的、可预期的任务（输出 JSON decision、跑 CI 命令、
+归档 spec），不需要 opus 的推理深度。
+
+## 方案
+
+把 `agent_model` 的 Python 默认值从 `None` 改为 `"claude-sonnet-4-6"`：
+
+```python
+# before
+agent_model: str | None = None
+
+# after
+agent_model: str | None = "claude-sonnet-4-6"
+```
+
+helm values 已经有 `SISYPHUS_AGENT_MODEL` 的 env 覆盖路径（pydantic-settings
+env_prefix = `SISYPHUS_`），生产可用 helm 覆盖；测试依旧用 `claude-haiku-4-5`。
+
+### 故意不做
+
+- **不**在 `values.yaml` 重复写死 model 字符串 —— Settings 层已有默认，
+  helm 只在需要覆盖时才写，保持"只有一个真相"
+- **不**改 `values.dev.yaml` —— dev 环境也受益于 sonnet；如需 haiku 测试
+  可在 CI job 的 helm 参数里临时覆盖
+- **不**改 analyze agent 的 model —— analyze agent 由 user 创 intent issue
+  时决定，sisyphus 不控（参见代码注释）
+
+## 取舍
+
+- **为什么 sonnet-4-6 而非 haiku** —— 生产 sisyphus 子 agent（verifier / fixer）
+  需要理解 stage 日志、判断 pass/fix/escalate，haiku 在复杂 failure case
+  准确率不稳定；sonnet 在成本和准确率之间取得平衡
+- **为什么改 Python 默认而非 helm 默认** —— Settings 层的 `None` 默认有误导性
+  （暗示"省钱"但实际是最贵模型）；显式写出默认让代码意图清晰，helm 覆盖
+  机制保留弹性
+
+## 影响面
+
+- `orchestrator/src/orchestrator/config.py`：`agent_model` 默认 `None` → `"claude-sonnet-4-6"`
+- `orchestrator/tests/test_contract_default_agent_model_sonnet.py`：新增合约测试

--- a/openspec/changes/REQ-default-agent-model-sonnet-1777131381/specs/agent-model-default/contract.spec.yaml
+++ b/openspec/changes/REQ-default-agent-model-sonnet-1777131381/specs/agent-model-default/contract.spec.yaml
@@ -1,0 +1,21 @@
+capability: agent-model-default
+version: "1.0"
+description: |
+  Sets the default model for all sisyphus-dispatched sub-agents to
+  claude-sonnet-4-6 (previously None → BKD default of claude-opus).
+
+  Affected agents: verifier, fixer, accept, pr_ci_watch, done_archive,
+  staging_test. The model is configurable via SISYPHUS_AGENT_MODEL env var.
+
+settings:
+  agent_model:
+    field: orchestrator.config.Settings.agent_model
+    type: "str | None"
+    previous_default: null
+    current_default: "claude-sonnet-4-6"
+    env_var: SISYPHUS_AGENT_MODEL
+    rationale: |
+      Previous default None resolved to BKD per-engine default (claude-opus),
+      the most expensive model. Sonnet-4-6 provides sufficient quality for
+      structured-output sub-agents (verifier JSON decisions, CI runner commands,
+      spec archival) at significantly lower token cost.

--- a/openspec/changes/REQ-default-agent-model-sonnet-1777131381/specs/agent-model-default/spec.md
+++ b/openspec/changes/REQ-default-agent-model-sonnet-1777131381/specs/agent-model-default/spec.md
@@ -1,0 +1,26 @@
+# agent-model-default delta
+
+## ADDED Requirements
+
+### Requirement: Settings.agent_model MUST default to claude-sonnet-4-6
+
+The `orchestrator/src/orchestrator/config.py` Settings class SHALL define
+`agent_model` with a default value of `"claude-sonnet-4-6"` (not `None`).
+All sisyphus-dispatched sub-agents (verifier, fixer, accept, pr_ci_watch,
+done_archive, staging_test) MUST use this model when no override is provided
+via the `SISYPHUS_AGENT_MODEL` environment variable. The previous default
+(`None`, which caused BKD to fall back to its per-engine default of claude-opus)
+MUST no longer be the behaviour of a freshly installed orchestrator without
+explicit env overrides.
+
+#### Scenario: DAMS-S1 Settings.agent_model resolves to claude-sonnet-4-6 without env override
+
+- **GIVEN** environment variable `SISYPHUS_AGENT_MODEL` is not set
+- **WHEN** `Settings()` is instantiated
+- **THEN** `settings.agent_model` MUST equal `"claude-sonnet-4-6"`
+
+#### Scenario: DAMS-S2 Settings.agent_model is overridable via SISYPHUS_AGENT_MODEL env
+
+- **GIVEN** environment variable `SISYPHUS_AGENT_MODEL` is set to `"claude-haiku-4-5"`
+- **WHEN** `Settings()` is instantiated
+- **THEN** `settings.agent_model` MUST equal `"claude-haiku-4-5"`

--- a/openspec/changes/REQ-default-agent-model-sonnet-1777131381/tasks.md
+++ b/openspec/changes/REQ-default-agent-model-sonnet-1777131381/tasks.md
@@ -1,0 +1,23 @@
+# REQ-default-agent-model-sonnet-1777131381 — tasks
+
+## Stage: spec
+
+- [x] author proposal.md（动机、方案、取舍、影响面）
+- [x] author specs/agent-model-default/spec.md（ADDED delta，DAMS-S1/S2 scenarios）
+- [x] author specs/agent-model-default/contract.spec.yaml
+
+## Stage: implementation
+
+- [x] orchestrator/src/orchestrator/config.py：`agent_model` default `None` → `"claude-sonnet-4-6"`，更新注释
+
+## Stage: test
+
+- [x] orchestrator/tests/test_contract_default_agent_model_sonnet.py：
+  - DAMS-S1 无 env override 时 settings.agent_model == "claude-sonnet-4-6"
+  - DAMS-S2 SISYPHUS_AGENT_MODEL env 可覆盖
+
+## Stage: PR
+
+- [x] git push feat/REQ-default-agent-model-sonnet-1777131381
+- [x] gh pr create
+- [x] move issue to review

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -117,11 +117,11 @@ class Settings(BaseSettings):
 
     # ─── agent model 控制 ─────────────────────────────────────────────────
     # sisyphus 起的 agent 用哪个模型（verifier / fixer / accept / pr_ci_watch /
-    # done_archive / staging_test）。None = 用 BKD per-engine 默认。
-    # 生产 None 走 BKD 默认（opus）；测试 helm values 覆盖成 'claude-haiku-4-5'。
+    # done_archive / staging_test）。None = 用 BKD per-engine 默认（opus）。
+    # 默认 claude-sonnet-4-6（成本低于 opus；测试 helm values 可覆盖成 'claude-haiku-4-5'）。
     # 注意：analyze agent 的 model 是 user 创 intent issue 时定的，sisyphus 不控；
     # analyze fan out 的 sub-issue model 由 analyze prompt 自己控（见 analyze.md.j2）。
-    agent_model: str | None = None
+    agent_model: str | None = "claude-sonnet-4-6"
 
     # ─── aissh-tao MCP server id (vm-node04) ─────────────────────────────
     # BKD agent 跑在 Coder workspace 没装 kubectl，所有 vm-node04 上的 kubectl 命令

--- a/orchestrator/tests/test_contract_dams_challenger.py
+++ b/orchestrator/tests/test_contract_dams_challenger.py
@@ -1,0 +1,56 @@
+"""Contract tests for REQ-default-agent-model-sonnet-1777131381.
+
+Capability: agent-model-default
+Author: challenger-agent (black-box, written from spec only)
+
+Scenarios:
+  DAMS-S1  Settings.agent_model resolves to claude-sonnet-4-6 without env override
+  DAMS-S2  Settings.agent_model is overridable via SISYPHUS_AGENT_MODEL env
+"""
+from __future__ import annotations
+
+import importlib
+
+
+def test_dams_s1_agent_model_defaults_to_claude_sonnet_4_6(monkeypatch) -> None:
+    """DAMS-S1: Without SISYPHUS_AGENT_MODEL env set, Settings().agent_model
+    MUST equal 'claude-sonnet-4-6'.
+
+    GIVEN  SISYPHUS_AGENT_MODEL is not set
+    WHEN   Settings() is instantiated
+    THEN   settings.agent_model == "claude-sonnet-4-6"
+    """
+    monkeypatch.delenv("SISYPHUS_AGENT_MODEL", raising=False)
+
+    from orchestrator import config as config_mod
+
+    reloaded = importlib.reload(config_mod)
+    assert reloaded.settings.agent_model == "claude-sonnet-4-6", (
+        f"settings.agent_model must default to 'claude-sonnet-4-6' when "
+        f"SISYPHUS_AGENT_MODEL is not set; got {reloaded.settings.agent_model!r}. "
+        f"The previous default (None) resolved to BKD's per-engine default "
+        f"(claude-opus), which is the most expensive model."
+    )
+
+
+def test_dams_s2_agent_model_overridable_via_env(monkeypatch) -> None:
+    """DAMS-S2: When SISYPHUS_AGENT_MODEL=claude-haiku-4-5, Settings().agent_model
+    MUST equal 'claude-haiku-4-5'.
+
+    GIVEN  SISYPHUS_AGENT_MODEL is set to "claude-haiku-4-5"
+    WHEN   Settings() is instantiated
+    THEN   settings.agent_model == "claude-haiku-4-5"
+    """
+    monkeypatch.setenv("SISYPHUS_AGENT_MODEL", "claude-haiku-4-5")
+
+    from orchestrator import config as config_mod
+
+    reloaded = importlib.reload(config_mod)
+    assert reloaded.settings.agent_model == "claude-haiku-4-5", (
+        f"settings.agent_model must honour SISYPHUS_AGENT_MODEL override; "
+        f"expected 'claude-haiku-4-5', got {reloaded.settings.agent_model!r}"
+    )
+
+    # Restore to sonnet default so subsequent tests see the correct default.
+    monkeypatch.delenv("SISYPHUS_AGENT_MODEL", raising=False)
+    importlib.reload(config_mod)

--- a/orchestrator/tests/test_contract_default_agent_model_sonnet.py
+++ b/orchestrator/tests/test_contract_default_agent_model_sonnet.py
@@ -1,0 +1,47 @@
+"""Contract regression for REQ-default-agent-model-sonnet-1777131381.
+
+Settings.agent_model MUST default to "claude-sonnet-4-6" so that all
+sisyphus-dispatched sub-agents (verifier, fixer, accept, pr_ci_watch,
+done_archive, staging_test) use sonnet instead of the implicit BKD
+per-engine default (claude-opus) when no explicit model override is given.
+
+Scenarios covered:
+  DAMS-S1  Settings.agent_model == "claude-sonnet-4-6" without env override
+  DAMS-S2  SISYPHUS_AGENT_MODEL env overrides the default
+"""
+from __future__ import annotations
+
+import importlib
+
+
+def test_dams_s1_agent_model_defaults_to_sonnet(monkeypatch) -> None:
+    """DAMS-S1: without SISYPHUS_AGENT_MODEL env, settings.agent_model
+    MUST equal 'claude-sonnet-4-6' (not None, not opus).
+    """
+    from orchestrator import config as config_mod
+
+    monkeypatch.delenv("SISYPHUS_AGENT_MODEL", raising=False)
+    reloaded = importlib.reload(config_mod)
+    assert reloaded.settings.agent_model == "claude-sonnet-4-6", (
+        f"settings.agent_model MUST default to 'claude-sonnet-4-6'; "
+        f"got {reloaded.settings.agent_model!r} "
+        f"(REQ-default-agent-model-sonnet-1777131381)"
+    )
+
+
+def test_dams_s2_agent_model_overridable_via_env(monkeypatch) -> None:
+    """DAMS-S2: SISYPHUS_AGENT_MODEL env MUST override the default, e.g.
+    to 'claude-haiku-4-5' for cost-sensitive test environments.
+    """
+    from orchestrator import config as config_mod
+
+    monkeypatch.setenv("SISYPHUS_AGENT_MODEL", "claude-haiku-4-5")
+    reloaded = importlib.reload(config_mod)
+    assert reloaded.settings.agent_model == "claude-haiku-4-5", (
+        f"SISYPHUS_AGENT_MODEL=claude-haiku-4-5 MUST override the default; "
+        f"got {reloaded.settings.agent_model!r}"
+    )
+
+    # Restore to default
+    monkeypatch.delenv("SISYPHUS_AGENT_MODEL", raising=False)
+    importlib.reload(config_mod)


### PR DESCRIPTION
## Summary

- Changes `Settings.agent_model` default from `None` (→ BKD per-engine default = claude-opus) to `"claude-sonnet-4-6"`
- Affects all sisyphus-dispatched sub-agents: verifier, fixer, accept, pr_ci_watch, done_archive, staging_test
- Model remains overridable via `SISYPHUS_AGENT_MODEL` env var (no helm changes needed for test environments to use haiku)

## Motivation

Previous `None` default silently resolved to claude-opus at BKD, the most expensive model. These sub-agents do structured, predictable work (output JSON decisions, run CI commands, archive specs) that does not require opus-level reasoning. Sonnet-4-6 provides a good balance of cost and capability for these tasks.

## Test plan

- [x] `openspec validate REQ-default-agent-model-sonnet-1777131381` passes
- [x] `orchestrator/tests/test_contract_default_agent_model_sonnet.py`: DAMS-S1 (default == sonnet), DAMS-S2 (env override works)
- [ ] `make ci-unit-test` in runner pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)