### PR TITLE
feat(orchestrator): minimal accept_env_gc skeleton (REQ-accept-env-gc-minimal-1777138424)

### DIFF
--- a/openspec/changes/REQ-accept-env-gc-minimal-1777138424/proposal.md
+++ b/openspec/changes/REQ-accept-env-gc-minimal-1777138424/proposal.md
@@ -1,0 +1,24 @@
+# Proposal: minimal accept_env_gc skeleton
+
+## Problem
+
+`teardown_accept_env` runs `make accept-env-down` best-effort after every accept stage (pass or fail). If it fails, the accept environment — a Kubernetes namespace `accept-{req_id.lower()}` containing helm releases and all their resources — is left behind permanently. There is no background cleanup, so orphaned namespaces accumulate over time and consume cluster resources.
+
+## Solution
+
+Add `accept_env_gc` as a background GC loop (parallel to `runner_gc`) that:
+
+1. Lists all Kubernetes namespaces matching the `accept-req-*` pattern
+2. Queries `req_state` for terminal REQs (done / escalated past retention)
+3. Deletes orphaned accept namespaces via `kubectl delete namespace` (cascades to all resources inside)
+
+**"No helm RBAC"**: we do not call `helm uninstall`. Namespace deletion is sufficient and requires only `namespaces:delete` (namespace-scoped is sufficient once we have the name). The RBAC requirement for `namespaces:list` is cluster-scoped; if the ServiceAccount lacks it, we disable the GC gracefully with a single INFO log (same pattern as `runner_gc._DISK_CHECK_DISABLED`).
+
+## Scope (minimal skeleton)
+
+- New module: `orchestrator/src/orchestrator/accept_env_gc.py`
+- Config: `accept_env_gc_interval_sec` (default 900s, same as `runner_gc_interval_sec`)
+- Wire into `main.py` startup
+- Unit tests (no K8s integration tests)
+
+Retention policy reuses `pvc_retain_on_escalate_days` (done → immediate, escalated → wait retention before GC).

--- a/openspec/changes/REQ-accept-env-gc-minimal-1777138424/specs/accept-env-gc/contract.spec.yaml
+++ b/openspec/changes/REQ-accept-env-gc-minimal-1777138424/specs/accept-env-gc/contract.spec.yaml
@@ -1,0 +1,78 @@
+capability: accept-env-gc
+version: "1.0"
+description: |
+  Background GC task that cleans up orphaned Kubernetes namespaces created by
+  accept-env-up (via make accept-env-up in integration/source repos).
+
+  teardown_accept_env runs make accept-env-down best-effort; failures are only
+  WARNING and do not block the state machine. This GC compensates by periodically
+  listing accept-req-* namespaces and deleting those belonging to terminal REQs.
+
+  "No helm RBAC": deletion is done via kubernetes CoreV1Api.delete_namespace
+  (cascades all resources inside), not helm uninstall. Requires only namespace
+  delete permission, not cluster-scoped helm list.
+
+settings:
+  accept_env_gc_interval_sec:
+    module: orchestrator.config
+    type: int
+    default: 900
+    env: SISYPHUS_ACCEPT_ENV_GC_INTERVAL_SEC
+    semantics: |
+      GC scan interval in seconds. 0 = disabled (dev/test environments without K8s).
+      Default 900 matches runner_gc_interval_sec default.
+
+  pvc_retain_on_escalate_days:
+    reused: true
+    semantics: |
+      Same retention window used by runner_gc for escalated REQs.
+      done → immediate GC; escalated → wait retention before GC.
+
+state_invariants:
+  ns_rbac_disabled_flag:
+    name: _NS_RBAC_DISABLED
+    module: orchestrator.accept_env_gc
+    type: bool
+    initial: false
+    transitions:
+      - "false → true on first ApiException(status=403) raised by list_namespace or delete_namespace"
+    persistence: "in-memory only; reset on process restart (intended)"
+    rationale: |
+      Mirrors runner_gc._DISK_CHECK_DISABLED pattern. ServiceAccount may lack
+      cluster-scoped namespaces:list. Permanent disablement avoids repeated
+      403 noise; single INFO log preserves operator grep-ability.
+
+namespace_pattern:
+  prefix: "accept-req-"
+  derivation: "accept-{req_id.lower()} where req_id starts with REQ-"
+  example: "accept-req-accept-env-gc-minimal-1777138424"
+  extraction: |
+    ns_name.startswith("accept-") AND ns_name[len("accept-"):].startswith("req-")
+    → req_lower = ns_name[len("accept-"):]
+    → match against {r.req_id.lower() for r in stale_rows}
+
+retention_policy:
+  done: "immediate GC (same as runner_gc)"
+  escalated: "GC only after pvc_retain_on_escalate_days elapsed since updated_at"
+  inflight: "never GC"
+
+log_events:
+  accept_env_gc_rbac_denied:
+    level: info
+    when: "ApiException(status=403) from list_namespace or delete_namespace"
+    emitted_at_most: "once per process lifetime (_NS_RBAC_DISABLED flag)"
+
+  accept_env_gc_ns_deleted:
+    level: info
+    when: "namespace successfully deleted"
+    fields: [namespace, req_lower]
+
+  accept_env_gc_swept:
+    level: info
+    when: "at least one namespace cleaned in a gc_once pass"
+    fields: [count, namespaces]
+
+  accept_env_gc_delete_failed:
+    level: warning
+    when: "delete_namespace raises non-404/403 ApiException"
+    fields: [namespace, error, status]

