### PR TITLE
fix(runner): install uv in both images (unblocks sisyphus self-dogfood)

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -52,6 +52,16 @@ ENV PATH="/usr/local/go/bin:/root/go/bin:$PATH" \
 # 退回 openspec 是 npm 上的占位空包，REQ-997 analyze 暴露的）
 RUN npm install -g @fission-ai/openspec@latest && openspec --version
 
+# ─── 4b. uv（sisyphus 自 dogfood + Python 业务仓 Makefile 用 uv run 必装） ─────
+# 实证 2026-04-26 REQ-impl-gh-incident-open-1777173133 dev_cross_check stderr：
+#   /bin/sh: 12: uv: not found
+#   make: *** [Makefile:27: ci-lint] Error 127
+# sisyphus Makefile ci-lint 走 `cd orchestrator && uv run ruff check`，runner 镜像
+# 没 uv → 所有 sisyphus 自 dogfood 在 dev_cross_check 必失败。Flutter runner 也加上
+# 跟 Go runner 对齐（避免 ttpos-flutter REQ 撞同款）。
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
+    && uv --version
+
 # ─── 5. sisyphus 合约脚本 ──────────────────
 # build context 必须是 sisyphus repo 根（CI workflow 已配 context: .）
 COPY scripts/check-scenario-refs.sh \

--- a/runner/go.Dockerfile
+++ b/runner/go.Dockerfile
@@ -54,6 +54,16 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/ins
     | sh -s -- -b /usr/local/bin v1.62.2 \
     && golangci-lint --version
 
+# ─── 3c. uv（sisyphus 自 dogfood + 任何 Python 业务仓 Makefile 用 uv run） ──────
+# 实证 2026-04-26 REQ-impl-gh-incident-open-1777173133 dev_cross_check stderr：
+#   /bin/sh: 12: uv: not found
+#   make: *** [Makefile:27: ci-lint] Error 127
+# sisyphus 自身 Makefile ci-lint 跑 `cd orchestrator && uv run ruff check`，runner
+# 镜像没 uv → 所有 sisyphus 自 dogfood 在 dev_cross_check 必失败。Python 业务仓也常
+# 用 uv（Astral 推 Python 包管），同步装上避免重蹈 golangci-lint 覆辙。
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
+    && uv --version
+
 # ─── 4. sisyphus 合约脚本 ──────────────────
 COPY scripts/check-scenario-refs.sh \
      scripts/check-tasks-section-ownership.sh \


### PR DESCRIPTION
## Summary
- Add \`uv\` to \`runner/go.Dockerfile\` and \`runner/Dockerfile\` (Flutter)
- Mirrors the existing golangci-lint install pattern

## Why
PR #117's fetch-stderr visibility surfaced the actual reason every sisyphus self-dogfood REQ has been silently failing at dev_cross_check. From REQ-impl-gh-incident-open-1777173133's \`artifact_checks.stderr_tail\`:
\`\`\`
/bin/sh: 12: uv: not found
make: *** [Makefile:27: ci-lint] Error 127
=== FAIL: sisyphus ===
\`\`\`
sisyphus's own Makefile ci-lint target uses \`uv run ruff check\` (line 26-38). Without uv the checker exits 127, fails loud, sends verifier in circles, and dogfood loops never close.

Same class of bug as REQ-final13's missing golangci-lint — env not code.

## Test plan
- [x] Pure Dockerfile change; helm + lint-test should pass without sisyphus changes
- [ ] Post-merge: image build → \`runner.image: ...:sha-X\` propagated via helm values → next dogfood REQ \`make ci-lint\` should run \`uv run ruff\` for real (passing or failing on real lint, not 127)
- [ ] Re-dispatch the cleanup-runner-zombie dogfood REQ once new runner image deployed; expect dev_cross_check to either pass cleanly or produce a real ruff diff fail (which fixer can actually fix)

## Out of scope
- helm values runner.image bump — separate ops step after image publish
- Other env-bug classes (e.g., spec_lint pyproject deps) — not encountered yet