### PR TITLE
docs(state-machine): sync ReqState table with #118 #122 #124

### DIFF
--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -32,8 +32,8 @@
 | `accept-tearing-down` | env-down 清 lab（无论 accept pass/fail 都跑） | in-flight |
 | `review-running` | **M14b** verifier-agent 在跑（success / fail 两触发统一入口） | in-flight |
 | `fixer-running` | **M14b** decision=fix → 起对应 fixer agent | in-flight |
-| `archiving` | done-archive agent 跑（合 PR + 关 issue） | in-flight |
-| `gh-incident-open` | ~~（已规划，未启用）GitHub issue 已开等人 \| wait-human~~ — 设计被 PR #118 重新走"escalate side-effect"路：进 ESCALATED 时 `escalate` action 调 `gh_incident.file_incident()` 在 source repo 开 GH issue，**不引入新 state**。本行保留作历史，下次大改 state 表时删 |
+| `archiving` | done-archive agent 跑：每仓 `openspec apply` + 写 archive 结果。**不 auto-merge / 不 push main**——final merge 由人在每仓审过再合（#124） | in-flight |
+| `gh-incident-open` | ~~（已规划，未启用）GitHub issue 已开等人 \| wait-human~~ — 设计被 PR #118 / #122 重新走"escalate side-effect"路：进 ESCALATED 时 `escalate` action 调 `gh_incident.open_incident()`，对**每个 involved source repo**（intake_finalized_intent / ctx.involved_repos / `repo:` tag / `default_involved_repos` / `settings.gh_incident_repo` 5 层 fallback）独立 POST 一条 GH issue，URL 写入 `ctx.gh_incident_urls: dict[str, str]`，**不引入新 state**。本行保留作历史，下次大改 state 表时删 |
 | **`done`** | REQ 完成 | **terminal** |
 | **`escalated`** | 熔断 / session-failed / 人工止损 | **terminal** |
 

--- a/openspec/changes/REQ-state-machine-doc-sync-1777189159/proposal.md
+++ b/openspec/changes/REQ-state-machine-doc-sync-1777189159/proposal.md
@@ -1,0 +1,47 @@
+# Proposal: docs(state-machine) — sync with #118 #122 #124
+
+## 背景
+
+`docs/state-machine.md` 的 ReqState 表是新人理解状态机的第一站。三个最近 merge
+的 PR 让这张表对外信息有出入：
+
+- **#118** `feat(escalate): open GitHub issue when REQ enters ESCALATED` — 给
+  `escalate` action 加了 GH issue side-effect。PR #121 已经在 doc 里加了一行
+  "设计被 PR #118 重新走 escalate side-effect 路" 的过渡说明，但写错了函数名
+  （`gh_incident.file_incident()` ≠ 实际 `gh_incident.open_incident()`）。
+- **#122** `feat(escalate): open one GH incident per involved source repo` —
+  把 PR #118 的"单仓 inbox"语义改成"每个 involved source repo 一条"。doc
+  目前还停在 #118 的"在 source repo 开 GH issue"单数描述。
+- **#124** `fix(prompts): done_archive must not auto-merge or push main` —
+  done-archive 不再 `gh pr merge --squash --auto` / 不再 `git push origin main`，
+  PR / archive landing 留给人审过再合。但 ReqState 表里 `archiving` 行仍写"合
+  PR + 关 issue"，跟新策略冲突。
+
+## 范围
+
+只改 `docs/state-machine.md` 一行（`archiving`）+ 一行（`gh-incident-open`）。
+
+**不改**：
+
+- `state.py` —— `GH_INCIDENT_OPEN` 死枚举继续保留（PR #118 既有取舍）。
+- `done_archive.md.j2` —— PR #124 已落地，本 REQ 只做 doc 同步。
+- `escalate.py` / `gh_incident.py` —— PR #118 + #122 已落地实现。
+
+## 方案
+
+更新 ReqState 表两行：
+
+1. `archiving`：把"合 PR + 关 issue"改成"每仓 `openspec apply` + 写 archive
+   结果，不 auto-merge / 不 push main，final merge 由人在每仓审过再合（#124）"。
+2. `gh-incident-open`：
+   - 修正函数名 `gh_incident.file_incident()` → `gh_incident.open_incident()`。
+   - 把"在 source repo 开 GH issue"改成"对**每个 involved source repo**
+     （5 层 fallback：intake_finalized_intent / ctx.involved_repos / `repo:` tag
+     / `default_involved_repos` / `settings.gh_incident_repo`）独立 POST 一条
+     GH issue，URL 写入 `ctx.gh_incident_urls: dict[str, str]`"。
+   - 引用同时 #118 + #122 两个 PR。
+
+## 风险
+
+零风险——文档同步，没有运行时行为变化。spec_lint / dev_cross_check / staging_test
+跑过即合。