--- a/openspec/changes/REQ-accept-env-gc-minimal-1777138424/specs/accept-env-gc/spec.md
+++ b/openspec/changes/REQ-accept-env-gc-minimal-1777138424/specs/accept-env-gc/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: accept_env_gc cleans orphaned accept namespaces
+
+The system SHALL provide a background GC task (`accept_env_gc.run_loop`) that
+periodically scans Kubernetes namespaces matching the pattern `accept-req-*` and
+deletes those whose corresponding REQ is in a terminal state (done or escalated
+past the retention window). The GC MUST NOT delete namespaces for REQs that are
+still in a non-terminal (in-flight) state. Deletion MUST be performed by calling
+`kubernetes.client.CoreV1Api.delete_namespace` (cascading all resources inside)
+rather than `helm uninstall`, so the implementation requires no helm RBAC.
+
+#### Scenario: AEGC-S1 done REQ의 accept namespace는 gc_once에서 삭제된다
+
+- **GIVEN** req_state에 state=done인 REQ-foo-123이 있음
+- **AND** K8s에 `accept-req-foo-123` namespace가 존재함
+- **WHEN** `gc_once()` 가 호출됨
+- **THEN** `core_v1.delete_namespace("accept-req-foo-123")` 가 호출됨
+- **AND** 반환값 `cleaned` 리스트에 `"accept-req-foo-123"` 이 포함됨
+
+#### Scenario: AEGC-S2 in-flight REQ의 accept namespace는 삭제되지 않는다
+
+- **GIVEN** req_state에 state=accept-running인 REQ-foo-123이 있음
+- **AND** K8s에 `accept-req-foo-123` namespace가 존재함
+- **WHEN** `gc_once()` 가 호출됨
+- **THEN** `core_v1.delete_namespace` 가 호출되지 않음
+- **AND** 반환값 `cleaned` 는 빈 리스트
+
+#### Scenario: AEGC-S3 escalated이고 retention 기간 내이면 삭제되지 않는다
+
+- **GIVEN** req_state에 state=escalated, updated_at=2시간 전인 REQ-foo-123이 있음
+- **AND** pvc_retain_on_escalate_days=1 (기본값)
+- **AND** K8s에 `accept-req-foo-123` namespace가 존재함
+- **WHEN** `gc_once()` 가 호출됨
+- **THEN** `core_v1.delete_namespace` 가 호출되지 않음
+
+#### Scenario: AEGC-S4 escalated이고 retention 초과이면 삭제된다
+
+- **GIVEN** req_state에 state=escalated, updated_at=30일 전인 REQ-foo-123이 있음
+- **AND** K8s에 `accept-req-foo-123` namespace가 존재함
+- **WHEN** `gc_once()` 가 호출됨
+- **THEN** `core_v1.delete_namespace("accept-req-foo-123")` 가 호출됨
+
+### Requirement: accept_env_gc degrades gracefully on RBAC 403
+
+The system SHALL detect Kubernetes API 403 (Forbidden) on `list_namespace` or
+`delete_namespace` calls and treat them as a permanent RBAC denial for the
+process lifetime. On the first 403, the system MUST emit exactly one
+`accept_env_gc.rbac_denied` log at INFO level and set a process-level flag
+`_NS_RBAC_DISABLED = True`. On all subsequent GC ticks, the system MUST skip
+the K8s API call entirely without emitting any additional log. The module MUST
+also skip immediately when no runner controller is initialized (dev/test
+environment).
+
+#### Scenario: AEGC-S5 K8s controller 없으면 skipped 반환
+
+- **GIVEN** k8s_runner controller가 초기화되어 있지 않음
+- **WHEN** `gc_once()` 가 호출됨
+- **THEN** `{"skipped": "no runner controller"}` 를 반환함
+- **AND** K8s API 호출이 없음
+
+#### Scenario: AEGC-S6 list_namespace 403 → 진행 불가 디스에이블
+
+- **GIVEN** `core_v1.list_namespace` 가 `ApiException(status=403)` 를 raise함
+- **WHEN** `gc_once()` 가 호출됨
+- **THEN** `_NS_RBAC_DISABLED` 가 True로 설정됨
+- **AND** INFO 레벨로 `accept_env_gc.rbac_denied` 가 한 번 기록됨
+- **AND** 반환값에 `"skipped"` 키가 포함됨
+
+#### Scenario: AEGC-S7 _NS_RBAC_DISABLED=True이면 list_namespace 호출 스킵
+
+- **GIVEN** `_NS_RBAC_DISABLED` 가 True임
+- **WHEN** `gc_once()` 가 호출됨
+- **THEN** `core_v1.list_namespace` 가 호출되지 않음
+- **AND** `{"skipped": "namespace rbac disabled"}` 를 반환함

