### PR TITLE
feat(orchestrator): accept_env_gc.py file skeleton (REQ-accept-env-gc-skeleton-v2-1777158943)

### DIFF
--- a/openspec/changes/REQ-accept-env-gc-skeleton-v2-1777158943/proposal.md
+++ b/openspec/changes/REQ-accept-env-gc-skeleton-v2-1777158943/proposal.md
@@ -1,0 +1,82 @@
+# REQ-accept-env-gc-skeleton-v2-1777158943: feat(orchestrator): accept_env_gc.py file skeleton only (opus retry)
+
+## 问题
+
+`teardown_accept_env` 在 accept 阶段以 best-effort 方式跑 `make accept-env-down`，
+失败只 WARNING、不阻塞状态机。后果是 K8s cluster 上常年留着 `accept-req-*` 孤儿
+namespace（含 helm release / PVC / pods），靠 ops 手清。
+
+后续会引入一个 background GC 任务（类似 `runner_gc.run_loop`）周期扫
+`accept-req-*` namespace 并 cascade 删终态 REQ 的那批。前置 REQ
+`REQ-accept-env-gc-minimal-1777138424` 试图一把交付（skeleton + 配置 + main.py
+wiring + 单测 + 实际逻辑）但因 sonnet 上下文偏长导致 escalate，并未合入 main。
+本 REQ（opus retry）刻意把范围切到**最小可独立交付的一刀**：只落 `accept_env_gc.py`
+的文件骨架，公开 API 表面 lock 住，不接任何调度、配置、行为。
+
+## 方案
+
+仅新增一个文件 `orchestrator/src/orchestrator/accept_env_gc.py`，模块内只声明
+两个 `async` 函数 stub（`gc_once` / `run_loop`），均直接抛
+`NotImplementedError("accept_env_gc skeleton only ...")`。模块顶部用 docstring
+说明这是占位骨架、未来 REQ 才会接 K8s API + DB + 调度。
+
+附一个最小单测 `orchestrator/tests/test_accept_env_gc_skeleton.py`：
+
+- 断言 `accept_env_gc.gc_once` / `accept_env_gc.run_loop` 是 `coroutine function`（用
+  `asyncio.iscoroutinefunction`）—— lock 住 async API 表面
+- 断言 `await accept_env_gc.gc_once()` 抛 `NotImplementedError`
+- 断言 `await accept_env_gc.run_loop()` 抛 `NotImplementedError`
+
+测试 lock 的是"骨架契约"，不是行为契约 —— 实现 REQ 把 `NotImplementedError`
+抽掉时，本测试用例同步删除（一次性占位测试，不进 archive 后的 specs 库）。
+
+### 故意不做
+
+- **不**改 `orchestrator/src/orchestrator/config.py` —— 没有 GC interval / retention
+  这种字段，因为根本没运行的代码用得着；要等真正接入逻辑的下一个 REQ 再加
+- **不**改 `orchestrator/src/orchestrator/main.py` —— `run_loop` 不进 startup
+  `_bg_tasks`，避免 orchestrator 启动时直接抛 `NotImplementedError` 把进程拖崩
+- **不**写实际 K8s API 调用、DB 查询、`_NS_RBAC_DISABLED` 这种 process 级 flag
+- **不**写跨场景行为单测（done / escalated retention / RBAC 403）—— 那些是
+  实现 REQ 的活，骨架 REQ 只测 API 表面
+- **不**写 contract test (`tests/integration/`) —— M18 challenger-agent 的活，
+  且骨架阶段无可观测行为可锁
+- **不**新建 capability 之外的耦合（不 import `db` / `k8s_runner` / `config`），
+  保证 import `orchestrator.accept_env_gc` 在测试里零副作用
+
+## 取舍
+
+- **为什么"骨架 only"值得单独占一个 REQ** —— 上一个全量 REQ
+  (`REQ-accept-env-gc-minimal-1777138424`) sonnet 跑爆 token / 反复 escalate，
+  说明"全量 8 段一把"在 sisyphus 当前 prompt + 上下文窗口下边界外。把这块
+  剥成"先落骨架文件、再落 wiring + 配置、再落实际逻辑"三段，每段独立可 review、
+  独立 ci-pass，可以验证 sisyphus 自身的"切片粒度"假设
+- **为什么 stub 抛 `NotImplementedError` 而不是空 pass** —— 万一未来不小心把
+  `run_loop` 接进 startup 里，立刻在 task 里 raise 比悄悄无限循环 sleep
+  显眼得多；属于"fail-loud 防呆"
+- **为什么测 `iscoroutinefunction` 而不是直接调** —— `async def` 的同步调用返
+  coroutine 而不是抛 NotImplementedError；测试得 `await` 才能拿到真异常。
+  同时 lock 住 API 必须是 async（实现 REQ 不能改成 sync）
+- **为什么不进 capability `accept-env-gc`** —— 本 REQ 不写任何业务行为契约，
+  只 lock 一个文件的 import + 两个函数的 async 签名。把这种"占位"
+  写进未来归档的 capability 会把 spec 库污染（archive 后留下"the system SHALL
+  raise NotImplementedError"），所以 specs 直接放 `accept-env-gc-skeleton`
+  capability，**不进** archive：done_archive 阶段拿 `openspec apply`
+  归档时人工 / 后续 REQ 会把它从 changes 删掉而不留 specs/
+
+## 影响面
+
+- 新增 `orchestrator/src/orchestrator/accept_env_gc.py`（约 30 行，含 docstring）
+- 新增 `orchestrator/tests/test_accept_env_gc_skeleton.py`（约 35 行）
+- 新增 `openspec/changes/REQ-accept-env-gc-skeleton-v2-1777158943/`（proposal /
+  tasks / specs/accept-env-gc-skeleton/{spec.md, contract.spec.yaml}）
+
+不动 / 不影响：
+
+- `orchestrator/src/orchestrator/config.py` —— 没新增 settings 字段
+- `orchestrator/src/orchestrator/main.py` —— 没接进 startup `_bg_tasks`
+- `orchestrator/src/orchestrator/state.py` / `actions/` / `checkers/` —— 状态机
+  / 推进动作 / checker 完全不知道这个模块存在
+- 其他 capability 的 specs —— 本 REQ 是新 capability `accept-env-gc-skeleton`，
+  不 MODIFY / REMOVE 任何已有 spec
+- 任何运行行为（pod / db / log 流量）—— 0 import side effect、0 startup wiring

