### PR TITLE
fix(admin): force_escalate must trigger runner cleanup (zombie pod)

### DIFF
--- a/openspec/changes/REQ-cleanup-runner-zombie-1777170378/proposal.md
+++ b/openspec/changes/REQ-cleanup-runner-zombie-1777170378/proposal.md
@@ -1,0 +1,128 @@
+# REQ-cleanup-runner-zombie-1777170378: fix(admin): force_escalate must trigger runner Pod cleanup to prevent zombie Pods
+
+## 问题
+
+`POST /admin/req/{req_id}/escalate` (`admin.force_escalate`) 用 raw SQL UPDATE
+把任意 state 的 REQ 推到 `escalated`，但**不调用 runner Pod cleanup**。
+
+所有走状态机 transition 进 `ESCALATED` 的路径（engine.step 的 terminal-cleanup
+钩子、escalate.py 内部 SESSION_FAILED 手 CAS）都会调用
+`engine._cleanup_runner_on_terminal(req_id, ReqState.ESCALATED)`，删 Pod 留 PVC。
+
+force_escalate 是这个清理网的唯一漏网：
+
+```python
+# admin.py 当前 force_escalate
+await pool.execute(
+    "UPDATE req_state SET state='escalated', "
+    "context = context || $2::jsonb, updated_at = now() WHERE req_id = $1",
+    req_id, '{"escalated_reason": "admin"}',
+)
+log.warning("admin.force_escalate", req_id=req_id, from_state=row.state.value)
+return {"action": "force_escalated", ...}
+# ↑ 没起 cleanup_runner_on_terminal task
+```
+
+后果（**zombie Pod**）：
+
+1. force_escalate 后 state=`escalated`，但 runner Pod (`runner-<req-id>`) 仍在跑 `sleep infinity`
+2. `runner_gc._active_req_ids` 把 escalated retention 期内的 REQ 当 active：
+
+   ```python
+   # runner_gc.py L52-58
+   if state == "escalated" and not ignore_retention:
+       updated_at = r["updated_at"]
+       if updated_at and (now - updated_at) < retention:
+           active.add(r["req_id"])
+   ```
+
+   active 集合内的 REQ 不进 `gc_orphans`，**整个保留期内 GC 一行都不动**
+3. PVC 也带着，整段时间占着 8 GiB memory limit / 250m CPU request /
+   `pvc_retain_on_escalate_days` × 多少 GiB workspace 磁盘
+4. retention 过期后 `gc_orphans` 才扫到，调 `cleanup_runner(retain_pvc=False)`
+   把 Pod + PVC 一锅端 —— 但中间这一整天，Pod 是真的活着
+
+实证：vm-node04 5991Mi 总内存的小盘子，每个 runner pod request 512Mi，
+"塞 2-3 个并发 runner"已经卡死调度。zombie Pod 占着别人调度不上。
+
+## 方案
+
+`admin.force_escalate` 在 SQL UPDATE 后**立即起 fire-and-forget cleanup task**，
+mirror `admin.complete` 的实现：
+
+```python
+task = asyncio.create_task(
+    engine._cleanup_runner_on_terminal(req_id, ReqState.ESCALATED)
+)
+_force_escalate_cleanup_tasks.add(task)
+task.add_done_callback(_force_escalate_cleanup_tasks.discard)
+```
+
+`_cleanup_runner_on_terminal` 已根据 `terminal_state == ReqState.ESCALATED`
+把 `retain_pvc` 设为 True —— 删 Pod、留 PVC 给人翻 workspace
+debug，过期由 runner_gc 兜底清。跟所有走 transition 进 ESCALATED 的路径行为一致。
+
+### 行为变化
+
+```
+之前：force_escalate → state=escalated → Pod 存活 retention 整段，PVC 留
+之后：force_escalate → state=escalated + 立即 cleanup task → Pod 几秒内删，PVC 留
+```
+
+PVC 保留逻辑不变 —— 还是给人 follow-up 续 verifier issue 的窗口
+（`(ESCALATED, VERIFY_FIX_NEEDED) → FIXER_RUNNING` 等三条 transition）。
+
+### 实现要点
+
+1. **fire-and-forget**：`asyncio.create_task` 起后立即返回 200，cleanup 失败
+   有 `_cleanup_runner_on_terminal` 内部 try/except + warning log，runner_gc 周期兜底。
+2. **task 引用**：用模块级 `_force_escalate_cleanup_tasks: set[asyncio.Task]`
+   防 task 被 GC（done_callback 自清）；跟 `_complete_cleanup_tasks` 同模式但
+   隔离作用域（便于测试 introspect 仅本 endpoint 起的 task）。
+3. **state=escalated 的 noop 分支不起 cleanup**：第二次 force_escalate 看到
+   `state == ReqState.ESCALATED` 直接返回 noop，不重复 schedule cleanup。
+   原因：第一次 force_escalate 已经清过 Pod；重起一轮纯浪费 K8s API 调用 +
+   多一行 warning 日志。
+4. **不需要等 task 完成**：HTTP 调用方拿 200 表示"DB 已改 + cleanup 已排队"，
+   不是"Pod 已删"。这跟 `admin.complete` 的契约一致。
+
+### 与现有 endpoint 的对比
+
+| endpoint | from_state | to_state | retain PVC | runner cleanup 触发 |
+|---|---|---|---|---|
+| force_escalate | * | escalated | yes | **本 REQ 之后：是**（之前漏） |
+| complete | escalated | done | no | 是 |
+| pause | * | (state 不动) | yes | pod-only delete（不算 terminal cleanup） |
+
+## 取舍
+
+- **为什么不在 runner_gc 改成 list Pod 而非 list PVC** —— 治标不治本：
+  GC 周期默认 60s，cleanup miss 一直拖到下轮才补，期间 kubectl get pods
+  看到一堆 escalated 的"沉睡"Pod。从根因（force_escalate 漏 schedule）修。
+  另外 PVC 是 K8s 资源主键（Pod 可能被 K8s evict 重建，PVC 永远跟 REQ 一对一），
+  GC 按 PVC sweep 是正确架构。
+- **为什么 retain_pvc=True 不改成 False** —— 跟 transition 路径行为一致是关键
+  原则：走 force_escalate 的 REQ 跟自动 escalate 的 REQ 应该有相同 PVC retention
+  契约（人可能想 kubectl exec 进 PVC 看现场）。想要立即收 PVC 的 admin 应该用
+  force_escalate（清 Pod 留 PVC）+ complete（清 PVC + state→done）两步。
+- **为什么 noop 分支不补 schedule cleanup** —— "已经 escalated"语义就是"前面那
+  次 force_escalate 已经把 Pod 清掉了"。如果有人手工 kubectl 重 apply 了 Pod
+  又来调 force_escalate，那是 K8s 资源状态跟 sisyphus state 失同步，runner_gc
+  PVC sweep 兜底（active set 含本 REQ → 不 sweep 当前 retention 内；过期才扫）。
+  实际场景里这是边角，不值得正常路径多 schedule 一轮。
+- **为什么不发 BKD tag 标 escalated_reason=admin-force** —— force_escalate 路径
+  本就在 ctx 里写 `escalated_reason=admin`（已存在）；BKD intent issue tag 由
+  正常 escalate action 维护，force_escalate 是绕过 escalate action 的纯 admin
+  override，不该再去碰 BKD（避免污染 verifier 看板）。
+
+## 影响面
+
+- 改 `orchestrator/src/orchestrator/admin.py`：
+  - `force_escalate` 函数体内加 cleanup task schedule（5 行新增）
+  - 新增模块级 `_force_escalate_cleanup_tasks` set（防 task 被 GC）
+  - 函数 docstring 增一段说明
+- 测试：`orchestrator/tests/test_admin.py` 加 2 个 case：
+  - `test_force_escalate_marks_escalated_and_triggers_cleanup`
+  - `test_force_escalate_noop_when_already_escalated_no_cleanup`
+- 不动 `engine.py` / `runner_gc.py` / `state.py` / migrations / BKD 集成层。
+- 不动 `force_escalate` 的 HTTP 契约（输入 / 输出 schema 不变；调用方无感）。

