### PR TITLE
feat(escalate): open one GH incident per involved source repo (REQ-gh-incident-per-involved-repo-1777180551)

### DIFF
--- a/openspec/changes/REQ-gh-incident-per-involved-repo-1777180551/design.md
+++ b/openspec/changes/REQ-gh-incident-per-involved-repo-1777180551/design.md
@@ -1,0 +1,77 @@
+# Design: per-involved-repo gh-incident
+
+## Resolution layer order
+
+The escalate action already knows two ways to find "what repos this REQ touches":
+
+1. The clone helper's `resolve_repos(ctx, tags=, default_repos=)` walks
+   `intake_finalized_intent.involved_repos` → `ctx.involved_repos` → `tags repo:` →
+   `settings.default_involved_repos` and returns the first non-empty list. This is the
+   exact information we want for incident routing — if you cloned repo-a + repo-b for
+   the dev stage, an escalation in those stages should surface in repo-a + repo-b.
+2. `settings.gh_incident_repo` is the existing single-inbox knob.
+
+Reusing `resolve_repos` keeps "where the code lives" and "where the incident lands"
+consistent — there's no scenario where we cloned repo-a but the incident lands somewhere
+else. The single-inbox knob is repurposed as **layer 5**: only consulted when layers 1-4
+are all empty (intake-stage escalate, infra failure pre-clone, and so on). When layers
+1-4 yield repos, the single-inbox knob is **ignored**; this avoids "every multi-repo REQ
+posts N+1 issues" (one extra in the central inbox), which would just dilute the central
+inbox into noise.
+
+## ctx shape
+
+- **New**: `ctx.gh_incident_urls: dict[str, str]` — `{repo_slug: html_url}` for every
+  successfully opened incident. This is the source of truth for idempotency: if
+  `repo-a` is already a key, skip the POST to `repo-a` on re-entry. Repo lookups are
+  exact-string (slug from layer N matches slug used in the prior call).
+- **Kept for compat**: `ctx.gh_incident_url: str` — set to the first newly opened URL
+  in this call (or, if all repos were already-handled idempotently, left untouched).
+  This keeps the single-URL admin view (`curl /admin/req/{id}`) and downstream
+  Metabase queries unchanged for single-repo deployments. New code reads
+  `gh_incident_urls`; legacy readers keep working off `gh_incident_url`.
+- **Unchanged**: `ctx.gh_incident_opened_at` is set on the first successful POST in
+  the call (one timestamp per escalate invocation, not per repo).
+
+## Per-repo failure isolation
+
+The original implementation wrapped `open_incident` in a try/except inside the function
+itself; we keep that. The new escalate loop additionally treats each repo's POST
+independently — a 4xx/5xx on `repo-a` returns `None` from `open_incident`, the loop
+skips that repo, and the next repo proceeds. Operationally this matters when:
+
+- The orchestrator PAT has Issues:Write on `repo-a` but not `repo-b` (cross-org REQ);
+  `repo-a` gets an incident, `repo-b` is logged and skipped.
+- GitHub returns 5xx mid-loop; we don't retry inside escalate (that's the caller's
+  retry boundary), but partial success is still useful.
+
+The `github-incident` BKD tag is added if **any** repo got a URL (either freshly
+opened or pre-existing in `gh_incident_urls`).
+
+## Why we don't migrate `gh_incident_url` → `gh_incident_urls` automatically
+
+Old contexts (REQs that escalated under the v1 implementation) have only
+`gh_incident_url` set. We deliberately do **not** auto-fill `gh_incident_urls` from
+`gh_incident_url` because:
+
+- The legacy URL has no recorded `repo` — we'd be guessing. Wrong-key fills would let
+  the per-repo idempotency path fire a duplicate POST against a different repo than
+  the one originally targeted.
+- Old REQs that escalated under v1 are already terminal; the worst-case re-entry
+  (admin resume → escalate again) is rare and the duplicate cost (one extra issue
+  in the legacy single-inbox repo) is acceptable.
+
+So: read `gh_incident_urls` for the per-repo idempotency check; ignore
+`gh_incident_url` for that purpose; new escalates always write `gh_incident_urls`.
+
+## Tradeoffs left for later
+
+- **Per-repo `gh_incident_opened_at`**: we keep one global timestamp per escalate
+  invocation rather than per repo, since downstream Metabase queries already group
+  by REQ; per-repo timestamps would just add noise without a known consumer.
+- **Cross-issue link-back**: we don't post a "see also: phona/repo-a#42" comment
+  on each repo's incident. Operators get the cross-reference via the BKD intent
+  issue's `github-incident` tag → `ctx.gh_incident_urls` → all URLs. Adding
+  comment edges later is a pure addition.
+- **Incident close on resume**: still out of scope (matches v1 design), since
+  closing requires a separate signal point in `done_archive`/admin-resume.

--- a/openspec/changes/REQ-gh-incident-per-involved-repo-1777180551/proposal.md
+++ b/openspec/changes/REQ-gh-incident-per-involved-repo-1777180551/proposal.md
@@ -1,0 +1,68 @@
+# REQ-gh-incident-per-involved-repo-1777180551: open one GH incident per involved source repo
+
+## Why
+
+Today `escalate.py` opens **one** GH incident issue in `settings.gh_incident_repo` (a single
+configured central inbox, e.g. `phona/sisyphus`). For multi-repo REQs that touch more than
+one source repo (e.g. `phona/repo-a` + `phona/repo-b`), the failure surfaces only in the
+central inbox — the maintainers of the actual code repos never see the incident in their
+own backlog. Symmetrically, when `gh_incident_repo` is left empty (current safe default),
+no issue is opened anywhere even though the involved repos are already known and the PAT
+has access.
+
+The fix: when the REQ's involved repos are resolvable (intake intent / ctx /
+`repo:` tags / `default_involved_repos`), open **one incident per involved repo** so each
+maintainer sees the failure in their own queue. The legacy single-inbox config stays as a
+fallback for REQs whose involved repos are unknown (intake-stage failures, unconfigured
+fallback) and as an explicit "send everything to a central triage queue" knob.
+
+## What changes
+
+- **MOD** `orchestrator/src/orchestrator/gh_incident.py`:
+  `open_incident(...)` now takes `repo: str` as an explicit kwarg. The function MUST
+  POST to `/repos/{repo}/issues` and MUST return `None` (without HTTP) when `repo` is
+  empty or `settings.github_token` is empty. The disabled-when-empty-token semantic
+  stays; the disabled-when-empty-repo semantic moves from "global setting" to "per-call
+  argument empty."
+- **MOD** `orchestrator/src/orchestrator/actions/escalate.py`:
+  In the real-escalate branch, resolve the **list of incident-target repos** via the
+  same multi-layer fallback that drives server-side cloning
+  (`actions/_clone.resolve_repos`):
+  1. `ctx.intake_finalized_intent.involved_repos`
+  2. `ctx.involved_repos`
+  3. tags `repo:<org>/<name>`
+  4. `settings.default_involved_repos`
+  5. `settings.gh_incident_repo` (last-resort single-inbox fallback)
+  Iterate, and for each repo not already in `ctx.gh_incident_urls`, call
+  `open_incident(repo=...)`. Persist the per-repo URLs to
+  `ctx.gh_incident_urls: dict[str, str]` (repo → url). Keep `ctx.gh_incident_url`
+  populated to the first successful URL for backward compatibility with admin views.
+  Per-repo failures are isolated: a 4xx/5xx on `repo-a` MUST NOT prevent the POST to
+  `repo-b`, and at least one successful URL is enough to add the `github-incident`
+  BKD tag.
+- **MOD** `orchestrator/tests/test_gh_incident.py`: refresh GHI-S1..S10 to use the new
+  `repo=` kwarg; add per-involved-repo scenarios.
+- **MOD** `orchestrator/tests/test_contract_gh_incident_open.py`: same refresh.
+- **NEW** specs/gh-incident-open delta: MODIFIED open_incident requirement (signature
+  change: `repo` kwarg) + MODIFIED escalate-action requirement (per-repo loop +
+  fallback chain) + ADDED Requirement: "incident repo resolution layers."
+
+## Impact
+
+- **Affected code**: `orchestrator/src/orchestrator/{gh_incident.py,actions/escalate.py}`,
+  the two unit/contract test files, `openspec/specs/gh-incident-open/spec.md`.
+- **Affected ops**: when `involved_repos` is non-empty (multi-repo REQ in intake or with
+  `repo:` tags), each REQ now creates **N** issues — one per involved repo — instead of
+  one. The PAT (`SISYPHUS_GITHUB_TOKEN`) MUST have `Issues: Read-and-write` on every
+  involved repo; if a repo lacks write scope the per-repo POST fails with 403, gets
+  logged at warning, and the rest of the loop continues. The `gh_incident_repo`
+  knob is unchanged in shape but is **demoted** from "primary target" to "last-resort
+  fallback when involved_repos is empty"; setups that today rely on it (single-inbox
+  triage) keep working with no helm change.
+- **Risk**: low — the per-repo loop short-circuits on empty involved_repos to the
+  existing single-inbox path; idempotency now keys on `(repo, gh_incident_urls)` so
+  resume cycles still produce one issue per repo.
+- **Rollout**: no helm change required. Operators running multi-repo REQs will see
+  N incidents per real-escalate; if that volume is undesired, set `gh_incident_repo`
+  + leave `default_involved_repos` empty + don't tag intent issues with `repo:`,
+  and you fall through to the legacy single-inbox path automatically.

--- a/openspec/changes/REQ-gh-incident-per-involved-repo-1777180551/specs/gh-incident-open/spec.md
+++ b/openspec/changes/REQ-gh-incident-per-involved-repo-1777180551/specs/gh-incident-open/spec.md
@@ -1,0 +1,146 @@
+# gh-incident-open: per-involved-repo loop
+
+## MODIFIED Requirements
+
+### Requirement: open_incident posts to the configured GitHub repo when a REQ escalates
+
+The orchestrator SHALL expose a `gh_incident.open_incident` async function that
+accepts an explicit `repo: str` kwarg. When `repo` and `settings.github_token` are
+both non-empty, it MUST POST to `https://api.github.com/repos/{repo}/issues` with
+a Bearer token, returning the resulting `html_url`. The function MUST return
+`None` (and skip the POST) when either `repo` or `settings.github_token` is empty,
+and MUST return `None` on any HTTP error without raising.
+
+#### Scenario: GHI-S1 disabled when repo argument is empty
+- **GIVEN** any `settings.github_token` value
+- **WHEN** `open_incident(repo="", req_id="REQ-1", reason="x", retry_count=0, intent_issue_id="i", failed_issue_id="i", project_id="p")` is called
+- **THEN** no HTTP request is made and the return value is `None`
+
+#### Scenario: GHI-S2 disabled when github_token is empty
+- **GIVEN** `settings.github_token = ""`
+- **WHEN** `open_incident(repo="phona/sisyphus", ...)` is called
+- **THEN** no HTTP request is made and the return value is `None`
+
+#### Scenario: GHI-S3 success returns the html_url from the GitHub response
+- **GIVEN** `settings.github_token` is set and the GH API returns 201 with `{"html_url": "https://github.com/phona/sisyphus/issues/42"}`
+- **WHEN** `open_incident(repo="phona/sisyphus", ...)` is called
+- **THEN** the POST URL MUST equal `https://api.github.com/repos/phona/sisyphus/issues` with `Authorization: Bearer ...` and `Accept: application/vnd.github+json` headers
+- **AND** the return value equals `"https://github.com/phona/sisyphus/issues/42"`
+
+#### Scenario: GHI-S4 request body contains REQ id, reason, and BKD cross-references
+- **GIVEN** the GH API is mocked to record the POST body
+- **WHEN** `open_incident(repo="phona/sisyphus", req_id="REQ-9", reason="fixer-round-cap", retry_count=0, intent_issue_id="intent-1", failed_issue_id="vfy-3", project_id="proj-A", state="fixer-running")` is called
+- **THEN** the JSON body MUST contain the substrings `REQ-9`, `fixer-round-cap`, `intent-1`, `vfy-3`, `proj-A`, and `fixer-running`
+- **AND** the JSON `labels` array MUST contain both `sisyphus:incident` and `reason:fixer-round-cap`
+
+#### Scenario: GHI-S5 HTTP failure returns None and does not raise
+- **GIVEN** the GH API returns HTTP 503 for `repo="phona/sisyphus"`
+- **WHEN** `open_incident(repo="phona/sisyphus", ...)` is called
+- **THEN** the call MUST NOT raise
+- **AND** the return value MUST be `None`
+
+### Requirement: escalate action opens an incident on real-escalate and is idempotent under resume cycles
+
+The `escalate` action MUST resolve the list of incident-target repos via the
+ordered fallback documented in "Requirement: incident repo resolution layers"
+and, for every repo not already present as a key in `ctx.gh_incident_urls`,
+MUST call `gh_incident.open_incident(repo=...)`. Successfully returned URLs
+MUST be persisted to `ctx.gh_incident_urls` (a `dict[str, str]` mapping
+repo slug to `html_url`); the first newly minted URL in the call MUST also
+be written to the legacy `ctx.gh_incident_url` for backward compatibility.
+The auto-resume branch MUST NOT call `open_incident`. Per-repo HTTP
+failures MUST NOT abort the loop or the escalate flow. The
+`github-incident` BKD tag MUST be appended when at least one URL was
+opened or already present in `ctx.gh_incident_urls`.
+
+#### Scenario: GHI-S6 real-escalate with single involved repo opens one incident
+- **GIVEN** `settings.github_token` is set, `ctx.involved_repos = ["phona/sisyphus"]`, `settings.gh_incident_repo = ""`, and `gh_incident.open_incident` is mocked to return `"https://github.com/phona/sisyphus/issues/42"`
+- **AND** the escalate input is `body.event = "verify.escalate"` with `ctx.escalated_reason = "verifier-decision-escalate"` (non-transient)
+- **WHEN** `escalate(...)` runs
+- **THEN** `gh_incident.open_incident` MUST be awaited exactly once with `repo="phona/sisyphus"`, `req_id`, `reason="verifier-decision-escalate"`, `intent_issue_id`, and `failed_issue_id` matching the input
+- **AND** `req_state.update_context` MUST be invoked with `gh_incident_urls = {"phona/sisyphus": "https://github.com/phona/sisyphus/issues/42"}`, `gh_incident_url = "https://github.com/phona/sisyphus/issues/42"`, and a non-empty `gh_incident_opened_at`
+- **AND** `bkd.merge_tags_and_update` MUST be called with `add` containing `escalated`, `reason:verifier-decision-escalate`, AND `github-incident`
+
+#### Scenario: GHI-S7 idempotent: pre-existing ctx.gh_incident_urls skips the second POST
+- **GIVEN** the same setup as GHI-S6
+- **AND** `ctx.gh_incident_urls = {"phona/sisyphus": "https://github.com/phona/sisyphus/issues/42"}` is already set
+- **WHEN** `escalate(...)` runs again (e.g. resume → re-escalate cycle)
+- **THEN** `gh_incident.open_incident` MUST NOT be awaited
+- **AND** `ctx.gh_incident_urls` MUST be preserved unchanged in the update
+- **AND** the BKD tag merge MUST still include `github-incident`
+
+#### Scenario: GHI-S8 auto-resume branch does not open an incident
+- **GIVEN** the input is `body.event = "session.failed"`, `auto_retry_count = 0` (transient with budget remaining)
+- **WHEN** `escalate(...)` runs
+- **THEN** `gh_incident.open_incident` MUST NOT be awaited
+- **AND** `bkd.follow_up_issue` MUST be awaited (auto-resume continues as today)
+
+#### Scenario: GHI-S9 GH failure does not abort the escalate flow
+- **GIVEN** the same setup as GHI-S6 except `gh_incident.open_incident` returns `None` (GH outage)
+- **WHEN** `escalate(...)` runs
+- **THEN** `bkd.merge_tags_and_update` MUST still be awaited
+- **AND** the action MUST return `{"escalated": True, ...}` as before
+- **AND** the persisted ctx MUST NOT include `gh_incident_url` or a non-empty `gh_incident_urls`
+- **AND** the BKD tag merge MUST NOT include `github-incident`
+
+#### Scenario: GHI-S10 disabled (no involved repos and no fallback) does not break escalate
+- **GIVEN** `ctx.involved_repos` is unset, all other layers are empty, and `settings.gh_incident_repo = ""`
+- **WHEN** `escalate(...)` runs through the real-escalate branch
+- **THEN** `gh_incident.open_incident` MUST NOT be awaited
+- **AND** the action MUST return `{"escalated": True, ...}` exactly as before this change
+- **AND** ctx MUST NOT be mutated with `gh_incident_url`, `gh_incident_urls`, or `gh_incident_opened_at`
+- **AND** the BKD tag merge MUST NOT include `github-incident`
+
+#### Scenario: GHI-S11 multi-repo REQ opens one incident per involved repo
+- **GIVEN** `settings.github_token` is set, `ctx.involved_repos = ["phona/repo-a", "phona/repo-b"]`, `settings.gh_incident_repo = ""`, and `gh_incident.open_incident` is mocked to return `"https://github.com/phona/repo-a/issues/7"` for `repo="phona/repo-a"` and `"https://github.com/phona/repo-b/issues/3"` for `repo="phona/repo-b"`
+- **AND** the escalate input is `body.event = "verify.escalate"` with `ctx.escalated_reason = "verifier-decision-escalate"`
+- **WHEN** `escalate(...)` runs
+- **THEN** `gh_incident.open_incident` MUST be awaited exactly twice — once with `repo="phona/repo-a"` and once with `repo="phona/repo-b"`
+- **AND** `req_state.update_context` MUST be invoked with `gh_incident_urls` containing both `{"phona/repo-a": "https://github.com/phona/repo-a/issues/7"}` and `{"phona/repo-b": "https://github.com/phona/repo-b/issues/3"}`
+- **AND** the BKD tag merge MUST include `github-incident` exactly once
+
+#### Scenario: GHI-S12 partial failure isolated: one repo fails, the other succeeds
+- **GIVEN** `ctx.involved_repos = ["phona/repo-a", "phona/repo-b"]` and `gh_incident.open_incident` returns `None` for `repo="phona/repo-a"` (e.g. 403 — PAT lacks Issues:Write) but returns `"https://github.com/phona/repo-b/issues/3"` for `repo="phona/repo-b"`
+- **WHEN** `escalate(...)` runs
+- **THEN** the action MUST return `{"escalated": True, ...}`
+- **AND** `ctx.gh_incident_urls` MUST equal `{"phona/repo-b": "https://github.com/phona/repo-b/issues/3"}` (failed repo absent)
+- **AND** the BKD tag merge MUST include `github-incident` (one success suffices)
+
+#### Scenario: GHI-S13 idempotent across multi-repo: only missing repos POSTed on re-entry
+- **GIVEN** `ctx.involved_repos = ["phona/repo-a", "phona/repo-b"]` and `ctx.gh_incident_urls = {"phona/repo-a": "https://github.com/phona/repo-a/issues/7"}` (repo-a already opened in a prior escalate call)
+- **AND** `gh_incident.open_incident` returns `"https://github.com/phona/repo-b/issues/3"` for `repo="phona/repo-b"`
+- **WHEN** `escalate(...)` runs again
+- **THEN** `gh_incident.open_incident` MUST be awaited exactly once with `repo="phona/repo-b"` (NOT for `phona/repo-a`)
+- **AND** the persisted `gh_incident_urls` MUST contain both `phona/repo-a` (existing) and `phona/repo-b` (newly added) keys
+
+## ADDED Requirements
+
+### Requirement: incident repo resolution layers
+
+The escalate action MUST resolve the list of incident-target repos via the
+following ordered fallback (the first non-empty layer wins):
+
+1. `ctx.intake_finalized_intent.involved_repos`
+2. `ctx.involved_repos`
+3. BKD intent issue tags of the form `repo:<org>/<name>`
+4. `settings.default_involved_repos`
+5. `[settings.gh_incident_repo]` (single-element list, only when non-empty) —
+   last-resort single-inbox fallback for REQs whose involved repos are unknown
+   (e.g. intake-stage failures pre-clone) and explicit "central triage queue"
+   deployments
+
+When all five layers are empty, the action MUST skip the GH incident loop
+entirely (no HTTP) and the BKD tag merge MUST NOT include `github-incident`.
+
+#### Scenario: GHI-S14 falls back to settings.gh_incident_repo when involved_repos empty
+- **GIVEN** `ctx.involved_repos` is unset, `ctx.intake_finalized_intent` is missing, no `repo:` tags, `settings.default_involved_repos = []`, but `settings.gh_incident_repo = "phona/sisyphus"`, `settings.github_token` is set, and `gh_incident.open_incident` returns `"https://github.com/phona/sisyphus/issues/99"`
+- **WHEN** `escalate(...)` runs (real-escalate path)
+- **THEN** `gh_incident.open_incident` MUST be awaited exactly once with `repo="phona/sisyphus"`
+- **AND** `ctx.gh_incident_urls` MUST equal `{"phona/sisyphus": "https://github.com/phona/sisyphus/issues/99"}`
+- **AND** the BKD tag merge MUST include `github-incident`
+
+#### Scenario: GHI-S15 layers 1-4 take precedence over settings.gh_incident_repo
+- **GIVEN** `ctx.involved_repos = ["phona/repo-a"]` and `settings.gh_incident_repo = "phona/sisyphus"` (both set)
+- **WHEN** `escalate(...)` runs
+- **THEN** `gh_incident.open_incident` MUST be awaited exactly once with `repo="phona/repo-a"` (NOT `phona/sisyphus`)
+- **AND** `ctx.gh_incident_urls` keys MUST equal `{"phona/repo-a"}` (no `phona/sisyphus` entry)

