### PR TITLE
fix(runner): add uv to runner image for ci-lint / ci-unit-test

### DIFF
--- a/openspec/changes/REQ-runner-image-add-uv-1777135052/proposal.md
+++ b/openspec/changes/REQ-runner-image-add-uv-1777135052/proposal.md
@@ -1,0 +1,28 @@
+# Proposal: Add uv to sisyphus runner image
+
+## Problem
+
+`make ci-lint`, `make ci-unit-test`, and `make ci-integration-test` in the sisyphus repo
+all invoke `uv run` (ruff / pytest). The runner Dockerfile does not install `uv`, so
+self-dogfood dev_cross_check and staging_test always fail with `uv: not found`.
+
+## Solution
+
+Copy the `uv` binary from the official `ghcr.io/astral-sh/uv:latest` image into the
+runner image. This is the recommended Docker pattern from the uv project and adds no
+runtime dependencies or layer overhead beyond the two binaries.
+
+```dockerfile
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+```
+
+## Scope
+
+Single-file change: `runner/Dockerfile`. No Python deps, no Makefile changes needed —
+the existing `uv run ruff` / `uv run pytest` invocations in the Makefile already handle
+`uv sync` implicitly via `uv run`.
+
+## Risk
+
+Low. The uv binary is statically linked; copying it into the image cannot break existing
+toolchain layers (Flutter / Go / openspec).

--- a/openspec/changes/REQ-runner-image-add-uv-1777135052/specs/runner-uv/spec.md
+++ b/openspec/changes/REQ-runner-image-add-uv-1777135052/specs/runner-uv/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: runner image includes uv binary
+
+The runner image SHALL include the `uv` Python package manager binary at
+`/usr/local/bin/uv` so that `uv run ruff check` and `uv run pytest` MUST succeed
+when invoked inside the runner container.
+
+#### Scenario: RUNNER-UV-S1 uv binary is present and executable in runner image
+- **GIVEN** the sisyphus runner image has been built from runner/Dockerfile
+- **WHEN** a process inside the container runs `uv --version`
+- **THEN** the command exits 0 and prints a version string matching `uv \d+\.\d+`
+
+#### Scenario: RUNNER-UV-S2 ci-lint target succeeds in runner container
+- **GIVEN** the runner container has the sisyphus source repo mounted at /workspace/source/sisyphus
+- **WHEN** `make ci-lint` is executed (no BASE_REV, full scan)
+- **THEN** the command exits 0 without `uv: not found` errors

--- a/openspec/changes/REQ-runner-image-add-uv-1777135052/tasks.md
+++ b/openspec/changes/REQ-runner-image-add-uv-1777135052/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: REQ-runner-image-add-uv-1777135052
+
+## Stage: contract / spec
+- [x] author specs/runner-uv/spec.md with ADDED Requirements and scenarios
+
+## Stage: implementation
+- [x] add `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/` to runner/Dockerfile (step 3, before openspec CLI)
+- [x] renumber subsequent Dockerfile section comments (4, 5, 6)
+
+## Stage: PR
+- [x] git push feat/REQ-runner-image-add-uv-1777135052
+- [x] gh pr create