--- a/openspec/changes/REQ-cleanup-runner-zombie-1777170378/specs/cleanup-runner-zombie/contract.spec.yaml
+++ b/openspec/changes/REQ-cleanup-runner-zombie-1777170378/specs/cleanup-runner-zombie/contract.spec.yaml
@@ -1,0 +1,127 @@
+capability: cleanup-runner-zombie
+version: "1.0"
+description: |
+  Bug fix for admin POST /admin/req/{req_id}/escalate: must schedule
+  fire-and-forget cleanup_runner_on_terminal(ReqState.ESCALATED) after the
+  raw SQL UPDATE so the runner Pod is deleted within seconds. Without this
+  fix the Pod survives the entire pvc_retain_on_escalate_days retention
+  window because runner_gc treats escalated-within-retention REQs as active
+  and skips them in gc_orphans.
+
+  跟 admin.complete 配对：complete 是 escalated→done + cleanup(retain_pvc=False)；
+  本 REQ 修的是 force_escalate 的 *→escalated + cleanup(retain_pvc=True)。
+  两个 endpoint 都用同一个底层 cleanup helper，差别只在 terminal_state 参数。
+
+http:
+  method: POST
+  path: /admin/req/{req_id}/escalate
+  auth: Bearer <webhook_token>   # 同 webhook._verify_token
+  request_body: none             # 既存契约：force_escalate 不接 body
+  responses:
+    "200_force_escalated":
+      condition: state was non-escalated, transition to escalated succeeded
+      body:
+        action: force_escalated
+        from_state: "<previous state name>"
+    "200_noop":
+      condition: state already escalated (idempotent retry)
+      body:
+        action: noop
+        state: "already escalated"
+    "404":
+      condition: no req_state row with req_id
+      body:
+        detail: "req <id> not found"
+    "401_or_403":
+      condition: missing / invalid Authorization header
+      handler: webhook._verify_token raises HTTPException
+
+precondition_chain:
+  description: |
+    检查顺序固定，保证 401 ≠ 404 ≠ noop 不互相覆盖；cleanup 只在真改 state
+    的分支起。
+  sequence:
+    - "1. _verify_token(authorization)  # 401/403 if invalid"
+    - "2. row = await req_state.get(pool, req_id)"
+    - "3. if row is None: raise HTTPException(404)  # no SQL, no cleanup"
+    - "4. if row.state == ReqState.ESCALATED: return noop  # no SQL, no cleanup"
+    - "5. SQL UPDATE state=escalated + escalated_reason ctx patch"
+    - "6. asyncio.create_task(_cleanup_runner_on_terminal(req_id, ReqState.ESCALATED))"
+    - "7. _force_escalate_cleanup_tasks.add(task) + done_callback"
+    - "8. return {action: force_escalated, from_state: <prev>, ...}"
+
+state_change:
+  before: "req_state.state ∈ {init, intaking, analyzing, ..., archiving, review-running, fixer-running}"
+  after: "req_state.state = 'escalated'"
+  context_patch:
+    escalated_reason: admin
+
+runner_cleanup:
+  trigger_path: |
+    asyncio.create_task(engine._cleanup_runner_on_terminal(req_id, ReqState.ESCALATED))
+  retain_pvc: true                         # ESCALATED 留 PVC 给人翻 workspace
+  fire_and_forget: true                    # endpoint 返回时 cleanup 还在跑；runner_gc 兜底失败
+  task_lifecycle:
+    - "set 引用：_force_escalate_cleanup_tasks: set[asyncio.Task]"
+    - "起 task 时 add(task)"
+    - "task.add_done_callback(_force_escalate_cleanup_tasks.discard)"
+    - "rationale: 避免 fire-and-forget task 被 asyncio loop GC（mirror engine._cleanup_tasks 模式）"
+  rationale: |
+    runner_gc._active_req_ids 把 escalated retention 期内的 REQ 当 active；
+    active 集合内的 REQ 不进 gc_orphans。所以 GC 整段 retention 内不会扫
+    Pod，必须在 force_escalate 路径自己 schedule cleanup，否则 Pod 是 zombie。
+
+invariants:
+  no_state_machine_pollution:
+    - "force_escalate 不在 state.py 加 admin.escalate event"
+    - "不动 TRANSITIONS 表"
+    - "admin override 是状态机外的工具，不进 transition 表"
+
+  retain_pvc_semantics_preserved:
+    - "cleanup task 必须传 ReqState.ESCALATED（→ retain_pvc=True）"
+    - "不能传 ReqState.DONE，否则 PVC 也被删，破坏 ESCALATED 的人工 debug 窗口"
+    - "PVC 跟 transition 路径进入 ESCALATED 的契约一致"
+
+  noop_branch_no_cleanup:
+    - "state=escalated 已 noop，不再 schedule cleanup"
+    - "rationale: 第一次 force_escalate 已清过 Pod，第二次只浪费 K8s API"
+    - "如果手工 kubectl apply 重建了 Pod，靠 runner_gc 在 retention 过期后兜底"
+
+interaction_with_runner_gc:
+  description: |
+    runner_gc 周期 = settings.runner_gc_interval_sec（默认 60s）。fire-and-forget
+    cleanup 通常在秒级删 Pod；即使任务挂了，runner_gc 会在 retention 过期后
+    通过 PVC sweep 兜底（cleanup_runner 处理 404 幂等，不会重复爆错）。
+  redundancy: by design
+
+interaction_with_complete:
+  description: |
+    force_escalate 后跟 complete 形成"踢死信队列 → 清死信队列"的两步操作：
+      POST /admin/req/REQ-X/escalate  → state=escalated, Pod 删, PVC 留
+      POST /admin/req/REQ-X/complete  → state=done,      PVC 删
+    两次 cleanup task 互不冲突：第一次以 ESCALATED 删 Pod；第二次以 DONE
+    再次跑 cleanup_runner（pod 已 404 跳过 + 删 PVC）。
+  example_sequence:
+    - "POST /admin/req/REQ-X/escalate     # state: analyzing → escalated, Pod 删 PVC 留"
+    - "POST /admin/req/REQ-X/complete     # state: escalated → done, PVC 删"
+
+failure_modes:
+  cleanup_task_exception:
+    cause: "K8s API 不通 / runner controller 挂了"
+    handler: "_cleanup_runner_on_terminal 内部 try/except，记 warning，runner_gc 兜底"
+    state_outcome: "DB state 仍是 escalated，retention 过期后 runner_gc 扫 PVC 重试清"
+    user_impact: "API 调用方仍拿 200（DB 已改），实际 Pod 释放可能延迟一个 GC 周期"
+
+  task_lost_no_callback:
+    cause: "asyncio loop GC 把 task 当孤儿回收（无 set reference）"
+    handler: "本 REQ 显式维护 _force_escalate_cleanup_tasks set + add_done_callback"
+    state_outcome: "task 跑完才从 set 移除，GC 不能回收"
+
+  concurrent_force_escalate:
+    cause: "两个 admin 同时 POST /escalate 同一 REQ"
+    handler: |
+      第一个：row.state='analyzing' → SQL UPDATE → 起 cleanup task
+      第二个：row.state 可能仍 read 到 'analyzing'（race），SQL UPDATE 把已 escalated
+              的行覆写为 escalated（幂等）+ 起第二个 cleanup task
+              但 cleanup_runner 本身幂等（404 处理），第二轮删 Pod 时已 404 → 无副作用
+    state_outcome: "state=escalated；可能起 1~2 个 cleanup task，结果相同"