--- a/openspec/changes/REQ-gh-incident-per-involved-repo-1777180551/tasks.md
+++ b/openspec/changes/REQ-gh-incident-per-involved-repo-1777180551/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: REQ-gh-incident-per-involved-repo-1777180551
+
+Single-repo REQ: only `phona/sisyphus` touched. Solo execution (no fan-out).
+
+## Stage: contract / spec
+
+- [x] author `openspec/changes/REQ-gh-incident-per-involved-repo-1777180551/proposal.md`
+- [x] author `openspec/changes/REQ-gh-incident-per-involved-repo-1777180551/design.md`
+- [x] author `openspec/changes/REQ-gh-incident-per-involved-repo-1777180551/specs/gh-incident-open/spec.md` (delta: MODIFIED + ADDED)
+- [x] `openspec validate openspec/changes/REQ-gh-incident-per-involved-repo-1777180551`
+- [x] `check-scenario-refs.sh` clean
+
+## Stage: implementation
+
+- [x] `gh_incident.open_incident`: add explicit `repo: str` kwarg; remove read of `settings.gh_incident_repo`; keep `github_token` empty-guard
+- [x] `actions/escalate.py`: import `_clone.resolve_repos`; add `_resolve_incident_repos` helper layering `gh_incident_repo` as layer 5
+- [x] `actions/escalate.py`: replace single-call POST with per-repo loop; idempotency on `ctx.gh_incident_urls`; legacy `ctx.gh_incident_url` stays populated (first URL)
+- [x] unit test refresh `tests/test_gh_incident.py` (GHI-S1..S5 add `repo=`, GHI-S6..S10 use new ctx shape)
+- [x] unit test refresh `tests/test_contract_gh_incident_open.py` (same)
+- [x] unit tests added: GHI-S11 per-involved-repo loop, GHI-S12 partial failure isolation, GHI-S13 idempotency on per-repo dict, GHI-S14 fallback to `gh_incident_repo` when involved_repos empty
+
+## Stage: PR
+
+- [x] `make ci-lint BASE_REV=$(git merge-base HEAD origin/main)` clean
+- [x] `make ci-unit-test` clean
+- [x] `make ci-integration-test` clean (no integration tests in scope; exit 5 → pass)
+- [x] `git push origin feat/REQ-gh-incident-per-involved-repo-1777180551`
+- [x] `gh pr create` against `main`

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -56,4 +56,5 @@ ignore = ["RUF001", "RUF002", "RUF003", "E501"]
 dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
+    "pytest-httpx>=0.32",
 ]

--- a/orchestrator/src/orchestrator/actions/escalate.py
+++ b/orchestrator/src/orchestrator/actions/escalate.py
@@ -8,8 +8,9 @@
 2. 否则（retry 用完 / verifier 主动判 escalate）:
    → 在 intent issue 上加 `escalated` + `reason:<细分>` tag
    → 落 ctx 标记 escalated_reason
-   → 若 settings.gh_incident_repo 非空且 ctx.gh_incident_url 未设：开一条 GH
-     issue（gh_incident.open_incident）+ `github-incident` BKD tag
+   → 解析 incident-target repos（involved_repos 5 层 fallback，layer 5 是
+     legacy settings.gh_incident_repo）；对每个 repo 独立 POST GH issue，
+     idempotent on ctx.gh_incident_urls；至少一条成功 → 加 `github-incident` BKD tag
    → state 进 ESCALATED
 
 不在 BKD 开新 issue（避免污染列表）；不 cancel 当前 issue（让人工有现场）。
@@ -27,6 +28,7 @@ from ..config import settings
 from ..state import Event, ReqState
 from ..store import db, req_state
 from . import register
+from ._clone import resolve_repos
 
 log = structlog.get_logger(__name__)
 
@@ -91,6 +93,23 @@ _SESSION_END_SIGNALS = {
     "watchdog.intake_no_result_tag",
     "archive.failed",
 }
+
+
+def _resolve_incident_repos(ctx: dict | None, tags) -> list[str]:
+    """Layered fallback for "where do incidents land for this REQ?"
+
+    Layers 1-4 mirror clone resolution (intake_finalized_intent / ctx.involved_repos /
+    `repo:` tags / settings.default_involved_repos). Layer 5 is settings.gh_incident_repo
+    — the legacy single-inbox knob, only consulted when 1-4 are all empty (intake-stage
+    failures pre-clone, "central triage queue" deployments).
+    """
+    repos, _src = resolve_repos(
+        ctx, tags=tags, default_repos=settings.default_involved_repos,
+    )
+    if repos:
+        return repos
+    fallback = (settings.gh_incident_repo or "").strip()
+    return [fallback] if fallback else []
 
 
 @register("escalate", idempotent=True)
@@ -165,34 +184,41 @@ async def escalate(*, body, req_id, tags, ctx):
 
     pool = db.get_pool()
 
-    # ─── GH 事故 issue（idempotent on ctx.gh_incident_url） ────────────────
-    # 仅在 real-escalate 路径开 issue（auto-resume 不开，会刷屏）。
-    # disabled (gh_incident_repo / github_token 任一为空) → open_incident 返
-    # None，flow 不变。GH 5xx / 401 等失败也只 log warning，escalate 仍正常完成。
-    existing_gh_url = (ctx or {}).get("gh_incident_url")
-    if existing_gh_url:
-        gh_url = existing_gh_url  # resume 后再 escalate，复用旧 URL
-    elif not settings.gh_incident_repo:
-        gh_url = None  # feature disabled; skip open_incident entirely
-    else:
+    # ─── GH 事故 issue（per-involved-repo loop, idempotent on ctx.gh_incident_urls） ─
+    # 仅在 real-escalate 路径开 issue（auto-resume 不开，会刷屏）。Layer 1-4 是
+    # involved_repos（跟 clone helper 对齐：哪几个仓被 clone，事故就在那几个仓里
+    # 落 issue）；Layer 5 是 settings.gh_incident_repo（legacy single-inbox fallback，
+    # intake 阶段失败 pre-clone / 集中三角部署）。
+    existing_urls = dict((ctx or {}).get("gh_incident_urls") or {})
+    incident_repos = _resolve_incident_repos(ctx, tags)
+    new_urls: dict[str, str] = {}
+    if incident_repos:
         # 取当前 state 给 issue body（best-effort，None 也能继续）
         try:
             row = await req_state.get(pool, req_id)
             state_str = row.state.value if row else None
         except Exception:
             state_str = None
-        gh_url = await gh_incident.open_incident(
-            req_id=req_id,
-            reason=final_reason,
-            retry_count=retry_count,
-            intent_issue_id=intent_issue_id,
-            failed_issue_id=failed_issue_id,
-            project_id=proj,
-            state=state_str,
-        )
+        for incident_repo in incident_repos:
+            if incident_repo in existing_urls:
+                continue  # idempotent: 此 repo 已开过 issue
+            url = await gh_incident.open_incident(
+                repo=incident_repo,
+                req_id=req_id,
+                reason=final_reason,
+                retry_count=retry_count,
+                intent_issue_id=intent_issue_id,
+                failed_issue_id=failed_issue_id,
+                project_id=proj,
+                state=state_str,
+            )
+            if url:
+                new_urls[incident_repo] = url
+
+    merged_urls = {**existing_urls, **new_urls}
 
     add_tags = ["escalated", f"reason:{final_reason}"]
-    if gh_url:
+    if merged_urls:
         # snapshot._STAGE_FROM_TAGS 已包含 'github-incident'，让 Metabase 看板自然识别
         add_tags.append("github-incident")
 
@@ -210,8 +236,13 @@ async def escalate(*, body, req_id, tags, ctx):
         "escalated_source_issue_id": failed_issue_id,
         "escalated_retry_count": retry_count,
     }
-    if gh_url and not existing_gh_url:
-        ctx_patch["gh_incident_url"] = gh_url
+    if new_urls:
+        # 全量替换 dict（merge of existing_urls + new_urls 已在 merged_urls）
+        ctx_patch["gh_incident_urls"] = merged_urls
+        # legacy single-URL field：保留首次成功 POST 的 URL，让 admin view /
+        # Metabase 旧 query 继续工作。优先 existing（保持旧值），否则取新 URL 第一条。
+        legacy_url = (ctx or {}).get("gh_incident_url") or next(iter(new_urls.values()))
+        ctx_patch["gh_incident_url"] = legacy_url
         ctx_patch["gh_incident_opened_at"] = datetime.now(UTC).isoformat(timespec="seconds")
     await req_state.update_context(pool, req_id, ctx_patch)
 

--- a/orchestrator/src/orchestrator/gh_incident.py
+++ b/orchestrator/src/orchestrator/gh_incident.py
@@ -5,10 +5,9 @@ open an incident — that would be noise). The GH issue is the canonical surface
 use to triage sisyphus failures (`gh issue list --label sisyphus:incident`); BKD tags
 remain the agent-facing signal.
 
-Disabled by default: empty `settings.gh_incident_repo` OR empty `settings.github_token`
-returns None without making any HTTP request. Helm operators flip it on by setting
-`env.gh_incident_repo: phona/sisyphus` once the orchestrator's PAT has
-`Issues: Read-and-write` on that repo.
+Disabled when `repo` (explicit kwarg, resolved by escalate from involved_repos /
+settings.gh_incident_repo fallback) OR `settings.github_token` is empty — both return
+None without making any HTTP request.
 
 Failure mode: any exception or non-2xx HTTP response logs a warning and returns None.
 The escalate action is the retry boundary for the failure path; we do not re-enter
