### PR TITLE
fix(checkers): expose git fetch stderr in silent-pass guard

### DIFF
--- a/orchestrator/src/orchestrator/checkers/dev_cross_check.py
+++ b/orchestrator/src/orchestrator/checkers/dev_cross_check.py
@@ -58,11 +58,19 @@ def _build_cmd(req_id: str) -> str:
         "ran=0; "
         "for repo in /workspace/source/*/; do "
         '  name=$(basename "$repo"); '
-        f'  if ! (cd "$repo" && git fetch origin "feat/{req_id}" 2>/dev/null && git checkout -B "feat/{req_id}" "origin/feat/{req_id}" 2>/dev/null); then '
-        f'    echo "=== FAIL dev_cross_check: $name has no feat/{req_id} branch on origin — refusing to silent-pass ===" >&2; '
+        # 暴露 fetch 真错（之前 2>/dev/null 把 auth/network/dns 失败全吞，silent-pass
+        # guard 一律打成"branch 不存在"，REQ-ttpos-pat-validate-v4 实证：branch 真在
+        # origin，fetch 失败原因被掩盖 → verifier 8min 思考还判不准）。
+        # 现在：捕 stderr，rev-parse 单独验 origin ref 是否真到位，失败时把 fetch 真
+        # 错塞进 silent-pass 信息里。
+        f'  fetch_err=$(cd "$repo" && git fetch origin "feat/{req_id}" 2>&1 || true); '
+        f'  if ! (cd "$repo" && git rev-parse --verify "refs/remotes/origin/feat/{req_id}" >/dev/null 2>&1); then '
+        f'    echo "=== FAIL dev_cross_check: $name has no feat/{req_id} branch reachable on origin — refusing to silent-pass ===" >&2; '
+        '    echo "git fetch stderr: $fetch_err" >&2; '
         "    fail=1; "
         "    continue; "
         "  fi; "
+        f'  cd "$repo" && git checkout -B "feat/{req_id}" "origin/feat/{req_id}" >/dev/null 2>&1; '
         '  if [ -f "$repo/Makefile" ] && grep -q \'^ci-lint:\' "$repo/Makefile"; then '
         '    base_rev=$(cd "$repo" && (git merge-base HEAD origin/main 2>/dev/null '
         '              || git merge-base HEAD origin/develop 2>/dev/null '

--- a/orchestrator/src/orchestrator/checkers/staging_test.py
+++ b/orchestrator/src/orchestrator/checkers/staging_test.py
@@ -72,11 +72,19 @@ def _build_cmd(req_id: str) -> str:
         'pids=""; '
         "for repo in /workspace/source/*/; do "
         '  name=$(basename "$repo"); '
-        f'  if ! (cd "$repo" && git fetch origin "feat/{req_id}" 2>/dev/null && git checkout -B "feat/{req_id}" "origin/feat/{req_id}" 2>/dev/null); then '
-        f'    echo "=== FAIL staging_test: $name has no feat/{req_id} branch on origin — refusing to silent-pass ===" >&2; '
+        # 暴露 fetch 真错（之前 2>/dev/null 把 auth/network/dns 失败全吞，silent-pass
+        # guard 一律打成"branch 不存在"，REQ-ttpos-pat-validate-v4 实证：branch 真在
+        # origin，fetch 失败原因被掩盖 → verifier 8min 思考还判不准）。
+        # 现在：捕 stderr，rev-parse 单独验 origin ref 是否真到位，失败时把 fetch 真
+        # 错塞进 silent-pass 信息里。
+        f'  fetch_err=$(cd "$repo" && git fetch origin "feat/{req_id}" 2>&1 || true); '
+        f'  if ! (cd "$repo" && git rev-parse --verify "refs/remotes/origin/feat/{req_id}" >/dev/null 2>&1); then '
+        f'    echo "=== FAIL staging_test: $name has no feat/{req_id} branch reachable on origin — refusing to silent-pass ===" >&2; '
+        '    echo "git fetch stderr: $fetch_err" >&2; '
         "    fail=1; "
         "    continue; "
         "  fi; "
+        f'  cd "$repo" && git checkout -B "feat/{req_id}" "origin/feat/{req_id}" >/dev/null 2>&1; '
         '  if [ -f "$repo/Makefile" ] '
         '       && grep -q \'^ci-unit-test:\' "$repo/Makefile" '
         '       && grep -q \'^ci-integration-test:\' "$repo/Makefile"; then '

--- a/orchestrator/tests/test_checkers_dev_cross_check.py
+++ b/orchestrator/tests/test_checkers_dev_cross_check.py
@@ -38,6 +38,13 @@ def _assert_for_each_repo_cmd(cmd: str) -> None:
     assert "fail=0" in cmd
     assert "fail=1" in cmd
     assert "[ $fail -eq 0 ]" in cmd  # 不能用 `exit $fail`：orch 包装的 exit-marker echo 不再跑
+    # fetch err 暴露（regression：之前 git fetch 2>/dev/null 把 auth/network 错全吞）
+    assert "fetch_err=" in cmd  # 捕到 stderr 不再丢
+    assert "git fetch stderr:" in cmd  # 失败 message 带真原因
+    assert "rev-parse --verify" in cmd  # 单独验 origin ref 在不在
+    assert 'git fetch origin "feat/' in cmd
+    # 不应再出现把 fetch stderr 全吞的写法
+    assert 'git fetch origin "feat/REQ-997" 2>/dev/null' not in cmd
 
 
 # ── pass ──────────────────────────────────────────────────────────────────