--- a/openspec/changes/REQ-cleanup-runner-zombie-1777170378/specs/cleanup-runner-zombie/spec.md
+++ b/openspec/changes/REQ-cleanup-runner-zombie-1777170378/specs/cleanup-runner-zombie/spec.md
@@ -1,0 +1,99 @@
+# cleanup-runner-zombie
+
+## ADDED Requirements
+
+### Requirement: /admin/req/{req_id}/escalate must schedule runner Pod cleanup after the SQL state update
+
+The orchestrator SHALL, immediately after the raw SQL UPDATE pushing
+`req_state.state` to `escalated`, schedule a fire-and-forget
+`asyncio.Task` that runs
+`engine._cleanup_runner_on_terminal(req_id, ReqState.ESCALATED)` so the
+runner Pod is deleted within seconds. This MUST happen before the
+endpoint returns its 200 response. The task MUST be tracked in a
+module-level `set[asyncio.Task]` (mirroring the existing
+`_complete_cleanup_tasks` pattern in `admin.complete`) with a
+`done_callback` that removes the task from the set so the asyncio event
+loop does not garbage-collect the in-flight task. Without this, the
+runner Pod owned by the REQ stays alive for the entire
+`pvc_retain_on_escalate_days` window because `runner_gc._active_req_ids`
+treats `escalated` REQs within retention as active and skips them in
+`gc_orphans`.
+
+#### Scenario: FRE-S1 force_escalate on in-flight REQ schedules cleanup task with ESCALATED terminal state
+
+- **GIVEN** a REQ row with `state='analyzing'` exists in `req_state` and
+  the K8s runner controller is initialized
+- **WHEN** the client sends `POST /admin/req/REQ-X/escalate` with a valid
+  Bearer token
+- **THEN** the endpoint MUST execute one SQL UPDATE setting
+  `state='escalated'` on the row keyed by `req_id='REQ-X'`
+- **AND** the response MUST be 200 with JSON body containing
+  `action == "force_escalated"` and `from_state == "analyzing"`
+- **AND** an `asyncio.Task` running
+  `engine._cleanup_runner_on_terminal('REQ-X', ReqState.ESCALATED)`
+  MUST be scheduled (fire-and-forget) before the endpoint returns,
+  so that one event loop tick later the cleanup callable has been
+  invoked exactly once with those arguments
+
+### Requirement: /admin/req/{req_id}/escalate noop branch on already-escalated REQ MUST NOT re-schedule cleanup
+
+The orchestrator MUST return HTTP 200 with `action == "noop"` when
+`force_escalate` is invoked on a REQ already in state `escalated`, and
+MUST NOT execute any SQL UPDATE and MUST NOT schedule a cleanup task. This is
+because the prior `force_escalate` call (or the canonical
+transition-driven path into `escalated`) already deleted the Pod, and a
+second cleanup wastes K8s API calls and adds a spurious warning log
+entry. The runner Pod is owned by `engine._cleanup_runner_on_terminal`
+on the original `escalated` transition; a second call here would either
+404 (Pod already gone) or race with whatever debug session a human is
+running.
+
+#### Scenario: FRE-S2 second force_escalate on already-escalated REQ is a 200 noop with no cleanup
+
+- **GIVEN** a REQ row with `state='escalated'` exists
+- **WHEN** the client sends `POST /admin/req/REQ-X/escalate`
+- **THEN** the response MUST be 200 with body containing
+  `action == "noop"` and `state == "already escalated"`
+- **AND** no SQL UPDATE on `req_state` MUST be executed
+- **AND** no `asyncio.Task` running `_cleanup_runner_on_terminal` MUST
+  be scheduled by this call
+
+### Requirement: /admin/req/{req_id}/escalate returns 404 before any SQL UPDATE or cleanup scheduling when the REQ is unknown
+
+The endpoint MUST return HTTP 404 Not Found when no row matches the
+`req_id` path parameter. This MUST happen before any SQL UPDATE or
+cleanup-task scheduling, so that "no such REQ" cannot be confused with
+"REQ in wrong state" and so that no cleanup attempt is made for a
+non-existent runner.
+
+#### Scenario: FRE-S3 unknown REQ returns 404 with no side effects
+
+- **GIVEN** no row in `req_state` with `req_id='REQ-DOES-NOT-EXIST'`
+- **WHEN** the client sends `POST /admin/req/REQ-DOES-NOT-EXIST/escalate`
+- **THEN** the response MUST be 404 with detail containing the literal
+  substring `not found`
+- **AND** no SQL UPDATE on `req_state` MUST be executed
+- **AND** no cleanup task MUST be scheduled
+
+### Requirement: /admin/req/{req_id}/escalate retains the PVC across the cleanup task
+
+The cleanup task scheduled by `force_escalate` MUST pass
+`ReqState.ESCALATED` (not `ReqState.DONE`) as the `terminal_state`
+argument so that `_cleanup_runner_on_terminal` deletes the Pod but
+keeps the PVC for the human-debug retention window. The system MUST
+NOT pass `ReqState.DONE` here even though `force_escalate` writes
+`escalated_reason='admin'` to context, because PVC retention semantics
+depend on the terminal-state argument and breaking PVC retention would
+remove the workspace before a human or follow-up verifier issue can
+inspect it.
+
+#### Scenario: FRE-S4 cleanup task argument is ReqState.ESCALATED so retain_pvc=True semantics apply
+
+- **GIVEN** a REQ row with `state='analyzing'` exists
+- **WHEN** the client sends `POST /admin/req/REQ-X/escalate`
+- **THEN** the scheduled cleanup task MUST be invoked with
+  `terminal_state == ReqState.ESCALATED`
+- **AND** `_cleanup_runner_on_terminal` (which derives
+  `retain_pvc=(terminal_state == ReqState.ESCALATED)`) MUST therefore
+  call `cleanup_runner` with `retain_pvc=True`, leaving the PVC in
+  place for the configured retention window