@@ -60,6 +59,7 @@ def _format_body(
 
 async def open_incident(
     *,
+    repo: str,
     req_id: str,
     reason: str,
     retry_count: int,
@@ -68,13 +68,14 @@ async def open_incident(
     project_id: str,
     state: str | None = None,
 ) -> str | None:
-    """POST a fresh issue to `settings.gh_incident_repo`. Returns html_url or None.
+    """POST a fresh issue to `repo`. Returns html_url or None.
 
-    Returns None (without HTTP) when disabled (no repo / no token). Returns None on
-    any HTTP error (logged at warning) — never raises, so the escalate flow can
-    proceed even if GitHub is unreachable.
+    Returns None (without HTTP) when `repo` or `settings.github_token` is empty.
+    Returns None on any HTTP error (logged at warning) — never raises, so the
+    escalate flow can proceed even if GitHub is unreachable / per-repo PAT scope
+    is missing.
     """
-    repo = settings.gh_incident_repo.strip()
+    repo = (repo or "").strip()
     token = settings.github_token.strip()
     if not repo or not token:
         log.debug("gh_incident.disabled", req_id=req_id,
@@ -102,15 +103,17 @@ async def open_incident(
             resp = await client.post(url, headers=headers, json=payload)
         if resp.status_code >= 300:
             log.warning("gh_incident.http_error",
-                        req_id=req_id, status=resp.status_code,
+                        req_id=req_id, repo=repo, status=resp.status_code,
                         body_tail=resp.text[-200:])
             return None
         html_url = resp.json().get("html_url")
         if not html_url:
-            log.warning("gh_incident.no_html_url", req_id=req_id, body_tail=resp.text[-200:])
+            log.warning("gh_incident.no_html_url", req_id=req_id, repo=repo,
+                        body_tail=resp.text[-200:])
             return None
-        log.info("gh_incident.opened", req_id=req_id, url=html_url, reason=reason)
+        log.info("gh_incident.opened", req_id=req_id, repo=repo,
+                 url=html_url, reason=reason)
         return html_url
     except Exception as e:
-        log.warning("gh_incident.failed", req_id=req_id, error=str(e))
+        log.warning("gh_incident.failed", req_id=req_id, repo=repo, error=str(e))
         return None

--- a/orchestrator/tests/test_contract_gh_incident_open.py
+++ b/orchestrator/tests/test_contract_gh_incident_open.py
@@ -1,23 +1,28 @@
-"""Contract tests for REQ-impl-gh-incident-open-1777173133:
-feat(orchestrator): open GitHub issue when REQ enters ESCALATED
+"""Contract tests for REQ-gh-incident-per-involved-repo-1777180551:
+feat(orchestrator): open one GitHub incident per involved source repo.
 
 Black-box behavioral contracts derived exclusively from:
-  openspec/changes/REQ-impl-gh-incident-open-1777173133/specs/gh-incident-open/spec.md
+  openspec/specs/gh-incident-open/spec.md (post REQ-gh-incident-per-involved-repo)
 
 Scenarios covered:
-  GHI-S1  open_incident disabled when gh_incident_repo is empty → None, no HTTP
-  GHI-S2  open_incident disabled when github_token is empty → None, no HTTP
-  GHI-S3  open_incident success → POST correct URL + headers, returns html_url
-  GHI-S4  open_incident POST body contains required fields and labels array
-  GHI-S5  open_incident HTTP failure (503) → None, does not raise
-  GHI-S6  escalate real-escalate: open_incident awaited once, ctx stores URL, github-incident tag
-  GHI-S7  escalate idempotent: ctx.gh_incident_url already set → open_incident NOT called
-  GHI-S8  escalate auto-resume branch → open_incident NOT called
-  GHI-S9  escalate: GH failure (open_incident→None) does not abort the flow
-  GHI-S10 escalate: disabled (gh_incident_repo='') → flow proceeds, no github-incident tag
+  GHI-S1   open_incident disabled when repo='' → None, no HTTP
+  GHI-S2   open_incident disabled when github_token='' → None, no HTTP
+  GHI-S3   open_incident success → POST correct URL + headers, returns html_url
+  GHI-S4   open_incident POST body contains required fields and labels array
+  GHI-S5   open_incident HTTP failure (503) → None, does not raise
+  GHI-S6   escalate single involved-repo: one POST, ctx.gh_incident_urls has the entry
+  GHI-S7   escalate idempotent: ctx.gh_incident_urls already covers all involved repos → no POST
+  GHI-S8   escalate auto-resume branch → no POST
+  GHI-S9   escalate: GH failure (open_incident→None) does not abort the flow
+  GHI-S10  escalate: no involved_repos and no settings.gh_incident_repo → no POST, no tag
+  GHI-S11  escalate multi-involved-repo → one POST per repo, urls dict has both keys
+  GHI-S12  escalate partial failure isolated → only successful repo persisted
+  GHI-S13  escalate idempotent across multi-repo: only missing repos POSTed on re-entry
+  GHI-S14  escalate falls back to settings.gh_incident_repo when involved_repos empty
+  GHI-S15  ctx.involved_repos beats settings.gh_incident_repo (layers 1-4 win)
 
-Function signatures verified at test design time (without reading source):
-  open_incident(*, req_id, reason, retry_count, intent_issue_id, failed_issue_id,
+Function signatures verified at test design time:
+  open_incident(*, repo, req_id, reason, retry_count, intent_issue_id, failed_issue_id,
                 project_id, state=None) -> str | None
   escalate(*, body, req_id, tags, ctx) -> dict
 
@@ -38,15 +43,16 @@ import pytest
 
 
 def _make_settings(
-    gh_incident_repo: str = "phona/sisyphus",
+    gh_incident_repo: str = "",
     github_token: str = "ghp_test_token",
     gh_incident_labels: list | None = None,
+    default_involved_repos: list | None = None,
 ) -> Any:
     s = MagicMock()
     s.gh_incident_repo = gh_incident_repo
     s.github_token = github_token
     s.gh_incident_labels = gh_incident_labels if gh_incident_labels is not None else ["sisyphus:incident"]
-    # Fields used by other parts of escalate that are not under test
+    s.default_involved_repos = list(default_involved_repos or [])
     s.bkd_base_url = "https://bkd.example.test/api"
     s.bkd_token = "test-token"
     s.max_auto_retries = 2
@@ -67,17 +73,18 @@ def _make_body(event: str = "verify.escalate", project_id: str = "proj-test") ->
 
 
 class TestOpenIncidentDisabled:
-    """Spec: open_incident returns None when either config setting is empty."""
+    """Spec: open_incident returns None when either input is empty."""
 
-    async def test_ghi_s1_disabled_when_gh_incident_repo_empty(self):
+    async def test_ghi_s1_disabled_when_repo_arg_empty(self):
         """
-        GHI-S1: gh_incident_repo='' → open_incident returns None without making any HTTP request.
+        GHI-S1: open_incident(repo="") → returns None without any HTTP request.
         """
         import orchestrator.gh_incident as ghi
 
-        s = _make_settings(gh_incident_repo="")
+        s = _make_settings()
         with patch.object(ghi, "settings", s):
             result = await ghi.open_incident(
+                repo="",
                 req_id="REQ-1",
                 reason="x",
                 retry_count=0,
@@ -87,18 +94,19 @@ class TestOpenIncidentDisabled:
             )
 
         assert result is None, (
-            f"open_incident MUST return None when gh_incident_repo is empty; got {result!r}"
+            f"open_incident MUST return None when repo arg is empty; got {result!r}"
         )
 
     async def test_ghi_s2_disabled_when_github_token_empty(self):
         """
-        GHI-S2: github_token='' → open_incident returns None without making any HTTP request.
+        GHI-S2: github_token='' → open_incident returns None without any HTTP request.
         """
         import orchestrator.gh_incident as ghi
 
         s = _make_settings(github_token="")
         with patch.object(ghi, "settings", s):
             result = await ghi.open_incident(
+                repo="phona/sisyphus",
                 req_id="REQ-1",
                 reason="x",
                 retry_count=0,
@@ -138,6 +146,7 @@ class TestOpenIncidentSuccess:
         s = _make_settings()
         with patch.object(ghi, "settings", s):
             result = await ghi.open_incident(
+                repo="phona/sisyphus",
                 req_id="REQ-1",
                 reason="test-reason",
                 retry_count=0,
@@ -152,7 +161,7 @@ class TestOpenIncidentSuccess:
 
         request = httpx_mock.get_request()
         assert request is not None, (
-            "open_incident MUST send an HTTP POST request when both settings are non-empty"
+            "open_incident MUST send an HTTP POST request when both inputs are non-empty"
         )
         assert str(request.url) == "https://api.github.com/repos/phona/sisyphus/issues", (
             f"POST URL must be 'https://api.github.com/repos/phona/sisyphus/issues'; "
@@ -184,6 +193,7 @@ class TestOpenIncidentSuccess:
         s = _make_settings()
         with patch.object(ghi, "settings", s):
             await ghi.open_incident(
+                repo="phona/sisyphus",
                 req_id="REQ-9",
                 reason="fixer-round-cap",
                 retry_count=0,
@@ -237,6 +247,7 @@ class TestOpenIncidentHTTPFailure:
         with patch.object(ghi, "settings", s):
             try:
                 result = await ghi.open_incident(
+                    repo="phona/sisyphus",
                     req_id="REQ-1",
                     reason="x",
                     retry_count=0,
@@ -256,10 +267,7 @@ class TestOpenIncidentHTTPFailure:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Part 4: escalate action integration — GHI-S6 to GHI-S10
-#
-# escalate(*, body, req_id, tags, ctx) → dict
-# Patches applied to orchestrator.actions.escalate module attributes.
+# Part 4: escalate action integration — GHI-S6 .. GHI-S15
 # ─────────────────────────────────────────────────────────────────────────────
 
 
@@ -279,20 +287,29 @@ def _make_escalate_mocks(
     open_incident_calls: list,
     merge_tags_calls: list,
     update_ctx_calls: list,
-    gh_return_url: str | None = "https://github.com/phona/sisyphus/issues/42",
+    gh_return: Any = "https://github.com/phona/sisyphus/issues/42",
 ) -> tuple[Any, Any, Any, Any]:
-    """Build mock objects for escalate's module-level imports."""
+    """Build mock objects for escalate's module-level imports.
 
-    # Mock gh_incident module
+    `gh_return` may be:
+      - a string  → all open_incident calls return that string
+      - None      → all calls return None (GH outage)
+      - a dict    → keyed by repo arg; missing keys → None
+      - a callable → called with kwargs, must return str | None
+    """
+
     mock_gh = MagicMock()
 
     async def _capture_open_incident(**kwargs):
         open_incident_calls.append(dict(kwargs))
-        return gh_return_url
+        if callable(gh_return):
+            return gh_return(**kwargs)
+        if isinstance(gh_return, dict):
+            return gh_return.get(kwargs.get("repo"))
+        return gh_return
 
     mock_gh.open_incident = _capture_open_incident
 
-    # Mock BKDClient (used as `async with BKDClient(...) as bkd:`)
     mock_bkd_inner = MagicMock()
 
     async def _capture_merge(*args, **kwargs):
@@ -308,7 +325,6 @@ def _make_escalate_mocks(
     mock_bkd_inst.__aexit__ = AsyncMock(return_value=False)
     mock_BKDClient = MagicMock(return_value=mock_bkd_inst)
 
-    # Mock req_state module
     mock_rs = MagicMock()
 
     async def _capture_update_ctx(*args, **kwargs):
@@ -318,7 +334,6 @@ def _make_escalate_mocks(
     mock_rs.cas_state = AsyncMock()
     mock_rs.get = AsyncMock()
 
-    # Mock k8s_runner module (cleanup calls — must not fail)
     mock_k8s = MagicMock()
     mock_k8s.cleanup_runner = AsyncMock()
     mock_k8s.delete_runner = AsyncMock()
@@ -328,7 +343,6 @@ def _make_escalate_mocks(
 
 
 def _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s):
-    """Return list of patch context managers for the escalate module."""
     return [
         patch("orchestrator.actions.escalate.settings", settings),
         patch("orchestrator.actions.escalate.gh_incident", mock_gh),
@@ -351,17 +365,16 @@ def _get_add_list(merge_call: dict) -> list:
     return add_list
 
 
-class TestEscalateRealEscalateGHIS6:
-    """GHI-S6: real-escalate → open_incident called once, ctx URL stored, github-incident tag added."""
+def _last_url_update(update_ctx_calls: list) -> dict | None:
+    matches = [u for u in update_ctx_calls
+               if "gh_incident_urls" in u or "gh_incident_url" in u]
+    return matches[-1] if matches else None
 
-    async def test_ghi_s6_real_escalate_opens_incident_and_stores_url(self):
-        """
-        GHI-S6: body.event='verify.escalate', ctx.escalated_reason='verifier-decision-escalate' →
-        - open_incident awaited exactly once with req_id + reason matching input
-        - req_state.update_context called with gh_incident_url + gh_incident_opened_at
-        - bkd.merge_tags_and_update 'add' contains 'escalated', 'reason:verifier-decision-escalate',
-          AND 'github-incident'
-        """
+
+class TestEscalateRealEscalateGHIS6:
+    """GHI-S6: real-escalate single involved repo → one POST, ctx.gh_incident_urls populated."""
+
+    async def test_ghi_s6_single_involved_repo_opens_one_incident(self):
         from orchestrator.actions.escalate import escalate
 
         open_incident_calls: list = []
@@ -371,7 +384,7 @@ class TestEscalateRealEscalateGHIS6:
         settings = _make_settings()
         mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
             open_incident_calls, merge_tags_calls, update_ctx_calls,
-            gh_return_url="https://github.com/phona/sisyphus/issues/42",
+            gh_return="https://github.com/phona/sisyphus/issues/42",
         )
 
         body = _make_body("verify.escalate")
@@ -379,76 +392,55 @@ class TestEscalateRealEscalateGHIS6:
             "escalated_reason": "verifier-decision-escalate",
             "escalated_source_issue_id": "fail-issue-ghi",
             "auto_retry_count": 5,
+            "involved_repos": ["phona/sisyphus"],
         }
 
         patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
         with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-            try:
-                await escalate(
-                    body=body,
-                    req_id="REQ-test-ghi",
-                    tags=["REQ-test-ghi", "verifier"],
-                    ctx=ctx,
-                )
-            except Exception as exc:
-                pytest.fail(
-                    f"escalate raised unexpectedly in real_escalate path: "
-                    f"{type(exc).__name__}: {exc}"
-                )
+            await escalate(
+                body=body,
+                req_id="REQ-test-ghi",
+                tags=["REQ-test-ghi", "verifier"],
+                ctx=ctx,
+            )
 
-        # Contract 1: open_incident called exactly once
         assert len(open_incident_calls) == 1, (
-            f"gh_incident.open_incident MUST be awaited exactly once in real_escalate; "
-            f"called {len(open_incident_calls)} time(s). Calls: {open_incident_calls!r}"
+            f"open_incident MUST be awaited exactly once for a single involved repo; "
+            f"got {len(open_incident_calls)} calls: {open_incident_calls!r}"
         )
         call = open_incident_calls[0]
-        assert call.get("req_id") == "REQ-test-ghi", (
-            f"open_incident must be called with req_id='REQ-test-ghi'; got call: {call!r}"
+        assert call.get("repo") == "phona/sisyphus", (
+            f"open_incident must be called with repo='phona/sisyphus'; got {call!r}"
         )
-        assert call.get("reason") == "verifier-decision-escalate", (
-            f"open_incident must be called with reason='verifier-decision-escalate'; "
-            f"got call: {call!r}"
+        assert call.get("req_id") == "REQ-test-ghi"
+        assert call.get("reason") == "verifier-decision-escalate"
+
+        u = _last_url_update(update_ctx_calls)
+        assert u is not None, (
+            f"update_context MUST be called with gh_incident_urls; "
+            f"all updates: {update_ctx_calls!r}"
+        )
+        assert u.get("gh_incident_urls") == {
+            "phona/sisyphus": "https://github.com/phona/sisyphus/issues/42",
+        }, f"gh_incident_urls dict mismatch: {u!r}"
+        assert u.get("gh_incident_url") == "https://github.com/phona/sisyphus/issues/42", (
+            f"legacy gh_incident_url must equal the first URL: {u!r}"
+        )
+        assert u.get("gh_incident_opened_at"), (
+            f"gh_incident_opened_at MUST be non-empty: {u!r}"
         )
 
-        # Contract 2: update_context includes gh_incident_url + gh_incident_opened_at
-        url_updates = [u for u in update_ctx_calls if "gh_incident_url" in u]
-        assert url_updates, (
-            f"req_state.update_context MUST be called with gh_incident_url; "
-            f"all captured updates: {update_ctx_calls!r}"
-        )
-        url_update = url_updates[-1]
-        assert url_update["gh_incident_url"] == "https://github.com/phona/sisyphus/issues/42", (
-            f"gh_incident_url must equal the URL returned by open_incident; "
-            f"got {url_update['gh_incident_url']!r}"
-        )
-        assert url_update.get("gh_incident_opened_at"), (
-            f"update_context MUST include non-empty gh_incident_opened_at; "
-            f"got update: {url_update!r}"
-        )
-
-        # Contract 3: bkd.merge_tags_and_update add list contains github-incident
-        assert merge_tags_calls, (
-            "bkd.merge_tags_and_update MUST be called in the real_escalate branch"
-        )
+        assert merge_tags_calls
         add_list = _get_add_list(merge_tags_calls[-1])
-        assert "github-incident" in add_list, (
-            f"bkd.merge_tags_and_update 'add' list MUST contain 'github-incident'; "
-            f"got add={add_list!r}, full call: {merge_tags_calls[-1]!r}"
-        )
-        assert "escalated" in add_list, (
-            f"bkd.merge_tags_and_update 'add' list MUST still contain 'escalated'; "
-            f"got add={add_list!r}"
-        )
+        assert "github-incident" in add_list
+        assert "escalated" in add_list
+        assert "reason:verifier-decision-escalate" in add_list
 
 
 class TestEscalateIdempotentGHIS7:
-    """GHI-S7: ctx.gh_incident_url already set → open_incident NOT called (resume cycle safe)."""
+    """GHI-S7: ctx.gh_incident_urls already covers the involved repo → no POST."""
 
-    async def test_ghi_s7_skips_open_incident_when_url_already_in_ctx(self):
-        """
-        GHI-S7: ctx.gh_incident_url is pre-set →
-        open_incident MUST NOT be awaited (idempotent under resume cycles).
-        """
+    async def test_ghi_s7_idempotent_when_urls_dict_covers_all(self):
         from orchestrator.actions.escalate import escalate
 
         open_incident_calls: list = []
@@ -458,7 +450,7 @@ class TestEscalateIdempotentGHIS7:
         settings = _make_settings()
         mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
             open_incident_calls, merge_tags_calls, update_ctx_calls,
-            gh_return_url="https://github.com/phona/sisyphus/issues/42",
+            gh_return="https://example/should/not/be/called",
         )
 
         body = _make_body("verify.escalate")
@@ -466,37 +458,34 @@ class TestEscalateIdempotentGHIS7:
             "escalated_reason": "verifier-decision-escalate",
             "escalated_source_issue_id": "fail-issue-ghi",
             "auto_retry_count": 5,
-            "gh_incident_url": "https://github.com/phona/sisyphus/issues/42",  # pre-set
+            "involved_repos": ["phona/sisyphus"],
+            "gh_incident_urls": {
+                "phona/sisyphus": "https://github.com/phona/sisyphus/issues/42",
+            },
         }
 
         patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
         with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-            try:
-                await escalate(
-                    body=body,
-                    req_id="REQ-test-ghi",
-                    tags=["REQ-test-ghi", "verifier"],
-                    ctx=ctx,
-                )
-            except Exception as exc:
-                pytest.fail(
-                    f"escalate raised unexpectedly: {type(exc).__name__}: {exc}"
-                )
+            await escalate(
+                body=body,
+                req_id="REQ-test-ghi",
+                tags=["REQ-test-ghi", "verifier"],
+                ctx=ctx,
+            )
 
         assert len(open_incident_calls) == 0, (
-            f"gh_incident.open_incident MUST NOT be called when ctx.gh_incident_url is already set; "
-            f"was called {len(open_incident_calls)} time(s): {open_incident_calls!r}"
+            f"open_incident MUST NOT be called when ctx.gh_incident_urls covers "
+            f"every involved repo; got {open_incident_calls!r}"
         )
+        # github-incident tag still emitted (existing URLs justify it)
+        add_list = _get_add_list(merge_tags_calls[-1])
+        assert "github-incident" in add_list
 
 
 class TestEscalateAutoResumeGHIS8:
-    """GHI-S8: auto-resume branch (transient + budget remaining) → open_incident NOT called."""
+    """GHI-S8: auto-resume branch → no POST."""
 
     async def test_ghi_s8_auto_resume_does_not_call_open_incident(self):
-        """
-        GHI-S8: body.event='session.failed' (transient), auto_retry_count=0 (budget left) →
-        open_incident MUST NOT be called; auto-resume follow-up proceeds normally.
-        """
         from orchestrator.actions.escalate import escalate
 
         open_incident_calls: list = []
@@ -506,47 +495,34 @@ class TestEscalateAutoResumeGHIS8:
         settings = _make_settings()
         mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
             open_incident_calls, merge_tags_calls, update_ctx_calls,
-            gh_return_url="https://github.com/phona/sisyphus/issues/99",
+            gh_return="https://example/should/not/be/called",
         )
 
         body = _make_body("session.failed")
         ctx = {
-            "escalated_reason": "session-failed",  # transient reason
-            "auto_retry_count": 0,  # budget remaining (0 < _MAX_AUTO_RETRY=2)
+            "escalated_reason": "session-failed",
+            "auto_retry_count": 0,  # budget remaining
+            "involved_repos": ["phona/sisyphus"],
         }
 
         patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
         with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-            try:
-                await escalate(
-                    body=body,
-                    req_id="REQ-test-ghi",
-                    tags=["REQ-test-ghi"],
-                    ctx=ctx,
-                )
-            except Exception as exc:
-                pytest.fail(
-                    f"escalate raised unexpectedly in auto-resume path: "
-                    f"{type(exc).__name__}: {exc}"
-                )
+            await escalate(
+                body=body,
+                req_id="REQ-test-ghi",
+                tags=["REQ-test-ghi"],
+                ctx=ctx,
+            )
 
         assert len(open_incident_calls) == 0, (
-            f"gh_incident.open_incident MUST NOT be called in the auto-resume branch "
-            f"(transient signal with budget remaining); "
-            f"was called {len(open_incident_calls)} time(s): {open_incident_calls!r}"
+            f"open_incident MUST NOT be called in auto-resume; got {open_incident_calls!r}"
         )
 
 
 class TestEscalateGHFailureGHIS9:
-    """GHI-S9: GH failure (open_incident→None) does NOT abort the escalate flow."""
+    """GHI-S9: GH outage → open_incident returns None; flow continues, no tag, no URL ctx fields."""
 
     async def test_ghi_s9_gh_failure_does_not_abort_escalate(self):
-        """
-        GHI-S9: open_incident returns None (GH outage) →
-        - bkd.merge_tags_and_update MUST still be called
-        - action MUST NOT raise
-        - ctx MUST NOT receive gh_incident_url
-        """
         from orchestrator.actions.escalate import escalate
 
         open_incident_calls: list = []
@@ -556,7 +532,7 @@ class TestEscalateGHFailureGHIS9:
         settings = _make_settings()
         mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
             open_incident_calls, merge_tags_calls, update_ctx_calls,
-            gh_return_url=None,  # GH outage → open_incident returns None
+            gh_return=None,  # outage
         )
 
         body = _make_body("verify.escalate")
@@ -564,65 +540,51 @@ class TestEscalateGHFailureGHIS9:
             "escalated_reason": "verifier-decision-escalate",
             "escalated_source_issue_id": "fail-issue-ghi",
             "auto_retry_count": 5,
+            "involved_repos": ["phona/sisyphus"],
         }
 
         result = None
         patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
         with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-            try:
-                result = await escalate(
-                    body=body,
-                    req_id="REQ-test-ghi",
-                    tags=["REQ-test-ghi", "verifier"],
-                    ctx=ctx,
-                )
-            except Exception as exc:
-                pytest.fail(
-                    f"escalate MUST NOT raise when open_incident returns None (GH outage); "
-                    f"got {type(exc).__name__}: {exc}"
-                )
+            result = await escalate(
+                body=body,
+                req_id="REQ-test-ghi",
+                tags=["REQ-test-ghi", "verifier"],
+                ctx=ctx,
+            )
 
-        # Contract 1: bkd.merge_tags_and_update still called
         assert merge_tags_calls, (
             "bkd.merge_tags_and_update MUST still be called even when open_incident returns None"
         )
-
-        # Contract 2: ctx not updated with gh_incident_url
-        url_updates = [u for u in update_ctx_calls if "gh_incident_url" in u]
+        url_updates = [u for u in update_ctx_calls
+                       if u.get("gh_incident_url") or u.get("gh_incident_urls")]
         assert not url_updates, (
-            f"ctx MUST NOT receive gh_incident_url when open_incident returns None; "
+            f"ctx MUST NOT receive gh_incident_url(s) when GH POSTs all returned None; "
             f"found: {url_updates!r}"
         )
-
-        # Contract 3: action returns expected shape (not an error)
+        add_list = _get_add_list(merge_tags_calls[-1])
+        assert "github-incident" not in add_list, (
+            f"'github-incident' tag MUST NOT be added when no URL was opened; "
+            f"got: {add_list!r}"
+        )
         if isinstance(result, dict):
-            assert result.get("escalated") is True, (
-                f"escalate MUST still return {{escalated: True, ...}} even when GH fails; "
-                f"got {result!r}"
-            )
+            assert result.get("escalated") is True
 
 
 class TestEscalateDisabledGHIS10:
-    """GHI-S10: gh_incident_repo='' → escalate proceeds normally, no github-incident tag."""
+    """GHI-S10: no involved_repos and no settings.gh_incident_repo → no POST, no tag."""
 
-    async def test_ghi_s10_disabled_escalate_proceeds_without_github_incident_tag(self):
-        """
-        GHI-S10: settings.gh_incident_repo='' →
-        - escalate does NOT raise
-        - ctx NOT mutated with gh_incident_url
-        - bkd.merge_tags_and_update 'add' does NOT contain 'github-incident'
-        - return value indicates escalated (not an error)
-        """
+    async def test_ghi_s10_disabled_default_keeps_old_behavior(self):
         from orchestrator.actions.escalate import escalate
 
         open_incident_calls: list = []
         merge_tags_calls: list = []
         update_ctx_calls: list = []
 
-        settings = _make_settings(gh_incident_repo="")  # DISABLED
+        settings = _make_settings(gh_incident_repo="")
         mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
             open_incident_calls, merge_tags_calls, update_ctx_calls,
-            gh_return_url="https://github.com/phona/sisyphus/issues/1",
+            gh_return="https://example/should/not/be/called",
         )
 
         body = _make_body("verify.escalate")
@@ -630,43 +592,273 @@ class TestEscalateDisabledGHIS10:
             "escalated_reason": "verifier-decision-escalate",
             "escalated_source_issue_id": "fail-issue-ghi",
             "auto_retry_count": 5,
+            # NO involved_repos
+        }
+
+        patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await escalate(
+                body=body,
+                req_id="REQ-test-ghi",
+                tags=["REQ-test-ghi", "verifier"],
+                ctx=ctx,
+            )
+
+        assert len(open_incident_calls) == 0, (
+            f"open_incident MUST NOT be called when all 5 layers are empty; "
+            f"got: {open_incident_calls!r}"
+        )
+        if merge_tags_calls:
+            add_list = _get_add_list(merge_tags_calls[-1])
+            assert "github-incident" not in add_list, (
+                f"'github-incident' tag MUST NOT appear; got: {add_list!r}"
+            )
+        url_updates = [u for u in update_ctx_calls
+                       if u.get("gh_incident_url") or u.get("gh_incident_urls")]
+        assert not url_updates, (
+            f"ctx MUST NOT receive gh_incident_url(s); found: {url_updates!r}"
+        )
+        if isinstance(result, dict):
+            assert result.get("escalated") is True
+
+
+class TestEscalateMultiRepoGHIS11:
+    """GHI-S11: multi-repo REQ → one POST per involved repo."""
+
+    async def test_ghi_s11_multi_repo_one_incident_per_repo(self):
+        from orchestrator.actions.escalate import escalate
+
+        open_incident_calls: list = []
+        merge_tags_calls: list = []
+        update_ctx_calls: list = []
+
+        settings = _make_settings()
+        gh_table = {
+            "phona/repo-a": "https://github.com/phona/repo-a/issues/7",
+            "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
+        }
+        mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
+            open_incident_calls, merge_tags_calls, update_ctx_calls,
+            gh_return=gh_table,
+        )
+
+        body = _make_body("verify.escalate")
+        ctx = {
+            "escalated_reason": "verifier-decision-escalate",
+            "auto_retry_count": 5,
+            "involved_repos": ["phona/repo-a", "phona/repo-b"],
+        }
+
+        patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            await escalate(
+                body=body,
+                req_id="REQ-test-ghi",
+                tags=["REQ-test-ghi", "verifier"],
+                ctx=ctx,
+            )
+
+        assert len(open_incident_calls) == 2, (
+            f"open_incident MUST be called once per involved repo (2 expected); "
+            f"got: {open_incident_calls!r}"
+        )
+        called_repos = sorted(c["repo"] for c in open_incident_calls)
+        assert called_repos == ["phona/repo-a", "phona/repo-b"]
+
+        u = _last_url_update(update_ctx_calls)
+        assert u is not None
+        assert u["gh_incident_urls"] == gh_table
+
+        add_list = _get_add_list(merge_tags_calls[-1])
+        assert add_list.count("github-incident") == 1
+
+
+class TestEscalatePartialFailureGHIS12:
+    """GHI-S12: partial repo failure isolated; succeeded repo persisted."""
+
+    async def test_ghi_s12_partial_failure_isolated(self):
+        from orchestrator.actions.escalate import escalate
+
+        open_incident_calls: list = []
+        merge_tags_calls: list = []
+        update_ctx_calls: list = []
+
+        settings = _make_settings()
+        gh_table = {
+            "phona/repo-a": None,  # 403 / outage
+            "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
+        }
+        mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
+            open_incident_calls, merge_tags_calls, update_ctx_calls,
+            gh_return=gh_table,
+        )
+
+        body = _make_body("verify.escalate")
+        ctx = {
+            "escalated_reason": "verifier-decision-escalate",
+            "auto_retry_count": 5,
+            "involved_repos": ["phona/repo-a", "phona/repo-b"],
         }
 
         result = None
         patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
         with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-            try:
-                result = await escalate(
-                    body=body,
-                    req_id="REQ-test-ghi",
-                    tags=["REQ-test-ghi", "verifier"],
-                    ctx=ctx,
-                )
-            except Exception as exc:
-                pytest.fail(
-                    f"escalate MUST NOT raise when gh_incident_repo is empty; "
-                    f"got {type(exc).__name__}: {exc}"
-                )
-
-        # Contract 1: no github-incident tag in the add list
-        if merge_tags_calls:
-            add_list = _get_add_list(merge_tags_calls[-1])
-            assert "github-incident" not in add_list, (
-                f"When gh_incident_repo is empty, 'github-incident' MUST NOT appear "
-                f"in bkd.merge_tags_and_update 'add' list; "
-                f"got: {add_list!r}, full call: {merge_tags_calls[-1]!r}"
+            result = await escalate(
+                body=body,
+                req_id="REQ-test-ghi",
+                tags=["REQ-test-ghi", "verifier"],
+                ctx=ctx,
             )
 
-        # Contract 2: ctx not updated with gh_incident_url
-        url_updates = [u for u in update_ctx_calls if "gh_incident_url" in u]
-        assert not url_updates, (
-            f"ctx MUST NOT receive gh_incident_url when gh_incident_repo is empty; "
-            f"found: {url_updates!r}"
+        if isinstance(result, dict):
+            assert result.get("escalated") is True
+
+        u = _last_url_update(update_ctx_calls)
+        assert u is not None
+        assert u["gh_incident_urls"] == {
+            "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
+        }, f"Only the successful repo MUST be persisted; got {u!r}"
+
+        add_list = _get_add_list(merge_tags_calls[-1])
+        assert "github-incident" in add_list
+
+
+class TestEscalateMultiRepoIdempotentGHIS13:
+    """GHI-S13: re-entry only POSTs the missing repos."""
+
+    async def test_ghi_s13_only_missing_repos_posted_on_reentry(self):
+        from orchestrator.actions.escalate import escalate
+
+        open_incident_calls: list = []
+        merge_tags_calls: list = []
+        update_ctx_calls: list = []
+
+        settings = _make_settings()
+        mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
+            open_incident_calls, merge_tags_calls, update_ctx_calls,
+            gh_return="https://github.com/phona/repo-b/issues/3",
         )
 
-        # Contract 3: action proceeds (returns expected shape)
-        if isinstance(result, dict):
-            assert result.get("escalated") is True, (
-                f"escalate MUST return {{escalated: True, ...}} even when disabled; "
-                f"got {result!r}"
+        body = _make_body("verify.escalate")
+        ctx = {
+            "escalated_reason": "verifier-decision-escalate",
+            "auto_retry_count": 5,
+            "involved_repos": ["phona/repo-a", "phona/repo-b"],
+            "gh_incident_urls": {
+                "phona/repo-a": "https://github.com/phona/repo-a/issues/7",
+            },
+        }
+
+        patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            await escalate(
+                body=body,
+                req_id="REQ-test-ghi",
+                tags=["REQ-test-ghi", "verifier"],
+                ctx=ctx,
             )
+
+        assert len(open_incident_calls) == 1, (
+            f"Only the missing repo MUST be re-POSTed; got: {open_incident_calls!r}"
+        )
+        assert open_incident_calls[0]["repo"] == "phona/repo-b"
+
+        u = _last_url_update(update_ctx_calls)
+        assert u is not None
+        assert u["gh_incident_urls"] == {
+            "phona/repo-a": "https://github.com/phona/repo-a/issues/7",
+            "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
+        }, f"merged urls dict mismatch: {u!r}"
+
+
+class TestEscalateLegacyFallbackGHIS14:
+    """GHI-S14: no involved_repos → fall back to settings.gh_incident_repo."""
+
+    async def test_ghi_s14_falls_back_to_settings_gh_incident_repo(self):
+        from orchestrator.actions.escalate import escalate
+
+        open_incident_calls: list = []
+        merge_tags_calls: list = []
+        update_ctx_calls: list = []
+
+        settings = _make_settings(gh_incident_repo="phona/sisyphus")
+        mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
+            open_incident_calls, merge_tags_calls, update_ctx_calls,
+            gh_return="https://github.com/phona/sisyphus/issues/99",
+        )
+
+        body = _make_body("verify.escalate")
+        ctx = {
+            "escalated_reason": "verifier-decision-escalate",
+            "auto_retry_count": 5,
+            # No involved_repos / no repo: tags / no default_involved_repos
+        }
+
+        patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            await escalate(
+                body=body,
+                req_id="REQ-test-ghi",
+                tags=["REQ-test-ghi", "verifier"],
+                ctx=ctx,
+            )
+
+        assert len(open_incident_calls) == 1, (
+            f"open_incident MUST be called once with the legacy fallback repo; "
+            f"got: {open_incident_calls!r}"
+        )
+        assert open_incident_calls[0]["repo"] == "phona/sisyphus"
+
+        u = _last_url_update(update_ctx_calls)
+        assert u is not None
+        assert u["gh_incident_urls"] == {
+            "phona/sisyphus": "https://github.com/phona/sisyphus/issues/99",
+        }
+        add_list = _get_add_list(merge_tags_calls[-1])
+        assert "github-incident" in add_list
+
+
+class TestEscalateLayerPrecedenceGHIS15:
+    """GHI-S15: layers 1-4 (involved_repos) win over layer 5 (gh_incident_repo)."""
+
+    async def test_ghi_s15_involved_repos_take_precedence(self):
+        from orchestrator.actions.escalate import escalate
+
+        open_incident_calls: list = []
+        merge_tags_calls: list = []
+        update_ctx_calls: list = []
+
+        settings = _make_settings(gh_incident_repo="phona/sisyphus")  # layer 5 also set
+        mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
+            open_incident_calls, merge_tags_calls, update_ctx_calls,
+            gh_return="https://github.com/phona/repo-a/issues/1",
+        )
+
+        body = _make_body("verify.escalate")
+        ctx = {
+            "escalated_reason": "verifier-decision-escalate",
+            "auto_retry_count": 5,
+            "involved_repos": ["phona/repo-a"],  # layer 2
+        }
+
+        patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            await escalate(
+                body=body,
+                req_id="REQ-test-ghi",
+                tags=["REQ-test-ghi", "verifier"],
+                ctx=ctx,
+            )
+
+        assert len(open_incident_calls) == 1, (
+            f"Only the layer-2 repo MUST be POSTed; got: {open_incident_calls!r}"
+        )
+        assert open_incident_calls[0]["repo"] == "phona/repo-a", (
+            f"layer 2 MUST beat layer 5; got repo={open_incident_calls[0]['repo']!r}"
+        )
+
+        u = _last_url_update(update_ctx_calls)
+        assert u is not None
+        assert set(u["gh_incident_urls"].keys()) == {"phona/repo-a"}, (
+            f"Only the layer-2 repo MUST appear in gh_incident_urls; got: {u!r}"
+        )

