### PR TITLE
fix(state): route ANALYZING|INTAKING + verify.escalate to escalate (REQ-fix-clone-failed-illegal-transition-1777164809)

### DIFF
--- a/openspec/changes/REQ-fix-clone-failed-illegal-transition-1777164809/proposal.md
+++ b/openspec/changes/REQ-fix-clone-failed-illegal-transition-1777164809/proposal.md
@@ -1,0 +1,57 @@
+# REQ-fix-clone-failed-illegal-transition-1777164809: fix(state): add (ANALYZING|INTAKING, VERIFY_ESCALATE) → ESCALATED transitions
+
+## 问题
+
+`actions/start_analyze.py` 与 `actions/start_analyze_with_finalized_intent.py` 在 `clone_involved_repos_into_runner` 失败（auth / repo not found / network）或 `ctx.intake_finalized_intent` 缺失时，会 `return {"emit": "verify.escalate", ...}`，让 engine 链式推进到标准 escalate 路径。但 transition 表里**没有** `(ANALYZING, VERIFY_ESCALATE)` 这一行。
+
+链路实际是：
+
+1. webhook 收到 `intent:analyze` → engine.step 拿到 `(INIT, INTENT_ANALYZE)` transition → CAS 把 state 推到 `ANALYZING` → dispatch `start_analyze`
+2. `start_analyze` 跑 `_clone` helper → exit_code != 0 → return `{"emit": "verify.escalate"}`
+3. engine reload state（现在是 ANALYZING）→ chained step `(ANALYZING, VERIFY_ESCALATE)` → `decide()` 返 None → `engine.illegal_transition` log → return skip
+
+同样 `(INTAKING, INTAKE_PASS)` transition CAS 后 state 已是 ANALYZING，`start_analyze_with_finalized_intent` emit verify.escalate 也撞同一个空洞。
+
+**症状**：clone 失败 / finalized intent 缺失的 REQ 永远卡在 `analyzing`，runner pod / PVC 不被回收，要等 watchdog 60 min 兜 SESSION_FAILED 才能被推到 ESCALATED；intent issue 上的 escalated tag / reason 也写不上。
+
+## 根因
+
+action handler 主动 emit verify.escalate 当作"我决定 escalate"用，跟 verifier-agent 决策时 emit 的语义复用同一个事件，但 transition 表只覆盖 `(REVIEW_RUNNING, VERIFY_ESCALATE)` 跟 REQ-fixer-round-cap 引入的 `(FIXER_RUNNING, VERIFY_ESCALATE)`。pre-verifier 的 in-flight state（这里是 ANALYZING）从来没补 VERIFY_ESCALATE 出口。
+
+## 方案
+
+### 状态机：补 ANALYZING / INTAKING → ESCALATED transition
+
+在 `orchestrator/src/orchestrator/state.py` 的 TRANSITIONS 表新增两条：
+
+```python
+(ReqState.ANALYZING, Event.VERIFY_ESCALATE):
+    Transition(ReqState.ESCALATED, "escalate",
+               "start_analyze 内部失败（clone / 缺 finalized intent）→ escalate"),
+(ReqState.INTAKING, Event.VERIFY_ESCALATE):
+    Transition(ReqState.ESCALATED, "escalate",
+               "intake 阶段 action 主动 emit escalate（防御对称）"),
+```
+
+复用既有 `escalate` action 收口 reason / intent issue tag / runner cleanup，不开第二条 escalate 实现。
+
+INTAKING 这条目前没有 action 触达（`start_intake` 不 emit verify.escalate），但跟 ANALYZING 形状对称：未来若 `start_intake` 加 server-side clone 也是同样的失败模式。补上比让状态机静默卡死好。
+
+### 测试
+
+- `orchestrator/tests/test_state.py:EXPECTED` 加两行 (ANALYZING / INTAKING, VERIFY_ESCALATE) → ESCALATED + escalate
+- `orchestrator/tests/test_engine.py` 加端到端 chain 测试：
+  - `test_start_analyze_clone_failed_chains_to_escalate`：INIT → ANALYZING (start_analyze) → ESCALATED (escalate)
+  - `test_start_analyze_with_finalized_intent_clone_failed_chains_to_escalate`：INTAKING → ANALYZING (start_analyze_with_finalized_intent) → ESCALATED (escalate)
+
+## 取舍
+
+- **不改 action emit 形状**：start_analyze 系列保留 `emit verify.escalate` 不改成 `emit session.failed`。理由：verify.escalate 的语义是"决定不修，给人"，跟 clone/auth/repo 不存在的失败模式语义一致；session.failed 的语义是 agent session 崩 / watchdog 超时，跟 action 主动判失败不是一回事。混用反而模糊 escalate.py 里 hard reason / canonical signals 的解析。
+- **不补全部 in-flight state**：只加 ANALYZING / INTAKING 两条。其他 stage（spec_lint / dev_cross_check / staging_test / pr_ci / accept）的 action 现状不会主动 emit verify.escalate（fail 走 invoke_verifier_for_*_fail 转 REVIEW_RUNNING，由 verifier 决策）。先补真有 emit 路径的 state，避免噪声 transition。
+- **不 reset runner / PVC**：escalate action 内部已处理 cleanup（escalated 时 retain_pvc=True 给人 debug）。本 fix 只让状态机能走通这条路。
+
+## 兼容性
+
+- 既有逻辑：`(REVIEW_RUNNING, VERIFY_ESCALATE)` / `(FIXER_RUNNING, VERIFY_ESCALATE)` / `(ESCALATED, VERIFY_ESCALATE)` 不动。
+- ESCALATED 是 self-loop terminal：新加的 ANALYZING / INTAKING transition 把 state 推到 ESCALATED 后由 engine `_TERMINAL_STATES` cleanup 路径接管 —— 跟原 `(PR_CI_RUNNING, PR_CI_TIMEOUT) → ESCALATED + escalate` 完全相同形状。
+- 老 REQ 无 migration：当前卡在 ANALYZING 的 REQ 等 watchdog 兜 SESSION_FAILED 推 ESCALATED；新 REQ 直接走新 transition。