--- a/openspec/changes/REQ-accept-env-gc-skeleton-v2-1777158943/specs/accept-env-gc-skeleton/contract.spec.yaml
+++ b/openspec/changes/REQ-accept-env-gc-skeleton-v2-1777158943/specs/accept-env-gc-skeleton/contract.spec.yaml
@@ -1,0 +1,65 @@
+capability: accept-env-gc-skeleton
+version: "0.1"
+description: |
+  Pure file-skeleton placeholder for the future accept_env_gc subsystem.
+
+  Locks the public coroutine API surface (module path + two async function
+  names) so the follow-up implementation REQ can land K8s + DB logic without
+  changing callers. No business behaviour is described here; both stubs raise
+  NotImplementedError when awaited and ship zero side-effecting imports so the
+  module is safe to import in unit tests without production env vars.
+
+  This capability is *throwaway*: the follow-up implementation REQ will retire
+  it entirely (delete the skeleton test, replace stubs with real bodies, and
+  introduce a separate long-lived `accept-env-gc` capability that documents
+  the actual GC behaviour). Do NOT extend this spec with additional behavioural
+  requirements; route those through the implementation REQ instead.
+
+module:
+  path: orchestrator/src/orchestrator/accept_env_gc.py
+  python_module: orchestrator.accept_env_gc
+
+api_surface:
+  gc_once:
+    kind: coroutine_function
+    signature: "async def gc_once() -> typing.NoReturn"
+    body: 'raise NotImplementedError("accept_env_gc skeleton ...")'
+    semantics: |
+      Skeleton stub. Future implementation will perform a single GC pass over
+      `accept-req-*` namespaces and return a result dict. Skeleton MUST raise
+      NotImplementedError so accidental wiring fails loud.
+
+  run_loop:
+    kind: coroutine_function
+    signature: "async def run_loop() -> typing.NoReturn"
+    body: 'raise NotImplementedError("accept_env_gc skeleton ...")'
+    semantics: |
+      Skeleton stub. Future implementation will be the long-running periodic
+      GC loop registered into `main.startup`'s `_bg_tasks`. Skeleton MUST
+      raise NotImplementedError so accidental wiring fails loud (rather than
+      hanging in an infinite no-op sleep loop).
+
+import_constraints:
+  forbidden_at_skeleton_stage:
+    - orchestrator.config
+    - orchestrator.k8s_runner
+    - orchestrator.store
+    - kubernetes
+    - asyncpg
+    - httpx
+  rationale: |
+    Importing the module at this skeleton stage MUST have zero runtime side
+    effects (no DB pool init, no K8s client creation, no env-var-dependent
+    Settings load). This keeps the unit test trivially safe to run in any
+    environment, including ones that have no SISYPHUS_* env vars set.
+
+throwaway_marker:
+  retire_in: implementation_req
+  retire_actions:
+    - delete orchestrator/tests/test_accept_env_gc_skeleton.py
+    - replace NotImplementedError stubs with real bodies
+    - introduce separate `accept-env-gc` capability for behavioural contracts
+  rationale: |
+    The long-lived spec library (openspec/specs/) MUST NOT contain a
+    requirement of the form "the system SHALL raise NotImplementedError";
+    that is purely a build-up-the-pipeline artifact, not a durable contract.

