### PR TITLE
fix(checkers): detect ci-* targets via make -p -n (resolves include)

### DIFF
--- a/orchestrator/src/orchestrator/actions/_integration_resolver.py
+++ b/orchestrator/src/orchestrator/actions/_integration_resolver.py
@@ -32,20 +32,22 @@ log = structlog.get_logger(__name__)
 
 
 # 单 shell 调用扫两个 root，每个候选 dir 一行，前缀 I:/S: 标识来源。
-# grep -E '^accept-env-up:' 严格匹配开头（避免 doc 注释里出现的字符串误匹配）。
+# 用 `make -p -n` 解析 Makefile + include 子 mk（实证 ttpos-server-go：
+# accept-env-up 在 ttpos-scripts/accept-env.mk via include，顶层 grep 漏判 →
+# resolver 误判"无 integration repo"），跟 dev_cross_check / staging_test 同根因。
 _SCAN_SCRIPT = r"""
 set +e
 for d in /workspace/integration/*/; do
   [ -d "$d" ] || continue
   [ -f "${d}Makefile" ] || continue
-  if grep -qE '^accept-env-up:' "${d}Makefile" 2>/dev/null; then
+  if (cd "$d" && make -p -n 2>/dev/null | grep -qE '^accept-env-up:'); then
     printf 'I:%s\n' "${d%/}"
   fi
 done
 for d in /workspace/source/*/; do
   [ -d "$d" ] || continue
   [ -f "${d}Makefile" ] || continue
-  if grep -qE '^accept-env-up:' "${d}Makefile" 2>/dev/null; then
+  if (cd "$d" && make -p -n 2>/dev/null | grep -qE '^accept-env-up:'); then
     printf 'S:%s\n' "${d%/}"
   fi
 done

--- a/orchestrator/src/orchestrator/checkers/dev_cross_check.py
+++ b/orchestrator/src/orchestrator/checkers/dev_cross_check.py
@@ -71,7 +71,11 @@ def _build_cmd(req_id: str) -> str:
         "    continue; "
         "  fi; "
         f'  cd "$repo" && git checkout -B "feat/{req_id}" "origin/feat/{req_id}" >/dev/null 2>&1; '
-        '  if [ -f "$repo/Makefile" ] && grep -q \'^ci-lint:\' "$repo/Makefile"; then '
+        # ci-lint target 检测：用 `make -p -n` 解析 Makefile（含 include 子 mk）
+        # 而非 `grep '^ci-lint:'` 顶层（实证 ttpos-server-go：ci-* 在
+        # ttpos-scripts/lint-ci-test.mk via `include`，顶层 grep 漏判 →
+        # checker 误报"0 source repos eligible" silent fail）。
+        '  if [ -f "$repo/Makefile" ] && (cd "$repo" && make -p -n 2>/dev/null | grep -q \'^ci-lint:\'); then '
         '    base_rev=$(cd "$repo" && (git merge-base HEAD origin/main 2>/dev/null '
         '              || git merge-base HEAD origin/develop 2>/dev/null '
         '              || git merge-base HEAD origin/dev 2>/dev/null '

--- a/orchestrator/src/orchestrator/checkers/staging_test.py
+++ b/orchestrator/src/orchestrator/checkers/staging_test.py
@@ -85,9 +85,11 @@ def _build_cmd(req_id: str) -> str:
         "    continue; "
         "  fi; "
         f'  cd "$repo" && git checkout -B "feat/{req_id}" "origin/feat/{req_id}" >/dev/null 2>&1; '
-        '  if [ -f "$repo/Makefile" ] '
-        '       && grep -q \'^ci-unit-test:\' "$repo/Makefile" '
-        '       && grep -q \'^ci-integration-test:\' "$repo/Makefile"; then '
+        # ci-unit-test / ci-integration-test target 检测：解析 Makefile（含 include 子 mk）
+        # 而非 grep 顶层（实证 ttpos-server-go：ci-* 在 ttpos-scripts/lint-ci-test.mk via include
+        # → 顶层 grep 漏判 → "0 source repos eligible" silent fail）。
+        '  if [ -f "$repo/Makefile" ] && (cd "$repo" && make -p -n 2>/dev/null | grep -qE \'^ci-unit-test:\') '
+        '       && (cd "$repo" && make -p -n 2>/dev/null | grep -qE \'^ci-integration-test:\'); then '
         "    ( "
         '      echo "=== staging_test (unit): $name ==="; '
         '      cd "$repo" && make ci-unit-test > "/tmp/staging-test-logs/$name-unit.log" 2>&1 '


### PR DESCRIPTION
## Summary
`grep -q '^ci-lint:' "$repo/Makefile"` only sees the top-level Makefile and is blind to `include`. Replace with `make -p -n` (parses + all includes, no execution) piped to grep.

## Why
ZonEaseTech/ttpos-server-go's Makefile delegates ci-* targets to `ttpos-scripts/lint-ci-test.mk` via include — exactly the [phona/ttpos-ci](https://github.com/phona/ttpos-ci) contract pattern. Sisyphus checkers couldn't see them and falsely reported "0 source repos eligible", escalating every ttpos REQ at dev_cross_check.

## Test plan
- [x] `uv run pytest tests/ -x -q` → 739 passed
- [ ] Post-merge: re-dispatch ttpos REQ; dev_cross_check should run `make ci-lint` for real instead of silent-pass guard