### PR TITLE
test(self): add pipeline-validation v3 no-op marker (REQ-validate-fresh-3-1777132879)

### DIFF
--- a/openspec/changes/REQ-validate-fresh-3-1777132879/proposal.md
+++ b/openspec/changes/REQ-validate-fresh-3-1777132879/proposal.md
@@ -1,0 +1,29 @@
+# REQ-validate-fresh-3-1777132879: test(self): full-chain dogfood validation on sha-ddf4ea4 (sonnet default + all P3 fix)
+
+## 问题
+
+sha-ddf4ea4（PR #99：`feat(config): default agent_model = claude-sonnet-4-6`）合并后，sisyphus
+默认 agent 模型切换到 claude-sonnet-4-6，同时随附了多条 P3 级别 bug fix（checker fail-loud
+当无 feat 分支 / runner_gc RBAC 日志降级 / Metabase silent-pass 检测器等）。这些改动叠加后，
+需要在**零业务面积**下跑一次端到端 fresh-pipeline smoke，隔离判断 sisyphus 自身管道是否
+仍然正常闭合。
+
+## 方案
+
+在 `orchestrator/src/orchestrator/_pipeline_marker.py` 追加一个新常量
+`PIPELINE_VALIDATION_REQ_V3`，其值为本 REQ id 字符串
+`"REQ-validate-fresh-3-1777132879"`。
+
+- 与原有 `PIPELINE_VALIDATION_REQ` 常量共存，不破坏现有 contract test
+- 不在生产路径被 import —— 只由 contract 测试白盒引用
+- 没有 docstring 之外的副作用 —— 模块加载仅定义一个 str 常量，无 IO / 无网络
+- 配套 `orchestrator/tests/test_contract_pipeline_marker_v3.py` 覆盖 PVR3-S1..PVR3-S4
+
+## 取舍
+
+- **为什么追加而不是覆盖** —— 覆盖原常量会导致 PVR-S2 的 pattern 测试
+  (`^REQ-validate-fresh-pipeline-\d+$`) 失败；追加新常量、新测试可保持两套 contract 独立
+- **为什么命名 V3** —— `REQ-validate-fresh-3-*` 的命名约定引入了版本号而非 `-pipeline-`
+  后缀；新常量名与 REQ 命名对齐
+- **为什么不新建模块** —— 单一 `_pipeline_marker.py` 承载所有 fresh-validation marker
+  常量，维护成本更低，且都归属同一 openspec capability（pipeline-marker）

