### PR TITLE
fix(k8s_runner): retry exec_in_runner on stream-race silent fail

### DIFF
--- a/orchestrator/src/orchestrator/k8s_runner.py
+++ b/orchestrator/src/orchestrator/k8s_runner.py
@@ -521,7 +521,47 @@ class RunnerController:
 
         exit_code 用 `; echo __MARKER__:$?` 附在命令末尾，stdout 里 parse。
         (K8s stream client `.returncode` 在不同版本不稳定。)
+
+        race: 偶发 stream `is_open()` 在数据 buffer 之前就 False，loop 立刻退出，
+        stdout/stderr 全空、exit_code=-1。实证 2026-04-26 dev_cross_check checker
+        1.22s silent fail（verifier byxkqvdf 决策诊断为"pod exec 连接层异常"）。
+        防御：内层尝试拿到 marker；若失败 + 极短耗时 + 零输出 → 重试一次（不算重试到底，
+        让真业务报错和 race 区分开）。
         """
+        attempts = 2
+        last_result: ExecResult | None = None
+        for attempt in range(attempts):
+            result = await self._exec_once(
+                req_id, command, env=env, workdir=workdir, timeout_sec=timeout_sec,
+            )
+            last_result = result
+            # marker 拿到（无论成功 0 还是非 0）→ 真业务结果，直接返
+            if result.exit_code != -1:
+                return result
+            # exit_code=-1 但有任何输出 → 不是 race，是真 truncate / timeout，直接返
+            if result.stdout or result.stderr:
+                return result
+            # exit_code=-1 + 全空 + 极短耗时 → 几乎肯定是 stream race
+            # （正常命令至少耗时几百 ms 起步；marker echo 本身需要 fork+exec）
+            if result.duration_sec > 5:
+                return result  # 跑过一阵才 -1，可能是 timeout，不重试
+            if attempt < attempts - 1:
+                log.warning(
+                    "exec_in_runner.stream_race_retry",
+                    req_id=req_id, attempt=attempt + 1,
+                    duration_sec=round(result.duration_sec, 2),
+                )
+                await asyncio.sleep(0.5)
+                continue
+        # 所有重试都 -1+空 → 真异常
+        return last_result  # type: ignore[return-value]
+
+    async def _exec_once(
+        self, req_id: str, command: str,
+        *, env: dict[str, str] | None,
+        workdir: str,
+        timeout_sec: int,
+    ) -> ExecResult:
         pod_name = self.pod_name(req_id)
 
         env_prefix = ""
@@ -548,15 +588,24 @@ class RunnerController:
         deadline = time.monotonic() + timeout_sec
 
         try:
+            # 防 race：第一次 update 给 stream 真的 warm-up 时间。
+            # K8s exec channel 偶发 is_open() 在 buffer 填充前就 False，
+            # 之前 loop 立刻退出导致 stdout/stderr 全空。先 update 一次让
+            # 服务端 SPDY frame 到位，再进 polling loop。
+            resp.update(timeout=2)
+            if resp.peek_stdout():
+                stdout_buf.append(resp.read_stdout())
+            if resp.peek_stderr():
+                stderr_buf.append(resp.read_stderr())
+
             while resp.is_open() and time.monotonic() < deadline:
-                # update 的 timeout 单位是秒（浮点 OK）
                 resp.update(timeout=1)
                 if resp.peek_stdout():
                     stdout_buf.append(resp.read_stdout())
                 if resp.peek_stderr():
                     stderr_buf.append(resp.read_stderr())
                 await asyncio.sleep(0.01)
-            # 最后拉一次残留
+            # 最后拉一次残留（含 stream 关闭后 buffer 里剩的 frame）
             if resp.peek_stdout():
                 stdout_buf.append(resp.read_stdout())
             if resp.peek_stderr():
@@ -569,13 +618,10 @@ class RunnerController:
         stdout = "".join(stdout_buf)
         stderr = "".join(stderr_buf)
 
-        # parse exit code 从 stdout 最后一行
         exit_code = _parse_exit_marker(stdout)
-        # 把 marker 从 stdout 去掉（别污染业务日志）
         if exit_code is not None:
             stdout = _strip_exit_marker(stdout)
         else:
-            # 没找到 marker = 命令被 truncate / timeout
             exit_code = -1
 
         return ExecResult(

--- a/orchestrator/tests/test_k8s_runner.py
+++ b/orchestrator/tests/test_k8s_runner.py
@@ -431,3 +431,104 @@ def test_strip_exit_marker_cleans_tail():
 def test_strip_exit_marker_no_op_when_missing():
     stdout = "line1\nline2\n"
     assert _strip_exit_marker(stdout) == "line1\nline2\n"
+
+
+# ─── exec stream race retry (regression: REQ-ttpos-pat-validate-v2 dev_cross_check) ──
+
+
+def _fake_stream_resp(stdout: str, stderr: str = "", *, opens: int = 1):
+    """Mock kubernetes WSClient: 第一次 update 灌一次数据，之后 is_open=False。
+
+    opens=0 模拟 race：is_open 立刻 False、peek_* 全 False，零输出。
+    """
+    resp = MagicMock()
+    state = {"opens_left": opens, "stdout": stdout, "stderr": stderr}
+    resp.is_open = lambda: state["opens_left"] > 0
+    resp.update = MagicMock()
+    resp.peek_stdout = lambda: bool(state["stdout"])
+    resp.peek_stderr = lambda: bool(state["stderr"])
+
+    def _read_stdout():
+        out, state["stdout"] = state["stdout"], ""
+        state["opens_left"] = 0
+        return out
+
+    def _read_stderr():
+        err, state["stderr"] = state["stderr"], ""
+        return err
+
+    resp.read_stdout = _read_stdout
+    resp.read_stderr = _read_stderr
+    resp.close = MagicMock()
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_exec_in_runner_retries_on_stream_race(monkeypatch):
+    """实证 race: 第一次 stream 全空 + 极短耗时 → 自动重试一次拿到真结果。"""
+    rc = _make_controller()
+    calls = {"n": 0}
+
+    def fake_stream(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # race: is_open 立刻 False，零输出
+            return _fake_stream_resp("", "", opens=0)
+        # retry: 正常返结果
+        return _fake_stream_resp("hello\n__SISY_EXEC_EXIT__:0\n")
+
+    monkeypatch.setattr("orchestrator.k8s_runner.stream", fake_stream)
+    result = await rc.exec_in_runner("REQ-1", "echo hi", timeout_sec=2)
+    assert calls["n"] == 2, "应重试一次"
+    assert result.exit_code == 0
+    assert "hello" in result.stdout
+
+
+@pytest.mark.asyncio
+async def test_exec_in_runner_no_retry_on_normal_success(monkeypatch):
+    """正常一次过的命令不应触发重试。"""
+    rc = _make_controller()
+    calls = {"n": 0}
+
+    def fake_stream(*args, **kwargs):
+        calls["n"] += 1
+        return _fake_stream_resp("ok\n__SISY_EXEC_EXIT__:0\n")
+
+    monkeypatch.setattr("orchestrator.k8s_runner.stream", fake_stream)
+    result = await rc.exec_in_runner("REQ-1", "true", timeout_sec=2)
+    assert calls["n"] == 1
+    assert result.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_exec_in_runner_no_retry_on_nonzero_exit(monkeypatch):
+    """命令真失败（exit_code != 0 但 != -1）也别重试，让 caller 判。"""
+    rc = _make_controller()
+    calls = {"n": 0}
+
+    def fake_stream(*args, **kwargs):
+        calls["n"] += 1
+        return _fake_stream_resp("err\n__SISY_EXEC_EXIT__:1\n", "boom\n")
+
+    monkeypatch.setattr("orchestrator.k8s_runner.stream", fake_stream)
+    result = await rc.exec_in_runner("REQ-1", "false", timeout_sec=2)
+    assert calls["n"] == 1
+    assert result.exit_code == 1
+    assert "boom" in result.stderr
+
+
+@pytest.mark.asyncio
+async def test_exec_in_runner_no_retry_when_partial_output(monkeypatch):
+    """有 stdout/stderr 但 marker 缺（被 truncate）→ 不重试，是真 truncate 不是 race。"""
+    rc = _make_controller()
+    calls = {"n": 0}
+
+    def fake_stream(*args, **kwargs):
+        calls["n"] += 1
+        return _fake_stream_resp("partial output no marker\n")
+
+    monkeypatch.setattr("orchestrator.k8s_runner.stream", fake_stream)
+    result = await rc.exec_in_runner("REQ-1", "long", timeout_sec=2)
+    assert calls["n"] == 1
+    assert result.exit_code == -1
+    assert "partial" in result.stdout


### PR DESCRIPTION
## Summary
- Wrap \`exec_in_runner\` in a 2-attempt retry that fires only on the precise stream-race signature (exit_code=-1, empty stdout/stderr, duration < 5s)
- Add an explicit \`update(timeout=2)\` warm-up before the polling loop so \`is_open()\` reflects reality

## Why
Verifier on REQ-ttpos-pat-validate-v2-1777167476 (issue \`byxkqvdf\`, 2026-04-26 ~02:05 UTC) diagnosed dev_cross_check's silent fail as:
> infra flaky: exec_in_runner 返回 exit_code=-1（无 exit marker），stdout/stderr 均为空，耗时仅 1.22s，make ci-lint 根本未执行；runner pod 已运行 15 分钟但 exec 产生零输出，属于 pod exec 连接层异常，非代码 bug

Repro pattern: \`WSClient.is_open()\` returns False before SPDY frames are buffered → polling loop exits with zero reads → exit_code=-1, empty output, duration ~1s. Caller sees a "checker fail" that's actually a connectivity hiccup, escalates to verifier (which thinks for 757s = 12 min), human pages.

The retry signature is intentionally narrow:
- ✅ retry: \`exit_code=-1\` AND empty stdout AND empty stderr AND duration < 5s
- ❌ no retry: any non-zero exit code (real test failure)
- ❌ no retry: any output (real partial truncate)
- ❌ no retry: long duration (real timeout)

## Test plan
- [x] \`uv run pytest tests/test_k8s_runner.py -x -q\` → 31 passed
  - test_exec_in_runner_retries_on_stream_race
  - test_exec_in_runner_no_retry_on_normal_success
  - test_exec_in_runner_no_retry_on_nonzero_exit
  - test_exec_in_runner_no_retry_when_partial_output
- [ ] Post-merge: re-dispatch a ttpos REQ that hits dev_cross_check, observe \`exec_in_runner.stream_race_retry\` log line if race triggers + checker reaching make ci-lint output

## Out of scope
- Tuning timeout values (warm-up 2s, race threshold 5s, max attempts 2) — picked from the observed timing; revisit if production data shows otherwise
- Replacing the marker-based exit code parse (still needed; \`returncode\` is documented unstable)
- The \`cleanup_runner\` zombie-pod bug (likely related — same WSClient layer — separate investigation)