--- a/openspec/changes/REQ-fix-clone-failed-illegal-transition-1777164809/specs/clone-failed-escalate-route/contract.spec.yaml
+++ b/openspec/changes/REQ-fix-clone-failed-illegal-transition-1777164809/specs/clone-failed-escalate-route/contract.spec.yaml
@@ -1,0 +1,64 @@
+capability: clone-failed-escalate-route
+version: "1.0"
+description: |
+  State-machine routes for action-emitted verify.escalate from pre-verifier
+  in-flight states. Specifically: when start_analyze /
+  start_analyze_with_finalized_intent fails its server-side clone (or the
+  finalized intent is missing) and emits {"emit": "verify.escalate"}, the
+  engine MUST chain to the standard escalate action instead of logging
+  illegal_transition and stranding the REQ in ANALYZING.
+
+state_machine_changes:
+  added_transitions:
+    - from: ANALYZING
+      event: VERIFY_ESCALATE
+      to: ESCALATED
+      action: escalate
+      reason: "start_analyze 内部失败（clone / 缺 finalized intent）→ escalate"
+    - from: INTAKING
+      event: VERIFY_ESCALATE
+      to: ESCALATED
+      action: escalate
+      reason: "intake 阶段 action 主动 emit escalate（防御对称）"
+
+actions_emit_paths:
+  start_analyze:
+    module: orchestrator.actions.start_analyze
+    emits_verify_escalate_when:
+      - "_clone.clone_involved_repos_into_runner returns clone_rc != None (helper exit_code != 0)"
+    return_shape:
+      emit: "verify.escalate"
+      reason: "clone failed (rc={exit_code}) for repos={repos}"
+    cas_state_at_emit: "ANALYZING"
+    transition_required: "(ANALYZING, VERIFY_ESCALATE) → ESCALATED + escalate"
+
+  start_analyze_with_finalized_intent:
+    module: orchestrator.actions.start_analyze_with_finalized_intent
+    emits_verify_escalate_when:
+      - "ctx.intake_finalized_intent is missing / falsy"
+      - "_clone.clone_involved_repos_into_runner returns clone_rc != None"
+    return_shape:
+      emit: "verify.escalate"
+      reason: |
+        "intake_finalized_intent missing in ctx" or
+        "clone failed (rc={exit_code}) for repos={repos}"
+    cas_state_at_emit: "ANALYZING"
+    transition_required: "(ANALYZING, VERIFY_ESCALATE) → ESCALATED + escalate"
+
+  escalate:
+    module: orchestrator.actions.escalate
+    invariant: |
+      reused as-is. No changes to escalate action itself: reason resolution,
+      hard reasons set, auto-resume gating, intent issue tagging, runner
+      cleanup all unchanged. The two new transitions simply route
+      action-emitted verify.escalate from ANALYZING / INTAKING into the
+      same escalate handler that already covers (REVIEW_RUNNING,
+      VERIFY_ESCALATE) and (FIXER_RUNNING, VERIFY_ESCALATE).
+
+unchanged_transitions:
+  - "(REVIEW_RUNNING, VERIFY_ESCALATE) → ESCALATED + escalate"
+  - "(FIXER_RUNNING, VERIFY_ESCALATE) → ESCALATED + escalate"
+  - "(ESCALATED, VERIFY_ESCALATE) → ESCALATED (self-loop, no action)"
+  - "(INTAKING, INTAKE_PASS) → ANALYZING + start_analyze_with_finalized_intent"
+  - "(INTAKING, INTAKE_FAIL) → ESCALATED + escalate"
+  - "All session.failed self-loops via escalate action"

