### PR TITLE
docs: runner PAT setup + 4-step verification playbook

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,6 +304,10 @@ wait
 > - 任何 prompt / action 想在 runner 里跑 push/PR 操作，必须先改设计回来这条注释。
 > - 全链需要 GH write 的部分（dev push feat/REQ-* + 开 PR、archive merge PR）由
 >   BKD agent 在 Coder workspace 完成，是 BKD 的事，不是 sisyphus 的事。
+>
+> **PAT 配置 + 验证 playbook**：见 [integration-contracts.md §1c](./integration-contracts.md#1c-runner-github-pat只读)。
+> patch K8s secret 前必跑 4 步 API 探测（curl /user / /user/orgs / /repos/x / git ls-remote），
+> 否则 GitHub "Write access not granted" 错误文案常误导根因判断。
 
 每个 REQ 在 `sisyphus-runners` namespace 起一个：
 - **Pod** `runner-<REQ>` —— privileged + DinD + fuse-overlayfs

--- a/docs/integration-contracts.md
+++ b/docs/integration-contracts.md
@@ -45,6 +45,77 @@ clone 用 sisyphus 提供的 helper（不要手写 `git clone`）：
 helper 行为：clone 到约定路径、用 `$GH_TOKEN` 做 auth、idempotent
 （已存在则 `git fetch && git checkout main`）、shallow + 按需 unshallow。
 
+## 1c. Runner GitHub PAT（**只读**）
+
+> **设计契约**：runner pod 只用 `$GH_TOKEN` 做 `git clone`（读私有仓）。
+> 所有 `git push` / `gh pr create` / `gh pr merge` 都在 BKD Coder workspace
+> （"开发机"）里跑，用 Coder 自己注入的 gh auth，**跟这个 PAT 无关**。
+> 详见 [architecture.md §8](./architecture.md#8-runnerk8s-pod--pvcper-req)。
+
+### 1c.1 PAT 选型（按推荐度）
+
+| 类型 | scope / 权限 | 跨 org? | 推荐度 |
+|---|---|---|---|
+| **Fine-grained PAT**（org 内生成） | Repository: 选具体仓；Permissions → **Contents: Read-only**（+ Packages: Read-only 如需拉 ghcr 私有镜像） | 限 1 org | ⭐⭐⭐ 最干净 |
+| **Fine-grained PAT**（user 生成 + org 授权） | 同上，但 resource owner 选 org | 同左 | ⭐⭐ |
+| **Classic PAT** | 必勾 `repo`（GitHub 不细分；含 r+w，runner 不会用 write 那部分） + `read:org`（看 org 成员关系，debug 用） + `read:packages`（如需） | 跨 org，scope 范围大 | ⭐ 临时凑合，过期短一些 |
+
+### 1c.2 验证 playbook（patch K8s secret 之前必跑）
+
+GitHub 对私有仓返 403/404 时文案有歧义（"Write access not granted" 实际可能是 read 也没权限），
+patch secret 前必须**先用 API 探一遍**：
+
+```bash
+PAT='ghp_xxx'   # 千万别 echo 进 transcript / commit 进代码
+
+# 1. PAT 能 auth + 实际 scope 是什么
+curl -sS -D - -o /dev/null -H "Authorization: token $PAT" https://api.github.com/user \
+  | grep -iE "^(x-oauth-scopes|github-authentication-token-expiration)"
+# 期望：x-oauth-scopes 含 "repo"（classic）或为空但 fine-grained permissions 配对了
+#       expiration 还没过
+
+# 2. PAT user 加入了哪些 org
+curl -sS -H "Authorization: token $PAT" https://api.github.com/user/orgs \
+  | python3 -c "import json,sys; print([o['login'] for o in json.load(sys.stdin)])"
+# 期望：含目标 org（如 ZonEaseTech）；空 [] 八成是 user 不在 org 里 OR 没勾 read:org
+
+# 3. PAT 能看到目标私有仓
+curl -sS -o /tmp/r -w "HTTP=%{http_code}\n" -H "Authorization: token $PAT" \
+  https://api.github.com/repos/<org>/<repo>
+python3 -c "import json; d=json.load(open('/tmp/r')); \
+  print(d.get('message') or f\"OK private={d.get('private')} permissions={d.get('permissions')}\")"
+# 期望：HTTP=200，permissions.pull=true（push 不需要也无害）
+# HTTP=404 = PAT 不可见该仓（user 不在 org / 没访问权限 / scope 不够）
+
+# 4. git 实测（runner 视角）
+git ls-remote https://x-access-token:$PAT@github.com/<org>/<repo>.git HEAD
+# 期望：返 SHA + HEAD；返 fatal/403 = 还有问题
+```
+
+四步全过才 patch K8s secret：
+
+```bash
+TOKEN='ghp_xxx'
+kubectl -n sisyphus-runners patch secret sisyphus-runner-secrets --type=merge \
+  -p "{\"stringData\":{\"gh_token\":\"$TOKEN\",\"ghcr_token\":\"$TOKEN\"}}"
+unset TOKEN
+```
+
+### 1c.3 常见误诊
+
+| 报错 | 实际意思 |
+|---|---|
+| `git clone ... 403: Write access to repository not granted` | GitHub 通用文案，**不一定**是写权限不够；可能是 PAT 完全没读权限（scope 没勾 / user 不在 org） |
+| `repos/<org>/<repo>` 返 404（仓真实存在） | PAT 没有 `repo` scope OR user 不在 org；GitHub 隐藏私有仓存在 |
+| `/user/orgs` 返 `[]` | (a) user 真没 org，OR (b) classic PAT 没勾 `read:org` —— 加 scope 重测 |
+| PAT patch 后 runner 仍 403 | runner pod 是 patch **之前**起的，env 不会回传；删 pod 让新 pod 拿新 secret，或派新 REQ |
+
+### 1c.4 patch 完用 dogfood REQ 验
+
+派一个 `intent:analyze` + `repo:<org>/<target-repo>` tag 的 BKD issue，
+看 orch 日志 `clone.exec` → `clone.done`（成功）或 `clone.failed`（失败原因）。
+**不要直接 helm rollout** —— 部分 cluster `--reuse-values` 模式下 secret patch 不需要 rollout。
+
 ## 2. Makefile target 契约（硬约束）
 
 ### 2.1 source repo 必须有

--- a/orchestrator/helm/values.yaml
+++ b/orchestrator/helm/values.yaml
@@ -127,12 +127,16 @@ runner:
   #     测试、跑 accept-env-up/down。如果未来需要在 runner 里写 GH 状态
   #     （如 PR review comment / status check），先回到本注释打回设计——默认拒绝。
   #
-  # 推荐 PAT 配置（按优先级）：
-  #   1. Fine-grained PAT — 限定 sisyphus 涉及的 repo，权限只勾 **Contents: Read-only**
-  #      （+ Packages: Read-only 如果跨仓拉 ghcr 镜像）
-  #   2. Deploy Key (per-repo) + 单独 read:packages PAT —— 隔离最干净，但配置繁琐
-  #   3. Classic PAT —— GitHub 不细分，只能给整个 `repo` (含 write)。**违背 read-only
-  #      设计契约**，仅 dev 临时用，必须配 branch protection 防 runner 误写。
+  # PAT 选型 + 4 步验证 playbook 见 docs/integration-contracts.md §1c
+  # 速查（推荐度从高到低）：
+  #   1. Fine-grained PAT (org 内生成) — Contents: Read-only + 限定具体仓。最干净
+  #   2. Deploy Key (per-repo) + read:packages PAT —— 隔离干净，但配置繁琐
+  #   3. Classic PAT —— 必勾 `repo` + `read:org` (+ `read:packages` 如需)
+  #      classic 没有 read-only-repo scope，只能给 r+w；runner 不主动写但属过度授权
+  #
+  # ⚠️ patch secret 之前必跑 4 步 PAT 验证（curl /user 看 scopes / /user/orgs / /repos/x / git ls-remote）
+  #     —— GitHub 私有仓 403 文案 "Write access not granted" 经常误导，跳过验证容易判错根因
+  #     完整命令模板见 docs/integration-contracts.md §1c.2
   #
   # createSecrets=true 时 helm 帮建 secret（用下方 secret 段的值）；
   # 生产建议 createSecrets=false + existingSecretName 指向 SealedSecret / ESO 管的 secret


### PR DESCRIPTION
## Summary
- New \`docs/integration-contracts.md\` §1c: PAT type comparison + 4-step API probe playbook + common mis-diagnoses table
- \`docs/architecture.md\` §8: link to the new §1c
- \`orchestrator/helm/values.yaml\`: trim runner-secret comment to quick reference + pointer

## Why
Today's debugging dance: a classic PAT was generated with **zero scopes ticked**, returned 403 on \`git clone\`. GitHub's misleading wording "Write access to repository not granted" sent us down the "PAT needs write scope" path twice (against the runner = read-only design contract). A 4-step API probe (\`/user\` for X-OAuth-Scopes / \`/user/orgs\` / \`/repos/<x>\` / \`git ls-remote\`) would have caught it in 5 seconds.

The playbook codifies that probe as the **mandatory pre-step before \`kubectl patch secret\`**, plus a mis-diagnoses table mapping common 403/404 messages to actual root cause.

## Test plan
- [x] \`docs/integration-contracts.md\` renders cleanly (no broken markdown)
- [x] Internal links from architecture.md §8 → integration-contracts.md §1c resolve
- [x] helm values.yaml YAML still parses (only comment changes)
- [ ] Future operator provisioning a runner PAT follows §1c.2 → catches scope/org issues before patching secret