--- a/openspec/changes/REQ-cleanup-runner-zombie-1777170378/tasks.md
+++ b/openspec/changes/REQ-cleanup-runner-zombie-1777170378/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: REQ-cleanup-runner-zombie-1777170378
+
+## Stage: spec
+
+- [x] `openspec/changes/REQ-cleanup-runner-zombie-1777170378/proposal.md`
+- [x] `openspec/changes/REQ-cleanup-runner-zombie-1777170378/tasks.md`
+- [x] `openspec/changes/REQ-cleanup-runner-zombie-1777170378/specs/cleanup-runner-zombie/spec.md`
+- [x] `openspec/changes/REQ-cleanup-runner-zombie-1777170378/specs/cleanup-runner-zombie/contract.spec.yaml`
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/admin.py`：
+  - 新增 `_force_escalate_cleanup_tasks: set[asyncio.Task]` 模块级集合
+  - `force_escalate` 函数 SQL UPDATE 后 schedule
+    `engine._cleanup_runner_on_terminal(req_id, ReqState.ESCALATED)` fire-and-forget
+  - `force_escalate` docstring 增一段说明：raw SQL UPDATE 必须显式触发 cleanup，
+    runner_gc 不会扫 escalated retention 内的 Pod
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_admin.py`：
+  - `test_force_escalate_marks_escalated_and_triggers_cleanup`：state=analyzing →
+    SQL UPDATE 跑一次 + `_cleanup_runner_on_terminal(req_id, ReqState.ESCALATED)`
+    被 schedule 一次（asyncio.sleep(0) 让 task 跑）
+  - `test_force_escalate_noop_when_already_escalated_no_cleanup`：state=escalated
+    → 200 noop，没 SQL UPDATE 没 cleanup task
+  - 既存 `test_force_escalate_404_when_not_found` 不变（404 路径不该 schedule cleanup）
+
+## Stage: PR
+
+- [x] git push feat/REQ-cleanup-runner-zombie-1777170378
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/admin.py
+++ b/orchestrator/src/orchestrator/admin.py
@@ -90,12 +90,23 @@ async def emit_event(
     )
 
 
