### PR TITLE
fix(runner): add kubectl to runner images (REQ-runner-add-kubectl-only-1777138424)

### DIFF
--- a/openspec/changes/REQ-runner-add-kubectl-only-1777138424/proposal.md
+++ b/openspec/changes/REQ-runner-add-kubectl-only-1777138424/proposal.md
@@ -1,0 +1,22 @@
+# Proposal: add kubectl to runner image
+
+## Problem
+
+Runner pods have `KUBECONFIG=/root/.kube/config` injected (via `runner-secrets`), which gives access to the K3s cluster. However, the `kubectl` binary is not present in the runner image (`runner/Dockerfile` and `runner/go.Dockerfile`). Any agent step that calls `kubectl` inside the runner pod fails with `kubectl: not found`.
+
+This blocks:
+- accept-stage agents running `kubectl` to inspect or manage cluster resources
+- staging-test agents that need to verify pod/service state during tests
+
+## Solution
+
+Add a `kubectl` download step to both runner Dockerfiles, pinned to `v1.31.4` via `ARG KUBECTL_VERSION`. Fetch the binary from `dl.k8s.io` (official release endpoint), place it at `/usr/local/bin/kubectl`, and verify with `kubectl version --client` at build time.
+
+No changes to orchestrator code, helm values, or runtime scripts.
+
+## Scope
+
+- `runner/Dockerfile` — full Flutter runner
+- `runner/go.Dockerfile` — Go-only lightweight runner
+
+Both images receive the same `kubectl` version.

--- a/openspec/changes/REQ-runner-add-kubectl-only-1777138424/specs/runner-kubectl/spec.md
+++ b/openspec/changes/REQ-runner-add-kubectl-only-1777138424/specs/runner-kubectl/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: runner Dockerfiles include kubectl binary from dl.k8s.io
+
+Both `runner/Dockerfile` and `runner/go.Dockerfile` SHALL include a `RUN` instruction
+that downloads the `kubectl` binary from `https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl`,
+installs it to `/usr/local/bin/kubectl`, and marks it executable. The built images
+MUST provide a working `kubectl` client so that runner-pod steps that invoke
+`kubectl` against the cluster (accept-stage, staging-test) do not fail with
+`kubectl: not found`.
+
+#### Scenario: RUNNER-KUBECTL-S1 Dockerfile declares kubectl download instruction
+
+- **GIVEN** the file `runner/Dockerfile` in the sisyphus repository
+- **WHEN** the file content is inspected
+- **THEN** it contains `https://dl.k8s.io/release/` and `/usr/local/bin/kubectl`
+
+#### Scenario: RUNNER-KUBECTL-S2 go.Dockerfile declares kubectl download instruction
+
+- **GIVEN** the file `runner/go.Dockerfile` in the sisyphus repository
+- **WHEN** the file content is inspected
+- **THEN** it contains `https://dl.k8s.io/release/` and `/usr/local/bin/kubectl`
+
+#### Scenario: RUNNER-KUBECTL-S3 kubectl step appears before openspec in Dockerfile layer order
+
+- **GIVEN** the file `runner/Dockerfile` in the sisyphus repository
+- **WHEN** the file content is parsed for layer ordering
+- **THEN** the kubectl download instruction appears before the openspec npm install instruction

--- a/openspec/changes/REQ-runner-add-kubectl-only-1777138424/tasks.md
+++ b/openspec/changes/REQ-runner-add-kubectl-only-1777138424/tasks.md
@@ -1,0 +1,16 @@
+# Tasks: REQ-runner-add-kubectl-only-1777138424
+
+## Stage: spec
+
+- [x] author specs/runner-kubectl/spec.md with Dockerfile-content scenarios
+
+## Stage: implementation
+
+- [x] add kubectl download step to runner/Dockerfile (step 3, pinned KUBECTL_VERSION=v1.31.4)
+- [x] add kubectl download step to runner/go.Dockerfile (step 2, same version)
+- [x] renumber section headers in both Dockerfiles to keep sequential numbering
+
+## Stage: PR
+
+- [x] git push feat/REQ-runner-add-kubectl-only-1777138424
+- [x] gh pr create