--- a/openspec/changes/REQ-accept-env-gc-minimal-1777138424/tasks.md
+++ b/openspec/changes/REQ-accept-env-gc-minimal-1777138424/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: REQ-accept-env-gc-minimal-1777138424
+
+## Stage: spec
+- [x] author specs/accept-env-gc/spec.md with ADDED Requirements and Scenarios
+- [x] author specs/accept-env-gc/contract.spec.yaml
+
+## Stage: implementation
+- [x] implement orchestrator/src/orchestrator/accept_env_gc.py (gc_once + run_loop)
+- [x] add accept_env_gc_interval_sec to config.py
+- [x] wire accept_env_gc.run_loop() into main.py startup
+
+## Stage: tests
+- [x] unit tests in orchestrator/tests/test_accept_env_gc.py (no K8s required)
+
+## Stage: PR
+- [x] git push feat/REQ-accept-env-gc-minimal-1777138424
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/accept_env_gc.py
+++ b/orchestrator/src/orchestrator/accept_env_gc.py
@@ -109,9 +109,10 @@ async def gc_once() -> dict:
             elif e.status == 403:
                 _NS_RBAC_DISABLED = True
                 log.info(
-                    "accept_env_gc.delete_rbac_denied",
+                    "accept_env_gc.rbac_denied",
                     namespace=ns_name,
-                    hint="ServiceAccount lacks namespace delete permission",
+                    hint="ServiceAccount lacks namespace delete permission; "
+                         "accept_env_gc disabled until restart",
                 )
                 break
             else:

--- a/orchestrator/src/orchestrator/accept_env_gc.py
+++ b/orchestrator/src/orchestrator/accept_env_gc.py
@@ -1,0 +1,144 @@
+"""accept_env_gc：清理孤儿 accept env namespace（v0.1 minimal skeleton）。
+
+create_accept 通过 make accept-env-up 在 K8s 集群创建 namespace accept-{req_id.lower()}
+（含 helm release）。teardown_accept_env best-effort 跑 make accept-env-down，失败只
+warning 不阻塞状态机。本 GC 补位：周期扫 accept-* namespace，对终态 REQ 直接 delete
+namespace（cascade 清所有资源）。
+
+"no helm RBAC"：不调 helm uninstall（需要 ClusterRole），只 delete namespace。
+RBAC 403 时进程级禁用（同 runner_gc 磁盘检测），不污染日志。
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from kubernetes.client import ApiException
+
+from . import k8s_runner
+from .config import settings
+from .store import db
+
+log = structlog.get_logger(__name__)
+
+_TERMINAL_STATES = {"done", "escalated"}
+
+# 403 时进程级禁用，避免每轮 GC 都打日志；重启后重新探测一次
+_NS_RBAC_DISABLED = False
+
+_ACCEPT_NS_PREFIX = "accept-"
+
+
+def _req_lower_from_ns(ns_name: str) -> str | None:
+    """'accept-req-foo-123' → 'req-foo-123'（DB req_id.lower()）。非 accept-req-* 返 None。"""
+    if not ns_name.startswith(_ACCEPT_NS_PREFIX):
+        return None
+    suffix = ns_name[len(_ACCEPT_NS_PREFIX):]
+    if not suffix.startswith("req-"):
+        return None
+    return suffix
+
+
+async def _stale_req_ids_lower() -> set[str]:
+    """返回需要 GC accept namespace 的 req_id.lower() 集合。
+
+    规则同 runner_gc：done → 立即清；escalated → 超 retention 才清。
+    """
+    pool = db.get_pool()
+    rows = await pool.fetch("SELECT req_id, state, updated_at FROM req_state")
+    stale: set[str] = set()
+    now = datetime.now(UTC)
+    retention = timedelta(days=settings.pvc_retain_on_escalate_days)
+    for r in rows:
+        state = r["state"]
+        if state not in _TERMINAL_STATES:
+            continue
+        if state == "done":
+            stale.add(r["req_id"].lower())
+        elif state == "escalated":
+            updated_at = r["updated_at"]
+            if updated_at and (now - updated_at) >= retention:
+                stale.add(r["req_id"].lower())
+    return stale
+
+
+async def gc_once() -> dict:
+    """单次 GC：找终态 REQ 的孤儿 accept namespace 并删除。"""
+    global _NS_RBAC_DISABLED
+
+    try:
+        rc = k8s_runner.get_controller()
+    except RuntimeError:
+        return {"skipped": "no runner controller"}
+
+    if _NS_RBAC_DISABLED:
+        return {"skipped": "namespace rbac disabled"}
+
+    # list_namespace 是 cluster-scoped 调用；ServiceAccount 缺权限时 403 进程级禁用
+    try:
+        ns_list = await asyncio.to_thread(rc.core_v1.list_namespace)
+    except ApiException as e:
+        if e.status == 403:
+            _NS_RBAC_DISABLED = True
+            log.info(
+                "accept_env_gc.rbac_denied",
+                hint="ServiceAccount lacks cluster-scoped namespaces:list; "
+                     "accept_env_gc disabled until restart",
+            )
+            return {"skipped": "namespace list rbac denied"}
+        log.debug("accept_env_gc.list_ns_failed", error=str(e), status=e.status)
+        return {"error": f"list_namespace failed: {e.status}"}
+
+    stale_lower = await _stale_req_ids_lower()
+    cleaned: list[str] = []
+
+    for ns in ns_list.items:
+        ns_name = ns.metadata.name
+        req_lower = _req_lower_from_ns(ns_name)
+        if req_lower is None or req_lower not in stale_lower:
+            continue
+
+        try:
+            await asyncio.to_thread(rc.core_v1.delete_namespace, ns_name)
+            log.info("accept_env_gc.ns_deleted", namespace=ns_name, req_lower=req_lower)
+            cleaned.append(ns_name)
+        except ApiException as e:
+            if e.status == 404:
+                pass  # 已被删，幂等
+            elif e.status == 403:
+                _NS_RBAC_DISABLED = True
+                log.info(
+                    "accept_env_gc.delete_rbac_denied",
+                    namespace=ns_name,
+                    hint="ServiceAccount lacks namespace delete permission",
+                )
+                break
+            else:
+                log.warning(
+                    "accept_env_gc.delete_failed",
+                    namespace=ns_name, error=str(e), status=e.status,
+                )
+
+    if cleaned:
+        log.info("accept_env_gc.swept", count=len(cleaned), namespaces=cleaned)
+    return {"cleaned": cleaned, "stale_req_count": len(stale_lower)}
+
+
+async def run_loop() -> None:
+    """orchestrator 启动的后台 GC 任务，周期扫 accept namespace。"""
+    interval = settings.accept_env_gc_interval_sec
+    log.info("accept_env_gc.loop.started", interval_sec=interval)
+    while True:
+        try:
+            result = await gc_once()
+            if result.get("cleaned"):
+                log.info("accept_env_gc.tick.swept", result=result)
+            else:
+                log.debug("accept_env_gc.tick", result=result)
+        except asyncio.CancelledError:
+            log.info("accept_env_gc.loop.stopped")
+            raise
+        except Exception as e:
+            log.exception("accept_env_gc.loop.error", error=str(e))
+        await asyncio.sleep(interval)

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -115,6 +115,13 @@ class Settings(BaseSettings):
     # 默认 3 × 120s = 6min，覆盖 K3s 节点偶发慢启动；生产可调更高。
     runner_ready_attempts: int = 3
 
+    # ─── accept env GC ────────────────────────────────────────────────────
+    # 周期清理孤儿 accept-* namespace（teardown_accept_env best-effort 失败时的补位）。
+    # 不调 helm uninstall（需要 ClusterRole），直接 delete namespace cascade 清资源。
+    # RBAC 403 时进程级禁用，同 runner_gc 磁盘检测处理方式。
+    # interval 0 = 不启动（dev / 无 K8s 环境）。
+    accept_env_gc_interval_sec: int = 900    # 15 min，同 runner_gc_interval_sec 默认
+
     # ─── agent model 控制 ─────────────────────────────────────────────────
     # sisyphus 起的 agent 用哪个模型（verifier / fixer / accept / pr_ci_watch /
     # done_archive / staging_test）。None = 用 BKD per-engine 默认（opus）。

--- a/orchestrator/src/orchestrator/main.py
+++ b/orchestrator/src/orchestrator/main.py
@@ -7,7 +7,7 @@ import logging
 import structlog
 from fastapi import FastAPI
 
-from . import k8s_runner, runner_gc, snapshot, watchdog
+from . import accept_env_gc, k8s_runner, runner_gc, snapshot, watchdog
 from .admin import admin as admin_api
 from .config import settings
 from .migrate import apply_pending
@@ -66,6 +66,9 @@ async def startup() -> None:
         # 5. 起 runner GC 后台任务（周期清 done/escalated 过保留期的 PVC）
         if settings.runner_gc_interval_sec > 0:
             _bg_tasks.append(asyncio.create_task(runner_gc.run_loop(), name="runner_gc"))
+        # 5b. 起 accept env GC 后台任务（周期清孤儿 accept-* namespace）
+        if settings.accept_env_gc_interval_sec > 0:
+            _bg_tasks.append(asyncio.create_task(accept_env_gc.run_loop(), name="accept_env_gc"))
     except Exception as e:
         # dev / 单机 / 没 kubeconfig 的场景允许失败（调 action 会抛，但 http 主进程能起）
         log.warning("k8s_runner.init_failed", error=str(e))

--- a/orchestrator/tests/test_accept_env_gc.py
+++ b/orchestrator/tests/test_accept_env_gc.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from kubernetes.client import ApiException

--- a/orchestrator/tests/test_accept_env_gc.py
+++ b/orchestrator/tests/test_accept_env_gc.py
@@ -1,0 +1,167 @@
+"""accept_env_gc.gc_once 단테스트：mock PG pool + k8s_runner controller。"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from kubernetes.client import ApiException
+
+from orchestrator import accept_env_gc, k8s_runner
+
+
+class _FakePool:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def fetch(self, sql, *args):
+        return self._rows
+
+
+def _row(req_id, state, updated_at=None):
+    return {"req_id": req_id, "state": state, "updated_at": updated_at}
+
+
+def _ns(name):
+    ns = MagicMock()
+    ns.metadata.name = name
+    return ns
+
+
+@pytest.fixture(autouse=True)
+def _reset_rbac_flag():
+    """각 테스트 전후 _NS_RBAC_DISABLED 리셋。"""
+    accept_env_gc._NS_RBAC_DISABLED = False
+    yield
+    accept_env_gc._NS_RBAC_DISABLED = False
+
+
+@pytest.fixture
+def mock_controller(monkeypatch):
+    fake = MagicMock()
+    fake.core_v1.list_namespace = MagicMock(return_value=MagicMock(items=[]))
+    fake.core_v1.delete_namespace = MagicMock()
+    k8s_runner.set_controller(fake)
+    yield fake
+    k8s_runner.set_controller(None)
+
+
+@pytest.mark.asyncio
+async def test_skips_when_no_controller():
+    k8s_runner.set_controller(None)
+    result = await accept_env_gc.gc_once()
+    assert "skipped" in result
+
+
+@pytest.mark.asyncio
+async def test_skips_when_rbac_disabled(mock_controller):
+    accept_env_gc._NS_RBAC_DISABLED = True
+    result = await accept_env_gc.gc_once()
+    assert result.get("skipped") == "namespace rbac disabled"
+    mock_controller.core_v1.list_namespace.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_403_disables_gc(monkeypatch, mock_controller):
+    pool = _FakePool([_row("REQ-1", "done")])
+    monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
+    mock_controller.core_v1.list_namespace.side_effect = ApiException(status=403, reason="Forbidden")
+
+    result = await accept_env_gc.gc_once()
+    assert "skipped" in result
+    assert accept_env_gc._NS_RBAC_DISABLED is True
+
+
+@pytest.mark.asyncio
+async def test_done_req_ns_deleted(monkeypatch, mock_controller):
+    """done 상태 REQ의 accept namespace는 즉시 삭제。"""
+    pool = _FakePool([_row("REQ-foo-123", "done")])
+    monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
+    mock_controller.core_v1.list_namespace.return_value = MagicMock(
+        items=[_ns("accept-req-foo-123"), _ns("other-ns"), _ns("kube-system")]
+    )
+
+    result = await accept_env_gc.gc_once()
+    assert "accept-req-foo-123" in result["cleaned"]
+    mock_controller.core_v1.delete_namespace.assert_called_once_with("accept-req-foo-123")
+
+
+@pytest.mark.asyncio
+async def test_inflight_ns_not_deleted(monkeypatch, mock_controller):
+    """진행 중인 REQ의 namespace는 삭제하지 않음。"""
+    pool = _FakePool([_row("REQ-foo-123", "accept-running")])
+    monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
+    mock_controller.core_v1.list_namespace.return_value = MagicMock(
+        items=[_ns("accept-req-foo-123")]
+    )
+
+    result = await accept_env_gc.gc_once()
+    assert result["cleaned"] == []
+    mock_controller.core_v1.delete_namespace.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_escalated_within_retention_not_deleted(monkeypatch, mock_controller):
+    """escalated이지만 retention 기간 내 → 삭제하지 않음。"""
+    recent = datetime.now(UTC) - timedelta(hours=2)
+    pool = _FakePool([_row("REQ-foo-123", "escalated", updated_at=recent)])
+    monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
+    mock_controller.core_v1.list_namespace.return_value = MagicMock(
+        items=[_ns("accept-req-foo-123")]
+    )
+
+    result = await accept_env_gc.gc_once()
+    assert result["cleaned"] == []
+    mock_controller.core_v1.delete_namespace.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_escalated_past_retention_deleted(monkeypatch, mock_controller):
+    """escalated이고 retention 초과 → namespace 삭제。"""
+    old = datetime.now(UTC) - timedelta(days=30)
+    pool = _FakePool([_row("REQ-foo-123", "escalated", updated_at=old)])
+    monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
+    mock_controller.core_v1.list_namespace.return_value = MagicMock(
+        items=[_ns("accept-req-foo-123")]
+    )
+
+    result = await accept_env_gc.gc_once()
+    assert "accept-req-foo-123" in result["cleaned"]
+
+
+@pytest.mark.asyncio
+async def test_non_accept_ns_ignored(monkeypatch, mock_controller):
+    """accept-req-* 패턴이 아닌 namespace는 무시。"""
+    pool = _FakePool([_row("REQ-foo-123", "done")])
+    monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
+    mock_controller.core_v1.list_namespace.return_value = MagicMock(
+        items=[_ns("kube-system"), _ns("sisyphus-runners"), _ns("default")]
+    )
+
+    result = await accept_env_gc.gc_once()
+    assert result["cleaned"] == []
+    mock_controller.core_v1.delete_namespace.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_404_treated_as_idempotent(monkeypatch, mock_controller):
+    """삭제 시 404 → 이미 삭제된 것, 정상 처리。"""
+    pool = _FakePool([_row("REQ-foo-123", "done")])
+    monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
+    mock_controller.core_v1.list_namespace.return_value = MagicMock(
+        items=[_ns("accept-req-foo-123")]
+    )
+    mock_controller.core_v1.delete_namespace.side_effect = ApiException(status=404, reason="NotFound")
+
+    result = await accept_env_gc.gc_once()
+    # 404는 오류로 취급하지 않음 (이미 삭제된 상태)
+    assert result.get("error") is None
+
+
+def test_req_lower_from_ns():
+    """네임스페이스 이름에서 req_lower 추출 로직 검증。"""
+    assert accept_env_gc._req_lower_from_ns("accept-req-foo-123") == "req-foo-123"
+    assert accept_env_gc._req_lower_from_ns("accept-req-accept-env-gc-minimal-1777138424") == "req-accept-env-gc-minimal-1777138424"
+    assert accept_env_gc._req_lower_from_ns("kube-system") is None
+    assert accept_env_gc._req_lower_from_ns("accept-something-else") is None  # not "accept-req-"
+    assert accept_env_gc._req_lower_from_ns("default") is None