+# 持引用防 fire-and-forget cleanup task 被 GC（done_callback 自清）。
+# 跟 _complete_cleanup_tasks 同模式但隔离作用域，便于测试 introspect 仅本 endpoint 起的 task。
+_force_escalate_cleanup_tasks: set[asyncio.Task] = set()
+
+
 @admin.post("/req/{req_id}/escalate")
 async def force_escalate(
     req_id: str,
     authorization: str | None = Header(default=None),
 ) -> dict:
-    """强制 REQ 进入 escalated（卡死时手工止损）。"""
+    """强制 REQ 进入 escalated（卡死时手工止损）+ 立即清 runner Pod（保 PVC 给人工 debug）。
+
+    所有走状态机 transition 进 ESCALATED 的路径都会被 engine._cleanup_runner_on_terminal
+    清掉 Pod（retain_pvc=True）。force_escalate 是 raw SQL UPDATE 绕过 engine，必须在
+    这里手动起同一个 cleanup task，否则 Pod 会以 zombie 存活整个 pvc_retain_on_escalate_days
+    保留期（runner_gc 把 escalated retention 内的 REQ 当 active，不扫 Pod）。
+    """
     _verify_token(authorization)
 
     pool = db.get_pool()
@@ -113,6 +124,17 @@ async def force_escalate(
         req_id,
         '{"escalated_reason": "admin"}',
     )
+
+    # 立即触发 runner cleanup（不等 runner_gc 下一轮）；fire-and-forget。
+    # retain_pvc=True 由 _cleanup_runner_on_terminal 内部根据 ESCALATED 自动设置，
+    # 跟所有走 transition 进 ESCALATED 的路径行为一致：删 Pod，留 PVC 给人工 debug，
+    # 过期由 runner_gc 按 pvc_retain_on_escalate_days 兜底清。
+    task = asyncio.create_task(
+        engine._cleanup_runner_on_terminal(req_id, ReqState.ESCALATED)
+    )
+    _force_escalate_cleanup_tasks.add(task)
+    task.add_done_callback(_force_escalate_cleanup_tasks.discard)
+
     log.warning("admin.force_escalate", req_id=req_id, from_state=row.state.value)
     return {"action": "force_escalated", "from_state": row.state.value}
 

--- a/orchestrator/tests/test_admin.py
+++ b/orchestrator/tests/test_admin.py
@@ -66,6 +66,148 @@ async def test_force_escalate_404_when_not_found(monkeypatch):
     assert ei.value.status_code == 404
 
 