--- a/orchestrator/tests/test_contract_runner_kubectl.py
+++ b/orchestrator/tests/test_contract_runner_kubectl.py
@@ -1,0 +1,96 @@
+"""Contract tests for REQ-runner-add-kubectl-only-1777138424.
+
+Black-box behavioral contracts derived from:
+  openspec/changes/REQ-runner-add-kubectl-only-1777138424/specs/runner-kubectl/spec.md
+
+Scenarios covered:
+  RUNNER-KUBECTL-S1  runner/Dockerfile declares kubectl download instruction
+  RUNNER-KUBECTL-S2  runner/go.Dockerfile declares kubectl download instruction
+  RUNNER-KUBECTL-S3  kubectl step appears before openspec npm install in Dockerfile layer order
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DOCKERFILE = REPO_ROOT / "runner" / "Dockerfile"
+GO_DOCKERFILE = REPO_ROOT / "runner" / "go.Dockerfile"
+
+_KUBECTL_DL_URL = "https://dl.k8s.io/release/"
+_KUBECTL_BIN = "/usr/local/bin/kubectl"
+
+
+# ── RUNNER-KUBECTL-S1 ────────────────────────────────────────────────────────
+
+
+def test_RUNNER_KUBECTL_S1_dockerfile_contains_kubectl_download_url():
+    """S1: runner/Dockerfile fetches kubectl from dl.k8s.io."""
+    assert DOCKERFILE.exists(), f"runner/Dockerfile not found at {DOCKERFILE}"
+    content = DOCKERFILE.read_text()
+    assert _KUBECTL_DL_URL in content, (
+        f"runner/Dockerfile MUST contain '{_KUBECTL_DL_URL}'; "
+        "kubectl binary must be downloaded from the official dl.k8s.io endpoint"
+    )
+
+
+def test_RUNNER_KUBECTL_S1_dockerfile_installs_to_usr_local_bin():
+    """S1: runner/Dockerfile places kubectl at /usr/local/bin/kubectl."""
+    content = DOCKERFILE.read_text()
+    assert _KUBECTL_BIN in content, (
+        f"runner/Dockerfile MUST contain '{_KUBECTL_BIN}'; "
+        "kubectl binary must be installed to /usr/local/bin/kubectl"
+    )
+
+
+# ── RUNNER-KUBECTL-S2 ────────────────────────────────────────────────────────
+
+
+def test_RUNNER_KUBECTL_S2_go_dockerfile_contains_kubectl_download_url():
+    """S2: runner/go.Dockerfile fetches kubectl from dl.k8s.io."""
+    assert GO_DOCKERFILE.exists(), f"runner/go.Dockerfile not found at {GO_DOCKERFILE}"
+    content = GO_DOCKERFILE.read_text()
+    assert _KUBECTL_DL_URL in content, (
+        f"runner/go.Dockerfile MUST contain '{_KUBECTL_DL_URL}'; "
+        "kubectl binary must be downloaded from the official dl.k8s.io endpoint"
+    )
+
+
+def test_RUNNER_KUBECTL_S2_go_dockerfile_installs_to_usr_local_bin():
+    """S2: runner/go.Dockerfile places kubectl at /usr/local/bin/kubectl."""
+    content = GO_DOCKERFILE.read_text()
+    assert _KUBECTL_BIN in content, (
+        f"runner/go.Dockerfile MUST contain '{_KUBECTL_BIN}'; "
+        "kubectl binary must be installed to /usr/local/bin/kubectl"
+    )
+
+
+# ── RUNNER-KUBECTL-S3 ────────────────────────────────────────────────────────
+
+
+def test_RUNNER_KUBECTL_S3_kubectl_layer_before_openspec_layer():
+    """S3: kubectl download RUN appears before openspec npm install RUN in runner/Dockerfile."""
+    content = DOCKERFILE.read_text()
+    lines = content.splitlines()
+
+    kubectl_line: int | None = None
+    openspec_line: int | None = None
+
+    for i, line in enumerate(lines):
+        if _KUBECTL_DL_URL in line and kubectl_line is None:
+            kubectl_line = i
+        # openspec npm install: "npm install -g @fission-ai/openspec"
+        if "npm install" in line and "openspec" in line and openspec_line is None:
+            openspec_line = i
+
+    assert kubectl_line is not None, (
+        "runner/Dockerfile must contain a RUN instruction that downloads kubectl "
+        f"from {_KUBECTL_DL_URL}"
+    )
+    assert openspec_line is not None, (
+        "runner/Dockerfile must contain a RUN instruction that installs openspec via npm"
+    )
+    assert kubectl_line < openspec_line, (
+        f"kubectl download (line {kubectl_line + 1}) MUST appear BEFORE "
+        f"openspec npm install (line {openspec_line + 1}) in runner/Dockerfile; "
+        "layer ordering ensures kubectl is available when openspec is installed"
+    )

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -41,12 +41,21 @@ RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
 ENV PATH="/usr/local/go/bin:/root/go/bin:$PATH" \
     GOPATH=/root/go
 
-# ─── 3. openspec CLI ─────────────────────────────────────────────────────
+# ─── 3. kubectl ──────────────────────────────────────────────────────────
+# accept 阶段 / staging-test agent 要对 K3s 集群跑 helm / kubectl。
+# KUBECONFIG 由 runner-secrets 挂入，但二进制不在 base image 里必须在此装。
+ARG KUBECTL_VERSION=v1.31.4
+RUN curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+      -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && kubectl version --client
+
+# ─── 4. openspec CLI ─────────────────────────────────────────────────────
 # 真包名是 @fission-ai/openspec（旧 Dockerfile 装的 @fission-codes/openspec 不存在，
 # 退回 openspec 是 npm 上的占位空包，REQ-997 analyze 暴露的）
 RUN npm install -g @fission-ai/openspec@latest && openspec --version
 
-# ─── 4. sisyphus 合约脚本 ──────────────────
+# ─── 5. sisyphus 合约脚本 ──────────────────
 # build context 必须是 sisyphus repo 根（CI workflow 已配 context: .）
 COPY scripts/check-scenario-refs.sh \
      scripts/check-tasks-section-ownership.sh \
@@ -56,7 +65,7 @@ COPY scripts/check-scenario-refs.sh \
 RUN chmod +x /opt/sisyphus/scripts/*.sh
 ENV PATH="/opt/sisyphus/scripts:$PATH"
 
-# ─── 5. DinD 入口 ─────────────────────────────────────────────────────────
+# ─── 6. DinD 入口 ─────────────────────────────────────────────────────────
 COPY runner/entrypoint.sh /usr/local/bin/sisyphus-entrypoint.sh
 RUN chmod +x /usr/local/bin/sisyphus-entrypoint.sh
 

--- a/runner/go.Dockerfile
+++ b/runner/go.Dockerfile
@@ -36,19 +36,27 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
-# ─── 2. openspec CLI ─────────────────────────────────────────────────────
+# ─── 2. kubectl ──────────────────────────────────────────────────────────
+# accept 阶段 / staging-test agent 要对 K3s 集群跑 helm / kubectl。
+ARG KUBECTL_VERSION=v1.31.4
+RUN curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+      -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && kubectl version --client
+
+# ─── 3. openspec CLI ─────────────────────────────────────────────────────
 # 真包名是 @fission-ai/openspec（旧版本误装 npm 上的占位 openspec@0.0.0 是空的，导致
 # REQ-997 analyze 报 "openspec: command not found"）
 RUN npm install -g @fission-ai/openspec@latest && openspec --version
 
-# ─── 2b. golangci-lint（业务仓 Makefile ci-lint target 依赖） ──────────
+# ─── 3b. golangci-lint（业务仓 Makefile ci-lint target 依赖） ──────────
 # REQ-final13 实证：ubox-crosser dev-cross-check → ci-lint 调 golangci-lint，没装
 # 时 fixer 死循环试图修 Makefile 也修不好。Go runner image 装上避免 env-bug 转 fix-dev。
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
     | sh -s -- -b /usr/local/bin v1.62.2 \
     && golangci-lint --version
 
-# ─── 3. sisyphus 合约脚本 ──────────────────
+# ─── 4. sisyphus 合约脚本 ──────────────────
 COPY scripts/check-scenario-refs.sh \
      scripts/check-tasks-section-ownership.sh \
      scripts/pre-commit-acl.sh \
@@ -57,7 +65,7 @@ COPY scripts/check-scenario-refs.sh \
 RUN chmod +x /opt/sisyphus/scripts/*.sh
 ENV PATH="/opt/sisyphus/scripts:$PATH"
 
-# ─── 4. DinD 入口（跟 runner/entrypoint.sh 共用） ──────────────────────
+# ─── 5. DinD 入口（跟 runner/entrypoint.sh 共用） ──────────────────────
 COPY runner/entrypoint.sh /usr/local/bin/sisyphus-entrypoint.sh
 RUN chmod +x /usr/local/bin/sisyphus-entrypoint.sh
 


### PR DESCRIPTION
## Summary

- Adds `kubectl v1.31.4` download step to `runner/Dockerfile` (Flutter full runner, step 3)
- Adds `kubectl v1.31.4` download step to `runner/go.Dockerfile` (Go-only runner, step 2)
- Renumbers section headers in both files to keep sequential ordering

## Motivation

Runner pods already have `KUBECONFIG=/root/.kube/config` injected via `runner-secrets`, giving access to the K3s cluster. However the `kubectl` binary was not present in either runner image, causing any agent step that invokes `kubectl` (accept-stage helm/kubectl calls, staging-test pod inspection) to fail with `kubectl: not found`.

## Test plan

- [ ] `openspec validate REQ-runner-add-kubectl-only-1777138424` passes (verified locally ✅)
- [ ] GHA `runner-image` workflow builds both `runner/Dockerfile` and `runner/go.Dockerfile` without error
- [ ] `kubectl version --client` runs successfully inside built image (verified at build time via RUN step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)