### PR TITLE
fix(state): add ANALYZING/INTAKING + VERIFY_ESCALATE transitions

### DIFF
--- a/orchestrator/src/orchestrator/state.py
+++ b/orchestrator/src/orchestrator/state.py
@@ -101,6 +101,19 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
     (ReqState.INIT, Event.INTENT_ANALYZE):
         Transition(ReqState.ANALYZING, "start_analyze", "kick off"),
 
+    # start_analyze 内部判 escalate（如 clone_involved_repos 失败 → emit VERIFY_ESCALATE）
+    # 没这条 transition 会被 engine.illegal_transition 吞掉，REQ 卡 ANALYZING 60min
+    # 才靠 watchdog auto_resume，浪费一轮 BKD agent token；实证 2026-04-26 REQ-ttpos-pat-validate。
+    (ReqState.ANALYZING, Event.VERIFY_ESCALATE):
+        Transition(ReqState.ESCALATED, "escalate",
+                   "start_analyze 内部判 escalate（clone failed 等）"),
+
+    # 同理 start_analyze_with_finalized_intent (INTAKING → ANALYZING via INTAKE_PASS) 内部
+    # 也可能 emit VERIFY_ESCALATE（intent 缺字段 / clone failed）。补 INTAKING 那条避免漏。
+    (ReqState.INTAKING, Event.VERIFY_ESCALATE):
+        Transition(ReqState.ESCALATED, "escalate",
+                   "start_analyze_with_finalized_intent 内部判 escalate"),
+
     (ReqState.ANALYZING, Event.ANALYZE_DONE):
         Transition(ReqState.SPEC_LINT_RUNNING, "create_spec_lint", "下发 openspec validate 任务"),
 

--- a/orchestrator/tests/test_state.py
+++ b/orchestrator/tests/test_state.py
@@ -13,6 +13,9 @@ EXPECTED = [
     (ReqState.INTAKING,             Event.INTAKE_PASS,         ReqState.ANALYZING,           "start_analyze_with_finalized_intent"),
     (ReqState.INTAKING,             Event.INTAKE_FAIL,         ReqState.ESCALATED,           "escalate"),
     (ReqState.INIT,                 Event.INTENT_ANALYZE,      ReqState.ANALYZING,           "start_analyze"),
+    # 内部 emit verify.escalate 路径（clone_involved_repos 失败等）
+    (ReqState.ANALYZING,            Event.VERIFY_ESCALATE,     ReqState.ESCALATED,           "escalate"),
+    (ReqState.INTAKING,             Event.VERIFY_ESCALATE,     ReqState.ESCALATED,           "escalate"),
     (ReqState.ANALYZING,            Event.ANALYZE_DONE,        ReqState.SPEC_LINT_RUNNING,   "create_spec_lint"),
     (ReqState.SPEC_LINT_RUNNING,    Event.SPEC_LINT_PASS,      ReqState.CHALLENGER_RUNNING,  "start_challenger"),
     (ReqState.SPEC_LINT_RUNNING,    Event.SPEC_LINT_FAIL,      ReqState.REVIEW_RUNNING,      "invoke_verifier_for_spec_lint_fail"),


### PR DESCRIPTION
## Summary
- Wire `(ANALYZING, VERIFY_ESCALATE) → ESCALATED` and `(INTAKING, VERIFY_ESCALATE) → ESCALATED` in the TRANSITIONS table
- Both target the existing `escalate` action — no new code paths

## Why
`start_analyze` / `start_analyze_with_finalized_intent` emit `Event.VERIFY_ESCALATE` when:
- `clone_involved_repos_into_runner` returns non-zero (private repo missing scope, etc.), or
- `ctx.intake_finalized_intent` is missing on the finalized variant

The TRANSITIONS table only had VERIFY_ESCALATE wired from REVIEW_RUNNING / FIXER_RUNNING / ESCALATED, so an emit from ANALYZING / INTAKING was swallowed by `engine.illegal_transition`. The REQ then sat at ANALYZING for ~60 min until watchdog auto-resume kicked in, wasting a BKD agent dispatch on an empty workspace.

Reproduced 2026-04-26 ~00:51 UTC with REQ-ttpos-pat-validate-1777164631:
```
{"event": "clone.failed", ...}
{"event": "engine.illegal_transition", "state": "analyzing", "evt": "verify.escalate"}
```
The earlier dogfood REQ-fix-clone-failed-illegal-transition-1777164809 was opened to land this fix via the pipeline but verifier judged escalate before the spec landed (pre-existing default_involved_repos drift; fixed separately by helm reuse-values --set), so this small mechanical patch goes in by hand.

## Test plan
- [x] Extend `test_state.EXPECTED` with both new (state, event, next, action) tuples → covered by existing parametrize loop
- [x] `uv run pytest tests/test_state.py -x -q` → 44 passed
- [ ] Post-merge: dispatch a fresh dogfood REQ that intentionally triggers clone.failed and observe `engine.transitioned analyzing → escalated evt=verify.escalate` instead of `engine.illegal_transition`

## Out of scope
- Why `cleanup_runner` doesn't actually remove the runner pod on escalate (separate observation, 4 zombie pods cleaned manually this round; needs its own investigation)
- The `default_involved_repos` configmap drift (already fixed via `helm upgrade --reuse-values --set env.default_involved_repos={phona/sisyphus}`)