--- a/openspec/changes/REQ-validate-fresh-3-1777132879/specs/pipeline-marker-v3/spec.md
+++ b/openspec/changes/REQ-validate-fresh-3-1777132879/specs/pipeline-marker-v3/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: _pipeline_marker 模块 MUST 提供 v3 验证常量
+
+The module at `orchestrator/src/orchestrator/_pipeline_marker.py` SHALL expose a
+module-level string attribute named `PIPELINE_VALIDATION_REQ_V3`. The attribute
+MUST hold the literal string `"REQ-validate-fresh-3-1777132879"`, identifying
+the specific fresh-pipeline dogfood run that validated sha-ddf4ea4 (sonnet
+default + all P3 fix). The constant MUST coexist with the original
+`PIPELINE_VALIDATION_REQ` without modifying it, and the module MUST NOT import
+this constant anywhere in the production code path (engine / router / actions /
+checkers / store).
+
+#### Scenario: PVR3-S1 module imports cleanly with zero side effects
+
+- **GIVEN** a fresh Python interpreter with `orchestrator/src` on `sys.path`
+- **WHEN** the test calls `importlib.import_module("orchestrator._pipeline_marker")`
+- **THEN** the import returns a module object that exposes `PIPELINE_VALIDATION_REQ_V3`
+  without raising, and no log line, network call, or filesystem write is
+  observable as a side effect of the import
+
+### Requirement: v3 常量 MUST 是字符串且匹配 REQ-validate-fresh-3 命名模式
+
+The module `orchestrator._pipeline_marker` SHALL define a module-level attribute
+named `PIPELINE_VALIDATION_REQ_V3`. The attribute MUST be a `str` instance, and
+its value MUST match the regular expression `^REQ-validate-fresh-3-\d+$`.
+This pattern, rather than a hard-coded literal, is the contract: future
+`REQ-validate-fresh-3-*` smoke runs are expected to bump only the trailing
+timestamp while keeping the prefix stable, so contract tests written today
+continue to pass against future smoke REQs without per-REQ test edits.
+
+#### Scenario: PVR3-S2 constant is str and matches REQ-validate-fresh-3 pattern
+
+- **GIVEN** the module `orchestrator._pipeline_marker` has been imported
+- **WHEN** the test reads attribute `PIPELINE_VALIDATION_REQ_V3` from the module
+- **THEN** the attribute is an instance of `str` and its value matches the
+  regex `^REQ-validate-fresh-3-\d+$`
+
+#### Scenario: PVR3-S3 re-import returns the same constant value
+
+- **GIVEN** the module has been imported once and `PIPELINE_VALIDATION_REQ_V3`
+  was captured into a local variable `first`
+- **WHEN** the test invokes `importlib.reload` on the module and re-reads
+  `PIPELINE_VALIDATION_REQ_V3` into `second`
+- **THEN** `first == second` (the constant is stable across reloads, confirming
+  no import-time randomness or env-driven branch)
+
+### Requirement: v3 常量 MUST NOT 被 re-export 到 orchestrator 包命名空间
+
+The constant `PIPELINE_VALIDATION_REQ_V3` MUST be accessible only via the
+explicit submodule path `orchestrator._pipeline_marker.PIPELINE_VALIDATION_REQ_V3`.
+It MUST NOT be re-exported from `orchestrator/__init__.py` or surfaced through
+any other production module's `__all__` or attribute, keeping the marker
+invisible to anyone reading the package's public surface.
+
+#### Scenario: PVR3-S4 v3 constant is not present on orchestrator package object
+
+- **GIVEN** `orchestrator` has been imported as a package
+- **WHEN** the test inspects `dir(orchestrator)` and
+  `getattr(orchestrator, "PIPELINE_VALIDATION_REQ_V3", None)`
+- **THEN** `PIPELINE_VALIDATION_REQ_V3` is NOT in `dir(orchestrator)` and the
+  `getattr` call returns `None` (the constant is reachable only via the
+  fully-qualified submodule path)

--- a/openspec/changes/REQ-validate-fresh-3-1777132879/tasks.md
+++ b/openspec/changes/REQ-validate-fresh-3-1777132879/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: REQ-validate-fresh-3-1777132879
+
+## Stage: contract / spec
+
+- [x] author specs/pipeline-marker-v3/spec.md — delta format, all scenarios with SHALL/MUST in body and `#### Scenario:` headings
+
+## Stage: implementation
+
+- [x] add `PIPELINE_VALIDATION_REQ_V3` constant to `orchestrator/src/orchestrator/_pipeline_marker.py`
+- [x] author unit tests in `orchestrator/tests/test_contract_pipeline_marker_v3.py` (PVR3-S1..PVR3-S4)
+
+## Stage: PR
+
+- [x] git push feat/REQ-validate-fresh-3-1777132879
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/_pipeline_marker.py
+++ b/orchestrator/src/orchestrator/_pipeline_marker.py
@@ -1,13 +1,14 @@
-"""Pipeline-validation smoke marker (REQ-validate-fresh-pipeline-1777123726).
+"""Pipeline-validation smoke markers.
 
 Self-dogfood scaffolding: this module exists solely to give every
-"validate-fresh-pipeline" smoke REQ a tiny, deterministic, no-op delta. No
+"validate-fresh" smoke REQ a tiny, deterministic, no-op delta. No
 production module imports it; the orchestrator's runtime behavior is unchanged
 whether this file is present or absent.
 
 See `openspec/changes/REQ-validate-fresh-pipeline-1777123726/proposal.md` for