--- a/openspec/changes/REQ-accept-env-gc-skeleton-v2-1777158943/specs/accept-env-gc-skeleton/spec.md
+++ b/openspec/changes/REQ-accept-env-gc-skeleton-v2-1777158943/specs/accept-env-gc-skeleton/spec.md
@@ -1,0 +1,58 @@
+# accept-env-gc-skeleton delta
+
+## ADDED Requirements
+
+### Requirement: orchestrator MUST ship an accept_env_gc skeleton module exposing async gc_once and run_loop stubs
+
+The orchestrator package SHALL ship a module
+`orchestrator.accept_env_gc` (file `orchestrator/src/orchestrator/accept_env_gc.py`)
+that exposes two top-level coroutine functions: `gc_once()` and `run_loop()`.
+Both functions MUST be defined with `async def` so that
+`asyncio.iscoroutinefunction(accept_env_gc.gc_once)` and
+`asyncio.iscoroutinefunction(accept_env_gc.run_loop)` both return `True`.
+This pins the public coroutine API surface of the future GC subsystem so the
+follow-up implementation REQ can land business logic without changing the
+contract that callers (e.g. `main.py` startup wiring) will rely on. The module
+SHALL NOT introduce any imports of `orchestrator.config`,
+`orchestrator.k8s_runner`, `orchestrator.store`, or any kubernetes / asyncpg /
+httpx client at this skeleton stage, so that `import orchestrator.accept_env_gc`
+has zero runtime side effects (no DB pool init, no K8s client creation) and is
+safe to import inside unit tests that do not set the production env vars.
+
+#### Scenario: AEGS-S1 module exposes gc_once and run_loop as async coroutine functions
+
+- **GIVEN** a Python interpreter with the `orchestrator` package importable
+- **WHEN** the test imports `orchestrator.accept_env_gc as accept_env_gc`
+- **THEN** the import MUST succeed without raising
+- **AND** `asyncio.iscoroutinefunction(accept_env_gc.gc_once)` MUST be `True`
+- **AND** `asyncio.iscoroutinefunction(accept_env_gc.run_loop)` MUST be `True`
+
+### Requirement: gc_once and run_loop MUST raise NotImplementedError until a follow-up REQ lands the implementation
+
+The skeleton coroutines `gc_once()` and `run_loop()` SHALL each raise
+`NotImplementedError` when awaited, with a message that explicitly identifies
+the function as a skeleton placeholder (containing the literal substring
+`accept_env_gc skeleton`). This fail-loud stub SHALL prevent any caller (e.g.
+an accidental `main.py` startup task) from silently succeeding or hanging
+forever in a no-op infinite loop. The follow-up implementation REQ MUST
+replace both bodies with real K8s + DB logic and MUST also retire the
+skeleton-only contract test that asserts the `NotImplementedError` raise
+(this skeleton-stage test is intentionally throwaway and not part of the
+long-lived `accept-env-gc` capability that the implementation REQ will
+introduce).
+
+#### Scenario: AEGS-S2 awaiting gc_once raises NotImplementedError with the skeleton marker
+
+- **GIVEN** the freshly imported `orchestrator.accept_env_gc` module
+- **WHEN** the test awaits `accept_env_gc.gc_once()`
+- **THEN** a `NotImplementedError` MUST be raised
+- **AND** the exception message MUST contain the literal substring
+  `accept_env_gc skeleton`
+
+#### Scenario: AEGS-S3 awaiting run_loop raises NotImplementedError with the skeleton marker
+
+- **GIVEN** the freshly imported `orchestrator.accept_env_gc` module
+- **WHEN** the test awaits `accept_env_gc.run_loop()`
+- **THEN** a `NotImplementedError` MUST be raised
+- **AND** the exception message MUST contain the literal substring
+  `accept_env_gc skeleton`