--- a/orchestrator/tests/test_contract_gh_incident_per_repo.py
+++ b/orchestrator/tests/test_contract_gh_incident_per_repo.py
@@ -1,0 +1,952 @@
+"""Contract tests: per-involved-repo GH incident opening.
+REQ-gh-incident-per-involved-repo-1777180551
+
+Black-box challenger. Derived from:
+  openspec/changes/REQ-gh-incident-per-involved-repo-1777180551/specs/gh-incident-open/spec.md
+
+Scenarios covered: GHI-S1 through GHI-S15.
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is truly wrong, escalate to spec_fixer to correct the spec.
+"""
+from __future__ import annotations
+
+import json
+from typing import ClassVar
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+
+# ─── Shared helpers ──────────────────────────────────────────────────────────
+
+class _FakeBody:
+    """Minimal fake WebhookBody for escalate action tests."""
+    def __init__(
+        self,
+        event: str = "session.completed",
+        issue_id: str = "issue-test",
+        project_id: str = "proj-test",
+    ):
+        self.event = event
+        self.issueId = issue_id
+        self.projectId = project_id
+        self.issueNumber = None
+
+
+class _FakeBKD:
+    """Minimal BKD client stub for escalate action tests."""
+    def __init__(self, *a, **kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def follow_up_issue(self, *a, **kw):
+        pass
+
+    async def merge_tags_and_update(self, proj, issue_id, *, add, **kw):
+        pass
+
+
+def _make_collecting_bkd(tag_log: list):
+    """Returns a BKDClient class whose merge_tags_and_update appends to tag_log."""
+    class _CollectingBKD(_FakeBKD):
+        async def merge_tags_and_update(self, proj, issue_id, *, add, **kw):
+            tag_log.append(list(add))
+
+    return _CollectingBKD
+
+
+def _make_collecting_bkd_full(tag_log: list, followup_log: list):
+    """Returns a BKDClient that records both merge_tags_and_update and follow_up_issue."""
+    class _FullBKD(_FakeBKD):
+        async def merge_tags_and_update(self, proj, issue_id, *, add, **kw):
+            tag_log.append(list(add))
+
+        async def follow_up_issue(self, *a, **kw):
+            followup_log.append({"args": a, "kwargs": kw})
+
+    return _FullBKD
+
+
+def _make_ctx(involved_repos=None, gh_incident_urls=None, **extra):
+    ctx = dict(extra)
+    if involved_repos is not None:
+        ctx["involved_repos"] = involved_repos
+    if gh_incident_urls is not None:
+        ctx["gh_incident_urls"] = dict(gh_incident_urls)
+    return ctx
+
+
+async def _run_escalate(monkeypatch, ctx, body=None, tags=None, *, bkd_cls=None,
+                        open_incident_mock=None, ctx_updates=None):
+    """
+    Helper: call actions.escalate with mocked deps, return (result, ctx_updates_list).
+    ctx_updates: externally-provided list to capture update_context calls.
+    """
+    from orchestrator.actions import escalate as esc_mod
+    from orchestrator import gh_incident as ghi
+    from orchestrator.bkd import BKDClient as RealBKDClient
+    from orchestrator.store import req_state as rs_mod, db
+
+    if body is None:
+        body = _FakeBody()
+    if tags is None:
+        tags = []
+    if ctx_updates is None:
+        ctx_updates = []
+
+    # Capture update_context calls
+    captured: list[dict] = ctx_updates
+
+    async def _capture_update(pool, req_id, patch):
+        captured.append(dict(patch))
+
+    monkeypatch.setattr(rs_mod, "update_context", _capture_update)
+
+    # Mock req_state.get to return a minimal fake row
+    class _FakeRow:
+        state: ClassVar = None
+        context: ClassVar = {}
+
+    monkeypatch.setattr(rs_mod, "get", AsyncMock(return_value=_FakeRow()))
+    monkeypatch.setattr(rs_mod, "cas_transition", AsyncMock(return_value=True))
+
+    # Mock db.get_pool → anything (req_state is fully mocked above)
+    monkeypatch.setattr(db, "get_pool", lambda: MagicMock())
+
+    # BKD
+    if bkd_cls is not None:
+        monkeypatch.setattr(esc_mod, "BKDClient", bkd_cls)
+
+    # gh_incident.open_incident
+    if open_incident_mock is not None:
+        monkeypatch.setattr(ghi, "open_incident", open_incident_mock)
+
+    result = await esc_mod.escalate(body=body, req_id="REQ-test", tags=tags, ctx=ctx)
+    return result, captured
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GHI-S1..S5: open_incident function contract
+# ═══════════════════════════════════════════════════════════════════════════════
+
+async def test_ghi_s1_open_incident_disabled_when_repo_empty(monkeypatch):
+    """GHI-S1: open_incident(repo="") MUST return None with no HTTP request made."""
+    from orchestrator import gh_incident
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "github_token", "gh-real-token")
+
+    http_calls: list = []
+
+    async def _deny(*a, **kw):
+        http_calls.append(1)
+        raise AssertionError("GHI-S1: MUST NOT make HTTP call when repo=''")
+
+    mock_client = AsyncMock()
+    mock_client.post = _deny
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("orchestrator.gh_incident.httpx.AsyncClient", return_value=mock_cm):
+        result = await gh_incident.open_incident(
+            repo="",
+            req_id="REQ-1",
+            reason="test",
+            retry_count=0,
+            intent_issue_id="i1",
+            failed_issue_id="f1",
+            project_id="p1",
+        )
+
+    assert result is None, f"GHI-S1: open_incident with repo='' MUST return None, got {result!r}"
+    assert not http_calls, "GHI-S1: no HTTP request MUST be made when repo is empty"
+
+
+async def test_ghi_s2_open_incident_disabled_when_token_empty(monkeypatch):
+    """GHI-S2: open_incident with settings.github_token="" MUST return None, no HTTP."""
+    from orchestrator import gh_incident
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "github_token", "")
+
+    http_calls: list = []
+
+    async def _deny(*a, **kw):
+        http_calls.append(1)
+        raise AssertionError("GHI-S2: MUST NOT make HTTP call when github_token=''")
+
+    mock_client = AsyncMock()
+    mock_client.post = _deny
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("orchestrator.gh_incident.httpx.AsyncClient", return_value=mock_cm):
+        result = await gh_incident.open_incident(
+            repo="phona/sisyphus",
+            req_id="REQ-2",
+            reason="test",
+            retry_count=0,
+            intent_issue_id="i2",
+            failed_issue_id="f2",
+            project_id="p2",
+        )
+
+    assert result is None, (
+        f"GHI-S2: open_incident with empty token MUST return None, got {result!r}"
+    )
+    assert not http_calls, "GHI-S2: no HTTP call MUST be made when token is empty"
+
+
+async def test_ghi_s3_success_returns_html_url(monkeypatch):
+    """GHI-S3: open_incident MUST POST to correct URL with Bearer/Accept headers and return html_url."""
+    from orchestrator import gh_incident
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "github_token", "gh-real-token")
+
+    post_calls: list[dict] = []
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    mock_response.json.return_value = {"html_url": "https://github.com/phona/sisyphus/issues/42"}
+    mock_response.text = '{"html_url": "https://github.com/phona/sisyphus/issues/42"}'
+
+    async def _capture_post(url, **kwargs):
+        post_calls.append({"url": url, **kwargs})
+        return mock_response
+
+    mock_client = AsyncMock()
+    mock_client.post = _capture_post
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("orchestrator.gh_incident.httpx.AsyncClient", return_value=mock_cm):
+        result = await gh_incident.open_incident(
+            repo="phona/sisyphus",
+            req_id="REQ-3",
+            reason="test",
+            retry_count=0,
+            intent_issue_id="i3",
+            failed_issue_id="f3",
+            project_id="p3",
+        )
+
+    assert result == "https://github.com/phona/sisyphus/issues/42", (
+        f"GHI-S3: return value MUST equal html_url from GH response, got {result!r}"
+    )
+    assert len(post_calls) == 1, f"GHI-S3: exactly one POST expected, got {len(post_calls)}"
+
+    posted_url = post_calls[0]["url"]
+    assert posted_url == "https://api.github.com/repos/phona/sisyphus/issues", (
+        f"GHI-S3: POST URL MUST be https://api.github.com/repos/phona/sisyphus/issues, "
+        f"got {posted_url!r}"
+    )
+
+    headers = post_calls[0].get("headers", {})
+    auth_vals = [str(v) for v in headers.values()]
+    assert any("Bearer" in v for v in auth_vals), (
+        f"GHI-S3: Authorization: Bearer header MUST be present, got headers={headers}"
+    )
+    assert any("application/vnd.github" in v for v in auth_vals), (
+        f"GHI-S3: Accept: application/vnd.github+json header MUST be present, "
+        f"got headers={headers}"
+    )
+
+
+async def test_ghi_s4_request_body_contains_required_fields(monkeypatch):
+    """GHI-S4: POST body MUST contain REQ-9, reason, cross-refs and labels sisyphus:incident + reason:..."""
+    from orchestrator import gh_incident
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "github_token", "gh-real-token")
+    monkeypatch.setattr(cfg, "gh_incident_labels", ["sisyphus:incident"])
+
+    post_calls: list[dict] = []
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    mock_response.json.return_value = {"html_url": "https://github.com/phona/sisyphus/issues/1"}
+    mock_response.text = "{}"
+
+    async def _capture(url, **kwargs):
+        post_calls.append({"url": url, **kwargs})
+        return mock_response
+
+    mock_client = AsyncMock()
+    mock_client.post = _capture
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("orchestrator.gh_incident.httpx.AsyncClient", return_value=mock_cm):
+        await gh_incident.open_incident(
+            repo="phona/sisyphus",
+            req_id="REQ-9",
+            reason="fixer-round-cap",
+            retry_count=0,
+            intent_issue_id="intent-1",
+            failed_issue_id="vfy-3",
+            project_id="proj-A",
+            state="fixer-running",
+        )
+
+    assert len(post_calls) == 1, f"GHI-S4: expected exactly one POST, got {len(post_calls)}"
+    body_payload = post_calls[0].get("json") or {}
+
+    body_str = json.dumps(body_payload)
+    for expected in ("REQ-9", "fixer-round-cap", "intent-1", "vfy-3", "proj-A", "fixer-running"):
+        assert expected in body_str, (
+            f"GHI-S4: JSON body MUST contain {expected!r}. "
+            f"body_str (first 500 chars): {body_str[:500]!r}"
+        )
+
+    labels = body_payload.get("labels", [])
+    assert "sisyphus:incident" in labels, (
+        f"GHI-S4: labels MUST contain 'sisyphus:incident', got labels={labels}"
+    )
+    assert "reason:fixer-round-cap" in labels, (
+        f"GHI-S4: labels MUST contain 'reason:fixer-round-cap', got labels={labels}"
+    )
+
+
+async def test_ghi_s5_http_failure_returns_none_no_raise(monkeypatch):
+    """GHI-S5: HTTP 503 MUST return None and not raise any exception."""
+    from orchestrator import gh_incident
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "github_token", "gh-real-token")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 503
+    mock_response.text = "Service Unavailable"
+    mock_response.json.return_value = {"message": "Service Unavailable"}
+
+    async def _error_response(url, **kwargs):
+        return mock_response
+
+    mock_client = AsyncMock()
+    mock_client.post = _error_response
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    raised = None
+    with patch("orchestrator.gh_incident.httpx.AsyncClient", return_value=mock_cm):
+        try:
+            result = await gh_incident.open_incident(
+                repo="phona/sisyphus",
+                req_id="REQ-5",
+                reason="test",
+                retry_count=0,
+                intent_issue_id="i5",
+                failed_issue_id="f5",
+                project_id="p5",
+            )
+        except Exception as e:
+            raised = e
+
+    assert raised is None, (
+        f"GHI-S5: open_incident MUST NOT raise on HTTP 503, "
+        f"got {type(raised).__name__}: {raised}"
+    )
+    assert result is None, (  # type: ignore[possibly-undefined]
+        f"GHI-S5: open_incident MUST return None on HTTP 503, got {result!r}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GHI-S6..S15: escalate action contract (per-involved-repo loop)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+async def test_ghi_s6_real_escalate_single_repo_opens_one_incident(monkeypatch):
+    """GHI-S6: single involved repo → open_incident called once, ctx.gh_incident_urls set, github-incident tagged."""
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "github_token", "gh-real-token")
+    monkeypatch.setattr(cfg, "gh_incident_repo", "")
+    monkeypatch.setattr(cfg, "default_involved_repos", [])
+
+    open_calls: list[dict] = []
+
+    async def _mock_open(*, repo, req_id, reason, **kw):
+        open_calls.append({"repo": repo, "req_id": req_id, "reason": reason})
+        if repo == "phona/sisyphus":
+            return "https://github.com/phona/sisyphus/issues/42"
+        return None
+
+    tag_log: list = []
+    ctx_updates: list[dict] = []
+    ctx = _make_ctx(
+        involved_repos=["phona/sisyphus"],
+        escalated_reason="verifier-decision-escalate",
+        intent_issue_id="intent-s6",
+    )
+
+    result, ctx_updates = await _run_escalate(
+        monkeypatch,
+        ctx=ctx,
+        body=_FakeBody(event="session.completed", issue_id="issue-s6"),
+        bkd_cls=_make_collecting_bkd(tag_log),
+        open_incident_mock=_mock_open,
+        ctx_updates=ctx_updates,
+    )
+
+    # Contract 1: open_incident called exactly once with repo="phona/sisyphus"
+    assert len(open_calls) == 1, (
+        f"GHI-S6: open_incident MUST be awaited exactly once, got {len(open_calls)} calls"
+    )
+    assert open_calls[0]["repo"] == "phona/sisyphus", (
+        f"GHI-S6: open_incident MUST be called with repo='phona/sisyphus', "
+        f"got {open_calls[0]['repo']!r}"
+    )
+    assert open_calls[0]["req_id"] == "REQ-test", (
+        f"GHI-S6: open_incident must receive req_id, got {open_calls[0].get('req_id')!r}"
+    )
+
+    # Contract 2: update_context called with gh_incident_urls
+    gh_url_updates = [u for u in ctx_updates if "gh_incident_urls" in u]
+    assert gh_url_updates, (
+        f"GHI-S6: update_context MUST be called with gh_incident_urls. "
+        f"All ctx updates: {ctx_updates}"
+    )
+    assert gh_url_updates[-1]["gh_incident_urls"] == {
+        "phona/sisyphus": "https://github.com/phona/sisyphus/issues/42"
+    }, (
+        f"GHI-S6: gh_incident_urls MUST map phona/sisyphus → url. "
+        f"Got {gh_url_updates[-1]['gh_incident_urls']}"
+    )
+    # Also: gh_incident_url (legacy) must be set
+    assert any("gh_incident_url" in u for u in ctx_updates), (
+        f"GHI-S6: legacy ctx.gh_incident_url MUST also be set"
+    )
+
+    # Contract 3: BKD tag includes 'github-incident'
+    assert tag_log, f"GHI-S6: bkd.merge_tags_and_update MUST be called, but tag_log={tag_log}"
+    all_tags = [t for tags in tag_log for t in tags]
+    assert "github-incident" in all_tags, (
+        f"GHI-S6: bkd.merge_tags_and_update MUST include 'github-incident' tag. "
+        f"Got add tags: {tag_log}"
+    )
+    assert "escalated" in all_tags, (
+        f"GHI-S6: bkd.merge_tags_and_update MUST include 'escalated' tag. "
+        f"Got add tags: {tag_log}"
+    )
+
+    # Contract 4: action returns escalated=True
+    assert isinstance(result, dict) and result.get("escalated") is True, (
+        f"GHI-S6: action MUST return dict with escalated=True, got {result!r}"
+    )
+
+
+async def test_ghi_s7_idempotent_preexisting_urls_skips_post(monkeypatch):
+    """GHI-S7: pre-existing ctx.gh_incident_urls → open_incident NOT called, gh_incident_urls preserved, github-incident tagged."""
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "github_token", "gh-real-token")
+    monkeypatch.setattr(cfg, "gh_incident_repo", "")
+    monkeypatch.setattr(cfg, "default_involved_repos", [])
+
+    open_calls: list = []
+
+    async def _should_not_be_called(*, repo, **kw):
+        open_calls.append(repo)
+        return None
+
+    tag_log: list = []
+    ctx_updates: list = []
+    existing_urls = {"phona/sisyphus": "https://github.com/phona/sisyphus/issues/42"}
+    ctx = _make_ctx(
+        involved_repos=["phona/sisyphus"],
+        gh_incident_urls=existing_urls,
+        escalated_reason="verifier-decision-escalate",
+        intent_issue_id="intent-s7",
+    )
+
+    result, ctx_updates = await _run_escalate(
+        monkeypatch,
+        ctx=ctx,
+        body=_FakeBody(event="session.completed", issue_id="issue-s7"),
+        bkd_cls=_make_collecting_bkd(tag_log),
+        open_incident_mock=_should_not_be_called,
+        ctx_updates=ctx_updates,
+    )
+
+    # Contract 1: open_incident MUST NOT be called (idempotent)
+    assert open_calls == [], (
+        f"GHI-S7: open_incident MUST NOT be called when repo already in ctx.gh_incident_urls. "
+        f"Got calls for: {open_calls}"
+    )
+
+    # Contract 2: ctx.gh_incident_urls preserved (not cleared)
+    gh_url_updates = [u for u in ctx_updates if "gh_incident_urls" in u]
+    # Either no update (nothing new to write) or preserved value
+    for u in gh_url_updates:
+        assert "phona/sisyphus" in u.get("gh_incident_urls", {}), (
+            f"GHI-S7: ctx.gh_incident_urls MUST be preserved (not cleared). Got: {u}"
+        )
+
+    # Contract 3: github-incident still added (at least one url present = existing)
+    all_tags = [t for tags in tag_log for t in tags]
+    assert "github-incident" in all_tags, (
+        f"GHI-S7: github-incident MUST be in BKD tags even with pre-existing urls. "
+        f"Got add tags: {tag_log}"
+    )
+
+
+async def test_ghi_s8_auto_resume_does_not_open_incident(monkeypatch):
+    """GHI-S8: auto-resume path (session.failed, retry_count=0) MUST NOT call open_incident, MUST call follow_up_issue."""
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "github_token", "gh-real-token")
+    monkeypatch.setattr(cfg, "gh_incident_repo", "")
+    monkeypatch.setattr(cfg, "default_involved_repos", [])
+
+    open_calls: list = []
+
+    async def _should_not_be_called(*, repo, **kw):
+        open_calls.append(repo)
+        return None
+
+    tag_log: list = []
+    followup_log: list = []
+    ctx = _make_ctx(
+        involved_repos=["phona/sisyphus"],
+        auto_retry_count=0,
+        intent_issue_id="intent-s8",
+    )
+
+    result, ctx_updates = await _run_escalate(
+        monkeypatch,
+        ctx=ctx,
+        body=_FakeBody(event="session.failed", issue_id="issue-s8"),
+        bkd_cls=_make_collecting_bkd_full(tag_log, followup_log),
+        open_incident_mock=_should_not_be_called,
+    )
+
+    # Contract 1: open_incident MUST NOT be called in auto-resume path
+    assert open_calls == [], (
+        f"GHI-S8: open_incident MUST NOT be called in auto-resume path. "
+        f"Got calls: {open_calls}"
+    )
+
+    # Contract 2: follow_up_issue MUST be called (auto-resume continues)
+    assert followup_log, (
+        f"GHI-S8: bkd.follow_up_issue MUST be awaited for auto-resume. "
+        f"Got followup_log={followup_log}"
+    )
+
+
+async def test_ghi_s9_gh_failure_does_not_abort_escalate(monkeypatch):
+    """GHI-S9: open_incident returns None (GH outage) → action still returns escalated=True, no gh_incident_url in ctx, no github-incident tag."""
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "github_token", "gh-real-token")
+    monkeypatch.setattr(cfg, "gh_incident_repo", "")
+    monkeypatch.setattr(cfg, "default_involved_repos", [])
+
+    async def _always_none(*, repo, **kw):
+        return None  # GH outage
+
+    tag_log: list = []
+    ctx_updates: list = []
+    ctx = _make_ctx(
+        involved_repos=["phona/sisyphus"],
+        escalated_reason="verifier-decision-escalate",
+        intent_issue_id="intent-s9",
+    )
+
+    result, ctx_updates = await _run_escalate(
+        monkeypatch,
+        ctx=ctx,
+        body=_FakeBody(event="session.completed", issue_id="issue-s9"),
+        bkd_cls=_make_collecting_bkd(tag_log),
+        open_incident_mock=_always_none,
+        ctx_updates=ctx_updates,
+    )
+
+    # Contract 1: action returns escalated=True even when GH fails
+    assert isinstance(result, dict) and result.get("escalated") is True, (
+        f"GHI-S9: action MUST return escalated=True even on GH failure. Got {result!r}"
+    )
+
+    # Contract 2: ctx MUST NOT include gh_incident_url or non-empty gh_incident_urls
+    for u in ctx_updates:
+        if "gh_incident_url" in u:
+            # Only allowed if it's from a PREVIOUS value (legacy), not a new post
+            assert not u.get("gh_incident_url"), (
+                f"GHI-S9: ctx MUST NOT include gh_incident_url on GH failure. Got: {u}"
+            )
+        if "gh_incident_urls" in u:
+            assert not u.get("gh_incident_urls"), (
+                f"GHI-S9: ctx MUST NOT include non-empty gh_incident_urls on GH failure. Got: {u}"
+            )
+
+    # Contract 3: BKD tag merge MUST NOT include 'github-incident'
+    assert tag_log, "GHI-S9: bkd.merge_tags_and_update MUST still be called"
+    all_tags = [t for tags in tag_log for t in tags]
+    assert "github-incident" not in all_tags, (
+        f"GHI-S9: 'github-incident' MUST NOT be in BKD tags when GH POST failed. "
+        f"Got tags: {all_tags}"
+    )
+
+    # Contract 4: escalation continues (bkd was called)
+    assert tag_log, "GHI-S9: bkd.merge_tags_and_update MUST still be awaited"
+
+
+async def test_ghi_s10_no_repos_no_fallback_does_not_break_escalate(monkeypatch):
+    """GHI-S10: no involved repos + no fallback → open_incident NOT called, action returns escalated=True, no gh_incident_* in ctx."""
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "github_token", "gh-real-token")
+    monkeypatch.setattr(cfg, "gh_incident_repo", "")
+    monkeypatch.setattr(cfg, "default_involved_repos", [])
+
+    open_calls: list = []
+
+    async def _should_not_be_called(*, repo, **kw):
+        open_calls.append(repo)
+        return None
+
+    tag_log: list = []
+    ctx_updates: list = []
+    ctx = _make_ctx(
+        # no involved_repos
+        escalated_reason="verifier-decision-escalate",
+        intent_issue_id="intent-s10",
+    )
+
+    result, ctx_updates = await _run_escalate(
+        monkeypatch,
+        ctx=ctx,
+        body=_FakeBody(event="session.completed", issue_id="issue-s10"),
+        bkd_cls=_make_collecting_bkd(tag_log),
+        open_incident_mock=_should_not_be_called,
+        ctx_updates=ctx_updates,
+    )
+
+    # Contract 1: open_incident MUST NOT be called
+    assert open_calls == [], (
+        f"GHI-S10: open_incident MUST NOT be called when no repos. Got: {open_calls}"
+    )
+
+    # Contract 2: action returns escalated=True
+    assert isinstance(result, dict) and result.get("escalated") is True, (
+        f"GHI-S10: action MUST return escalated=True. Got {result!r}"
+    )
+
+    # Contract 3: ctx MUST NOT be mutated with gh_incident_url/gh_incident_urls/gh_incident_opened_at
+    for u in ctx_updates:
+        assert "gh_incident_url" not in u, (
+            f"GHI-S10: ctx MUST NOT be mutated with gh_incident_url. Got update: {u}"
+        )
+        assert "gh_incident_urls" not in u, (
+            f"GHI-S10: ctx MUST NOT be mutated with gh_incident_urls. Got update: {u}"
+        )
+        assert "gh_incident_opened_at" not in u, (
+            f"GHI-S10: ctx MUST NOT be mutated with gh_incident_opened_at. Got update: {u}"
+        )
+
+    # Contract 4: github-incident MUST NOT be in tags
+    all_tags = [t for tags in tag_log for t in tags]
+    assert "github-incident" not in all_tags, (
+        f"GHI-S10: 'github-incident' MUST NOT be in BKD tags. Got: {all_tags}"
+    )
+
+
+async def test_ghi_s11_multi_repo_opens_one_incident_per_repo(monkeypatch):
+    """GHI-S11: two involved repos → open_incident called twice, ctx.gh_incident_urls has both."""
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "github_token", "gh-real-token")
+    monkeypatch.setattr(cfg, "gh_incident_repo", "")
+    monkeypatch.setattr(cfg, "default_involved_repos", [])
+
+    open_calls: list[dict] = []
+
+    async def _mock_open(*, repo, **kw):
+        open_calls.append({"repo": repo})
+        if repo == "phona/repo-a":
+            return "https://github.com/phona/repo-a/issues/7"
+        if repo == "phona/repo-b":
+            return "https://github.com/phona/repo-b/issues/3"
+        return None
+
+    tag_log: list = []
+    ctx_updates: list = []
+    ctx = _make_ctx(
+        involved_repos=["phona/repo-a", "phona/repo-b"],
+        escalated_reason="verifier-decision-escalate",
+        intent_issue_id="intent-s11",
+    )
+
+    result, ctx_updates = await _run_escalate(
+        monkeypatch,
+        ctx=ctx,
+        body=_FakeBody(event="session.completed", issue_id="issue-s11"),
+        bkd_cls=_make_collecting_bkd(tag_log),
+        open_incident_mock=_mock_open,
+        ctx_updates=ctx_updates,
+    )
+
+    # Contract 1: open_incident called exactly twice
+    assert len(open_calls) == 2, (
+        f"GHI-S11: open_incident MUST be called exactly twice, got {len(open_calls)} calls. "
+        f"Repos: {[c['repo'] for c in open_calls]}"
+    )
+    repos_called = {c["repo"] for c in open_calls}
+    assert repos_called == {"phona/repo-a", "phona/repo-b"}, (
+        f"GHI-S11: must call for both repos, got {repos_called}"
+    )
+
+    # Contract 2: ctx.gh_incident_urls contains both
+    gh_url_updates = [u for u in ctx_updates if "gh_incident_urls" in u]
+    assert gh_url_updates, f"GHI-S11: update_context MUST include gh_incident_urls"
+    final_urls = gh_url_updates[-1]["gh_incident_urls"]
+    assert "phona/repo-a" in final_urls, (
+        f"GHI-S11: gh_incident_urls MUST contain phona/repo-a. Got: {final_urls}"
+    )
+    assert "phona/repo-b" in final_urls, (
+        f"GHI-S11: gh_incident_urls MUST contain phona/repo-b. Got: {final_urls}"
+    )
+    assert final_urls["phona/repo-a"] == "https://github.com/phona/repo-a/issues/7"
+    assert final_urls["phona/repo-b"] == "https://github.com/phona/repo-b/issues/3"
+
+    # Contract 3: github-incident tagged exactly once (not N times)
+    all_add_tag_lists = tag_log
+    github_incident_count = sum(1 for tags in all_add_tag_lists if "github-incident" in tags)
+    assert github_incident_count >= 1, (
+        f"GHI-S11: github-incident MUST be in BKD tags. Got: {tag_log}"
+    )
+
+
+async def test_ghi_s12_partial_failure_isolated(monkeypatch):
+    """GHI-S12: repo-a fails (None), repo-b succeeds → action escalated=True, only repo-b in ctx, github-incident tagged."""
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "github_token", "gh-real-token")
+    monkeypatch.setattr(cfg, "gh_incident_repo", "")
+    monkeypatch.setattr(cfg, "default_involved_repos", [])
+
+    async def _partial(*, repo, **kw):
+        if repo == "phona/repo-a":
+            return None  # 403 — PAT lacks Issues:Write
+        if repo == "phona/repo-b":
+            return "https://github.com/phona/repo-b/issues/3"
+        return None
+
+    tag_log: list = []
+    ctx_updates: list = []
+    ctx = _make_ctx(
+        involved_repos=["phona/repo-a", "phona/repo-b"],
+        escalated_reason="verifier-decision-escalate",
+        intent_issue_id="intent-s12",
+    )
+
+    result, ctx_updates = await _run_escalate(
+        monkeypatch,
+        ctx=ctx,
+        body=_FakeBody(event="session.completed", issue_id="issue-s12"),
+        bkd_cls=_make_collecting_bkd(tag_log),
+        open_incident_mock=_partial,
+        ctx_updates=ctx_updates,
+    )
+
+    # Contract 1: action returns escalated=True (not aborted by partial failure)
+    assert isinstance(result, dict) and result.get("escalated") is True, (
+        f"GHI-S12: action MUST return escalated=True on partial failure. Got {result!r}"
+    )
+
+    # Contract 2: ctx.gh_incident_urls = only repo-b (failed repo absent)
+    gh_url_updates = [u for u in ctx_updates if "gh_incident_urls" in u]
+    assert gh_url_updates, "GHI-S12: update_context MUST include gh_incident_urls (repo-b succeeded)"
+    final_urls = gh_url_updates[-1]["gh_incident_urls"]
+    assert "phona/repo-b" in final_urls, (
+        f"GHI-S12: successful repo-b MUST be in gh_incident_urls. Got: {final_urls}"
+    )
+    assert "phona/repo-a" not in final_urls, (
+        f"GHI-S12: failed repo-a MUST NOT be in gh_incident_urls. Got: {final_urls}"
+    )
+
+    # Contract 3: github-incident tag added (one success suffices)
+    all_tags = [t for tags in tag_log for t in tags]
+    assert "github-incident" in all_tags, (
+        f"GHI-S12: github-incident MUST be tagged even with partial failure. Got: {all_tags}"
+    )
+
+
+async def test_ghi_s13_idempotent_multi_repo_only_posts_missing(monkeypatch):
+    """GHI-S13: repo-a already in ctx.gh_incident_urls → only repo-b POSTed, final ctx has both."""
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "github_token", "gh-real-token")
+    monkeypatch.setattr(cfg, "gh_incident_repo", "")
+    monkeypatch.setattr(cfg, "default_involved_repos", [])
+
+    open_calls: list[dict] = []
+
+    async def _mock_open(*, repo, **kw):
+        open_calls.append({"repo": repo})
+        return f"https://github.com/{repo}/issues/3"
+
+    tag_log: list = []
+    ctx_updates: list = []
+    existing_urls = {"phona/repo-a": "https://github.com/phona/repo-a/issues/7"}
+    ctx = _make_ctx(
+        involved_repos=["phona/repo-a", "phona/repo-b"],
+        gh_incident_urls=existing_urls,
+        escalated_reason="verifier-decision-escalate",
+        intent_issue_id="intent-s13",
+    )
+
+    result, ctx_updates = await _run_escalate(
+        monkeypatch,
+        ctx=ctx,
+        body=_FakeBody(event="session.completed", issue_id="issue-s13"),
+        bkd_cls=_make_collecting_bkd(tag_log),
+        open_incident_mock=_mock_open,
+        ctx_updates=ctx_updates,
+    )
+
+    # Contract 1: open_incident called exactly once (only for repo-b)
+    assert len(open_calls) == 1, (
+        f"GHI-S13: open_incident MUST be called exactly once (only repo-b). "
+        f"Got calls: {open_calls}"
+    )
+    assert open_calls[0]["repo"] == "phona/repo-b", (
+        f"GHI-S13: MUST call for repo-b (NOT repo-a). Got repo: {open_calls[0]['repo']!r}"
+    )
+    assert not any(c["repo"] == "phona/repo-a" for c in open_calls), (
+        f"GHI-S13: repo-a MUST NOT be POSTed again. Got calls: {open_calls}"
+    )
+
+    # Contract 2: persisted gh_incident_urls contains BOTH repos
+    gh_url_updates = [u for u in ctx_updates if "gh_incident_urls" in u]
+    assert gh_url_updates, (
+        f"GHI-S13: update_context MUST include gh_incident_urls. ctx_updates={ctx_updates}"
+    )
+    final_urls = gh_url_updates[-1]["gh_incident_urls"]
+    assert "phona/repo-a" in final_urls, (
+        f"GHI-S13: existing repo-a MUST be preserved in gh_incident_urls. Got: {final_urls}"
+    )
+    assert "phona/repo-b" in final_urls, (
+        f"GHI-S13: newly opened repo-b MUST be in gh_incident_urls. Got: {final_urls}"
+    )
+    assert final_urls["phona/repo-a"] == "https://github.com/phona/repo-a/issues/7", (
+        f"GHI-S13: repo-a url MUST be the original (not overwritten). Got: {final_urls}"
+    )
+
+
+async def test_ghi_s14_fallback_to_gh_incident_repo(monkeypatch):
+    """GHI-S14: no involved repos, gh_incident_repo set → open_incident called with gh_incident_repo, github-incident tagged."""
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "github_token", "gh-real-token")
+    monkeypatch.setattr(cfg, "gh_incident_repo", "phona/sisyphus")
+    monkeypatch.setattr(cfg, "default_involved_repos", [])
+
+    open_calls: list[dict] = []
+
+    async def _mock_open(*, repo, **kw):
+        open_calls.append({"repo": repo})
+        return "https://github.com/phona/sisyphus/issues/99"
+
+    tag_log: list = []
+    ctx_updates: list = []
+    ctx = _make_ctx(
+        # no involved_repos
+        escalated_reason="verifier-decision-escalate",
+        intent_issue_id="intent-s14",
+    )
+
+    result, ctx_updates = await _run_escalate(
+        monkeypatch,
+        ctx=ctx,
+        body=_FakeBody(event="session.completed", issue_id="issue-s14"),
+        bkd_cls=_make_collecting_bkd(tag_log),
+        open_incident_mock=_mock_open,
+        ctx_updates=ctx_updates,
+    )
+
+    # Contract 1: open_incident called once with repo="phona/sisyphus" (fallback)
+    assert len(open_calls) == 1, (
+        f"GHI-S14: open_incident MUST be called exactly once (with fallback repo). "
+        f"Got calls: {open_calls}"
+    )
+    assert open_calls[0]["repo"] == "phona/sisyphus", (
+        f"GHI-S14: MUST call with gh_incident_repo='phona/sisyphus' as fallback. "
+        f"Got repo: {open_calls[0]['repo']!r}"
+    )
+
+    # Contract 2: ctx.gh_incident_urls = {phona/sisyphus: url}
+    gh_url_updates = [u for u in ctx_updates if "gh_incident_urls" in u]
+    assert gh_url_updates, "GHI-S14: update_context MUST include gh_incident_urls"
+    final_urls = gh_url_updates[-1]["gh_incident_urls"]
+    assert final_urls == {"phona/sisyphus": "https://github.com/phona/sisyphus/issues/99"}, (
+        f"GHI-S14: gh_incident_urls MUST equal expected map. Got: {final_urls}"
+    )
+
+    # Contract 3: github-incident tagged
+    all_tags = [t for tags in tag_log for t in tags]
+    assert "github-incident" in all_tags, (
+        f"GHI-S14: github-incident MUST be in BKD tags. Got: {all_tags}"
+    )
+
+
+async def test_ghi_s15_layers_1_to_4_take_precedence_over_gh_incident_repo(monkeypatch):
+    """GHI-S15: ctx.involved_repos set + gh_incident_repo set → only ctx.involved_repos is used."""
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "github_token", "gh-real-token")
+    monkeypatch.setattr(cfg, "gh_incident_repo", "phona/sisyphus")  # legacy single-inbox
+    monkeypatch.setattr(cfg, "default_involved_repos", [])
+
+    open_calls: list[dict] = []
+
+    async def _mock_open(*, repo, **kw):
+        open_calls.append({"repo": repo})
+        return f"https://github.com/{repo}/issues/1"
+
+    tag_log: list = []
+    ctx_updates: list = []
+    ctx = _make_ctx(
+        involved_repos=["phona/repo-a"],  # Layer 2: ctx.involved_repos
+        escalated_reason="verifier-decision-escalate",
+        intent_issue_id="intent-s15",
+    )
+
+    result, ctx_updates = await _run_escalate(
+        monkeypatch,
+        ctx=ctx,
+        body=_FakeBody(event="session.completed", issue_id="issue-s15"),
+        bkd_cls=_make_collecting_bkd(tag_log),
+        open_incident_mock=_mock_open,
+        ctx_updates=ctx_updates,
+    )
+
+    # Contract 1: open_incident called ONLY for phona/repo-a (NOT for phona/sisyphus)
+    repos_called = [c["repo"] for c in open_calls]
+    assert "phona/repo-a" in repos_called, (
+        f"GHI-S15: open_incident MUST be called for ctx.involved_repos[0]='phona/repo-a'. "
+        f"Got calls: {repos_called}"
+    )
+    assert "phona/sisyphus" not in repos_called, (
+        f"GHI-S15: gh_incident_repo='phona/sisyphus' MUST NOT be used when involved_repos is set. "
+        f"Got calls: {repos_called}"
+    )
+    assert len(open_calls) == 1, (
+        f"GHI-S15: MUST call exactly once (phona/repo-a only). Got calls: {repos_called}"
+    )
+
+    # Contract 2: ctx.gh_incident_urls keys = {phona/repo-a} (no sisyphus)
+    gh_url_updates = [u for u in ctx_updates if "gh_incident_urls" in u]
+    assert gh_url_updates, "GHI-S15: update_context MUST include gh_incident_urls"
+    final_urls = gh_url_updates[-1]["gh_incident_urls"]
+    assert set(final_urls.keys()) == {"phona/repo-a"}, (
+        f"GHI-S15: gh_incident_urls keys MUST be {{'phona/repo-a'}}, "
+        f"not including gh_incident_repo. Got keys: {set(final_urls.keys())}"
+    )