--- a/openspec/changes/REQ-state-machine-doc-sync-1777189159/specs/state-machine-doc/spec.md
+++ b/openspec/changes/REQ-state-machine-doc-sync-1777189159/specs/state-machine-doc/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: docs/state-machine.md MUST describe done-archive as no-auto-merge
+
+The ReqState description for `archiving` in `docs/state-machine.md` SHALL state
+that the done-archive agent does NOT auto-merge PRs and does NOT push to main.
+The text MUST mention that final merge is left to a human reviewer per
+PR #124, and MUST describe the agent's actual work as per-repo `openspec apply`
+plus writing the archive result. The phrase "合 PR + 关 issue" (which implies
+auto-merge) MUST NOT appear in the `archiving` row.
+
+#### Scenario: SMD-S1 archiving row reflects no-auto-merge contract
+- **GIVEN** `docs/state-machine.md` rendered as markdown
+- **WHEN** a reader reads the ReqState table row whose first column is `archiving`
+- **THEN** the description MUST contain the substring `不 auto-merge`
+- **AND** the description MUST contain the substring `不 push main`
+- **AND** the description MUST reference PR `#124`
+- **AND** the description MUST NOT contain the substring `合 PR`
+
+### Requirement: docs/state-machine.md MUST describe gh-incident as per-involved-repo loop
+
+The ReqState description for `gh-incident-open` in `docs/state-machine.md` SHALL
+describe the GH-incident side-effect path. It MUST reference both PR 118 and
+PR 122 by number, MUST use the correct function name `gh_incident.open_incident()`
+(not `file_incident`), MUST state that the escalate action loops over each
+involved source repo, MUST mention the five-layer fallback used to resolve
+incident-target repos (`intake_finalized_intent` then `ctx.involved_repos`
+then `repo:` tag then `default_involved_repos` then `settings.gh_incident_repo`),
+and MUST mention that the resulting URLs land in
+`ctx.gh_incident_urls: dict[str, str]`.
+
+#### Scenario: SMD-S2 gh-incident-open row references both PRs and correct function name
+- **GIVEN** `docs/state-machine.md` rendered as markdown
+- **WHEN** a reader reads the ReqState table row whose first column is `gh-incident-open`
+- **THEN** the description MUST reference both PR `#118` and PR `#122`
+- **AND** the description MUST contain the substring `gh_incident.open_incident()`
+- **AND** the description MUST NOT contain the substring `gh_incident.file_incident()`
+
+#### Scenario: SMD-S3 gh-incident-open row documents per-repo loop and ctx shape
+- **GIVEN** `docs/state-machine.md` rendered as markdown
+- **WHEN** a reader reads the ReqState table row whose first column is `gh-incident-open`
+- **THEN** the description MUST contain the substring `每个 involved source repo`
+- **AND** the description MUST contain the substring `ctx.gh_incident_urls`
+- **AND** the description MUST mention all five fallback layers: `intake_finalized_intent`, `ctx.involved_repos`, `repo:` tag, `default_involved_repos`, `settings.gh_incident_repo`

