### PR TITLE
fix(runner): add helm to runner images (REQ-runner-add-helm-only-1777138424)

### DIFF
--- a/openspec/changes/REQ-runner-add-helm-only-1777138424/proposal.md
+++ b/openspec/changes/REQ-runner-add-helm-only-1777138424/proposal.md
@@ -1,0 +1,37 @@
+# Proposal: Add helm to runner image
+
+## Background
+
+sisyphus runner pods need `helm` for the `accept` stage, where `make accept-env-up` / `make accept-env-down`
+deploy lab environments via Helm charts on K3s. The runner image currently has `KUBECONFIG` wired to the
+K3s cluster but lacks the `helm` binary, causing accept-stage failures when business repos use Helm.
+
+This was identified in PR #79 and split into this focused fix.
+
+## Scope
+
+One repo: `phona/sisyphus`.
+
+Two Dockerfiles:
+- `runner/Dockerfile` — Flutter full runner (~5 GB)
+- `runner/go.Dockerfile` — Go-only lightweight runner (~1 GB)
+
+Both images must have `helm` installed so that any repo's accept stage can run `helm install/upgrade/uninstall`.
+
+## Approach
+
+Install helm from the official release tarball (pinned version, deterministic):
+
+```dockerfile
+ARG HELM_VERSION=3.17.3
+RUN curl -fsSL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
+      | tar -xz --strip-components=1 -C /usr/local/bin linux-amd64/helm \
+    && helm version
+```
+
+No apt repository needed; the tarball approach is the same pattern we already use for Go.
+
+## Risk
+
+Low. Helm is a standalone static binary; adding it does not conflict with any existing tooling.
+Build time increase: ~10 s per image (tarball download + unpack).

--- a/openspec/changes/REQ-runner-add-helm-only-1777138424/specs/runner-helm/spec.md
+++ b/openspec/changes/REQ-runner-add-helm-only-1777138424/specs/runner-helm/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: runner images include the helm CLI
+
+Both sisyphus runner images (full Flutter runner and Go-only runner) SHALL include the `helm` binary
+so that accept-stage Makefile targets that invoke `helm install`, `helm upgrade`, or `helm uninstall`
+can execute without error. The version MUST be pinned as a build ARG (`HELM_VERSION`) to ensure
+reproducible builds.
+
+#### Scenario: RUNNER-HELM-S1 helm binary present in full runner image
+
+- **GIVEN** the full runner image (runner/Dockerfile) is built
+- **WHEN** the container runs `helm version`
+- **THEN** the command exits 0 and prints a version string matching `v3.x.y`
+
+#### Scenario: RUNNER-HELM-S2 helm binary present in Go runner image
+
+- **GIVEN** the Go-only runner image (runner/go.Dockerfile) is built
+- **WHEN** the container runs `helm version`
+- **THEN** the command exits 0 and prints a version string matching `v3.x.y`
+
+#### Scenario: RUNNER-HELM-S3 helm version is pinned via build ARG
+
+- **GIVEN** either runner Dockerfile
+- **WHEN** built without overriding `HELM_VERSION`
+- **THEN** the installed helm matches the default `HELM_VERSION` value in the Dockerfile

--- a/openspec/changes/REQ-runner-add-helm-only-1777138424/tasks.md
+++ b/openspec/changes/REQ-runner-add-helm-only-1777138424/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: REQ-runner-add-helm-only-1777138424
+
+## Stage: contract / spec
+
+- [x] author specs/runner-helm/spec.md with ADDED Requirements + 3 scenarios
+
+## Stage: implementation
+
+- [x] add helm install step to runner/Dockerfile (full Flutter runner)
+- [x] add helm install step to runner/go.Dockerfile (Go-only runner)
+
+## Stage: PR
+
+- [x] git push feat/REQ-runner-add-helm-only-1777138424
+- [x] gh pr create