--- a/openspec/changes/REQ-accept-env-gc-skeleton-v2-1777158943/tasks.md
+++ b/openspec/changes/REQ-accept-env-gc-skeleton-v2-1777158943/tasks.md
@@ -1,0 +1,30 @@
+# REQ-accept-env-gc-skeleton-v2-1777158943 — tasks
+
+## Stage: spec
+
+- [x] author proposal.md（动机：minimal REQ 没合 main，骨架切片重试；故意不做范围）
+- [x] author specs/accept-env-gc-skeleton/spec.md（2 条 Requirement，
+      ADDED delta，每条带 SHALL/MUST prose + Scenario）
+- [x] author specs/accept-env-gc-skeleton/contract.spec.yaml（API 表面契约：
+      模块路径、2 个函数签名 + async 标记）
+
+## Stage: implementation
+
+- [x] orchestrator/src/orchestrator/accept_env_gc.py：模块 docstring +
+      `async def gc_once()` + `async def run_loop()`，两者抛
+      `NotImplementedError("accept_env_gc skeleton only ...")`，零外部 import
+      （除 `__future__ annotations`）
+
+## Stage: test
+
+- [x] orchestrator/tests/test_accept_env_gc_skeleton.py：
+  - AEGS-S1 `accept_env_gc` 模块可被 import 且 `gc_once` / `run_loop`
+    都是 `asyncio.iscoroutinefunction`-True
+  - AEGS-S2 `await accept_env_gc.gc_once()` 抛 `NotImplementedError`
+  - AEGS-S3 `await accept_env_gc.run_loop()` 抛 `NotImplementedError`
+
+## Stage: PR
+
+- [x] git push feat/REQ-accept-env-gc-skeleton-v2-1777158943
+- [x] gh pr create
+- [x] move BKD issue to review