--- a/orchestrator/tests/test_checkers_no_feat_branch_fail_loud.py
+++ b/orchestrator/tests/test_checkers_no_feat_branch_fail_loud.py
@@ -13,7 +13,7 @@ push to a declared-involved repo.
 This REQ tightens dev_cross_check and staging_test (NOT spec_lint, because
 spec changes may legitimately consolidate in a single spec_home repo): if a
 cloned repo lacks feat/<REQ>, the checker now sets fail=1 and emits a
-'has no feat/<REQ> branch on origin — refusing to silent-pass' line to
+'has no feat/<REQ> branch reachable on origin — refusing to silent-pass' line to
 stderr, instead of '[skip] $name: no feat branch / not involved'.
 
 Scenarios:
@@ -102,13 +102,13 @@ def _make_repo_without_feat_branch(parent: Path, name: str) -> Path:
         pytest.param(
             build_dev_cross_check_cmd,
             "dev_cross_check",
-            f"FAIL dev_cross_check: repo-a has no feat/{REQ_ID} branch on origin",
+            f"FAIL dev_cross_check: repo-a has no feat/{REQ_ID} branch reachable on origin",
             id="dev_cross_check",
         ),
         pytest.param(
             build_staging_test_cmd,
             "staging_test",
-            f"FAIL staging_test: repo-a has no feat/{REQ_ID} branch on origin",
+            f"FAIL staging_test: repo-a has no feat/{REQ_ID} branch reachable on origin",
             id="staging_test",
         ),
     ],
@@ -222,7 +222,7 @@ def test_spec_lint_no_feat_branch_still_silent_skip_to_guard_c(tmp_path):
 def test_build_cmd_emits_per_repo_no_feat_branch_fail_loud_literal(builder, name):
     """CNFB-S6: shell template MUST contain the per-repo fail-loud line + fail=1 marker."""
     cmd = builder(REQ_ID)
-    assert f"FAIL {name}: $name has no feat/{REQ_ID} branch on origin" in cmd, (
+    assert f"FAIL {name}: $name has no feat/{REQ_ID} branch reachable on origin" in cmd, (
         f"{name}: shell template missing per-repo fail-loud literal.\n"
         f"got cmd: {cmd}"
     )

--- a/orchestrator/tests/test_checkers_staging_test.py
+++ b/orchestrator/tests/test_checkers_staging_test.py
@@ -43,6 +43,11 @@ def _assert_for_each_repo_cmd(cmd: str) -> None:
     # log 文件名 split unit / int
     assert "$name-unit.log" in cmd
     assert "$name-int.log" in cmd
+    # fetch err 暴露（regression：之前 git fetch 2>/dev/null 把 auth/network 错全吞）
+    assert "fetch_err=" in cmd
+    assert "git fetch stderr:" in cmd
+    assert "rev-parse --verify" in cmd
+    assert 'git fetch origin "feat/REQ-997" 2>/dev/null' not in cmd
 
 
 # ── pass：验 cmd 是 for-each-repo 并行版 ─────────────────────────────────────


### PR DESCRIPTION
## Summary
- dev_cross_check + staging_test 不再用 \`git fetch origin "feat/$req_id" 2>/dev/null\` 把 fetch stderr 全吞
- 失败时 silent-pass guard 信息附带真实 fetch err
- 用 \`git rev-parse --verify refs/remotes/origin/feat/$req_id\` 单独确认 ref 是否真到位

## Why
REQ-ttpos-pat-validate-v4-1777170769 实证：branch \`feat/REQ-ttpos-pat-validate-v4-1777170769\` 真在 origin（sonnet challenger 02:45:38 push 成功，gh api 02:46+ 可见），但 dev_cross_check 02:46:03 说 "has no feat/$req_id branch on origin"。verifier 9a6mhly0 思考 514s 也判不准（因为看不到 fetch 真错）→ escalate。

REQ-cleanup-runner-zombie-1777170378 进 fixer 兜了一轮 dev_cross_check 又掉进 staging_test 同款坑（1s silent fail），同根因。

\`2>/dev/null\` 把 auth 失败、DNS 抖、shallow-clone 拉不到新 ref 全部归一成"branch 不存在"，误导 verifier 判 escalate。

## Fix
两个 checker 都改成：
\`\`\`bash
fetch_err=$(cd "$repo" && git fetch origin "feat/$req_id" 2>&1 || true)
if ! (cd "$repo" && git rev-parse --verify "refs/remotes/origin/feat/$req_id" >/dev/null 2>&1); then
  echo "=== FAIL ...: $name has no feat/$req_id branch reachable on origin ===" >&2
  echo "git fetch stderr: $fetch_err" >&2
  fail=1; continue
fi
cd "$repo" && git checkout -B "feat/$req_id" "origin/feat/$req_id" >/dev/null 2>&1
\`\`\`

## Test plan
- [x] \`uv run pytest tests/test_checkers_dev_cross_check.py tests/test_checkers_staging_test.py -x -q\` → 14 passed
- [x] \`_assert_for_each_repo_cmd\` 加 4 条断言确认新模板字段，且禁掉旧 \`2>/dev/null\` 写法
- [ ] Post-merge: 重派 ttpos REQ，artifact_checks.stderr_tail 应能看到 \`git fetch stderr: ...\` 真原因（多半暴露出 clone helper 没把 PAT 写进 .git/config 这类配置 bug，下个迭代修）

## Out of scope
- 修 fetch 真错的根因（先暴露，看到了再针对修；可能在 \`sisyphus-clone-repos.sh\` 不写 credential.helper）
- 其他 silent-pass guard 路径（spec_lint、accept 等；逐个确认是否同款再修）