--- a/orchestrator/tests/test_contract_gh_incident_per_repo.py
+++ b/orchestrator/tests/test_contract_gh_incident_per_repo.py
@@ -13,8 +13,7 @@ from __future__ import annotations
 
 import json
 from typing import ClassVar
-from unittest.mock import AsyncMock, MagicMock, call, patch
-
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # ─── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -86,10 +85,10 @@ async def _run_escalate(monkeypatch, ctx, body=None, tags=None, *, bkd_cls=None,
     Helper: call actions.escalate with mocked deps, return (result, ctx_updates_list).
     ctx_updates: externally-provided list to capture update_context calls.
     """
-    from orchestrator.actions import escalate as esc_mod
     from orchestrator import gh_incident as ghi
-    from orchestrator.bkd import BKDClient as RealBKDClient
-    from orchestrator.store import req_state as rs_mod, db
+    from orchestrator.actions import escalate as esc_mod
+    from orchestrator.store import db
+    from orchestrator.store import req_state as rs_mod
 
     if body is None:
         body = _FakeBody()
@@ -422,7 +421,7 @@ async def test_ghi_s6_real_escalate_single_repo_opens_one_incident(monkeypatch):
     )
     # Also: gh_incident_url (legacy) must be set
     assert any("gh_incident_url" in u for u in ctx_updates), (
-        f"GHI-S6: legacy ctx.gh_incident_url MUST also be set"
+        "GHI-S6: legacy ctx.gh_incident_url MUST also be set"
     )
 
     # Contract 3: BKD tag includes 'github-incident'
@@ -467,7 +466,7 @@ async def test_ghi_s7_idempotent_preexisting_urls_skips_post(monkeypatch):
         intent_issue_id="intent-s7",
     )
 
-    result, ctx_updates = await _run_escalate(
+    _, ctx_updates = await _run_escalate(
         monkeypatch,
         ctx=ctx,
         body=_FakeBody(event="session.completed", issue_id="issue-s7"),
@@ -520,7 +519,7 @@ async def test_ghi_s8_auto_resume_does_not_open_incident(monkeypatch):
         intent_issue_id="intent-s8",
     )
 
-    result, ctx_updates = await _run_escalate(
+    await _run_escalate(
         monkeypatch,
         ctx=ctx,
         body=_FakeBody(event="session.failed", issue_id="issue-s8"),
@@ -684,7 +683,7 @@ async def test_ghi_s11_multi_repo_opens_one_incident_per_repo(monkeypatch):
         intent_issue_id="intent-s11",
     )
 
-    result, ctx_updates = await _run_escalate(
+    _, ctx_updates = await _run_escalate(
         monkeypatch,
         ctx=ctx,
         body=_FakeBody(event="session.completed", issue_id="issue-s11"),
@@ -705,7 +704,7 @@ async def test_ghi_s11_multi_repo_opens_one_incident_per_repo(monkeypatch):
 
     # Contract 2: ctx.gh_incident_urls contains both
     gh_url_updates = [u for u in ctx_updates if "gh_incident_urls" in u]
-    assert gh_url_updates, f"GHI-S11: update_context MUST include gh_incident_urls"
+    assert gh_url_updates, "GHI-S11: update_context MUST include gh_incident_urls"
     final_urls = gh_url_updates[-1]["gh_incident_urls"]
     assert "phona/repo-a" in final_urls, (
         f"GHI-S11: gh_incident_urls MUST contain phona/repo-a. Got: {final_urls}"
@@ -803,7 +802,7 @@ async def test_ghi_s13_idempotent_multi_repo_only_posts_missing(monkeypatch):
         intent_issue_id="intent-s13",
     )
 
-    result, ctx_updates = await _run_escalate(
+    _, ctx_updates = await _run_escalate(
         monkeypatch,
         ctx=ctx,
         body=_FakeBody(event="session.completed", issue_id="issue-s13"),
@@ -863,7 +862,7 @@ async def test_ghi_s14_fallback_to_gh_incident_repo(monkeypatch):
         intent_issue_id="intent-s14",
     )
 
-    result, ctx_updates = await _run_escalate(
+    _, ctx_updates = await _run_escalate(
         monkeypatch,
         ctx=ctx,
         body=_FakeBody(event="session.completed", issue_id="issue-s14"),
@@ -919,7 +918,7 @@ async def test_ghi_s15_layers_1_to_4_take_precedence_over_gh_incident_repo(monke
         intent_issue_id="intent-s15",
     )
 
-    result, ctx_updates = await _run_escalate(
+    _, ctx_updates = await _run_escalate(
         monkeypatch,
         ctx=ctx,
         body=_FakeBody(event="session.completed", issue_id="issue-s15"),

--- a/orchestrator/tests/test_gh_incident.py
+++ b/orchestrator/tests/test_gh_incident.py
@@ -1,6 +1,7 @@
 """Unit tests for orchestrator.gh_incident.open_incident + escalate integration.
 