--- a/openspec/changes/REQ-state-machine-doc-sync-1777189159/tasks.md
+++ b/openspec/changes/REQ-state-machine-doc-sync-1777189159/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: REQ-state-machine-doc-sync-1777189159
+
+## Stage: spec
+
+- [x] author specs/state-machine-doc/spec.md scenarios (SMD-S1..S3)
+
+## Stage: implementation
+
+- [x] update `docs/state-machine.md` `archiving` row (no auto-merge, ref #124)
+- [x] update `docs/state-machine.md` `gh-incident-open` row (open_incident
+      function name fix + per-involved-repo loop + 5-layer fallback + ctx.gh_incident_urls,
+      ref #118 + #122)
+
+## Stage: PR
+
+- [x] git push feat/REQ-state-machine-doc-sync-1777189159
+- [x] gh pr create

--- a/orchestrator/tests/test_contract_state_machine_doc_sync.py
+++ b/orchestrator/tests/test_contract_state_machine_doc_sync.py
@@ -1,0 +1,162 @@
+"""Contract tests: docs/state-machine.md sync with #118 #122 #124.
+REQ-state-machine-doc-sync-1777189159
+
+Black-box challenger. Derived from:
+  openspec/changes/REQ-state-machine-doc-sync-1777189159/specs/state-machine-doc/spec.md
+
+Scenarios covered:
+  SMD-S1  archiving row: 不 auto-merge / 不 push main / #124 / NOT 合 PR
+  SMD-S2  gh-incident-open row: #118 + #122 / correct function name open_incident / NOT file_incident
+  SMD-S3  gh-incident-open row: per-repo loop / ctx.gh_incident_urls / all 5 fallback layers
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is truly wrong, escalate to spec_fixer to correct the spec.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+
+def _load_state_machine_doc() -> str:
+    repo_root = pathlib.Path(__file__).parent.parent.parent
+    doc_path = repo_root / "docs" / "state-machine.md"
+    return doc_path.read_text(encoding="utf-8")
+
+
+def _find_table_row(content: str, first_col: str) -> str:
+    """Return the full table row whose first column matches first_col (backtick-quoted)."""
+    pattern = re.compile(
+        r"^\|[^|]*`" + re.escape(first_col) + r"`[^|]*\|.*$",
+        re.MULTILINE,
+    )
+    matches = pattern.findall(content)
+    assert matches, f"Table row with first column `{first_col}` not found in docs/state-machine.md"
+    # Return all matched rows joined so multi-line tables also work
+    return "\n".join(matches)
+
+
+# ─── SMD-S1: archiving row reflects no-auto-merge contract ──────────────────
+
+def test_smd_s1_archiving_contains_no_auto_merge() -> None:
+    """SMD-S1: archiving row MUST contain '不 auto-merge'."""
+    row = _find_table_row(_load_state_machine_doc(), "archiving")
+    assert "不 auto-merge" in row, (
+        f"archiving row missing '不 auto-merge'. Row content:\n{row}"
+    )
+
+
+def test_smd_s1_archiving_contains_no_push_main() -> None:
+    """SMD-S1: archiving row MUST contain '不 push main'."""
+    row = _find_table_row(_load_state_machine_doc(), "archiving")
+    assert "不 push main" in row, (
+        f"archiving row missing '不 push main'. Row content:\n{row}"
+    )
+
+
+def test_smd_s1_archiving_references_pr124() -> None:
+    """SMD-S1: archiving row MUST reference PR #124."""
+    row = _find_table_row(_load_state_machine_doc(), "archiving")
+    assert "#124" in row, (
+        f"archiving row missing reference to PR #124. Row content:\n{row}"
+    )
+
+
+def test_smd_s1_archiving_not_contain_merge_pr() -> None:
+    """SMD-S1: archiving row MUST NOT contain '合 PR' (implies auto-merge)."""
+    row = _find_table_row(_load_state_machine_doc(), "archiving")
+    assert "合 PR" not in row, (
+        f"archiving row still contains '合 PR' which implies auto-merge — must be removed. Row content:\n{row}"
+    )
+
+
+# ─── SMD-S2: gh-incident-open row: correct PRs and function name ─────────────
+
+def test_smd_s2_gh_incident_references_pr118() -> None:
+    """SMD-S2: gh-incident-open row MUST reference PR #118."""
+    row = _find_table_row(_load_state_machine_doc(), "gh-incident-open")
+    assert "#118" in row, (
+        f"gh-incident-open row missing reference to PR #118. Row content:\n{row}"
+    )
+
+
+def test_smd_s2_gh_incident_references_pr122() -> None:
+    """SMD-S2: gh-incident-open row MUST reference PR #122."""
+    row = _find_table_row(_load_state_machine_doc(), "gh-incident-open")
+    assert "#122" in row, (
+        f"gh-incident-open row missing reference to PR #122. Row content:\n{row}"
+    )
+
+
+def test_smd_s2_gh_incident_correct_function_name() -> None:
+    """SMD-S2: gh-incident-open row MUST contain 'gh_incident.open_incident()'."""
+    row = _find_table_row(_load_state_machine_doc(), "gh-incident-open")
+    assert "gh_incident.open_incident()" in row, (
+        f"gh-incident-open row missing correct function name 'gh_incident.open_incident()'. Row content:\n{row}"
+    )
+
+
+def test_smd_s2_gh_incident_not_contain_file_incident() -> None:
+    """SMD-S2: gh-incident-open row MUST NOT contain 'gh_incident.file_incident()'."""
+    row = _find_table_row(_load_state_machine_doc(), "gh-incident-open")
+    assert "gh_incident.file_incident()" not in row, (
+        f"gh-incident-open row still contains deprecated 'gh_incident.file_incident()'. Row content:\n{row}"
+    )
+
+
+# ─── SMD-S3: gh-incident-open row: per-repo loop + ctx shape + 5 fallbacks ───
+
+def test_smd_s3_gh_incident_per_repo_loop() -> None:
+    """SMD-S3: gh-incident-open row MUST contain '每个 involved source repo'."""
+    row = _find_table_row(_load_state_machine_doc(), "gh-incident-open")
+    assert "每个 involved source repo" in row, (
+        f"gh-incident-open row missing '每个 involved source repo'. Row content:\n{row}"
+    )
+
+
+def test_smd_s3_gh_incident_ctx_urls() -> None:
+    """SMD-S3: gh-incident-open row MUST contain 'ctx.gh_incident_urls'."""
+    row = _find_table_row(_load_state_machine_doc(), "gh-incident-open")
+    assert "ctx.gh_incident_urls" in row, (
+        f"gh-incident-open row missing 'ctx.gh_incident_urls'. Row content:\n{row}"
+    )
+
+
+def test_smd_s3_gh_incident_fallback_intake_finalized_intent() -> None:
+    """SMD-S3: gh-incident-open row MUST mention fallback layer 'intake_finalized_intent'."""
+    row = _find_table_row(_load_state_machine_doc(), "gh-incident-open")
+    assert "intake_finalized_intent" in row, (
+        f"gh-incident-open row missing fallback 'intake_finalized_intent'. Row content:\n{row}"
+    )
+
+
+def test_smd_s3_gh_incident_fallback_ctx_involved_repos() -> None:
+    """SMD-S3: gh-incident-open row MUST mention fallback layer 'ctx.involved_repos'."""
+    row = _find_table_row(_load_state_machine_doc(), "gh-incident-open")
+    assert "ctx.involved_repos" in row, (
+        f"gh-incident-open row missing fallback 'ctx.involved_repos'. Row content:\n{row}"
+    )
+
+
+def test_smd_s3_gh_incident_fallback_repo_tag() -> None:
+    """SMD-S3: gh-incident-open row MUST mention fallback layer 'repo:' tag."""
+    row = _find_table_row(_load_state_machine_doc(), "gh-incident-open")
+    assert "repo:" in row, (
+        f"gh-incident-open row missing fallback 'repo:' tag. Row content:\n{row}"
+    )
+
+
+def test_smd_s3_gh_incident_fallback_default_involved_repos() -> None:
+    """SMD-S3: gh-incident-open row MUST mention fallback layer 'default_involved_repos'."""
+    row = _find_table_row(_load_state_machine_doc(), "gh-incident-open")
+    assert "default_involved_repos" in row, (
+        f"gh-incident-open row missing fallback 'default_involved_repos'. Row content:\n{row}"
+    )
+
+
+def test_smd_s3_gh_incident_fallback_settings_gh_incident_repo() -> None:
+    """SMD-S3: gh-incident-open row MUST mention fallback layer 'settings.gh_incident_repo'."""
+    row = _find_table_row(_load_state_machine_doc(), "gh-incident-open")
+    assert "settings.gh_incident_repo" in row, (
+        f"gh-incident-open row missing fallback 'settings.gh_incident_repo'. Row content:\n{row}"
+    )


### PR DESCRIPTION
## Summary

Three docs-only edits in `docs/state-machine.md` to bring the ReqState table back in line with merged behavior changes:

- **`archiving` row** — drop `合 PR + 关 issue` wording. PR #124 removed `gh pr merge --squash --auto` and `git push origin main` from `done_archive.md.j2`; the agent now does per-repo `openspec apply` + writes archive result, and humans handle the final merge. New row text says exactly that and references #124.
- **`gh-incident-open` row** — two fixes:
  - Function name typo from PR #121 follow-up: `gh_incident.file_incident()` → `gh_incident.open_incident()` (matches `orchestrator/src/orchestrator/gh_incident.py:60`).
  - Update single-repo wording to per-involved-repo loop (#122). Spell out the 5-layer fallback (`intake_finalized_intent` → `ctx.involved_repos` → `repo:` tag → `default_involved_repos` → `settings.gh_incident_repo`) and the new ctx shape (`ctx.gh_incident_urls: dict[str, str]`). Reference both #118 and #122.

## Why

The ReqState table is the entry point for new readers. After #118/#121 left the wrong function name and #122/#124 changed semantics without updating this table, the table no longer matches reality — `archiving` claims "合 PR" while the agent doesn't merge, and `gh-incident-open` describes a single-repo POST that no longer exists.

## Spec

`openspec/changes/REQ-state-machine-doc-sync-1777189159/` — proposal, tasks, `specs/state-machine-doc/spec.md` (SMD-S1..S3 verifying the table contains the new wording / forbids the old wording / uses the right function name).

Validated:

- `openspec validate REQ-state-machine-doc-sync-1777189159 --strict` → clean
- `scripts/check-scenario-refs.sh` → 236 scenarios, all references resolved

## Test plan

- [x] `openspec validate REQ-state-machine-doc-sync-1777189159 --strict` clean
- [x] `scripts/check-scenario-refs.sh` clean
- [ ] sisyphus self-dogfood: spec_lint / dev_cross_check / staging_test / pr_ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)