### PR TITLE
fix(runner): add uv to Dockerfile only (no docker-run contract test)

### DIFF
--- a/openspec/changes/REQ-runner-uv-dockerfile-only-1777136147/proposal.md
+++ b/openspec/changes/REQ-runner-uv-dockerfile-only-1777136147/proposal.md
@@ -1,0 +1,27 @@
+# Proposal: Add uv to sisyphus runner Dockerfile
+
+## Problem
+
+`make ci-lint`, `make ci-unit-test`, and `make ci-integration-test` invoke `uv run`
+(ruff / pytest). The runner Dockerfile does not install `uv`, so dev_cross_check and
+staging_test fail with `uv: not found` when the business repo uses uv.
+
+## Solution
+
+Copy the `uv` and `uvx` binaries from the official `ghcr.io/astral-sh/uv:latest` image
+into the runner image using Docker multi-stage copy. This is the recommended pattern from
+the uv project and adds no runtime dependencies.
+
+```dockerfile
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+```
+
+## Scope
+
+Single-file change: `runner/Dockerfile`. No contract test is written for this REQ
+(docker-build/run contract tests are excluded per REQ scope).
+
+## Risk
+
+Low. The uv binary is statically linked; copying it into the image cannot break existing
+toolchain layers (Flutter / Go / openspec).

--- a/openspec/changes/REQ-runner-uv-dockerfile-only-1777136147/specs/runner-uv/spec.md
+++ b/openspec/changes/REQ-runner-uv-dockerfile-only-1777136147/specs/runner-uv/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: runner Dockerfile includes uv binary via multi-stage copy
+
+The runner Dockerfile SHALL include a `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/`
+instruction so that the built image MUST provide the `uv` and `uvx` executables at
+`/usr/local/bin/uv` and `/usr/local/bin/uvx` respectively.
+
+#### Scenario: RUNNER-UV-ONLY-S1 Dockerfile declares uv copy instruction
+- **GIVEN** the file `runner/Dockerfile` in the sisyphus repository
+- **WHEN** the file content is inspected
+- **THEN** it contains `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/`
+
+#### Scenario: RUNNER-UV-ONLY-S2 uv appears before openspec in Dockerfile layer order
+- **GIVEN** the file `runner/Dockerfile` in the sisyphus repository
+- **WHEN** the file content is parsed for layer ordering
+- **THEN** the uv COPY instruction appears before the openspec npm install instruction

--- a/openspec/changes/REQ-runner-uv-dockerfile-only-1777136147/tasks.md
+++ b/openspec/changes/REQ-runner-uv-dockerfile-only-1777136147/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: REQ-runner-uv-dockerfile-only-1777136147
+
+## Stage: contract / spec
+- [x] author specs/runner-uv/spec.md with ADDED Requirements + scenarios
+
+## Stage: implementation
+- [x] add `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/` to runner/Dockerfile
+
+## Stage: PR
+- [x] git push feat/REQ-runner-uv-dockerfile-only-1777136147
+- [x] gh pr create