-the rationale.
+the original rationale.
 """
 from __future__ import annotations
 
 PIPELINE_VALIDATION_REQ: str = "REQ-validate-fresh-pipeline-1777123726"
+PIPELINE_VALIDATION_REQ_V3: str = "REQ-validate-fresh-3-1777132879"

--- a/orchestrator/tests/test_contract_pipeline_marker_v3.py
+++ b/orchestrator/tests/test_contract_pipeline_marker_v3.py
@@ -1,0 +1,48 @@
+"""Contract tests for REQ-validate-fresh-3-1777132879.
+
+Black/white-box behavioral contracts derived from:
+  openspec/changes/REQ-validate-fresh-3-1777132879/specs/pipeline-marker-v3/spec.md
+
+Scenarios covered:
+  PVR3-S1   module imports cleanly with zero observable side effects
+  PVR3-S2   PIPELINE_VALIDATION_REQ_V3 is a str matching ^REQ-validate-fresh-3-\\d+$
+  PVR3-S3   importlib.reload returns the same constant value
+  PVR3-S4   v3 constant is not re-exported from the orchestrator package
+"""
+from __future__ import annotations
+
+import importlib
+import re
+
+PVR3_PATTERN = re.compile(r"^REQ-validate-fresh-3-\d+$")
+
+
+def test_pvr3_s1_module_imports_cleanly() -> None:
+    mod = importlib.import_module("orchestrator._pipeline_marker")
+    assert mod is not None
+    assert hasattr(mod, "PIPELINE_VALIDATION_REQ_V3")
+
+
+def test_pvr3_s2_constant_is_str_and_matches_req_pattern() -> None:
+    from orchestrator import _pipeline_marker
+
+    value = _pipeline_marker.PIPELINE_VALIDATION_REQ_V3
+    assert isinstance(value, str)
+    assert PVR3_PATTERN.match(value), (
+        f"PIPELINE_VALIDATION_REQ_V3={value!r} does not match {PVR3_PATTERN.pattern}"
+    )
+
+
+def test_pvr3_s3_module_has_no_side_effects_on_reimport() -> None:
+    mod = importlib.import_module("orchestrator._pipeline_marker")
+    first = mod.PIPELINE_VALIDATION_REQ_V3
+    reloaded = importlib.reload(mod)
+    second = reloaded.PIPELINE_VALIDATION_REQ_V3
+    assert first == second
+
+
+def test_pvr3_s4_constant_is_not_re_exported_from_package() -> None:
+    import orchestrator
+
+    assert "PIPELINE_VALIDATION_REQ_V3" not in dir(orchestrator)
+    assert getattr(orchestrator, "PIPELINE_VALIDATION_REQ_V3", None) is None

--- a/orchestrator/tests/test_contract_pipeline_marker_v3_challenger.py
+++ b/orchestrator/tests/test_contract_pipeline_marker_v3_challenger.py
@@ -1,0 +1,71 @@
+"""Challenger contract tests for REQ-validate-fresh-3-1777132879.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-validate-fresh-3-1777132879/specs/pipeline-marker-v3/spec.md
+
+Scenarios covered:
+  PVR3-S1  module imports cleanly; PIPELINE_VALIDATION_REQ_V3 exposed; zero side effects
+  PVR3-S2  PIPELINE_VALIDATION_REQ_V3 is str matching ^REQ-validate-fresh-3-\\d+$
+  PVR3-S3  importlib.reload returns the same constant value (no randomness)
+  PVR3-S4  PIPELINE_VALIDATION_REQ_V3 NOT re-exported from orchestrator package namespace
+  PVR3-S1+ PIPELINE_VALIDATION_REQ (v1) still present and unmodified (coexistence contract)
+"""
+from __future__ import annotations
+
+import importlib
+import re
+
+PVR3_PATTERN = re.compile(r"^REQ-validate-fresh-3-\d+$")
+
+
+def test_pvr3_s1_module_imports_cleanly_and_exposes_v3_constant() -> None:
+    mod = importlib.import_module("orchestrator._pipeline_marker")
+    assert mod is not None
+    assert mod.__name__ == "orchestrator._pipeline_marker"
+    assert hasattr(mod, "PIPELINE_VALIDATION_REQ_V3"), (
+        "module orchestrator._pipeline_marker must expose PIPELINE_VALIDATION_REQ_V3"
+    )
+
+
+def test_pvr3_s2_v3_constant_is_str_and_matches_req_pattern() -> None:
+    from orchestrator import _pipeline_marker
+
+    value = _pipeline_marker.PIPELINE_VALIDATION_REQ_V3
+    assert isinstance(value, str), (
+        f"PIPELINE_VALIDATION_REQ_V3 must be str, got {type(value).__name__!r}"
+    )
+    assert PVR3_PATTERN.match(value), (
+        f"PIPELINE_VALIDATION_REQ_V3={value!r} does not match pattern {PVR3_PATTERN.pattern!r}"
+    )
+
+
+def test_pvr3_s3_reload_returns_same_constant_value() -> None:
+    mod = importlib.import_module("orchestrator._pipeline_marker")
+    first = mod.PIPELINE_VALIDATION_REQ_V3
+    reloaded = importlib.reload(mod)
+    second = reloaded.PIPELINE_VALIDATION_REQ_V3
+    assert first == second, (
+        f"PIPELINE_VALIDATION_REQ_V3 changed across reload: {first!r} != {second!r}"
+    )
+
+
+def test_pvr3_s4_v3_constant_not_in_orchestrator_package_namespace() -> None:
+    import orchestrator
+
+    assert "PIPELINE_VALIDATION_REQ_V3" not in dir(orchestrator), (
+        "PIPELINE_VALIDATION_REQ_V3 must not appear in dir(orchestrator)"
+    )
+    assert getattr(orchestrator, "PIPELINE_VALIDATION_REQ_V3", None) is None, (
+        "PIPELINE_VALIDATION_REQ_V3 must not be accessible via orchestrator package object"
+    )
+
+
+def test_pvr3_s1_plus_original_constant_coexists_unmodified() -> None:
+    from orchestrator import _pipeline_marker
+
+    assert hasattr(_pipeline_marker, "PIPELINE_VALIDATION_REQ"), (
+        "original PIPELINE_VALIDATION_REQ must still be present alongside V3 (coexistence)"
+    )
+    assert isinstance(_pipeline_marker.PIPELINE_VALIDATION_REQ, str), (
+        "original PIPELINE_VALIDATION_REQ must remain a str"
+    )


### PR DESCRIPTION
## Summary

Fresh dogfood smoke REQ validating sha-ddf4ea4 (sonnet default + all P3 fix) end-to-end through the full sisyphus pipeline with zero business payload.

- `orchestrator/src/orchestrator/_pipeline_marker.py`: add `PIPELINE_VALIDATION_REQ_V3 = "REQ-validate-fresh-3-1777132879"` constant alongside existing `PIPELINE_VALIDATION_REQ` (no existing test broken)
- `orchestrator/tests/test_contract_pipeline_marker_v3.py`: 4 contract tests covering PVR3-S1..PVR3-S4 (clean import, str+regex shape, reload stability, not re-exported from package)
- `openspec/changes/REQ-validate-fresh-3-1777132879/`: proposal.md, tasks.md, specs/pipeline-marker-v3/spec.md (delta format, all scenarios with SHALL/MUST in body and `#### Scenario:` headings)

## Test plan

- [x] `openspec validate REQ-validate-fresh-3-1777132879` → valid
- [x] `pytest tests/test_contract_pipeline_marker_v3.py` → 4 passed
- [x] `pytest -m "not integration"` → 641 passed (3 pre-existing ruff failures on Coder workspace unrelated to this change)
- [ ] spec_lint (mechanical, run by sisyphus)
- [ ] dev_cross_check (mechanical, run by sisyphus)
- [ ] staging_test (mechanical, run by sisyphus)
- [ ] pr_ci_watch (mechanical, run by sisyphus)
- [ ] accept (mechanical, run by sisyphus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)