--- a/openspec/changes/REQ-fix-clone-failed-illegal-transition-1777164809/specs/clone-failed-escalate-route/spec.md
+++ b/openspec/changes/REQ-fix-clone-failed-illegal-transition-1777164809/specs/clone-failed-escalate-route/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: 状态机必须支持 ANALYZING 在 VERIFY_ESCALATE 事件下推进到 ESCALATED
+
+The state machine MUST define a transition `(ANALYZING, VERIFY_ESCALATE) → (ESCALATED, action="escalate")`. This transition allows the `start_analyze` and `start_analyze_with_finalized_intent` action handlers to chained-emit `verify.escalate` when the server-side `_clone` helper fails (non-zero exit code) or when `ctx.intake_finalized_intent` is missing, reusing the standard `escalate` action for reason persistence, intent-issue tagging, and runner cleanup. Without this transition, the engine MUST log `engine.illegal_transition` and the REQ row stays in `analyzing` until the watchdog escalates via `SESSION_FAILED`.
+
+#### Scenario: CFE-S1 ANALYZING + VERIFY_ESCALATE 推到 ESCALATED
+
+- **GIVEN** state machine 当前 state=ANALYZING
+- **WHEN** Event.VERIFY_ESCALATE 被 dispatch
+- **THEN** decide() 返回非 None Transition：next_state=ESCALATED，action="escalate"
+
+#### Scenario: CFE-S2 start_analyze emit verify.escalate 完整链路推到 ESCALATED
+
+- **GIVEN** REQ 当前 state=INIT，body.event="intent.analyze"，stub `start_analyze` 返回 `{"emit": "verify.escalate", "reason": "clone failed (rc=5)"}`，stub `escalate` 返回 `{"ok": True}`
+- **WHEN** engine.step 处理 Event.INTENT_ANALYZE
+- **THEN** action 调用顺序为 start_analyze, escalate；req_state.state=ESCALATED；step 返回 dict 中 `chained.action == "escalate"`，**不**出现 `engine.illegal_transition` log
+
+#### Scenario: CFE-S3 start_analyze_with_finalized_intent emit verify.escalate 推到 ESCALATED
+
+- **GIVEN** REQ 当前 state=INTAKING，body.event="session.completed"，stub `start_analyze_with_finalized_intent` 返回 `{"emit": "verify.escalate", "reason": "intake_finalized_intent missing in ctx"}`，stub `escalate` 返回 `{"ok": True}`
+- **WHEN** engine.step 处理 Event.INTAKE_PASS
+- **THEN** action 调用顺序为 start_analyze_with_finalized_intent, escalate；req_state.state=ESCALATED；chain 不报 illegal_transition
+
+### Requirement: 状态机必须支持 INTAKING 在 VERIFY_ESCALATE 事件下推进到 ESCALATED
+
+The state machine MUST define a transition `(INTAKING, VERIFY_ESCALATE) → (ESCALATED, action="escalate")`. This is a defensive symmetry counterpart to the `ANALYZING` transition: although the current `start_intake` action does not emit `verify.escalate`, future evolution where intake-stage actions perform server-side clones or other failable bootstrap work MUST be able to emit `verify.escalate` and rely on the engine to drive the standard escalate path rather than silently logging `engine.illegal_transition`. The transition MUST coexist with `(INTAKING, INTAKE_PASS)` and `(INTAKING, INTAKE_FAIL)` without behavior change.
+
+#### Scenario: CFE-S4 INTAKING + VERIFY_ESCALATE 推到 ESCALATED
+
+- **GIVEN** state machine 当前 state=INTAKING
+- **WHEN** Event.VERIFY_ESCALATE 被 dispatch
+- **THEN** decide() 返回非 None Transition：next_state=ESCALATED，action="escalate"
+
+#### Scenario: CFE-S5 INTAKING 既有 transition 不被影响
+
+- **GIVEN** state machine 当前 state=INTAKING
+- **WHEN** Event.INTAKE_PASS / Event.INTAKE_FAIL 被 dispatch
+- **THEN** decide() 仍返回原 Transition（ANALYZING + start_analyze_with_finalized_intent / ESCALATED + escalate），不被新加的 VERIFY_ESCALATE transition 干扰