-Covers GHI-S1..GHI-S10 from openspec/changes/REQ-impl-gh-incident-open-1777173133.
+Covers GHI-S1..GHI-S15 from openspec/specs/gh-incident-open/spec.md (the
+per-involved-repo loop introduced by REQ-gh-incident-per-involved-repo-1777180551).
 """
 from __future__ import annotations
 
@@ -12,15 +13,20 @@ import httpx
 import pytest
 
 
-def _set_settings(monkeypatch, *, repo: str = "phona/sisyphus", token: str = "ghp_xxx",
-                  labels=None):
-    """Override config.settings for the duration of one test."""
+def _set_settings(monkeypatch, *, token: str = "ghp_xxx", labels=None,
+                  gh_incident_repo: str = "",
+                  default_involved_repos=None):
+    """Override config.settings on the gh_incident module."""
     from orchestrator import gh_incident
-    monkeypatch.setattr(gh_incident.settings, "gh_incident_repo", repo)
     monkeypatch.setattr(gh_incident.settings, "github_token", token)
+    monkeypatch.setattr(gh_incident.settings, "gh_incident_repo", gh_incident_repo)
     monkeypatch.setattr(
         gh_incident.settings, "gh_incident_labels",
         labels if labels is not None else ["sisyphus:incident"],
+    )
+    monkeypatch.setattr(
+        gh_incident.settings, "default_involved_repos",
+        default_involved_repos if default_involved_repos is not None else [],
     )
 
 
@@ -57,30 +63,30 @@ def _patch_client(monkeypatch, *, status_code: int = 201,
     return recorder
 
 
-# ─── GHI-S1: disabled when gh_incident_repo empty ─────────────────────────
+# ─── GHI-S1: disabled when repo argument is empty ─────────────────────────
 @pytest.mark.asyncio
 async def test_open_incident_disabled_when_repo_empty(monkeypatch):
     from orchestrator import gh_incident
-    _set_settings(monkeypatch, repo="", token="ghp_xxx")
+    _set_settings(monkeypatch, token="ghp_xxx")
     rec = _patch_client(monkeypatch)  # would record if called
 
     out = await gh_incident.open_incident(
-        req_id="REQ-1", reason="x", retry_count=0,
+        repo="", req_id="REQ-1", reason="x", retry_count=0,
         intent_issue_id="i", failed_issue_id="i", project_id="p",
     )
     assert out is None
-    assert rec == {}, "no HTTP request should be made when disabled"
+    assert rec == {}, "no HTTP request should be made when repo is empty"
 
 
 # ─── GHI-S2: disabled when github_token empty ────────────────────────────
 @pytest.mark.asyncio
 async def test_open_incident_disabled_when_token_empty(monkeypatch):
     from orchestrator import gh_incident
-    _set_settings(monkeypatch, repo="phona/sisyphus", token="")
+    _set_settings(monkeypatch, token="")
     rec = _patch_client(monkeypatch)
 
     out = await gh_incident.open_incident(
-        req_id="REQ-1", reason="x", retry_count=0,
+        repo="phona/sisyphus", req_id="REQ-1", reason="x", retry_count=0,
         intent_issue_id="i", failed_issue_id="i", project_id="p",
     )
     assert out is None
@@ -91,13 +97,14 @@ async def test_open_incident_disabled_when_token_empty(monkeypatch):
 @pytest.mark.asyncio
 async def test_open_incident_success_returns_html_url(monkeypatch):
     from orchestrator import gh_incident
-    _set_settings(monkeypatch, repo="phona/sisyphus", token="ghp_xxx")
+    _set_settings(monkeypatch, token="ghp_xxx")
     rec = _patch_client(
         monkeypatch, status_code=201,
         json_body={"html_url": "https://github.com/phona/sisyphus/issues/42"},
     )
 
     out = await gh_incident.open_incident(
+        repo="phona/sisyphus",
         req_id="REQ-9", reason="verifier-decision-escalate", retry_count=0,
         intent_issue_id="intent-1", failed_issue_id="vfy-3", project_id="proj-A",
         state="executing",
@@ -112,13 +119,14 @@ async def test_open_incident_success_returns_html_url(monkeypatch):
 @pytest.mark.asyncio
 async def test_open_incident_body_contains_context(monkeypatch):
     from orchestrator import gh_incident
-    _set_settings(monkeypatch, repo="phona/sisyphus", token="ghp_xxx")
+    _set_settings(monkeypatch, token="ghp_xxx")
     rec = _patch_client(
         monkeypatch, status_code=201,
         json_body={"html_url": "https://github.com/phona/sisyphus/issues/42"},
     )
 
     await gh_incident.open_incident(
+        repo="phona/sisyphus",
         req_id="REQ-9", reason="fixer-round-cap", retry_count=0,
         intent_issue_id="intent-1", failed_issue_id="vfy-3", project_id="proj-A",
         state="fixer-running",
@@ -138,11 +146,12 @@ async def test_open_incident_body_contains_context(monkeypatch):
 @pytest.mark.asyncio
 async def test_open_incident_http_503_returns_none(monkeypatch):
     from orchestrator import gh_incident
-    _set_settings(monkeypatch, repo="phona/sisyphus", token="ghp_xxx")
+    _set_settings(monkeypatch, token="ghp_xxx")
     _patch_client(monkeypatch, status_code=503,
                   json_body={"message": "service unavailable"})
 
     out = await gh_incident.open_incident(
+        repo="phona/sisyphus",
         req_id="REQ-9", reason="x", retry_count=0,
         intent_issue_id="i", failed_issue_id="i", project_id="p",
     )
@@ -152,10 +161,11 @@ async def test_open_incident_http_503_returns_none(monkeypatch):
 @pytest.mark.asyncio
 async def test_open_incident_network_error_returns_none(monkeypatch):
     from orchestrator import gh_incident
-    _set_settings(monkeypatch, repo="phona/sisyphus", token="ghp_xxx")
+    _set_settings(monkeypatch, token="ghp_xxx")
     _patch_client(monkeypatch, raise_exc=httpx.ConnectError("DNS failure"))
 
     out = await gh_incident.open_incident(
+        repo="phona/sisyphus",
         req_id="REQ-9", reason="x", retry_count=0,
         intent_issue_id="i", failed_issue_id="i", project_id="p",
     )
@@ -165,17 +175,18 @@ async def test_open_incident_network_error_returns_none(monkeypatch):
 @pytest.mark.asyncio
 async def test_open_incident_2xx_without_html_url_returns_none(monkeypatch):
     from orchestrator import gh_incident
-    _set_settings(monkeypatch, repo="phona/sisyphus", token="ghp_xxx")
+    _set_settings(monkeypatch, token="ghp_xxx")
     _patch_client(monkeypatch, status_code=200, json_body={"unexpected": "shape"})
 
     out = await gh_incident.open_incident(
+        repo="phona/sisyphus",
         req_id="REQ-9", reason="x", retry_count=0,
         intent_issue_id="i", failed_issue_id="i", project_id="p",
     )
     assert out is None
 
 
-# ─── escalate-integration tests (GHI-S6..GHI-S10) ─────────────────────────
+# ─── escalate-integration tests (GHI-S6..GHI-S15) ─────────────────────────
 # Sister tests to test_actions_smoke.py — kept here to keep gh-incident
 # scenarios in one file. The fixtures mirror the smoke-test style.
 
@@ -229,6 +240,17 @@ def _patch_db(monkeypatch):
     return patches
 
 
+def _patch_settings(monkeypatch, *, gh_incident_repo: str = "",
+                    default_involved_repos=None):
+    """Stub settings on actions.escalate (NOT gh_incident — that's mocked separately)."""
+    from orchestrator.actions import escalate as mod
+    monkeypatch.setattr(mod.settings, "gh_incident_repo", gh_incident_repo)
+    monkeypatch.setattr(
+        mod.settings, "default_involved_repos",
+        default_involved_repos if default_involved_repos is not None else [],
+    )
+
+
 def _make_body(*, issue_id="src-1", project_id="p", event="verify.escalate"):
     return type("B", (), {
         "issueId": issue_id, "projectId": project_id,
@@ -236,22 +258,25 @@ def _make_body(*, issue_id="src-1", project_id="p", event="verify.escalate"):
     })()
 
 
-@pytest.mark.asyncio
-async def test_escalate_real_path_opens_gh_incident(monkeypatch):
-    """GHI-S6: real-escalate calls open_incident, stores URL, appends github-incident tag."""
-    from orchestrator.actions import escalate as mod
-
-    fake_bkd = _make_fake_bkd()
-    _patch_bkd(monkeypatch, fake_bkd)
-    patches = _patch_db(monkeypatch)
-
+def _stub_req_state_get(monkeypatch):
     from orchestrator.store import req_state as rs
 
     class _Row:
         state = type("S", (), {"value": "executing"})()
     monkeypatch.setattr(rs, "get", AsyncMock(return_value=_Row()))
 
-    monkeypatch.setattr(mod.settings, "gh_incident_repo", "phona/sisyphus")
+
+@pytest.mark.asyncio
+async def test_escalate_real_path_opens_gh_incident(monkeypatch):
+    """GHI-S6: real-escalate single involved repo → one POST + ctx.gh_incident_urls."""
+    from orchestrator.actions import escalate as mod
+
+    fake_bkd = _make_fake_bkd()
+    _patch_bkd(monkeypatch, fake_bkd)
+    patches = _patch_db(monkeypatch)
+    _stub_req_state_get(monkeypatch)
+    _patch_settings(monkeypatch)
+
     open_inc = AsyncMock(return_value="https://github.com/phona/sisyphus/issues/42")
     monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
 
@@ -261,26 +286,28 @@ async def test_escalate_real_path_opens_gh_incident(monkeypatch):
         ctx={
             "intent_issue_id": "intent-1",
             "escalated_reason": "verifier-decision-escalate",
+            "involved_repos": ["phona/sisyphus"],
         },
     )
     assert out["escalated"] is True
 