+# ═══════════════════════════════════════════════════════════════════════
+# /admin/req/{req_id}/escalate runner-cleanup tests
+# (REQ-cleanup-runner-zombie-1777170378)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_force_escalate_marks_escalated_and_triggers_cleanup(monkeypatch):
+    """FRE-S1 happy path: force_escalate 改 state=escalated + schedule
+    cleanup_runner_on_terminal(ReqState.ESCALATED) fire-and-forget.
+
+    所有走 transition 进 ESCALATED 的路径都被 engine 自动清；force_escalate 是
+    raw SQL UPDATE 绕开 engine，必须自己起 cleanup task — 否则 Pod 以 zombie
+    存活整个 PVC retention 期。
+    """
+    from dataclasses import dataclass
+    from datetime import UTC
+    from datetime import datetime as _dt
+
+    from orchestrator import admin as admin_mod
+
+    @dataclass
+    class _Row:
+        req_id: str
+        project_id: str
+        state: ReqState
+        context: dict
+        history: list
+        created_at: _dt
+        updated_at: _dt
+
+    monkeypatch.setattr(admin_mod, "_verify_token", lambda x: None)
+
+    row = _Row(
+        req_id="REQ-X", project_id="p", state=ReqState.ANALYZING,
+        context={}, history=[],
+        created_at=_dt.now(UTC), updated_at=_dt.now(UTC),
+    )
+
+    async def _get(_pool, _req_id):
+        return row
+    monkeypatch.setattr("orchestrator.admin.req_state.get", _get)
+
+    executed: list[tuple] = []
+
+    class FakePool:
+        async def execute(self, sql, *args):
+            executed.append((sql, args))
+            return "UPDATE 1"
+
+    pool = FakePool()
+    monkeypatch.setattr("orchestrator.admin.db.get_pool", lambda: pool)
+
+    cleanup_calls: list[tuple] = []
+
+    async def _fake_cleanup(req_id, terminal_state):
+        cleanup_calls.append((req_id, terminal_state))
+
+    monkeypatch.setattr(
+        "orchestrator.admin.engine._cleanup_runner_on_terminal", _fake_cleanup,
+    )
+
+    result = await force_escalate("REQ-X", authorization="Bearer x")
+
+    assert result == {"action": "force_escalated", "from_state": "analyzing"}
+    # SQL UPDATE 跑了一次
+    assert len(executed) == 1
+    sql, _args = executed[0]
+    assert "UPDATE req_state" in sql
+    assert "state='escalated'" in sql
+    # cleanup task 已 schedule，跑一帧让它执行
+    await asyncio.sleep(0)
+    assert cleanup_calls == [("REQ-X", ReqState.ESCALATED)], (
+        "force_escalate must schedule _cleanup_runner_on_terminal with "
+        "ReqState.ESCALATED so the runner Pod is deleted (PVC retained for "
+        "human debug); without this, Pod stays alive for the entire PVC "
+        "retention window as a zombie."
+    )
+
+
+@pytest.mark.asyncio
+async def test_force_escalate_noop_when_already_escalated_no_cleanup(monkeypatch):
+    """FRE-S2 noop: state=escalated → 200 noop, 没 SQL UPDATE 没 cleanup task.
+
+    幂等：第二次 force_escalate 不该重复起 cleanup（POD 早已被首次 cleanup 删过；
+    重起一轮纯浪费 K8s API + 多一行 warning 日志）。
+    """
+    from dataclasses import dataclass
+    from datetime import UTC
+    from datetime import datetime as _dt
+
+    from orchestrator import admin as admin_mod
+
+    @dataclass
+    class _Row:
+        req_id: str
+        project_id: str
+        state: ReqState
+        context: dict
+        history: list
+        created_at: _dt
+        updated_at: _dt
+
+    monkeypatch.setattr(admin_mod, "_verify_token", lambda x: None)
+
+    row = _Row(
+        req_id="REQ-X", project_id="p", state=ReqState.ESCALATED,
+        context={}, history=[],
+        created_at=_dt.now(UTC), updated_at=_dt.now(UTC),
+    )
+
+    async def _get(_pool, _req_id):
+        return row
+    monkeypatch.setattr("orchestrator.admin.req_state.get", _get)
+
+    executed: list = []
+
+    class FakePool:
+        async def execute(self, sql, *args):
+            executed.append((sql, args))
+            return "UPDATE 1"
+
+    monkeypatch.setattr("orchestrator.admin.db.get_pool", lambda: FakePool())
+
+    cleanup_calls: list = []
+
+    async def _fake_cleanup(req_id, terminal_state):
+        cleanup_calls.append((req_id, terminal_state))
+
+    monkeypatch.setattr(
+        "orchestrator.admin.engine._cleanup_runner_on_terminal", _fake_cleanup,
+    )
+
+    result = await force_escalate("REQ-X", authorization="Bearer x")
+
+    assert result == {"action": "noop", "state": "already escalated"}
+    assert executed == []
+    # 跑一帧确认没起 cleanup task
+    await asyncio.sleep(0)
+    assert cleanup_calls == []
+
+
 @pytest.mark.asyncio
 async def test_get_req_404(monkeypatch):
     from orchestrator import admin as admin_mod