--- a/orchestrator/tests/test_contract_runner_uv_dockerfile_only.py
+++ b/orchestrator/tests/test_contract_runner_uv_dockerfile_only.py
@@ -1,0 +1,64 @@
+"""Contract tests for runner Dockerfile uv binary (REQ-runner-uv-dockerfile-only-1777136147).
+
+Black-box structural contracts derived from:
+  openspec/changes/REQ-runner-uv-dockerfile-only-1777136147/specs/runner-uv/spec.md
+
+Scenarios covered:
+  RUNNER-UV-ONLY-S1  Dockerfile declares uv COPY instruction (exact string match)
+  RUNNER-UV-ONLY-S2  uv COPY instruction appears before openspec npm install in layer order
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "runner" / "Dockerfile"
+
+UV_COPY_INSTRUCTION = "COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/"
+
+
+def _dockerfile_text() -> str:
+    return DOCKERFILE.read_text(encoding="utf-8")
+
+
+def test_runner_uv_only_s1_dockerfile_contains_uv_copy_instruction() -> None:
+    """
+    RUNNER-UV-ONLY-S1: runner/Dockerfile SHALL contain the exact instruction
+    `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/`
+    so that the built image provides uv and uvx at /usr/local/bin/.
+    """
+    text = _dockerfile_text()
+    assert UV_COPY_INSTRUCTION in text, (
+        f"RUNNER-UV-ONLY-S1 contract: runner/Dockerfile MUST contain\n"
+        f"  {UV_COPY_INSTRUCTION!r}\n"
+        f"but it was not found. "
+        f"uv is required for business repos that use `uv run` in ci-lint/ci-unit-test targets."
+    )
+
+
+def test_runner_uv_only_s2_uv_copy_before_openspec_npm_install() -> None:
+    """
+    RUNNER-UV-ONLY-S2: the uv COPY instruction SHALL appear before the openspec
+    npm install instruction in Dockerfile layer order.
+    Earlier layers build before later ones; uv must be available before openspec
+    npm install runs (in case openspec toolchain ever requires uv).
+    """
+    text = _dockerfile_text()
+
+    uv_pos = text.find(UV_COPY_INSTRUCTION)
+    assert uv_pos != -1, (
+        f"RUNNER-UV-ONLY-S2 prerequisite: uv COPY instruction not found in runner/Dockerfile. "
+        f"Cannot verify layer ordering. (S1 should have caught this first.)"
+    )
+
+    npm_install_pos = text.find("npm install")
+    assert npm_install_pos != -1, (
+        "RUNNER-UV-ONLY-S2: expected 'npm install' (openspec installation) in runner/Dockerfile "
+        "but it was not found — cannot verify uv precedes openspec layer."
+    )
+
+    assert uv_pos < npm_install_pos, (
+        f"RUNNER-UV-ONLY-S2 contract: uv COPY instruction (pos={uv_pos}) MUST appear before "
+        f"'npm install' (pos={npm_install_pos}) in runner/Dockerfile. "
+        f"Current ordering violates the spec requirement."
+    )

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -41,12 +41,15 @@ RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
 ENV PATH="/usr/local/go/bin:/root/go/bin:$PATH" \
     GOPATH=/root/go
 
-# ─── 3. openspec CLI ─────────────────────────────────────────────────────
+# ─── 3. uv (Python package manager — ci-lint / ci-unit-test 用 uv run) ──────
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+# ─── 4. openspec CLI ─────────────────────────────────────────────────────
 # 真包名是 @fission-ai/openspec（旧 Dockerfile 装的 @fission-codes/openspec 不存在，
 # 退回 openspec 是 npm 上的占位空包，REQ-997 analyze 暴露的）
 RUN npm install -g @fission-ai/openspec@latest && openspec --version
 
-# ─── 4. sisyphus 合约脚本 ──────────────────
+# ─── 5. sisyphus 合约脚本 ──────────────────
 # build context 必须是 sisyphus repo 根（CI workflow 已配 context: .）
 COPY scripts/check-scenario-refs.sh \
      scripts/check-tasks-section-ownership.sh \
@@ -56,7 +59,7 @@ COPY scripts/check-scenario-refs.sh \
 RUN chmod +x /opt/sisyphus/scripts/*.sh
 ENV PATH="/opt/sisyphus/scripts:$PATH"
 
-# ─── 5. DinD 入口 ─────────────────────────────────────────────────────────
+# ─── 6. DinD 入口 ─────────────────────────────────────────────────────────
 COPY runner/entrypoint.sh /usr/local/bin/sisyphus-entrypoint.sh
 RUN chmod +x /usr/local/bin/sisyphus-entrypoint.sh
 


### PR DESCRIPTION
## Summary

- Adds `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/` to `runner/Dockerfile`
- Renumbers section headers 3→4, 4→5, 5→6 accordingly
- Writes openspec spec with two Dockerfile-content scenarios (no docker-run tests)

## Motivation

`make ci-lint`, `make ci-unit-test`, and `make ci-integration-test` invoke `uv run`
(ruff / pytest). Without `uv` in the runner image these targets always fail with
`uv: not found` when the business repo uses uv.

## Test plan

- [ ] `openspec validate REQ-runner-uv-dockerfile-only-1777136147` passes (verified locally)
- [ ] spec_lint / dev_cross_check will verify via sisyphus pipeline
- [ ] No docker-run contract test per REQ scope (challenger may add later if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)