--- a/orchestrator/tests/test_contract_accept_env_gc_challenger.py
+++ b/orchestrator/tests/test_contract_accept_env_gc_challenger.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
-import pytest
 from kubernetes.client import ApiException
+import pytest
 
 from orchestrator import accept_env_gc, k8s_runner
 

--- a/orchestrator/tests/test_contract_accept_env_gc_challenger.py
+++ b/orchestrator/tests/test_contract_accept_env_gc_challenger.py
@@ -1,0 +1,212 @@
+"""Challenger contract tests for REQ-accept-env-gc-minimal-1777138424.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-accept-env-gc-minimal-1777138424/specs/accept-env-gc/spec.md
+  openspec/changes/REQ-accept-env-gc-minimal-1777138424/specs/accept-env-gc/contract.spec.yaml
+
+Scenarios covered:
+  AEGC-S1  done REQ → delete_namespace called; ns in cleaned list
+  AEGC-S2  in-flight REQ → delete_namespace NOT called; cleaned is empty
+  AEGC-S3  escalated + within retention window → NOT deleted
+  AEGC-S4  escalated + past retention window → deleted
+  AEGC-S5  no runner controller → {"skipped": "no runner controller"}
+  AEGC-S6  list_namespace raises ApiException(403) → _NS_RBAC_DISABLED=True, INFO log
+  AEGC-S7  _NS_RBAC_DISABLED=True → list_namespace skipped; {"skipped": "namespace rbac disabled"}
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from kubernetes.client import ApiException
+
+from orchestrator import accept_env_gc, k8s_runner
+
+
+# ─── helpers ───────────────────────────────────────────────────────────
+
+
+class _FakePool:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def fetch(self, sql, *args):
+        return self._rows
+
+
+def _row(req_id: str, state: str, updated_at: datetime | None = None) -> dict:
+    return {
+        "req_id": req_id,
+        "state": state,
+        "updated_at": updated_at or datetime.now(UTC),
+        "context": {},
+    }
+
+
+def _ns_item(name: str) -> MagicMock:
+    item = MagicMock()
+    item.metadata.name = name
+    return item
+
+
+def _ns_list(*names: str) -> MagicMock:
+    obj = MagicMock()
+    obj.items = [_ns_item(n) for n in names]
+    return obj
+
+
+# ─── fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def mock_core_v1():
+    """Return a fake CoreV1Api instance with list_namespace / delete_namespace."""
+    fake = MagicMock()
+    fake.list_namespace = MagicMock(return_value=_ns_list())
+    fake.delete_namespace = MagicMock(return_value=MagicMock())
+    return fake
+
+
+@pytest.fixture()
+def mock_controller(mock_core_v1):
+    """Inject a fake k8s_runner controller whose .core_v1 is our fake CoreV1Api."""
+    fake_ctrl = MagicMock()
+    fake_ctrl.core_v1 = mock_core_v1
+    k8s_runner.set_controller(fake_ctrl)
+    yield fake_ctrl
+    k8s_runner.set_controller(None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_rbac_flag():
+    """Reset _NS_RBAC_DISABLED between tests."""
+    accept_env_gc._NS_RBAC_DISABLED = False
+    yield
+    accept_env_gc._NS_RBAC_DISABLED = False
+
+
+# ─── AEGC-S1: done REQ → namespace deleted, in cleaned list ────────────
+
+
+@pytest.mark.asyncio
+async def test_aegc_s1_done_req_namespace_deleted(monkeypatch, mock_controller, mock_core_v1):
+    """AEGC-S1: done REQ → delete_namespace("accept-req-foo-123") called."""
+    pool = _FakePool([_row("REQ-foo-123", "done")])
+    monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
+    mock_core_v1.list_namespace.return_value = _ns_list("accept-req-foo-123")
+
+    result = await accept_env_gc.gc_once()
+
+    mock_core_v1.delete_namespace.assert_called_once_with("accept-req-foo-123")
+    assert "accept-req-foo-123" in result.get("cleaned", [])
+
+
+# ─── AEGC-S2: in-flight REQ → no deletion ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aegc_s2_inflight_req_not_deleted(monkeypatch, mock_controller, mock_core_v1):
+    """AEGC-S2: in-flight (accept-running) REQ → delete_namespace NOT called."""
+    pool = _FakePool([_row("REQ-foo-123", "accept-running")])
+    monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
+    mock_core_v1.list_namespace.return_value = _ns_list("accept-req-foo-123")
+
+    result = await accept_env_gc.gc_once()
+
+    mock_core_v1.delete_namespace.assert_not_called()
+    assert result.get("cleaned", []) == []
+
+
+# ─── AEGC-S3: escalated within retention → no deletion ────────────────
+
+
+@pytest.mark.asyncio
+async def test_aegc_s3_escalated_within_retention_not_deleted(
+    monkeypatch, mock_controller, mock_core_v1
+):
+    """AEGC-S3: escalated + 2h ago + default 1d retention → NOT deleted."""
+    recent = datetime.now(UTC) - timedelta(hours=2)
+    pool = _FakePool([_row("REQ-foo-123", "escalated", updated_at=recent)])
+    monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
+    mock_core_v1.list_namespace.return_value = _ns_list("accept-req-foo-123")
+
+    result = await accept_env_gc.gc_once()
+
+    mock_core_v1.delete_namespace.assert_not_called()
+    assert "accept-req-foo-123" not in result.get("cleaned", [])
+
+
+# ─── AEGC-S4: escalated past retention → deleted ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aegc_s4_escalated_past_retention_deleted(
+    monkeypatch, mock_controller, mock_core_v1
+):
+    """AEGC-S4: escalated + 30d ago → delete_namespace called."""
+    old = datetime.now(UTC) - timedelta(days=30)
+    pool = _FakePool([_row("REQ-foo-123", "escalated", updated_at=old)])
+    monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
+    mock_core_v1.list_namespace.return_value = _ns_list("accept-req-foo-123")
+
+    result = await accept_env_gc.gc_once()
+
+    mock_core_v1.delete_namespace.assert_called_once_with("accept-req-foo-123")
+    assert "accept-req-foo-123" in result.get("cleaned", [])
+
+
+# ─── AEGC-S5: no runner controller → skipped ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aegc_s5_no_controller_skipped():
+    """AEGC-S5: no runner controller → {"skipped": "no runner controller"}, no K8s calls."""
+    k8s_runner.set_controller(None)
+    result = await accept_env_gc.gc_once()
+
+    assert "skipped" in result
+    assert "no runner controller" in result["skipped"]
+
+
+# ─── AEGC-S6: list_namespace 403 → disable flag + INFO log ────────────
+
+
+@pytest.mark.asyncio
+async def test_aegc_s6_list_namespace_403_disables_flag(
+    monkeypatch, mock_controller, mock_core_v1, capsys
+):
+    """AEGC-S6: list_namespace ApiException(403) → _NS_RBAC_DISABLED=True, one INFO log."""
+    mock_core_v1.list_namespace.side_effect = ApiException(status=403, reason="Forbidden")
+    pool = _FakePool([])
+    monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
+
+    assert accept_env_gc._NS_RBAC_DISABLED is False
+    result = await accept_env_gc.gc_once()
+
+    assert accept_env_gc._NS_RBAC_DISABLED is True, "_NS_RBAC_DISABLED must be set True on 403"
+    assert "skipped" in result, "result must contain 'skipped' key after 403"
+
+    out = capsys.readouterr().out
+    assert "accept_env_gc.rbac_denied" in out, (
+        "INFO log 'accept_env_gc.rbac_denied' must be emitted once on first 403"
+    )
+
+
+# ─── AEGC-S7: _NS_RBAC_DISABLED=True → list_namespace not called ──────
+
+
+@pytest.mark.asyncio
+async def test_aegc_s7_rbac_disabled_skips_list_namespace(
+    monkeypatch, mock_controller, mock_core_v1
+):
+    """AEGC-S7: _NS_RBAC_DISABLED=True → list_namespace never called."""
+    accept_env_gc._NS_RBAC_DISABLED = True
+    pool = _FakePool([])
+    monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
+
+    result = await accept_env_gc.gc_once()
+
+    mock_core_v1.list_namespace.assert_not_called()
+    assert "skipped" in result
+    assert "namespace rbac disabled" in result["skipped"]


### PR DESCRIPTION
## Summary

- Adds `accept_env_gc` background GC task that cleans up orphaned Kubernetes namespaces (`accept-req-*`) created by `make accept-env-up` during the accept stage
- `teardown_accept_env` is best-effort only; failures leave namespaces permanently if not GC'd
- GC deletes namespaces via `CoreV1Api.delete_namespace` (cascade), no helm RBAC required
- RBAC 403 on `list_namespace` disables GC gracefully for the process lifetime with a single INFO log (mirrors `runner_gc._DISK_CHECK_DISABLED` pattern)
- Retention policy reuses `pvc_retain_on_escalate_days`: `done` → immediate GC, `escalated` → wait retention

## Changes

- `orchestrator/src/orchestrator/accept_env_gc.py` — new GC module (`gc_once` + `run_loop`)
- `orchestrator/src/orchestrator/config.py` — adds `accept_env_gc_interval_sec` (default 900s)
- `orchestrator/src/orchestrator/main.py` — wires `accept_env_gc.run_loop()` into startup
- `orchestrator/tests/test_accept_env_gc.py` — 10 unit tests (no K8s required)
- `openspec/changes/REQ-accept-env-gc-minimal-1777138424/` — proposal, tasks, spec, contract

## Test plan

- [x] All 10 new unit tests pass (`test_accept_env_gc.py`)
- [x] All 663 existing tests pass (excluding pre-existing `ruff`-not-found failure in `test_contract_makefile_ci_targets.py`)
- [ ] Integration: verify namespace `accept-req-*` is deleted after REQ reaches `done` state (manual, K8s cluster required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)