--- a/orchestrator/tests/test_contract_cleanup_runner_zombie.py
+++ b/orchestrator/tests/test_contract_cleanup_runner_zombie.py
@@ -1,0 +1,216 @@
+"""Contract tests for cleanup-runner-zombie (REQ-cleanup-runner-zombie-1777170378).
+
+Black-box challenger. Does NOT read admin.py. Derived from:
+  openspec/changes/REQ-cleanup-runner-zombie-1777170378/specs/cleanup-runner-zombie/spec.md
+
+Scenarios:
+  FRE-S1  force_escalate on in-flight REQ → 200 force_escalated + cleanup task scheduled
+  FRE-S2  force_escalate on already-escalated REQ → 200 noop, no SQL UPDATE, no cleanup
+  FRE-S3  unknown REQ → 404 with 'not found' in detail, no SQL UPDATE, no cleanup
+  FRE-S4  cleanup task MUST be called with terminal_state=ReqState.ESCALATED (→ retain_pvc=True)
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is wrong, escalate to spec_fixer to correct the spec.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+_TOKEN = "test-webhook-token"
+_AUTH = {"Authorization": f"Bearer {_TOKEN}"}
+
+
+def _row(state: str, req_id: str = "REQ-X") -> dict:
+    """Minimal asyncpg-compatible row dict for req_state.get to parse."""
+    return {
+        "req_id": req_id,
+        "project_id": "test-proj",
+        "state": state,
+        "history": "[]",
+        "context": "{}",
+        "created_at": datetime.now(UTC),
+        "updated_at": datetime.now(UTC),
+    }
+
+
+class _FakePool:
+    """Minimal asyncpg pool stub: returns preset fetchrow value, records execute calls."""
+
+    def __init__(self, fetchrow_return=None):
+        self._fetchrow_return = fetchrow_return
+        self.execute_calls: list[tuple] = []
+
+    async def fetchrow(self, sql, *args):
+        return self._fetchrow_return
+
+    async def execute(self, sql, *args):
+        self.execute_calls.append((sql, args))
+
+
+# ─── FRE-S1 ──────────────────────────────────────────────────────────────────
+
+
+async def test_fre_s1_schedules_cleanup_task_on_active_req(monkeypatch):
+    """FRE-S1: POST /admin/req/REQ-X/escalate with state='analyzing'
+    MUST return 200 {action='force_escalated', from_state='analyzing'} and schedule
+    a fire-and-forget asyncio.Task calling engine._cleanup_runner_on_terminal with
+    ReqState.ESCALATED before the endpoint returns.
+    """
+    from httpx import ASGITransport, AsyncClient
+    from orchestrator import engine as engine_mod
+    from orchestrator.main import app
+    from orchestrator.state import ReqState
+    from orchestrator.store import db
+
+    pool = _FakePool(fetchrow_return=_row("analyzing"))
+    cleanup_calls: list[dict] = []
+
+    async def _fake_cleanup(req_id, terminal_state):
+        cleanup_calls.append({"req_id": req_id, "terminal_state": terminal_state})
+
+    monkeypatch.setattr(db, "get_pool", lambda: pool)
+    monkeypatch.setattr(engine_mod, "_cleanup_runner_on_terminal", _fake_cleanup)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/admin/req/REQ-X/escalate", headers=_AUTH)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("action") == "force_escalated", f"expected action=force_escalated, got {body}"
+    assert body.get("from_state") == "analyzing", f"expected from_state=analyzing, got {body}"
+
+    # Allow fire-and-forget asyncio.Task one event-loop tick to execute
+    await asyncio.sleep(0)
+    assert len(cleanup_calls) == 1, (
+        f"cleanup must be scheduled exactly once; got {len(cleanup_calls)} calls"
+    )
+    assert cleanup_calls[0]["req_id"] == "REQ-X"
+    assert cleanup_calls[0]["terminal_state"] == ReqState.ESCALATED, (
+        f"cleanup must receive ReqState.ESCALATED, got {cleanup_calls[0]['terminal_state']}"
+    )
+
+
+# ─── FRE-S2 ──────────────────────────────────────────────────────────────────
+
+
+async def test_fre_s2_noop_on_already_escalated(monkeypatch):
+    """FRE-S2: POST /admin/req/REQ-X/escalate with state='escalated'
+    MUST return 200 {action='noop', state='already escalated'} and
+    MUST NOT execute any SQL UPDATE and MUST NOT schedule a cleanup task.
+    """
+    from httpx import ASGITransport, AsyncClient
+    from orchestrator import engine as engine_mod
+    from orchestrator.main import app
+    from orchestrator.store import db
+
+    pool = _FakePool(fetchrow_return=_row("escalated"))
+    cleanup_calls: list[dict] = []
+
+    async def _fake_cleanup(req_id, terminal_state):
+        cleanup_calls.append({"req_id": req_id, "terminal_state": terminal_state})
+
+    monkeypatch.setattr(db, "get_pool", lambda: pool)
+    monkeypatch.setattr(engine_mod, "_cleanup_runner_on_terminal", _fake_cleanup)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/admin/req/REQ-X/escalate", headers=_AUTH)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("action") == "noop", f"expected action=noop, got {body}"
+    assert "already escalated" in str(body.get("state", "")), (
+        f"expected state to contain 'already escalated', got {body}"
+    )
+
+    assert len(pool.execute_calls) == 0, (
+        f"no SQL UPDATE must be issued on noop path; got {pool.execute_calls}"
+    )
+    await asyncio.sleep(0)
+    assert len(cleanup_calls) == 0, (
+        f"no cleanup task must be scheduled on noop path; got {cleanup_calls}"
+    )
+
+
+# ─── FRE-S3 ──────────────────────────────────────────────────────────────────
+
+
+async def test_fre_s3_unknown_req_returns_404_no_side_effects(monkeypatch):
+    """FRE-S3: POST /admin/req/REQ-DOES-NOT-EXIST/escalate when no req_state row exists
+    MUST return 404 with detail containing 'not found' (case-insensitive).
+    MUST NOT execute any SQL UPDATE and MUST NOT schedule a cleanup task.
+    """
+    from httpx import ASGITransport, AsyncClient
+    from orchestrator import engine as engine_mod
+    from orchestrator.main import app
+    from orchestrator.store import db
+
+    pool = _FakePool(fetchrow_return=None)  # no row → req unknown
+    cleanup_calls: list[dict] = []
+
+    async def _fake_cleanup(req_id, terminal_state):
+        cleanup_calls.append({"req_id": req_id, "terminal_state": terminal_state})
+
+    monkeypatch.setattr(db, "get_pool", lambda: pool)
+    monkeypatch.setattr(engine_mod, "_cleanup_runner_on_terminal", _fake_cleanup)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/admin/req/REQ-DOES-NOT-EXIST/escalate", headers=_AUTH
+        )
+
+    assert resp.status_code == 404, f"expected 404, got {resp.status_code}: {resp.text}"
+    body = resp.json()
+    detail = str(body.get("detail", "")).lower()
+    assert "not found" in detail, (
+        f"404 detail must contain 'not found'; got detail={body.get('detail')!r}"
+    )
+
+    assert len(pool.execute_calls) == 0, (
+        f"no SQL UPDATE must be issued before 404; got {pool.execute_calls}"
+    )
+    await asyncio.sleep(0)
+    assert len(cleanup_calls) == 0, (
+        f"no cleanup task must be scheduled on 404 path; got {cleanup_calls}"
+    )
+
+
+# ─── FRE-S4 ──────────────────────────────────────────────────────────────────
+
+
+async def test_fre_s4_cleanup_arg_is_escalated_not_done(monkeypatch):
+    """FRE-S4: The cleanup task scheduled by force_escalate MUST pass
+    terminal_state=ReqState.ESCALATED (not ReqState.DONE), so that
+    _cleanup_runner_on_terminal derives retain_pvc=True and keeps the PVC
+    for the human-debug retention window.
+    """
+    from httpx import ASGITransport, AsyncClient
+    from orchestrator import engine as engine_mod
+    from orchestrator.main import app
+    from orchestrator.state import ReqState
+    from orchestrator.store import db
+
+    pool = _FakePool(fetchrow_return=_row("analyzing"))
+    terminal_state_args: list[ReqState] = []
+
+    async def _fake_cleanup(req_id, terminal_state):
+        terminal_state_args.append(terminal_state)
+
+    monkeypatch.setattr(db, "get_pool", lambda: pool)
+    monkeypatch.setattr(engine_mod, "_cleanup_runner_on_terminal", _fake_cleanup)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.post("/admin/req/REQ-X/escalate", headers=_AUTH)
+
+    await asyncio.sleep(0)
+    assert len(terminal_state_args) == 1, (
+        "cleanup_runner_on_terminal must be called exactly once"
+    )
+    assert terminal_state_args[0] == ReqState.ESCALATED, (
+        f"retain_pvc=True requires terminal_state=ReqState.ESCALATED; "
+        f"got {terminal_state_args[0]!r}. Passing ReqState.DONE would delete the PVC."
+    )
+    assert terminal_state_args[0] != ReqState.DONE, (
+        "MUST NOT pass ReqState.DONE — that would delete the PVC, "
+        "breaking the human-debug retention window"
+    )

--- a/orchestrator/tests/test_contract_cleanup_runner_zombie.py
+++ b/orchestrator/tests/test_contract_cleanup_runner_zombie.py
@@ -58,6 +58,7 @@ async def test_fre_s1_schedules_cleanup_task_on_active_req(monkeypatch):
     ReqState.ESCALATED before the endpoint returns.
     """
     from httpx import ASGITransport, AsyncClient