--- a/openspec/changes/REQ-fix-clone-failed-illegal-transition-1777164809/tasks.md
+++ b/openspec/changes/REQ-fix-clone-failed-illegal-transition-1777164809/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: REQ-fix-clone-failed-illegal-transition-1777164809
+
+## Stage: state machine
+
+- [x] `orchestrator/src/orchestrator/state.py`：TRANSITIONS 表新增 `(ANALYZING, VERIFY_ESCALATE) → Transition(ESCALATED, "escalate", ...)` 与 `(INTAKING, VERIFY_ESCALATE) → Transition(ESCALATED, "escalate", ...)` 两条，让 `start_analyze` / `start_analyze_with_finalized_intent` 在 clone 失败 / finalized intent 缺失时 emit `verify.escalate` 能链式推进到 escalate action
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_state.py`：EXPECTED 表加两行 `(ANALYZING / INTAKING, VERIFY_ESCALATE) → ESCALATED + escalate`
+- [x] `orchestrator/tests/test_engine.py`：
+  - `test_start_analyze_clone_failed_chains_to_escalate` —— 验 INIT → ANALYZING (start_analyze emit verify.escalate) → ESCALATED (escalate) 全链路通；最终 state=ESCALATED；chained.action=="escalate"
+  - `test_start_analyze_with_finalized_intent_clone_failed_chains_to_escalate` —— INTAKING → ANALYZING → ESCALATED 链路通
+
+## Stage: spec
+
+- [x] `openspec/changes/REQ-fix-clone-failed-illegal-transition-1777164809/proposal.md`
+- [x] `openspec/changes/REQ-fix-clone-failed-illegal-transition-1777164809/tasks.md`
+- [x] `openspec/changes/REQ-fix-clone-failed-illegal-transition-1777164809/specs/clone-failed-escalate-route/contract.spec.yaml`
+- [x] `openspec/changes/REQ-fix-clone-failed-illegal-transition-1777164809/specs/clone-failed-escalate-route/spec.md`
+
+## Stage: PR
+
+- [x] git push feat/REQ-fix-clone-failed-illegal-transition-1777164809
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/state.py
+++ b/orchestrator/src/orchestrator/state.py
@@ -191,6 +191,25 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
         Transition(ReqState.ESCALATED, "escalate",
                    "fixer round 触顶 / start_fixer 自判 escalate"),
 
+    # start_analyze / start_analyze_with_finalized_intent 在 dispatch agent 之前
+    # 跑 server-side clone helper；clone 失败（auth / repo not found / network）
+    # 直接 emit VERIFY_ESCALATE 不打 agent 进空 PVC。这两条 action 由
+    # (INIT, INTENT_ANALYZE) / (INTAKING, INTAKE_PASS) transition 触发，
+    # CAS 后 state 已是 ANALYZING；start_analyze_with_finalized_intent 也会
+    # 在 ctx.intake_finalized_intent 缺失时 emit VERIFY_ESCALATE。没有下面
+    # 这条 transition decide() 会返 None，engine 记 illegal_transition 后
+    # REQ 永远卡在 ANALYZING（直到 watchdog 兜 SESSION_FAILED）。复用
+    # escalate action 收口 reason / tag / runner cleanup。
+    (ReqState.ANALYZING, Event.VERIFY_ESCALATE):
+        Transition(ReqState.ESCALATED, "escalate",
+                   "start_analyze 内部失败（clone / 缺 finalized intent）→ escalate"),
+    # 防御性配对：当前没有 action 在 INTAKING 状态 emit VERIFY_ESCALATE，
+    # 但 start_intake 未来若加 server-side clone 也会复用同一形状 —— 留口
+    # 比让状态机静默卡死好。
+    (ReqState.INTAKING, Event.VERIFY_ESCALATE):
+        Transition(ReqState.ESCALATED, "escalate",
+                   "intake 阶段 action 主动 emit escalate（防御对称）"),
+
     # ─── 终态 ───────────────────────────────────────────────────────────
     (ReqState.ARCHIVING, Event.ARCHIVE_DONE):
         Transition(ReqState.DONE, None, "REQ complete"),

--- a/orchestrator/tests/test_engine.py
+++ b/orchestrator/tests/test_engine.py
@@ -513,6 +513,73 @@ async def test_verify_fix_needed_still_closes_verifier_via_normal_path(stub_acti
 
 
 @pytest.mark.asyncio
+async def test_start_analyze_clone_failed_chains_to_escalate(stub_actions):
+    """REQ-fix-clone-failed-illegal-transition-1777164809：start_analyze 在 clone
+    失败时 emit verify.escalate；CAS 已把 state 推到 ANALYZING，必须有
+    (ANALYZING, VERIFY_ESCALATE) → (ESCALATED, escalate) transition 兜住，否则
+    engine 记 illegal_transition 后 REQ 永远卡在 ANALYZING。
+    """
+    calls, reg = stub_actions
+
+    async def start_analyze(*, body, req_id, tags, ctx):
+        calls.append(("start_analyze", {"req_id": req_id}))
+        return {"emit": Event.VERIFY_ESCALATE.value, "reason": "clone failed (rc=5)"}
+
+    async def escalate(*, body, req_id, tags, ctx):
+        calls.append(("escalate", {"req_id": req_id, "ctx": dict(ctx)}))
+        return {"ok": True}
+
+    reg["start_analyze"] = start_analyze
+    reg["escalate"] = escalate
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.INIT.value)})
+    body = type("B", (), {"issueId": "x", "projectId": "p", "event": "intent.analyze"})()
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=["intent:analyze"],
+        cur_state=ReqState.INIT, ctx={}, event=Event.INTENT_ANALYZE,
+    )
+
+    # 链路：INIT → ANALYZING (start_analyze) → ESCALATED (escalate)
+    assert [n for n, _ in calls] == ["start_analyze", "escalate"]
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+
+    # chained 结果不该是 illegal_transition skip
+    chained = result.get("chained")
+    assert chained is not None
+    assert chained.get("action") == "escalate", f"chain should reach escalate, got {chained!r}"
+
+
+@pytest.mark.asyncio
+async def test_start_analyze_with_finalized_intent_clone_failed_chains_to_escalate(stub_actions):
+    """同样的 chain：INTAKING → ANALYZING (start_analyze_with_finalized_intent) →
+    emit verify.escalate → ESCALATED。验 INTAKE_PASS 路径下 ANALYZING 的兜底也成立。
+    """
+    calls, reg = stub_actions
+
+    async def start_analyze_with_finalized_intent(*, body, req_id, tags, ctx):
+        calls.append(("start_analyze_with_finalized_intent", {"req_id": req_id}))
+        return {"emit": Event.VERIFY_ESCALATE.value,
+                "reason": "intake_finalized_intent missing in ctx"}
+
+    async def escalate(*, body, req_id, tags, ctx):
+        calls.append(("escalate", {"req_id": req_id}))
+        return {"ok": True}
+
+    reg["start_analyze_with_finalized_intent"] = start_analyze_with_finalized_intent
+    reg["escalate"] = escalate
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.INTAKING.value)})
+    body = type("B", (), {"issueId": "x", "projectId": "p", "event": "session.completed"})()
+    await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=["intake", "result:pass"],
+        cur_state=ReqState.INTAKING, ctx={}, event=Event.INTAKE_PASS,
+    )
+
+    assert [n for n, _ in calls] == ["start_analyze_with_finalized_intent", "escalate"]
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+
+
+@pytest.mark.asyncio
 async def test_review_running_self_loop_other_event_does_not_close_verifier(stub_actions):
     """fix 必须只在 event == VERIFY_PASS 触发；其他 REVIEW_RUNNING self-loop 事件
     （如 SESSION_FAILED 经状态机 self-loop 给 escalate action 自决）不动 verifier stage_run。

--- a/orchestrator/tests/test_state.py
+++ b/orchestrator/tests/test_state.py
@@ -40,6 +40,11 @@ EXPECTED = [
     (ReqState.FIXER_RUNNING,        Event.FIXER_DONE,          ReqState.REVIEW_RUNNING,      "invoke_verifier_after_fix"),
     # fixer round cap：start_fixer 自检超 cap → 链 emit verify.escalate 走 escalate
     (ReqState.FIXER_RUNNING,        Event.VERIFY_ESCALATE,     ReqState.ESCALATED,           "escalate"),
+    # REQ-fix-clone-failed-illegal-transition-1777164809：start_analyze /
+    # start_analyze_with_finalized_intent clone 失败 / 缺 finalized intent 时
+    # 链 emit verify.escalate；CAS 已推到 ANALYZING（INTAKING 留口防御对称）。
+    (ReqState.ANALYZING,            Event.VERIFY_ESCALATE,     ReqState.ESCALATED,           "escalate"),
+    (ReqState.INTAKING,             Event.VERIFY_ESCALATE,     ReqState.ESCALATED,           "escalate"),
 ]
 
 


### PR DESCRIPTION
## Summary

- Add `(ANALYZING, VERIFY_ESCALATE) → (ESCALATED, "escalate")` transition so `start_analyze` / `start_analyze_with_finalized_intent` can chain-emit `verify.escalate` when their server-side `_clone` helper fails or `ctx.intake_finalized_intent` is missing.
- Add the symmetric `(INTAKING, VERIFY_ESCALATE) → (ESCALATED, "escalate")` transition for the same shape if any future intake-stage action needs to bail out.
- Reuse the existing `escalate` action verbatim — no changes to its reason resolution / hard-reasons / runner cleanup logic.

## Why

`start_analyze` returns `{"emit": "verify.escalate", "reason": "clone failed (rc=...)"}` when the clone helper exits non-zero. By the time the action runs, CAS has already pushed state from `INIT` (or `INTAKING`) to `ANALYZING`. The engine then reloads state and runs `decide(ANALYZING, VERIFY_ESCALATE)` — which returned `None`. The engine logged `illegal_transition`, no escalate ran, and the REQ stayed stuck in `analyzing` until the 60-min watchdog stuck threshold finally emitted `SESSION_FAILED`. Intent-issue tagging and runner cleanup all sat dormant for that hour.

## Test plan

- [x] `tests/test_state.py` — parametrized EXPECTED grew two rows; `test_no_orphan_actions` confirms `escalate` is registered.
- [x] `tests/test_engine.py` — two new chain tests (`test_start_analyze_clone_failed_chains_to_escalate`, `test_start_analyze_with_finalized_intent_clone_failed_chains_to_escalate`) drive the full INIT/INTAKING → ANALYZING → ESCALATED path with stub actions and assert no `illegal_transition`.
- [x] `make ci-lint` clean; `tests/test_state.py + test_engine.py + test_actions_start_analyze.py + test_intake.py + test_verifier.py + test_contract_fixer_round_cap.py` all green (173 tests).
- [x] `openspec validate REQ-fix-clone-failed-illegal-transition-1777164809 --strict` passes; `check-scenario-refs.sh` resolves all 219 scenario refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)