--- a/orchestrator/tests/test_contract_runner_helm.py
+++ b/orchestrator/tests/test_contract_runner_helm.py
@@ -1,0 +1,174 @@
+"""Contract tests for REQ-runner-add-helm-only-1777138424.
+
+Capability: runner-helm
+Author: challenger-agent (black-box, written from spec only)
+
+Scenarios covered:
+  RUNNER-HELM-S1  runner/Dockerfile installs helm; image can run `helm version` (exits 0, v3.x.y)
+  RUNNER-HELM-S2  runner/go.Dockerfile installs helm; image can run `helm version` (exits 0, v3.x.y)
+  RUNNER-HELM-S3  Both Dockerfiles pin HELM_VERSION via ARG; default matches semver pattern
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FULL_DOCKERFILE = REPO_ROOT / "runner" / "Dockerfile"
+GO_DOCKERFILE = REPO_ROOT / "runner" / "go.Dockerfile"
+
+# HELM_VERSION default can be "3.17.3" or "v3.17.3"
+_SEMVER_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+_ARG_HELM_RE = re.compile(r"^\s*ARG\s+HELM_VERSION\s*=\s*(\S+)", re.MULTILINE)
+# Install step uses the ARG: e.g. "helm-v${HELM_VERSION}"
+_HELM_INSTALL_RE = re.compile(r"helm-v\$\{?HELM_VERSION\}?", re.IGNORECASE)
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"Dockerfile not found at expected path: {path}"
+    return path.read_text()
+
+
+# ── RUNNER-HELM-S1: full runner image ───────────────────────────────────────
+
+def test_runner_helm_s1_full_dockerfile_exists():
+    """S1: runner/Dockerfile must exist at the canonical path."""
+    assert FULL_DOCKERFILE.exists(), (
+        f"runner/Dockerfile not found at {FULL_DOCKERFILE}; "
+        "both runner images must be present for sisyphus accept-stage to work"
+    )
+
+
+def test_runner_helm_s1_full_dockerfile_declares_helm_version_arg():
+    """S1: runner/Dockerfile MUST declare ARG HELM_VERSION with a pinned default."""
+    content = _read(FULL_DOCKERFILE)
+    match = _ARG_HELM_RE.search(content)
+    assert match is not None, (
+        "runner/Dockerfile must contain 'ARG HELM_VERSION=<pinned-version>' "
+        "so that builds are reproducible.\n"
+        "Relevant lines:\n"
+        + "\n".join(ln for ln in content.splitlines() if "HELM" in ln or "helm" in ln)
+    )
+
+
+def test_runner_helm_s1_full_dockerfile_install_step_uses_helm_version_arg():
+    """S1: runner/Dockerfile RUN step MUST install helm using $HELM_VERSION ARG."""
+    content = _read(FULL_DOCKERFILE)
+    assert _HELM_INSTALL_RE.search(content) is not None, (
+        "runner/Dockerfile must install helm via the HELM_VERSION ARG "
+        "(expected 'helm-v${HELM_VERSION}' in a RUN step).\n"
+        "Relevant lines:\n"
+        + "\n".join(ln for ln in content.splitlines() if "helm" in ln.lower())
+    )
+
+
+def test_runner_helm_s1_full_dockerfile_verifies_helm_binary():
+    """S1: runner/Dockerfile MUST call `helm version` after install to verify binary exits 0."""
+    content = _read(FULL_DOCKERFILE)
+    helm_lines = [ln for ln in content.splitlines() if "helm" in ln.lower()]
+    assert any("helm version" in ln for ln in helm_lines), (
+        "runner/Dockerfile must run `helm version` after install to verify "
+        "the binary is present and functional (spec RUNNER-HELM-S1).\n"
+        "Helm-related lines found:\n" + "\n".join(helm_lines)
+    )
+
+
+# ── RUNNER-HELM-S2: Go-only runner image ────────────────────────────────────
+
+def test_runner_helm_s2_go_dockerfile_exists():
+    """S2: runner/go.Dockerfile must exist at the canonical path."""
+    assert GO_DOCKERFILE.exists(), (
+        f"runner/go.Dockerfile not found at {GO_DOCKERFILE}; "
+        "the Go-only runner image must also carry helm for accept-stage compatibility"
+    )
+
+
+def test_runner_helm_s2_go_dockerfile_declares_helm_version_arg():
+    """S2: runner/go.Dockerfile MUST declare ARG HELM_VERSION with a pinned default."""
+    content = _read(GO_DOCKERFILE)
+    match = _ARG_HELM_RE.search(content)
+    assert match is not None, (
+        "runner/go.Dockerfile must contain 'ARG HELM_VERSION=<pinned-version>' "
+        "so that builds are reproducible.\n"
+        "Relevant lines:\n"
+        + "\n".join(ln for ln in content.splitlines() if "HELM" in ln or "helm" in ln)
+    )
+
+
+def test_runner_helm_s2_go_dockerfile_install_step_uses_helm_version_arg():
+    """S2: runner/go.Dockerfile RUN step MUST install helm using $HELM_VERSION ARG."""
+    content = _read(GO_DOCKERFILE)
+    assert _HELM_INSTALL_RE.search(content) is not None, (
+        "runner/go.Dockerfile must install helm via the HELM_VERSION ARG "
+        "(expected 'helm-v${HELM_VERSION}' in a RUN step).\n"
+        "Relevant lines:\n"
+        + "\n".join(ln for ln in content.splitlines() if "helm" in ln.lower())
+    )
+
+
+def test_runner_helm_s2_go_dockerfile_verifies_helm_binary():
+    """S2: runner/go.Dockerfile MUST call `helm version` after install to verify binary exits 0."""
+    content = _read(GO_DOCKERFILE)
+    helm_lines = [ln for ln in content.splitlines() if "helm" in ln.lower()]
+    assert any("helm version" in ln for ln in helm_lines), (
+        "runner/go.Dockerfile must run `helm version` after install to verify "
+        "the binary is present and functional (spec RUNNER-HELM-S2).\n"
+        "Helm-related lines found:\n" + "\n".join(helm_lines)
+    )
+
+
+# ── RUNNER-HELM-S3: version pinning ─────────────────────────────────────────
+
+def test_runner_helm_s3_full_dockerfile_helm_version_is_pinned_semver():
+    """S3: HELM_VERSION default in runner/Dockerfile MUST be a semver matching v3.x.y."""
+    content = _read(FULL_DOCKERFILE)
+    match = _ARG_HELM_RE.search(content)
+    assert match is not None, "ARG HELM_VERSION not found in runner/Dockerfile (see S3)"
+    default = match.group(1)
+    semver = _SEMVER_RE.match(default)
+    assert semver is not None, (
+        f"HELM_VERSION default in runner/Dockerfile must be a semver like '3.x.y' or 'v3.x.y', "
+        f"got {default!r}"
+    )
+    major = int(semver.group(1))
+    assert major == 3, (
+        f"HELM_VERSION must be a v3 release; got major={major} (full value: {default!r})"
+    )
+
+
+def test_runner_helm_s3_go_dockerfile_helm_version_is_pinned_semver():
+    """S3: HELM_VERSION default in runner/go.Dockerfile MUST be a semver matching v3.x.y."""
+    content = _read(GO_DOCKERFILE)
+    match = _ARG_HELM_RE.search(content)
+    assert match is not None, "ARG HELM_VERSION not found in runner/go.Dockerfile (see S3)"
+    default = match.group(1)
+    semver = _SEMVER_RE.match(default)
+    assert semver is not None, (
+        f"HELM_VERSION default in runner/go.Dockerfile must be a semver like '3.x.y' or 'v3.x.y', "
+        f"got {default!r}"
+    )
+    major = int(semver.group(1))
+    assert major == 3, (
+        f"HELM_VERSION must be a v3 release; got major={major} (full value: {default!r})"
+    )
+
+
+def test_runner_helm_s3_both_dockerfiles_pin_same_helm_version():
+    """S3: Both Dockerfiles MUST pin the same HELM_VERSION for build-to-build consistency."""
+    full_content = _read(FULL_DOCKERFILE)
+    go_content = _read(GO_DOCKERFILE)
+
+    full_match = _ARG_HELM_RE.search(full_content)
+    go_match = _ARG_HELM_RE.search(go_content)
+
+    assert full_match is not None, "ARG HELM_VERSION missing from runner/Dockerfile"
+    assert go_match is not None, "ARG HELM_VERSION missing from runner/go.Dockerfile"
+
+    full_ver = full_match.group(1)
+    go_ver = go_match.group(1)
+    assert full_ver == go_ver, (
+        "Both runner Dockerfiles must pin the same HELM_VERSION to avoid version skew "
+        "between the full and Go-only runner images.\n"
+        f"  runner/Dockerfile:    HELM_VERSION={full_ver!r}\n"
+        f"  runner/go.Dockerfile: HELM_VERSION={go_ver!r}"
+    )

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -34,19 +34,25 @@ RUN install -m 0755 -d /etc/apt/keyrings \
         fuse-overlayfs \
     && rm -rf /var/lib/apt/lists/*
 
-# ─── 2. Go 1.22 ─────────────────────────────────────────────────────────
+# ─── 2. helm ─────────────────────────────────────────────────────────────
+ARG HELM_VERSION=3.17.3
+RUN curl -fsSL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
+      | tar -xz --strip-components=1 -C /usr/local/bin linux-amd64/helm \
+    && helm version
+
+# ─── 3. Go 1.23 ─────────────────────────────────────────────────────────
 ARG GO_VERSION=1.23.4
 RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
       | tar -xz -C /usr/local
 ENV PATH="/usr/local/go/bin:/root/go/bin:$PATH" \
     GOPATH=/root/go
 
-# ─── 3. openspec CLI ─────────────────────────────────────────────────────
+# ─── 4. openspec CLI ─────────────────────────────────────────────────────
 # 真包名是 @fission-ai/openspec（旧 Dockerfile 装的 @fission-codes/openspec 不存在，
 # 退回 openspec 是 npm 上的占位空包，REQ-997 analyze 暴露的）
 RUN npm install -g @fission-ai/openspec@latest && openspec --version
 
-# ─── 4. sisyphus 合约脚本 ──────────────────
+# ─── 5. sisyphus 合约脚本 ──────────────────
 # build context 必须是 sisyphus repo 根（CI workflow 已配 context: .）
 COPY scripts/check-scenario-refs.sh \
      scripts/check-tasks-section-ownership.sh \
@@ -56,7 +62,7 @@ COPY scripts/check-scenario-refs.sh \
 RUN chmod +x /opt/sisyphus/scripts/*.sh
 ENV PATH="/opt/sisyphus/scripts:$PATH"
 
-# ─── 5. DinD 入口 ─────────────────────────────────────────────────────────
+# ─── 6. DinD 入口 ─────────────────────────────────────────────────────────
 COPY runner/entrypoint.sh /usr/local/bin/sisyphus-entrypoint.sh
 RUN chmod +x /usr/local/bin/sisyphus-entrypoint.sh
 

--- a/runner/go.Dockerfile
+++ b/runner/go.Dockerfile
@@ -36,19 +36,25 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
-# ─── 2. openspec CLI ─────────────────────────────────────────────────────
+# ─── 2. helm ─────────────────────────────────────────────────────────────
+ARG HELM_VERSION=3.17.3
+RUN curl -fsSL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
+      | tar -xz --strip-components=1 -C /usr/local/bin linux-amd64/helm \
+    && helm version
+
+# ─── 3. openspec CLI ─────────────────────────────────────────────────────
 # 真包名是 @fission-ai/openspec（旧版本误装 npm 上的占位 openspec@0.0.0 是空的，导致
 # REQ-997 analyze 报 "openspec: command not found"）
 RUN npm install -g @fission-ai/openspec@latest && openspec --version
 
-# ─── 2b. golangci-lint（业务仓 Makefile ci-lint target 依赖） ──────────
+# ─── 3b. golangci-lint（业务仓 Makefile ci-lint target 依赖） ──────────
 # REQ-final13 实证：ubox-crosser dev-cross-check → ci-lint 调 golangci-lint，没装
 # 时 fixer 死循环试图修 Makefile 也修不好。Go runner image 装上避免 env-bug 转 fix-dev。
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
     | sh -s -- -b /usr/local/bin v1.62.2 \
     && golangci-lint --version
 
-# ─── 3. sisyphus 合约脚本 ──────────────────
+# ─── 4. sisyphus 合约脚本 ──────────────────
 COPY scripts/check-scenario-refs.sh \
      scripts/check-tasks-section-ownership.sh \
      scripts/pre-commit-acl.sh \
@@ -57,7 +63,7 @@ COPY scripts/check-scenario-refs.sh \
 RUN chmod +x /opt/sisyphus/scripts/*.sh
 ENV PATH="/opt/sisyphus/scripts:$PATH"
 
-# ─── 4. DinD 入口（跟 runner/entrypoint.sh 共用） ──────────────────────
+# ─── 5. DinD 入口（跟 runner/entrypoint.sh 共用） ──────────────────────
 COPY runner/entrypoint.sh /usr/local/bin/sisyphus-entrypoint.sh
 RUN chmod +x /usr/local/bin/sisyphus-entrypoint.sh
 


### PR DESCRIPTION
## Summary

- Adds `helm` v3.17.3 (pinned, `ARG HELM_VERSION`) to `runner/Dockerfile` (Flutter full runner)
- Adds `helm` v3.17.3 to `runner/go.Dockerfile` (Go-only runner)
- Helm is installed from the official tarball — same pattern as Go, no apt repository needed

## Motivation

The `accept` stage runs `make accept-env-up` / `make accept-env-down` which invoke `helm install/upgrade/uninstall` against the K3s cluster. The runner pods already have `KUBECONFIG` wired but lacked the `helm` binary, causing accept-stage failures on repos that use Helm charts (e.g., ttpos-arch-lab after REQ-archlab-cookbook-helm-redo).

Split from #79.

## Test plan

- [ ] `runner-image` GHA job builds both `flavor: full` and `flavor: go` without error
- [ ] In a runner container: `helm version` exits 0 and prints `v3.17.3`
- [ ] accept-stage smoke: deploy a Helm-based lab env via `make accept-env-up` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)