+
     from orchestrator import engine as engine_mod
     from orchestrator.main import app
     from orchestrator.state import ReqState
@@ -100,6 +101,7 @@ async def test_fre_s2_noop_on_already_escalated(monkeypatch):
     MUST NOT execute any SQL UPDATE and MUST NOT schedule a cleanup task.
     """
     from httpx import ASGITransport, AsyncClient
+
     from orchestrator import engine as engine_mod
     from orchestrator.main import app
     from orchestrator.store import db
@@ -141,6 +143,7 @@ async def test_fre_s3_unknown_req_returns_404_no_side_effects(monkeypatch):
     MUST NOT execute any SQL UPDATE and MUST NOT schedule a cleanup task.
     """
     from httpx import ASGITransport, AsyncClient
+
     from orchestrator import engine as engine_mod
     from orchestrator.main import app
     from orchestrator.store import db
@@ -185,6 +188,7 @@ async def test_fre_s4_cleanup_arg_is_escalated_not_done(monkeypatch):
     for the human-debug retention window.
     """
     from httpx import ASGITransport, AsyncClient
+
     from orchestrator import engine as engine_mod
     from orchestrator.main import app
     from orchestrator.state import ReqState


### PR DESCRIPTION
## Summary

REQ-cleanup-runner-zombie-1777170378

`POST /admin/req/{req_id}/escalate` (`admin.force_escalate`) was the lone escape hatch in the runner-cleanup net: it does a raw SQL UPDATE of `req_state.state='escalated'` but **doesn't schedule the `cleanup_runner_on_terminal` task** that every transition-driven path into `ESCALATED` runs. Since `runner_gc._active_req_ids` treats `escalated` REQs as active during the full `pvc_retain_on_escalate_days` window, the runner Pod survived the entire retention period as a zombie — eating memory and a PVC slot when other REQs were trying to schedule.

This PR mirrors the existing `admin.complete` pattern: after the SQL UPDATE, schedule a fire-and-forget `asyncio.Task` running `engine._cleanup_runner_on_terminal(req_id, ReqState.ESCALATED)` and track it in a module-level set with a `done_callback` so the loop doesn't GC it. `terminal_state=ESCALATED` is preserved (not promoted to `DONE`) so PVC retention semantics stay identical to the canonical paths — only the Pod is deleted; the PVC remains for human debug.

## Changes

- `orchestrator/src/orchestrator/admin.py` — schedule cleanup task in `force_escalate`; new module-level `_force_escalate_cleanup_tasks` set; doc-strings updated
- `orchestrator/tests/test_admin.py` — `test_force_escalate_marks_escalated_and_triggers_cleanup` (FRE-S1) + `test_force_escalate_noop_when_already_escalated_no_cleanup` (FRE-S2)
- `openspec/changes/REQ-cleanup-runner-zombie-1777170378/` — proposal + tasks + spec.md (4 ADDED Requirements, scenarios FRE-S1..S4) + contract.spec.yaml

## Test plan

- [x] `uv run pytest tests/test_admin.py -q` (31 passed)
- [x] `uv run ruff check src/orchestrator/admin.py tests/test_admin.py` (clean)
- [x] `openspec validate REQ-cleanup-runner-zombie-1777170378` (valid)
- [x] `scripts/check-scenario-refs.sh --specs-search-path . .` (218 scenarios resolved)
- [ ] Post-merge: confirm next force_escalate run no longer leaves a Pod in `kubectl -n sisyphus-runners get pods` after a few seconds (PVC should still be there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)