--- a/orchestrator/src/orchestrator/accept_env_gc.py
+++ b/orchestrator/src/orchestrator/accept_env_gc.py
@@ -1,0 +1,25 @@
+"""accept_env_gc — file-skeleton placeholder (REQ-accept-env-gc-skeleton-v2-1777158943).
+
+Future GC subsystem will scan `accept-req-*` Kubernetes namespaces left behind
+by best-effort `make accept-env-down` and cascade-delete the ones whose REQ has
+reached a terminal state. This module currently only locks the public coroutine
+API surface (`gc_once`, `run_loop`) so the follow-up implementation REQ can land
+real K8s + DB logic without changing callers.
+
+Both stubs raise `NotImplementedError` when awaited so any accidental wiring
+fails loud rather than silently no-oping (or, worse, hanging in an infinite
+sleep loop). The follow-up implementation REQ will replace both bodies and
+retire the throwaway skeleton-only contract test that pins this behaviour.
+"""
+
+from __future__ import annotations
+
+_SKELETON_MARKER = "accept_env_gc skeleton — implementation deferred to follow-up REQ"
+
+
+async def gc_once() -> None:
+    raise NotImplementedError(_SKELETON_MARKER)
+
+
+async def run_loop() -> None:
+    raise NotImplementedError(_SKELETON_MARKER)

--- a/orchestrator/tests/test_accept_env_gc_skeleton.py
+++ b/orchestrator/tests/test_accept_env_gc_skeleton.py
@@ -1,0 +1,44 @@
+"""Skeleton-stage contract tests for orchestrator.accept_env_gc.
+
+Pins the public coroutine API surface introduced by
+REQ-accept-env-gc-skeleton-v2-1777158943:
+
+- `gc_once` and `run_loop` are async coroutine functions
+- both stubs raise `NotImplementedError` when awaited, with a message
+  containing the literal substring `accept_env_gc skeleton`
+
+This file is intentionally throwaway: the follow-up implementation REQ that
+replaces the stub bodies with real K8s + DB logic MUST also delete this
+test (the new behaviour will be covered by a long-lived `accept-env-gc`
+capability spec).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from orchestrator import accept_env_gc
+
+_SKELETON_MARKER = "accept_env_gc skeleton"
+
+
+def test_gc_once_and_run_loop_are_async_coroutine_functions() -> None:
+    """AEGS-S1: lock module exposure + async signature."""
+    assert asyncio.iscoroutinefunction(accept_env_gc.gc_once)
+    assert asyncio.iscoroutinefunction(accept_env_gc.run_loop)
+
+
+async def test_gc_once_raises_not_implemented_with_skeleton_marker() -> None:
+    """AEGS-S2: stub fails loud with skeleton marker."""
+    with pytest.raises(NotImplementedError) as exc_info:
+        await accept_env_gc.gc_once()
+    assert _SKELETON_MARKER in str(exc_info.value)
+
+
+async def test_run_loop_raises_not_implemented_with_skeleton_marker() -> None:
+    """AEGS-S3: stub fails loud with skeleton marker."""
+    with pytest.raises(NotImplementedError) as exc_info:
+        await accept_env_gc.run_loop()
+    assert _SKELETON_MARKER in str(exc_info.value)

--- a/orchestrator/tests/test_contract_accept_env_gc_skeleton.py
+++ b/orchestrator/tests/test_contract_accept_env_gc_skeleton.py
@@ -1,0 +1,55 @@
+"""Challenger contract tests for REQ-accept-env-gc-skeleton-v2-1777158943.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-accept-env-gc-skeleton-v2-1777158943/specs/accept-env-gc-skeleton/spec.md
+
+Scenarios covered:
+  AEGS-S1  module imports cleanly; gc_once and run_loop are async coroutine functions
+  AEGS-S2  awaiting gc_once() raises NotImplementedError containing "accept_env_gc skeleton"
+  AEGS-S3  awaiting run_loop() raises NotImplementedError containing "accept_env_gc skeleton"
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+
+import pytest
+
+SKELETON_MARKER = "accept_env_gc skeleton"
+
+
+def test_aegs_s1_module_imports_cleanly_and_exposes_async_api() -> None:
+    """AEGS-S1: import succeeds; gc_once and run_loop are coroutine functions."""
+    mod = importlib.import_module("orchestrator.accept_env_gc")
+    assert hasattr(mod, "gc_once"), "module must expose gc_once"
+    assert hasattr(mod, "run_loop"), "module must expose run_loop"
+    assert asyncio.iscoroutinefunction(mod.gc_once), (
+        "gc_once must be a coroutine function (defined with async def)"
+    )
+    assert asyncio.iscoroutinefunction(mod.run_loop), (
+        "run_loop must be a coroutine function (defined with async def)"
+    )
+
+
+async def test_aegs_s2_gc_once_raises_not_implemented_with_skeleton_marker() -> None:
+    """AEGS-S2: await gc_once() raises NotImplementedError with skeleton marker."""
+    from orchestrator import accept_env_gc
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await accept_env_gc.gc_once()
+    assert SKELETON_MARKER in str(exc_info.value), (
+        f"NotImplementedError message must contain {SKELETON_MARKER!r}, "
+        f"got: {exc_info.value!r}"
+    )
+
+
+async def test_aegs_s3_run_loop_raises_not_implemented_with_skeleton_marker() -> None:
+    """AEGS-S3: await run_loop() raises NotImplementedError with skeleton marker."""
+    from orchestrator import accept_env_gc
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await accept_env_gc.run_loop()
+    assert SKELETON_MARKER in str(exc_info.value), (
+        f"NotImplementedError message must contain {SKELETON_MARKER!r}, "
+        f"got: {exc_info.value!r}"
+    )