--- a/orchestrator/tests/test_contract_runner_uv_challenger.py
+++ b/orchestrator/tests/test_contract_runner_uv_challenger.py
@@ -1,0 +1,100 @@
+"""Challenger contract tests for REQ-runner-image-add-uv-1777135052.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-runner-image-add-uv-1777135052/specs/runner-uv/spec.md
+
+Scenarios covered:
+  RUNNER-UV-S1  uv binary is present and executable in runner image
+  RUNNER-UV-S2  ci-lint target succeeds in runner container without uv-not-found errors
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(_HERE, "..", ".."))
+IMAGE_TAG = "sisyphus-runner-contract-uv-test:latest"
+
+
+def _build_runner_image() -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            "docker", "build",
+            "-t", IMAGE_TAG,
+            "-f", os.path.join(REPO_ROOT, "runner", "Dockerfile"),
+            REPO_ROOT,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+
+@pytest.fixture(scope="module")
+def runner_image():
+    result = _build_runner_image()
+    if result.returncode != 0:
+        pytest.fail(
+            f"runner/Dockerfile build failed (exit {result.returncode}):\n"
+            f"stdout: {result.stdout[-2000:]}\nstderr: {result.stderr[-2000:]}"
+        )
+    yield IMAGE_TAG
+    subprocess.run(["docker", "rmi", "--force", IMAGE_TAG], capture_output=True)
+
+
+@pytest.mark.integration
+def test_runner_uv_s1_uv_binary_present_and_executable(runner_image):
+    """
+    Scenario: RUNNER-UV-S1
+    GIVEN the sisyphus runner image has been built from runner/Dockerfile
+    WHEN a process inside the container runs `uv --version`
+    THEN the command exits 0 and prints a version string matching `uv \\d+\\.\\d+`
+    """
+    result = subprocess.run(
+        ["docker", "run", "--rm", runner_image, "uv", "--version"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        f"RUNNER-UV-S1: `uv --version` exited {result.returncode}, expected 0.\n"
+        f"Output: {output}"
+    )
+    assert re.search(r"uv \d+\.\d+", output), (
+        f"RUNNER-UV-S1: version string matching 'uv N.N' not found in output: {output!r}"
+    )
+
+
+@pytest.mark.integration
+def test_runner_uv_s2_ci_lint_succeeds_without_uv_not_found(runner_image):
+    """
+    Scenario: RUNNER-UV-S2
+    GIVEN the runner container has the sisyphus source repo mounted at /workspace/source/sisyphus
+    WHEN `make ci-lint` is executed (no BASE_REV, full scan)
+    THEN the command exits 0 without `uv: not found` errors
+    """
+    result = subprocess.run(
+        [
+            "docker", "run", "--rm",
+            "--volume", f"{REPO_ROOT}:/workspace/source/sisyphus",
+            "--workdir", "/workspace/source/sisyphus",
+            runner_image,
+            "make", "ci-lint",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    combined = result.stdout + result.stderr
+    assert "uv: not found" not in combined, (
+        f"RUNNER-UV-S2: 'uv: not found' appeared in ci-lint output:\n{combined}"
+    )
+    assert result.returncode == 0, (
+        f"RUNNER-UV-S2: `make ci-lint` exited {result.returncode}, expected 0.\n"
+        f"Output (tail):\n{combined[-3000:]}"
+    )

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -41,12 +41,15 @@ RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
 ENV PATH="/usr/local/go/bin:/root/go/bin:$PATH" \
     GOPATH=/root/go
 
-# ─── 3. openspec CLI ─────────────────────────────────────────────────────
+# ─── 3. uv (Python package manager — ci-lint / ci-unit-test 用 uv run) ──────
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+# ─── 4. openspec CLI ─────────────────────────────────────────────────────
 # 真包名是 @fission-ai/openspec（旧 Dockerfile 装的 @fission-codes/openspec 不存在，
 # 退回 openspec 是 npm 上的占位空包，REQ-997 analyze 暴露的）
 RUN npm install -g @fission-ai/openspec@latest && openspec --version
 
-# ─── 4. sisyphus 合约脚本 ──────────────────
+# ─── 5. sisyphus 合约脚本 ──────────────────
 # build context 必须是 sisyphus repo 根（CI workflow 已配 context: .）
 COPY scripts/check-scenario-refs.sh \
      scripts/check-tasks-section-ownership.sh \
@@ -56,7 +59,7 @@ COPY scripts/check-scenario-refs.sh \
 RUN chmod +x /opt/sisyphus/scripts/*.sh
 ENV PATH="/opt/sisyphus/scripts:$PATH"
 
-# ─── 5. DinD 入口 ─────────────────────────────────────────────────────────
+# ─── 6. DinD 入口 ─────────────────────────────────────────────────────────
 COPY runner/entrypoint.sh /usr/local/bin/sisyphus-entrypoint.sh
 RUN chmod +x /usr/local/bin/sisyphus-entrypoint.sh
 


### PR DESCRIPTION
## Summary

- `make ci-lint`, `make ci-unit-test`, `make ci-integration-test` all call `uv run` (ruff / pytest)
- Runner Dockerfile was missing `uv`, causing self-dogfood dev_cross_check and staging_test to always fail with `uv: not found`
- Fix: copy `uv` + `uvx` binaries from the official `ghcr.io/astral-sh/uv:latest` image using the recommended multi-stage COPY pattern

## Change

`runner/Dockerfile` — new step 3 (single line):
```dockerfile
COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
```

No Makefile or pyproject.toml changes needed; `uv run` already handles `uv sync` implicitly.

## Test plan

- [ ] Build runner image locally: `docker build -t sisyphus-runner-test .`
- [ ] Verify: `docker run --rm sisyphus-runner-test uv --version` exits 0
- [ ] CI will run `make ci-lint` (ruff) and `make ci-unit-test` (pytest) in the runner — both should pass once the new image is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)