### PR TITLE
docs: codify "runner = read-only checker" design contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@
 - **失败先验，再试错** —— stage fail 不直接 bugfix，verifier-agent 主观判 pass / fix / escalate（M14b/c，3 路）。
 - **指标驱动改进** —— 每条决策入 `stage_runs` / `verifier_decisions`，13 张 Metabase 看板（M7 + M14e）回答"哪条 prompt 该改"。
 - **生产用最强模型** —— 不做"失败升级模型"自适应；haiku 只用于测试加速。
+- **runner = 只读 checker** —— K8s runner pod 只 clone 源、跑测试、跑 accept-env-*；**所有 GH 写操作（push / PR create / merge）都打回 BKD Coder workspace 执行**，由 Coder gh auth 处理，跟 runner secret 完全无关。runner GH_TOKEN 应是 fine-grained PAT, Contents: Read-only。详见 [docs/architecture.md §8](docs/architecture.md)。
 
 ## 跟相邻系统的层级
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -289,6 +289,22 @@ wait
 
 ## 8. Runner（K8s Pod + PVC，per-REQ）
 
+> **⚠️ 设计契约：runner = 只读 checker**
+>
+> Runner pod 内只允许：`git clone`（拉源码）、跑 `make ci-*` / `make accept-env-*`、
+> `kubectl exec` / `docker run`、读 GH check-runs。
+>
+> **任何 GH write 操作**（`git push`、`gh pr create`、`gh pr merge`、PR review
+> comment、status check write）**一律打回 BKD Coder workspace（"开发机"）执行**，
+> 由 Coder 自己注入的 gh auth 处理，跟 runner 的 `GH_TOKEN` secret 完全无关。
+>
+> 推论：
+> - runner secret `gh_token` 应是 **fine-grained PAT, Contents: Read-only**
+>   （或 Deploy Key），配错成 classic `repo` 不会让 sisyphus 主动写——但违背契约。
+> - 任何 prompt / action 想在 runner 里跑 push/PR 操作，必须先改设计回来这条注释。
+> - 全链需要 GH write 的部分（dev push feat/REQ-* + 开 PR、archive merge PR）由
+>   BKD agent 在 Coder workspace 完成，是 BKD 的事，不是 sisyphus 的事。
+
 每个 REQ 在 `sisyphus-runners` namespace 起一个：
 - **Pod** `runner-<REQ>` —— privileged + DinD + fuse-overlayfs
 - **PVC** `workspace-<REQ>` —— 挂 `/workspace`，存 clone 的 repos + 中间产物

--- a/orchestrator/helm/values.yaml
+++ b/orchestrator/helm/values.yaml
@@ -116,15 +116,23 @@ runner:
   imagePullSecrets: []        # 如果 runner image 私有需要填
 
   # 单一 runner secret：所有 runner Pod 要的凭证都在里面（keys 见下）
-  #   gh_token    → env GH_TOKEN              给 agent gh CLI / git clone（**只读 PAT**）
+  #   gh_token    → env GH_TOKEN              **只供 runner 内 git clone 私有仓**
   #   ghcr_user   → env SISYPHUS_GHCR_USER    docker login ghcr.io
   #   ghcr_token  → env SISYPHUS_GHCR_TOKEN   （通常跟 gh_token 同一个只读 PAT）
   #   kubeconfig  → 挂载到 /root/.kube/config  accept 阶段 agent 起 helm 用
   #