### PR DESCRIPTION
## Summary

Slice the `accept_env_gc` subsystem into its smallest independently-deliverable unit: ship the file skeleton only.

- Adds `orchestrator/src/orchestrator/accept_env_gc.py` with two `async` coroutine stubs `gc_once()` / `run_loop()` that raise `NotImplementedError("accept_env_gc skeleton …")`.
- Adds unit test `orchestrator/tests/test_accept_env_gc_skeleton.py` (3 cases AEGS-S1/S2/S3) pinning the public coroutine API surface.
- Adds throwaway openspec change `REQ-accept-env-gc-skeleton-v2-1777158943` with capability `accept-env-gc-skeleton`.

The prior `REQ-accept-env-gc-minimal-1777138424` attempted full delivery (skeleton + config + main.py wiring + behavioural tests + real K8s/DB logic) in one go but escalated under sonnet-default and never merged. This REQ (opus retry) drops the scope to just the file skeleton so subsequent REQs can land config + wiring + actual logic incrementally.

### Intentionally NOT in this PR

- No `config.py` settings field (no GC interval / retention)
- No `main.py` startup wiring (`run_loop` not added to `_bg_tasks` — accidental wiring would now `raise NotImplementedError` instead of hanging)
- No `kubernetes` / `asyncpg` / `httpx` / `orchestrator.config` / `orchestrator.k8s_runner` / `orchestrator.store` imports — `import orchestrator.accept_env_gc` is zero-side-effect
- No behavioural unit tests (done / escalated retention / RBAC 403) — those land with the implementation REQ
- No `tests/integration/` contract tests (M18 challenger-agent territory; skeleton has no observable behaviour)

The follow-up implementation REQ MUST delete `tests/test_accept_env_gc_skeleton.py`, replace the stub bodies, and introduce a separate long-lived `accept-env-gc` capability for the real behavioural contracts. The throwaway marker is encoded in `specs/accept-env-gc-skeleton/contract.spec.yaml` so this is not lost.

## Test plan

- [x] `openspec validate REQ-accept-env-gc-skeleton-v2-1777158943 --strict` → green
- [x] `scripts/check-scenario-refs.sh --specs-search-path . .` → green (214 scenarios across repo, no missing refs)
- [x] `BASE_REV=origin/main make ci-lint` → scoped lint of 2 changed `*.py` files: green
- [x] `make ci-unit-test` (full suite, 677 tests) → green; new file contributes 3 passing cases (AEGS-S1/S2/S3)
- [x] `make ci-integration-test` — N/A (no integration tests added; sisyphus pipeline runs it as part of staging-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)