-    # open_incident called once with correct kwargs
     open_inc.assert_awaited_once()
     kw = open_inc.await_args.kwargs
+    assert kw["repo"] == "phona/sisyphus"
     assert kw["req_id"] == "REQ-9"
     assert kw["reason"] == "verifier-decision-escalate"
     assert kw["intent_issue_id"] == "intent-1"
     assert kw["failed_issue_id"] == "vfy-3"
     assert kw["project_id"] == "p"
 
-    # ctx patched with gh_incident_url + opened_at
     final = patches[-1]
+    assert final["gh_incident_urls"] == {
+        "phona/sisyphus": "https://github.com/phona/sisyphus/issues/42",
+    }
     assert final["gh_incident_url"] == "https://github.com/phona/sisyphus/issues/42"
     assert "gh_incident_opened_at" in final
     assert final["escalated_reason"] == "verifier-decision-escalate"
 
-    # BKD tag merge includes github-incident
     fake_bkd.merge_tags_and_update.assert_awaited_once()
     add = fake_bkd.merge_tags_and_update.await_args.kwargs["add"]
     assert "escalated" in add
@@ -290,18 +317,14 @@ async def test_escalate_real_path_opens_gh_incident(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_escalate_idempotent_when_ctx_has_url(monkeypatch):
-    """GHI-S7: ctx.gh_incident_url already set → no second POST."""
+    """GHI-S7: ctx.gh_incident_urls already covers all involved repos → no second POST."""
     from orchestrator.actions import escalate as mod
 
     fake_bkd = _make_fake_bkd()
     _patch_bkd(monkeypatch, fake_bkd)
     patches = _patch_db(monkeypatch)
-
-    from orchestrator.store import req_state as rs
-
-    class _Row:
-        state = type("S", (), {"value": "executing"})()
-    monkeypatch.setattr(rs, "get", AsyncMock(return_value=_Row()))
+    _stub_req_state_get(monkeypatch)
+    _patch_settings(monkeypatch)
 
     open_inc = AsyncMock(return_value="https://example/should/not/be/called")
     monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
@@ -312,15 +335,19 @@ async def test_escalate_idempotent_when_ctx_has_url(monkeypatch):
         ctx={
             "intent_issue_id": "intent-1",
             "escalated_reason": "verifier-decision-escalate",
-            "gh_incident_url": "https://github.com/phona/sisyphus/issues/42",
+            "involved_repos": ["phona/sisyphus"],
+            "gh_incident_urls": {
+                "phona/sisyphus": "https://github.com/phona/sisyphus/issues/42",
+            },
         },
     )
 
     open_inc.assert_not_awaited()
-    # ctx_patch must not RE-write gh_incident_url (idempotent: leave existing alone)
     final = patches[-1]
+    # No new URL → ctx_patch must not REWRITE gh_incident_urls / gh_incident_url
+    assert "gh_incident_urls" not in final
     assert "gh_incident_url" not in final
-    # tag still includes github-incident (existing URL → still annotate BKD)
+    # Tag still includes github-incident (existing URLs → still annotate BKD)
     add = fake_bkd.merge_tags_and_update.await_args.kwargs["add"]
     assert "github-incident" in add
 
@@ -333,6 +360,7 @@ async def test_escalate_auto_resume_does_not_open_incident(monkeypatch):
     fake_bkd = _make_fake_bkd()
     _patch_bkd(monkeypatch, fake_bkd)
     _patch_db(monkeypatch)
+    _patch_settings(monkeypatch)
 
     open_inc = AsyncMock(return_value="https://example/should/not/be/called")
     monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
@@ -350,18 +378,14 @@ async def test_escalate_auto_resume_does_not_open_incident(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_escalate_gh_failure_does_not_abort(monkeypatch):
-    """GHI-S9: open_incident returns None → escalate still completes; no gh_incident_url written."""
+    """GHI-S9: open_incident returns None → escalate still completes; no URL ctx fields."""
     from orchestrator.actions import escalate as mod
 
     fake_bkd = _make_fake_bkd()
     _patch_bkd(monkeypatch, fake_bkd)
     patches = _patch_db(monkeypatch)
-
-    from orchestrator.store import req_state as rs
-
-    class _Row:
-        state = type("S", (), {"value": "executing"})()
-    monkeypatch.setattr(rs, "get", AsyncMock(return_value=_Row()))
+    _stub_req_state_get(monkeypatch)
+    _patch_settings(monkeypatch)
 
     open_inc = AsyncMock(return_value=None)  # GH outage / disabled
     monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
@@ -372,34 +396,30 @@ async def test_escalate_gh_failure_does_not_abort(monkeypatch):
         ctx={
             "intent_issue_id": "intent-1",
             "escalated_reason": "verifier-decision-escalate",
+            "involved_repos": ["phona/sisyphus"],
         },
     )
     assert out["escalated"] is True
     fake_bkd.merge_tags_and_update.assert_awaited_once()
     final = patches[-1]
     assert "gh_incident_url" not in final
-    # github-incident tag NOT appended when no URL was minted
+    assert "gh_incident_urls" not in final
     add = fake_bkd.merge_tags_and_update.await_args.kwargs["add"]
     assert "github-incident" not in add
 
 
 @pytest.mark.asyncio
 async def test_escalate_disabled_default_keeps_old_behavior(monkeypatch):
-    """GHI-S10: settings.gh_incident_repo='' (default) → behavior unchanged."""
+    """GHI-S10: no involved_repos and no settings.gh_incident_repo → behavior unchanged."""
     from orchestrator.actions import escalate as mod
 
     fake_bkd = _make_fake_bkd()
     _patch_bkd(monkeypatch, fake_bkd)
     patches = _patch_db(monkeypatch)
-
-    from orchestrator.store import req_state as rs
-
-    class _Row:
-        state = type("S", (), {"value": "executing"})()
-    monkeypatch.setattr(rs, "get", AsyncMock(return_value=_Row()))
+    _stub_req_state_get(monkeypatch)
+    _patch_settings(monkeypatch)
 
     # Don't mock open_incident — let it run with real (empty) settings
-    monkeypatch.setattr(mod.gh_incident.settings, "gh_incident_repo", "")
     monkeypatch.setattr(mod.gh_incident.settings, "github_token", "")
 
     body = _make_body(issue_id="vfy-3", event="verify.escalate")
@@ -413,7 +433,189 @@ async def test_escalate_disabled_default_keeps_old_behavior(monkeypatch):
     assert out["escalated"] is True
     final = patches[-1]
     assert "gh_incident_url" not in final
+    assert "gh_incident_urls" not in final
     add = fake_bkd.merge_tags_and_update.await_args.kwargs["add"]
     assert "github-incident" not in add
     assert "escalated" in add
     assert "reason:verifier-decision-escalate" in add
+
+
+@pytest.mark.asyncio
+async def test_escalate_multi_repo_opens_incident_per_repo(monkeypatch):
+    """GHI-S11: multi-repo REQ → one POST per involved repo."""
+    from orchestrator.actions import escalate as mod
+
+    fake_bkd = _make_fake_bkd()
+    _patch_bkd(monkeypatch, fake_bkd)
+    patches = _patch_db(monkeypatch)
+    _stub_req_state_get(monkeypatch)
+    _patch_settings(monkeypatch)
+
+    async def _open(*, repo, **_):
+        return {
+            "phona/repo-a": "https://github.com/phona/repo-a/issues/7",
+            "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
+        }.get(repo)
+
+    open_inc = AsyncMock(side_effect=_open)
+    monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
+
+    body = _make_body(issue_id="vfy-3", event="verify.escalate")
+    await mod.escalate(
+        body=body, req_id="REQ-9", tags=["verifier"],
+        ctx={
+            "intent_issue_id": "intent-1",
+            "escalated_reason": "verifier-decision-escalate",
+            "involved_repos": ["phona/repo-a", "phona/repo-b"],
+        },
+    )
+
+    assert open_inc.await_count == 2
+    repos_called = sorted(c.kwargs["repo"] for c in open_inc.await_args_list)
+    assert repos_called == ["phona/repo-a", "phona/repo-b"]
+
+    final = patches[-1]
+    assert final["gh_incident_urls"] == {
+        "phona/repo-a": "https://github.com/phona/repo-a/issues/7",
+        "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
+    }
+    add = fake_bkd.merge_tags_and_update.await_args.kwargs["add"]
+    assert add.count("github-incident") == 1
+
+
+@pytest.mark.asyncio
+async def test_escalate_partial_failure_isolated(monkeypatch):
+    """GHI-S12: one repo POST fails (None), the other succeeds → only the success persists."""
+    from orchestrator.actions import escalate as mod
+
+    fake_bkd = _make_fake_bkd()
+    _patch_bkd(monkeypatch, fake_bkd)
+    patches = _patch_db(monkeypatch)
+    _stub_req_state_get(monkeypatch)
+    _patch_settings(monkeypatch)
+
+    async def _open(*, repo, **_):
+        return None if repo == "phona/repo-a" else "https://github.com/phona/repo-b/issues/3"
+
+    open_inc = AsyncMock(side_effect=_open)
+    monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
+
+    body = _make_body(issue_id="vfy-3", event="verify.escalate")
+    out = await mod.escalate(
+        body=body, req_id="REQ-9", tags=["verifier"],
+        ctx={
+            "intent_issue_id": "intent-1",
+            "escalated_reason": "verifier-decision-escalate",
+            "involved_repos": ["phona/repo-a", "phona/repo-b"],
+        },
+    )
+    assert out["escalated"] is True
+
+    final = patches[-1]
+    assert final["gh_incident_urls"] == {
+        "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
+    }
+    add = fake_bkd.merge_tags_and_update.await_args.kwargs["add"]
+    assert "github-incident" in add  # one success suffices
+
+
+@pytest.mark.asyncio
+async def test_escalate_idempotent_per_repo_only_missing_posted(monkeypatch):
+    """GHI-S13: existing URLs preserved; only missing repos POSTed on re-entry."""
+    from orchestrator.actions import escalate as mod
+
+    fake_bkd = _make_fake_bkd()
+    _patch_bkd(monkeypatch, fake_bkd)
+    patches = _patch_db(monkeypatch)
+    _stub_req_state_get(monkeypatch)
+    _patch_settings(monkeypatch)
+
+    open_inc = AsyncMock(return_value="https://github.com/phona/repo-b/issues/3")
+    monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
+
+    body = _make_body(issue_id="vfy-3", event="verify.escalate")
+    await mod.escalate(
+        body=body, req_id="REQ-9", tags=["verifier"],
+        ctx={
+            "intent_issue_id": "intent-1",
+            "escalated_reason": "verifier-decision-escalate",
+            "involved_repos": ["phona/repo-a", "phona/repo-b"],
+            "gh_incident_urls": {
+                "phona/repo-a": "https://github.com/phona/repo-a/issues/7",
+            },
+        },
+    )
+
+    open_inc.assert_awaited_once()
+    assert open_inc.await_args.kwargs["repo"] == "phona/repo-b"
+
+    final = patches[-1]
+    assert final["gh_incident_urls"] == {
+        "phona/repo-a": "https://github.com/phona/repo-a/issues/7",
+        "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
+    }
+
+
+@pytest.mark.asyncio
+async def test_escalate_falls_back_to_settings_gh_incident_repo(monkeypatch):
+    """GHI-S14: no involved_repos → fall back to settings.gh_incident_repo (legacy single-inbox)."""
+    from orchestrator.actions import escalate as mod
+
+    fake_bkd = _make_fake_bkd()
+    _patch_bkd(monkeypatch, fake_bkd)
+    patches = _patch_db(monkeypatch)
+    _stub_req_state_get(monkeypatch)
+    _patch_settings(monkeypatch, gh_incident_repo="phona/sisyphus")
+
+    open_inc = AsyncMock(return_value="https://github.com/phona/sisyphus/issues/99")
+    monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
+
+    body = _make_body(issue_id="vfy-3", event="verify.escalate")
+    await mod.escalate(
+        body=body, req_id="REQ-9", tags=["verifier"],
+        ctx={
+            "intent_issue_id": "intent-1",
+            "escalated_reason": "verifier-decision-escalate",
+        },
+    )
+
+    open_inc.assert_awaited_once()
+    assert open_inc.await_args.kwargs["repo"] == "phona/sisyphus"
+
+    final = patches[-1]
+    assert final["gh_incident_urls"] == {
+        "phona/sisyphus": "https://github.com/phona/sisyphus/issues/99",
+    }
+    add = fake_bkd.merge_tags_and_update.await_args.kwargs["add"]
+    assert "github-incident" in add
+
+
+@pytest.mark.asyncio
+async def test_escalate_involved_repos_take_precedence_over_fallback(monkeypatch):
+    """GHI-S15: ctx.involved_repos beats settings.gh_incident_repo."""
+    from orchestrator.actions import escalate as mod
+
+    fake_bkd = _make_fake_bkd()
+    _patch_bkd(monkeypatch, fake_bkd)
+    patches = _patch_db(monkeypatch)
+    _stub_req_state_get(monkeypatch)
+    _patch_settings(monkeypatch, gh_incident_repo="phona/sisyphus")
+
+    open_inc = AsyncMock(return_value="https://github.com/phona/repo-a/issues/1")
+    monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
+
+    body = _make_body(issue_id="vfy-3", event="verify.escalate")
+    await mod.escalate(
+        body=body, req_id="REQ-9", tags=["verifier"],
+        ctx={
+            "intent_issue_id": "intent-1",
+            "escalated_reason": "verifier-decision-escalate",
+            "involved_repos": ["phona/repo-a"],
+        },
+    )
+
+    open_inc.assert_awaited_once()
+    assert open_inc.await_args.kwargs["repo"] == "phona/repo-a"
+
+    final = patches[-1]
+    assert set(final["gh_incident_urls"].keys()) == {"phona/repo-a"}

--- a/orchestrator/uv.lock
+++ b/orchestrator/uv.lock
@@ -1024,6 +1024,7 @@ dev = [
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-httpx" },
 ]
 
 [package.metadata]
@@ -1053,6 +1054,7 @@ provides-extras = ["dev"]
 dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-httpx", specifier = ">=0.32" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace the single-inbox `gh_incident_repo` POST with a **per-involved-repo loop**
  in `actions/escalate.py`. Resolution reuses `_clone.resolve_repos`
  (intake_finalized_intent → ctx.involved_repos → `repo:` tags →
  `default_involved_repos`); `settings.gh_incident_repo` becomes a layer-5
  last-resort fallback for REQs whose involved repos are unknown (intake-stage
  failures pre-clone, central-triage deployments).
- `gh_incident.open_incident(repo=...)` now takes the target repo as an explicit
  kwarg. Disabled-when-empty-token semantics unchanged; disabled-when-empty-repo
  moves from "global setting" to "argument empty."
- Idempotency keys on `ctx.gh_incident_urls: dict[str, str]` (repo → url);
  legacy `ctx.gh_incident_url` stays populated to the first opened URL for
  backward compat with admin views and existing Metabase queries.
- Per-repo POST failures isolated — a 4xx/5xx on one repo doesn't abort the
  loop, and at least one successful URL is enough to add the `github-incident`
  BKD tag.

## Spec delta

`openspec/specs/gh-incident-open/spec.md` (per
`openspec/changes/REQ-gh-incident-per-involved-repo-1777180551/`):

- **MODIFIED** open_incident requirement — adds explicit `repo: str` kwarg.
- **MODIFIED** escalate-action requirement — per-repo loop + new ctx shape.
- **ADDED** "incident repo resolution layers" requirement with the 5-layer
  fallback plus GHI-S11..S15 (multi-repo, partial failure, idempotent re-entry,
  legacy fallback, layer precedence).

## Test plan

- [x] `make ci-lint BASE_REV=$(git merge-base HEAD origin/main)` — clean
- [x] `make ci-unit-test` — 724 tests pass (including 32 gh_incident scenarios)
- [x] `make ci-integration-test` — exit 5 (no integration markers in scope) → pass
- [x] `openspec validate REQ-gh-incident-per-involved-repo-1777180551` — clean
- [x] `scripts/check-scenario-refs.sh` — 233 scenarios, all references resolved
- [ ] sisyphus self-dogfood: spec_lint / dev_cross_check / staging_test / pr_ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)