-  # ⚠️ Runner PAT 原则：最小权限只读。Fine-grained 首选（Contents Read +
-  # Statuses Read + Packages Read，限定到 sisyphus 涉及的 repo）；fallback 到
-  # classic `repo` + `read:packages` 必须配 branch protection / 90d rotation。
-  # 长远推荐 Deploy Key + read:packages PAT 或 GitHub App。详见 docs/V0.2-PLAN.md。
+  # ⚠️ 设计契约：**runner pod = 只读 checker**。所有 git push / gh pr create /
+  #     gh pr merge 都在 BKD Coder workspace（"开发机"）里跑，用 Coder 自己注入
+  #     的 gh auth，跟这里的 secret **完全无关**。runner 只 clone source、跑
+  #     测试、跑 accept-env-up/down。如果未来需要在 runner 里写 GH 状态
+  #     （如 PR review comment / status check），先回到本注释打回设计——默认拒绝。
+  #
+  # 推荐 PAT 配置（按优先级）：
+  #   1. Fine-grained PAT — 限定 sisyphus 涉及的 repo，权限只勾 **Contents: Read-only**
+  #      （+ Packages: Read-only 如果跨仓拉 ghcr 镜像）
+  #   2. Deploy Key (per-repo) + 单独 read:packages PAT —— 隔离最干净，但配置繁琐
+  #   3. Classic PAT —— GitHub 不细分，只能给整个 `repo` (含 write)。**违背 read-only
+  #      设计契约**，仅 dev 临时用，必须配 branch protection 防 runner 误写。
   #
   # createSecrets=true 时 helm 帮建 secret（用下方 secret 段的值）；
   # 生产建议 createSecrets=false + existingSecretName 指向 SealedSecret / ESO 管的 secret
@@ -132,9 +140,9 @@ runner:
   existingSecretName: ""
   secretName: sisyphus-runner-secrets
   secret:
-    gh_token: ""              # !! 建议填：GitHub PAT，scope=repo+read:packages
+    gh_token: ""              # !! 建议填：fine-grained PAT，**Contents: Read-only**（+ Packages: Read-only），限定 sisyphus 涉及的 repo
     ghcr_user: ""             # GHCR 用户名（通常是 GitHub 用户或 org 名）
-    ghcr_token: ""            # GHCR PAT（可跟 gh_token 同一个）
+    ghcr_token: ""            # GHCR PAT（read:packages 即可；可跟 gh_token 同一个）
     kubeconfig: ""            # kubeconfig 文件内容（accept 阶段 helm install 用）
                               # 生产建议单独放 --set-file runner.secret.kubeconfig=$HOME/.kube/config
 


### PR DESCRIPTION
## Summary
- Make the **runner = read-only checker** design contract explicit across CLAUDE.md, docs/architecture.md §8, and helm `values.yaml` runner-secret comments
- Recommend fine-grained PAT with **Contents: Read-only** for `sisyphus-runner-secrets/gh_token`; flag classic `repo` PAT as over-privileged
- All git push / gh pr create / gh pr merge stay in BKD Coder workspace, using Coder-injected gh auth — unrelated to sisyphus's runner secret

## Why
In a recent debugging round, I drifted into recommending a write-scoped PAT for the runner secret to "unblock the full pipeline", conflating runner clone (read) with BKD-side push/PR/merge (write). The user pushed back: *"我的设计上，runner里不做任何写操作呀。它只拿代码，拿产物检查。其它的操作都在开发机里。差点被你绕过去了。"*

Making the contract explicit at three levels prevents the same drift:
1. CLAUDE.md core-philosophy bullet — every future Claude session sees it on context-load
2. architecture.md §8 blockquote — anyone reading the runner section can't miss it
3. helm values.yaml comment — every operator setting up sisyphus reads the recommended PAT shape

## Changes
- `sisyphus/CLAUDE.md`: +1 bullet under 核心哲学 linking to architecture §8
- `docs/architecture.md` §8: prepend `> ⚠️ 设计契约：runner = 只读 checker` blockquote with allowed / banned ops +推论
- `orchestrator/helm/values.yaml`: rewrite runner.secret comment block, change `gh_token` default-value comment from `scope=repo+read:packages` to `fine-grained PAT, Contents: Read-only`

## Test plan
- [x] No code changes; pure docs + helm comments
- [x] helm template still parses (no YAML structure change, only comment edits)
- [ ] Future agents discussing PAT scope check this PR + memory ([sisyphus runner=只读 checker](https://github.com/phona/sisyphus/blob/main/sisyphus/CLAUDE.md))

## Out of scope
- Tightening real PAT in cluster — operator action, not a code change
- Adding runtime guard against runner emitting writes — separate dogfood REQ if ever needed