### PR TITLE
feat(runner): add android emulator + KVM passthrough

### DIFF
--- a/openspec/changes/REQ-runner-android-emulator-1777189159/design.md
+++ b/openspec/changes/REQ-runner-android-emulator-1777189159/design.md
@@ -1,0 +1,110 @@
+# Design: runner android emulator + KVM
+
+## Decision tree
+
+### 1. Which runner flavor gets the emulator?
+
+**Decision**: full Flutter flavor only (`runner/Dockerfile`).
+
+Rationale: the Go-only flavor (`runner/go.Dockerfile`) is ~1 GB by design and serves Go
+business repos that have no use for an Android device. Adding the system image + emulator
+to it would balloon it to ~2.5 GB for zero benefit. Mobile REQs already opt in to the full
+flavor via `runner_image: ghcr.io/phona/sisyphus-runner:main`.
+
+The `sisyphus-android-emulator.sh` helper script is shipped to `/opt/sisyphus/scripts/`
+in both flavors so the path is uniform; on the Go flavor the script will fail fast with
+`emulator: command not found`, which is the desired clear error.
+
+### 2. Which Android API level + system image variant?
+
+**Decision**: `system-images;android-34;google_apis;x86_64` (Android 14, no Google Play).
+
+- API 34 matches what current Flutter `stable` channel is built against; older API levels
+  don't expose the same `androidx.activity` APIs that recent ttpos-flutter REQs already
+  rely on.
+- `google_apis` (without `playstore`) is sufficient for instrumentation tests (most apps
+  need Google Maps / Location stubs but not the Play Store gate). The `playstore` variant
+  is locked to Google-signed userdata that complicates `adb root` and is licensed
+  differently.
+- `x86_64` (not `arm64-v8a`): vm-node04 is amd64; running an arm64 image under QEMU TCG
+  is an order of magnitude slower than x86_64 with KVM. ARM hosts are not in scope.
+
+### 3. KVM access path: device plugin vs hostPath?
+
+**Decision**: hostPath mount at `/dev/kvm` (same shape as existing `/dev/fuse`).
+
+- The runner Pod is already `privileged: true` (DinD prerequisite), so adding a
+  character-device hostPath mount is straightforward and consistent with the `/dev/fuse`
+  precedent in the same file.
+- A K8s device plugin (e.g. `kubevirt/kvm-device-plugin`) would be cleaner architecturally
+  but adds a cluster-wide DaemonSet just for this REQ. Sisyphus runs on a single-node K3s
+  on vm-node04; the cost/benefit of a device plugin doesn't pencil out.
+- **The mount is opt-in via a new orchestrator setting** (`runner_kvm_enabled`, default
+  `false`). On nodes that don't expose `/dev/kvm` (e.g. nested virt without host KVM),
+  enabling the flag would make Pod creation fail with `MountVolume.SetUp failed`. Keeping
+  it off by default preserves the current "single-node K3s" zero-config experience.
+
+### 4. AVD pre-creation in the image?
+
+**Decision**: pre-create one AVD `sisyphus-default` at build time (no userdata snapshot).
+
+- Pre-creating shaves ~10 s off each REQ's first emulator boot (the SDK has to lay out
+  ~200 MB of system image either way; pre-doing it puts the cost in image build, not test
+  runtime).
+- We do **not** pre-create a "snapshot" of a booted state — snapshots are tightly bound
+  to the kernel/QEMU versions and break across image rebuilds in subtle ways. Cold boot
+  with KVM is fast enough.
+- REQs that need a custom AVD (different screen size, locale, etc.) can still
+  `avdmanager create avd` at runtime — `sisyphus-default` is just a known-good baseline.
+
+### 5. Helper script vs document `emulator` flags in prose?
+
+**Decision**: ship `scripts/sisyphus-android-emulator.sh` with the canonical "headless
+boot + wait until ready" flags.
+
+The flag set that actually works in a privileged container without an X server is a
+3-line incantation that every REQ would otherwise re-derive:
+
+```
+emulator -avd sisyphus-default \
+  -no-window -no-audio -no-snapshot \
+  -gpu swiftshader_indirect \
+  -no-boot-anim -accel on &
+adb wait-for-device
+adb shell 'while [[ "$(getprop sys.boot_completed)" != "1" ]]; do sleep 1; done'
+```
+
+Encoding this once in a helper script keeps every business-repo Makefile a one-liner
+(`/opt/sisyphus/scripts/sisyphus-android-emulator.sh boot`). Mirrors the existing
+`sisyphus-clone-repos.sh` pattern.
+
+## Why an opt-in flag instead of "always on"
+
+Three reasons:
+
+1. **Backward compat**: existing dev / staging deployments don't necessarily have
+   `/dev/kvm` exposed (some K8s distros run inside containers themselves). Defaulting on
+   would break those deployments at next Pod rollover.
+2. **Trust boundary**: `/dev/kvm` is a host device. We pass it into a privileged container
+   anyway, but the *flag* documents intent — every operator opting in has to acknowledge
+   that the runner Pod can spawn KVM-accelerated VMs.
+3. **Symmetry with `kvmEnabled` upstream conventions**: KubeVirt, Tekton's Android
+   pipelines, and `actions/runner-images` all gate KVM access behind a flag, not behind
+   privileged context alone.
+
+## Tested invariants (covered by unit tests)
+
+- `build_pod(req)` with default `kvm_enabled=False` produces a Pod whose `volume_mounts`
+  list does **not** contain `/dev/kvm`. Backward-compat assertion.
+- `RunnerController(..., kvm_enabled=True).build_pod(req)` produces a Pod with a
+  `kvm` hostPath volume of type `CharDevice`, mounted at `/dev/kvm`.
+- Existing `/dev/fuse`, `/workspace`, `/root/.kube` mounts are untouched in both modes.
+
+## Out of scope
+
+- Changing the default `runner_image` from `:go` to `:main`. That decision is made
+  per-REQ via the prompt template; this REQ only adds the *capability* to the full
+  image, not the routing of which image to pick.
+- iOS simulators (macOS-only; not on Linux runner pod).
+- KVM nested-virtualization tuning on the host (`kvm-intel.nested=1` kernel parameter).
+  Documented as an operator prerequisite in the helm comment, not enforced.

--- a/openspec/changes/REQ-runner-android-emulator-1777189159/proposal.md
+++ b/openspec/changes/REQ-runner-android-emulator-1777189159/proposal.md
@@ -1,0 +1,60 @@
+# feat: runner add android emulator + KVM
+
+## Why
+
+Mobile / Flutter business repos that consume the **full Flutter runner image** need to run
+Android instrumentation tests (and accept-stage acceptance scenarios that drive an Android
+app) inside the per-REQ runner Pod. Today the image ships the Android SDK & platform tools
+(via `cirruslabs/flutter:stable`) but is missing two pieces:
+
+1. The Android **emulator** binary + a bootable **system image**, so `make ci-integration-test`
+   targets that need an emulator fail with `emulator: command not found` before any test runs.
+2. **Hardware acceleration access** (`/dev/kvm`). Without KVM the emulator falls back to the
+   software CPU, which on a 4-CPU pod limit takes 5–10 min just to boot — well past the
+   staging-test timeout. With KVM, cold boot is ~30–60 s.
+
+This REQ closes both gaps in the **full** runner only (Go runner stays lean), and adds an
+**opt-in operator switch** (`runner.kvmEnabled`) so the orchestrator only mounts `/dev/kvm`
+on clusters whose nodes actually expose it. Default off keeps existing single-node K3s
+deployments working unchanged.
+
+## What Changes
+
+- **runner/Dockerfile (full flavor only)**: install KVM userland (`qemu-kvm`,
+  `cpu-checker`), install the Android `emulator` package + `system-images;android-34;
+  google_apis;x86_64` via the SDK manager already present in the base image, pre-create
+  a default AVD `sisyphus-default`. **Go Dockerfile is not touched** — the Go-only flavor
+  stays ~1 GB.
+- **scripts/sisyphus-android-emulator.sh**: idempotent helper to boot the default AVD
+  headless and block until `sys.boot_completed=1`. Shipped into `/opt/sisyphus/scripts/`
+  in both runner images (callers in the Go flavor get a clear "emulator: not found" error
+  by design — only the full flavor has it).
+- **orchestrator runner Pod spec** (`k8s_runner.py`): when the new orchestrator setting
+  `runner_kvm_enabled=True`, mount the host's `/dev/kvm` character device read-write into
+  the runner Pod (mirroring the existing `/dev/fuse` pattern). Default `False` keeps
+  current behavior bit-identical — no `/dev/kvm` mount, no extra host requirement.
+- **orchestrator config + helm chart**: new `Settings.runner_kvm_enabled` (default `False`),
+  exposed as helm value `runner.kvmEnabled` and wired through the deployment env.
+- **runner README + CLAUDE.md** mentions Android emulator usage from the full-flavor pod.
+
+## Impact
+
+- **Affected specs**: new capability `runner-android-emulator` (this is purely additive).
+- **Affected code**:
+  - `runner/Dockerfile` (extend full flavor only)
+  - `scripts/sisyphus-android-emulator.sh` (new)
+  - `orchestrator/src/orchestrator/k8s_runner.py` (`__init__`, `build_pod`)
+  - `orchestrator/src/orchestrator/config.py` (new `runner_kvm_enabled`)
+  - `orchestrator/src/orchestrator/main.py` (pass new param)
+  - `orchestrator/helm/values.yaml` + `templates/deployment.yaml` (new env)
+  - `orchestrator/tests/test_k8s_runner.py` (mount toggle assertions)
+  - `runner/README.md`
+- **Deployment / migration**:
+  - **Default off** → existing deployments unaffected. No node prerequisites change.
+  - To opt in, operator: (a) confirm `kvm-ok` on each runner-eligible node, (b) set
+    `runner.kvmEnabled=true` in helm values, (c) `helm upgrade`. The orchestrator picks
+    up the new env on rollout-restart and subsequent Pods get `/dev/kvm` mounted.
+- **Image size**: full runner grows ~+1.5 GB (system image + emulator packages). Go
+  runner unchanged.
+- **Risk**: low. The mount is gated; the AVD/system image are passive payload until a
+  REQ runs `emulator -avd sisyphus-default`.

--- a/openspec/changes/REQ-runner-android-emulator-1777189159/specs/runner-android-emulator/spec.md
+++ b/openspec/changes/REQ-runner-android-emulator-1777189159/specs/runner-android-emulator/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: full runner image ships an Android emulator + bootable system image
+
+The full sisyphus runner image (`runner/Dockerfile`) SHALL include the Android `emulator` binary, the `system-images;android-34;google_apis;x86_64` system image, and a pre-created AVD named `sisyphus-default`. The image MUST allow `emulator -list-avds` to print `sisyphus-default` without further setup. The Go-only runner image (`runner/go.Dockerfile`) is intentionally out of scope and MUST NOT include these payloads.
+
+#### Scenario: RUNNER-AE-S1 emulator binary and default AVD present in full image
+
+- **GIVEN** the full runner image is built from `runner/Dockerfile`
+- **WHEN** the container runs `emulator -list-avds`
+- **THEN** the command exits 0 and stdout contains `sisyphus-default`
+
+### Requirement: orchestrator mounts /dev/kvm into runner Pod when opt-in flag is set
+
+The sisyphus orchestrator's runner controller SHALL accept a `kvm_enabled` boolean
+configuration (sourced from `Settings.runner_kvm_enabled`, default `False`). When
+`kvm_enabled` is `True`, every Pod returned by `build_pod(req_id)` MUST include a
+`hostPath` volume named `kvm` pointing at the host path `/dev/kvm` with type `CharDevice`,
+and the runner container MUST mount it at `/dev/kvm`. When `kvm_enabled` is `False`
+(default), the Pod spec MUST NOT contain any `/dev/kvm` volume or mount, preserving
+backward compatibility on clusters whose nodes do not expose `/dev/kvm`.
+
+#### Scenario: RUNNER-AE-S2 default off — no /dev/kvm mount
+
+- **GIVEN** a `RunnerController` constructed with default settings (`kvm_enabled` not set)
+- **WHEN** the controller calls `build_pod("REQ-1")`
+- **THEN** the resulting Pod's container `volume_mounts` list contains no entry whose
+  `mount_path` equals `/dev/kvm`, and `pod.spec.volumes` contains no volume named `kvm`
+
+#### Scenario: RUNNER-AE-S3 opt-in on — /dev/kvm mounted as CharDevice
+
+- **GIVEN** a `RunnerController` constructed with `kvm_enabled=True`
+- **WHEN** the controller calls `build_pod("REQ-1")`
+- **THEN** the resulting Pod has a hostPath volume named `kvm` with `path=/dev/kvm` and
+  `type=CharDevice`, and the runner container has a corresponding `volume_mount` at
+  `/dev/kvm`. Existing mounts (`/workspace`, `/dev/fuse`, `/root/.kube`) are unchanged.
+
+### Requirement: emulator boot helper script ships in /opt/sisyphus/scripts
+
+The full runner image SHALL ship `/opt/sisyphus/scripts/sisyphus-android-emulator.sh`
+on `$PATH`. The script MUST support a `boot` sub-command that starts `sisyphus-default`
+in headless mode (`-no-window -no-audio -no-snapshot -gpu swiftshader_indirect`) and
+blocks until `adb shell getprop sys.boot_completed` returns `1` or a configurable
+timeout (default 300 s) elapses. On timeout the script MUST exit non-zero so calling
+Makefile targets fail loudly rather than silently proceeding against a half-booted
+emulator.
+
+#### Scenario: RUNNER-AE-S4 boot helper exits 0 on completed boot signal
+
+- **GIVEN** the full runner pod is running with `/dev/kvm` mounted
+- **WHEN** the agent invokes `sisyphus-android-emulator.sh boot --timeout 300`
+- **THEN** the script starts the emulator headless, polls `getprop sys.boot_completed`
+  until it reads `1`, prints `[android-emulator] boot completed in <N>s`, and exits 0

--- a/openspec/changes/REQ-runner-android-emulator-1777189159/tasks.md
+++ b/openspec/changes/REQ-runner-android-emulator-1777189159/tasks.md
@@ -1,0 +1,37 @@
+# tasks: REQ-runner-android-emulator-1777189159
+
+## Stage: contract / spec
+
+- [x] author `specs/runner-android-emulator/spec.md` with delta `## ADDED Requirements`
+- [x] write 4 scenarios `RUNNER-AE-S{1..4}` covering: emulator binary present in full
+      image, KVM device mount toggle (default off, opt-in on), helper script boot
+
+## Stage: implementation
+
+- [x] `runner/Dockerfile`: install `qemu-kvm cpu-checker`, run
+      `sdkmanager "emulator" "system-images;android-34;google_apis;x86_64"`,
+      pre-create AVD `sisyphus-default` via `avdmanager`
+- [x] `runner/go.Dockerfile`: **not modified** (decision §1)
+- [x] new `scripts/sisyphus-android-emulator.sh` (boot/wait/halt sub-commands)
+- [x] `scripts/sisyphus-android-emulator.sh` shipped via `COPY` in both Dockerfiles
+      (Go flavor will fail fast with clear error if invoked — by design)
+- [x] `orchestrator/src/orchestrator/k8s_runner.py`:
+      add `kvm_enabled: bool = False` ctor param; in `build_pod` conditionally append
+      `/dev/kvm` hostPath volume + mount
+- [x] `orchestrator/src/orchestrator/config.py`: add `runner_kvm_enabled: bool = False`
+- [x] `orchestrator/src/orchestrator/main.py`: pass `kvm_enabled=settings.runner_kvm_enabled`
+      to `RunnerController(...)`
+- [x] `orchestrator/helm/values.yaml`: add `runner.kvmEnabled: false` with operator
+      prerequisite comment
+- [x] `orchestrator/helm/templates/deployment.yaml`: add `SISYPHUS_RUNNER_KVM_ENABLED`
+      env entry
+- [x] unit tests in `orchestrator/tests/test_k8s_runner.py`:
+      - `test_build_pod_no_kvm_mount_by_default`
+      - `test_build_pod_mounts_kvm_when_enabled`
+      - `test_build_pod_existing_mounts_unchanged_with_kvm_enabled`
+- [x] `runner/README.md`: add Android emulator + KVM section
+
+## Stage: PR
+
+- [x] git push `feat/REQ-runner-android-emulator-1777189159`
+- [x] gh pr create

--- a/orchestrator/helm/templates/deployment.yaml
+++ b/orchestrator/helm/templates/deployment.yaml
@@ -73,6 +73,8 @@ spec:
               value: {{ .Values.runner.retainOnEscalateDays | quote }}
             - name: SISYPHUS_RUNNER_GC_INTERVAL_SEC
               value: {{ .Values.runner.gcIntervalSec | quote }}
+            - name: SISYPHUS_RUNNER_KVM_ENABLED
+              value: {{ .Values.runner.kvmEnabled | default false | quote }}
             - name: SISYPHUS_K8S_IN_CLUSTER
               value: "true"
           livenessProbe:

--- a/orchestrator/helm/values.yaml
+++ b/orchestrator/helm/values.yaml
@@ -124,6 +124,12 @@ runner:
   readyTimeoutSec: 120        # ensure_runner 等 Pod Ready 的超时
   retainOnEscalateDays: 7     # escalated REQ 的 PVC 保留天数，过期 GC 清
   gcIntervalSec: 3600         # orphan PVC/Pod 回收扫描周期
+  # 把宿主 /dev/kvm 挂入 runner pod，给 Android emulator 跑硬件加速（冷启 ~30s vs
+  # 软 CPU 5-10min）。默认 false 兼容没暴露 /dev/kvm 的节点。开启前在每台 runner-
+  # 候选节点上跑 `kvm-ok` 确认；否则 Pod 创建会卡 MountVolume.SetUp failed。
+  # 仅 full Flutter runner image (`ghcr.io/phona/sisyphus-runner:main`) 内有 emulator
+  # 二进制；Go-only runner 不消费这个挂载。
+  kvmEnabled: false
 
   imagePullSecrets: []        # 如果 runner image 私有需要填
 

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -35,6 +35,10 @@ class Settings(BaseSettings):
     runner_secret_name: str = "sisyphus-runner-secrets"
     runner_image_pull_secrets: list[str] = Field(default_factory=list)
     runner_ready_timeout_sec: int = 120
+    # 把宿主 /dev/kvm 挂入 runner pod，给 Android emulator 走硬件加速。默认 false
+    # 兼容没暴露 /dev/kvm 的部署（嵌套虚拟化 / 普通 dev 环境）。开启前操作员需在
+    # 节点上跑 `kvm-ok` 确认 /dev/kvm 存在，否则 Pod 创建会卡 MountVolume.SetUp failed。
+    runner_kvm_enabled: bool = False
 
     # in-cluster = orchestrator 跑在 K8s pod 里，load_incluster_config()
     # False = 本地调试，load_kube_config() 读 ~/.kube/config

--- a/orchestrator/src/orchestrator/k8s_runner.py
+++ b/orchestrator/src/orchestrator/k8s_runner.py
@@ -90,6 +90,7 @@ class RunnerController:
         ready_timeout_sec: int = 120,
         ready_attempts: int = 3,
         in_cluster: bool = True,
+        kvm_enabled: bool = False,
         core_v1: client.CoreV1Api | None = None,
     ):
         self.namespace = namespace
@@ -104,6 +105,10 @@ class RunnerController:
         # M9：Pod Ready 外层 attempts（每次等 ready_timeout_sec）。超全部 attempts 抛
         # TimeoutError，让 engine.step 的 retry policy 接手决策 retry/escalate。
         self.ready_attempts = max(1, ready_attempts)
+        # KVM device passthrough — 启用后 build_pod 会挂宿主 /dev/kvm 进 runner pod，
+        # 给 Android emulator 走硬件加速（冷启 ~30s vs 软 CPU 5-10min）。默认 off
+        # 兼容没暴露 /dev/kvm 的节点（嵌套虚拟化里跑的 K8s）。
+        self.kvm_enabled = kvm_enabled
 
         if core_v1 is not None:
             # 测试注入 mock client
@@ -216,6 +221,21 @@ class RunnerController:
                 ),
             ),
         ]
+
+        # /dev/kvm passthrough（Android emulator 硬件加速）—— 见 __init__ kvm_enabled
+        # 注释。仅在 operator 显式 opt-in 时挂；missing 时不动 spec，保持现有部署兼容。
+        if self.kvm_enabled:
+            volume_mounts.append(
+                client.V1VolumeMount(name="kvm", mount_path="/dev/kvm"),
+            )
+            volumes.append(
+                client.V1Volume(
+                    name="kvm",
+                    host_path=client.V1HostPathVolumeSource(
+                        path="/dev/kvm", type="CharDevice",
+                    ),
+                ),
+            )
 
         container = client.V1Container(
             name="runner",

--- a/orchestrator/src/orchestrator/main.py
+++ b/orchestrator/src/orchestrator/main.py
@@ -60,6 +60,7 @@ async def startup() -> None:
             ready_timeout_sec=settings.runner_ready_timeout_sec,
             ready_attempts=settings.runner_ready_attempts,
             in_cluster=settings.k8s_in_cluster,
+            kvm_enabled=settings.runner_kvm_enabled,
         )
         k8s_runner.set_controller(controller)
         log.info("k8s_runner.initialized", namespace=settings.runner_namespace)

--- a/orchestrator/tests/test_contract_runner_android_emulator.py
+++ b/orchestrator/tests/test_contract_runner_android_emulator.py
@@ -1,0 +1,310 @@
+"""Contract tests for REQ-runner-android-emulator-1777189159.
+
+Capability: runner-android-emulator
+Author: challenger-agent (black-box, written from spec only)
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is genuinely wrong, escalate to spec_fixer to correct the spec.
+
+Scenarios covered:
+  RUNNER-AE-S1  full runner image ships emulator binary + system image +
+                pre-created AVD 'sisyphus-default'; Go image excludes them
+  RUNNER-AE-S2  RunnerController default off — no /dev/kvm volume or mount
+                in build_pod output
+  RUNNER-AE-S3  RunnerController opt-in on (kvm_enabled=True) — /dev/kvm
+                hostPath CharDevice mounted; existing mounts intact
+  RUNNER-AE-S4  sisyphus-android-emulator.sh boot sub-command uses headless
+                flags, polls sys.boot_completed, prints success message,
+                exits non-zero on timeout
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FULL_DOCKERFILE = REPO_ROOT / "runner" / "Dockerfile"
+GO_DOCKERFILE = REPO_ROOT / "runner" / "go.Dockerfile"
+EMULATOR_SCRIPT = REPO_ROOT / "scripts" / "sisyphus-android-emulator.sh"
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"File not found at expected path: {path}"
+    return path.read_text()
+
+
+def _make_controller(kvm_enabled: bool = False):
+    from orchestrator.k8s_runner import RunnerController
+
+    return RunnerController(
+        core_v1=MagicMock(),
+        namespace="sisyphus-runners",
+        runner_image="ghcr.io/phona/sisyphus-runner:main",
+        runner_sa="sisyphus-runner-sa",
+        runner_secret_name="sisyphus-runner-secrets",
+        storage_class="local-path",
+        workspace_size="10Gi",
+        kvm_enabled=kvm_enabled,
+    )
+
+
+# ── RUNNER-AE-S1: full image ships emulator + system image + AVD ─────────────
+
+
+def test_runner_ae_s1_full_dockerfile_installs_emulator_package():
+    """S1: runner/Dockerfile MUST install the Android 'emulator' package."""
+    content = _read(FULL_DOCKERFILE)
+    emulator_lines = [ln for ln in content.splitlines() if "emulator" in ln]
+    assert any("emulator" in ln for ln in emulator_lines), (
+        "runner/Dockerfile must install the Android 'emulator' package via sdkmanager "
+        "(spec RUNNER-AE-S1: `emulator -list-avds` must work inside the container).\n"
+        "Emulator-related lines found:\n" + "\n".join(emulator_lines)
+    )
+
+
+def test_runner_ae_s1_full_dockerfile_installs_system_image():
+    """S1: runner/Dockerfile MUST install system-images;android-34;google_apis;x86_64."""
+    content = _read(FULL_DOCKERFILE)
+    assert "system-images;android-34;google_apis;x86_64" in content, (
+        "runner/Dockerfile must install 'system-images;android-34;google_apis;x86_64' "
+        "via sdkmanager (spec RUNNER-AE-S1).\n"
+        "System-image-related lines:\n"
+        + "\n".join(
+            ln for ln in content.splitlines() if "system-image" in ln or "android-34" in ln
+        )
+    )
+
+
+def test_runner_ae_s1_full_dockerfile_precreates_sisyphus_default_avd():
+    """S1: runner/Dockerfile MUST pre-create an AVD named 'sisyphus-default' at build time."""
+    content = _read(FULL_DOCKERFILE)
+    assert "sisyphus-default" in content, (
+        "runner/Dockerfile must pre-create an AVD named 'sisyphus-default' at image "
+        "build time so that 'emulator -list-avds' prints 'sisyphus-default' without "
+        "further setup (spec RUNNER-AE-S1).\n"
+        "AVD-related lines:\n"
+        + "\n".join(
+            ln for ln in content.splitlines() if "avd" in ln.lower() or "emulator" in ln.lower()
+        )
+    )
+
+
+def test_runner_ae_s1_go_dockerfile_does_not_install_system_image():
+    """S1: runner/go.Dockerfile MUST NOT include the Android system image (Go flavor stays lean)."""
+    content = _read(GO_DOCKERFILE)
+    assert "system-images;android-34" not in content, (
+        "runner/go.Dockerfile must NOT install Android system images — "
+        "the Go-only runner flavor is intentionally kept lean (spec RUNNER-AE-S1). "
+        "Only the full Flutter runner carries the emulator payloads."
+    )
+
+
+def test_runner_ae_s1_go_dockerfile_does_not_precreate_avd():
+    """S1: runner/go.Dockerfile MUST NOT pre-create any AVD."""
+    content = _read(GO_DOCKERFILE)
+    avd_create_lines = [
+        ln for ln in content.splitlines()
+        if "avdmanager" in ln.lower() and "create" in ln.lower()
+    ]
+    assert len(avd_create_lines) == 0, (
+        "runner/go.Dockerfile must NOT pre-create any AVD — the Android emulator "
+        "is intentionally out of scope for the Go-only flavor (spec RUNNER-AE-S1).\n"
+        "Offending lines: " + "\n".join(avd_create_lines)
+    )
+
+
+# ── RUNNER-AE-S2: default off — no /dev/kvm mount ───────────────────────────
+
+
+def test_runner_ae_s2_default_off_no_kvm_volume_mount():
+    """S2: build_pod with default kvm_enabled must NOT mount /dev/kvm."""
+    controller = _make_controller(kvm_enabled=False)
+    pod = controller.build_pod("REQ-1")
+
+    containers = pod.spec.containers
+    assert containers, "Pod must have at least one container"
+    mounts = containers[0].volume_mounts or []
+    kvm_mounts = [m for m in mounts if getattr(m, "mount_path", None) == "/dev/kvm"]
+    assert len(kvm_mounts) == 0, (
+        "Pod built with default kvm_enabled=False must NOT contain a volume_mount "
+        f"at /dev/kvm (spec RUNNER-AE-S2). Found: {kvm_mounts}"
+    )
+
+
+def test_runner_ae_s2_default_off_no_kvm_volume():
+    """S2: build_pod with default kvm_enabled must NOT include a volume named 'kvm'."""
+    controller = _make_controller(kvm_enabled=False)
+    pod = controller.build_pod("REQ-1")
+
+    volumes = pod.spec.volumes or []
+    kvm_volumes = [v for v in volumes if getattr(v, "name", None) == "kvm"]
+    assert len(kvm_volumes) == 0, (
+        "Pod built with default kvm_enabled=False must NOT include a volume named 'kvm' "
+        f"(spec RUNNER-AE-S2). Found: {kvm_volumes}"
+    )
+
+
+# ── RUNNER-AE-S3: opt-in on — /dev/kvm mounted as CharDevice ─────────────────
+
+
+def test_runner_ae_s3_kvm_enabled_has_hostpath_volume_at_kvm():
+    """S3: build_pod with kvm_enabled=True must include hostPath volume 'kvm' at /dev/kvm."""
+    controller = _make_controller(kvm_enabled=True)
+    pod = controller.build_pod("REQ-1")
+
+    volumes = pod.spec.volumes or []
+    kvm_volumes = [v for v in volumes if getattr(v, "name", None) == "kvm"]
+    assert len(kvm_volumes) == 1, (
+        "Pod built with kvm_enabled=True must include exactly one volume named 'kvm' "
+        f"(spec RUNNER-AE-S3). Volume names: {[getattr(v, 'name', None) for v in volumes]}"
+    )
+    host_path = getattr(kvm_volumes[0], "host_path", None)
+    assert host_path is not None, (
+        "Volume 'kvm' must be a hostPath volume (spec RUNNER-AE-S3). "
+        f"Got: {kvm_volumes[0]}"
+    )
+    assert getattr(host_path, "path", None) == "/dev/kvm", (
+        f"hostPath volume 'kvm' must have path='/dev/kvm' (spec RUNNER-AE-S3). "
+        f"Got path={getattr(host_path, 'path', None)!r}"
+    )
+    assert getattr(host_path, "type", None) == "CharDevice", (
+        f"hostPath volume 'kvm' must have type='CharDevice' (spec RUNNER-AE-S3). "
+        f"Got type={getattr(host_path, 'type', None)!r}"
+    )
+
+
+def test_runner_ae_s3_kvm_enabled_has_kvm_volume_mount():
+    """S3: build_pod with kvm_enabled=True must mount the 'kvm' volume at /dev/kvm."""
+    controller = _make_controller(kvm_enabled=True)
+    pod = controller.build_pod("REQ-1")
+
+    containers = pod.spec.containers
+    assert containers, "Pod must have at least one container"
+    mounts = containers[0].volume_mounts or []
+    kvm_mounts = [m for m in mounts if getattr(m, "mount_path", None) == "/dev/kvm"]
+    assert len(kvm_mounts) == 1, (
+        "Pod built with kvm_enabled=True must have exactly one volume_mount at /dev/kvm "
+        f"(spec RUNNER-AE-S3). Mount paths: {[getattr(m, 'mount_path', None) for m in mounts]}"
+    )
+    assert getattr(kvm_mounts[0], "name", None) == "kvm", (
+        "The /dev/kvm volume_mount must reference volume named 'kvm' "
+        f"(spec RUNNER-AE-S3). Got name={getattr(kvm_mounts[0], 'name', None)!r}"
+    )
+
+
+def test_runner_ae_s3_existing_mounts_unchanged_with_kvm():
+    """S3: Enabling kvm_enabled=True must NOT remove /workspace, /dev/fuse, /root/.kube mounts."""
+    controller = _make_controller(kvm_enabled=True)
+    pod = controller.build_pod("REQ-1")
+
+    containers = pod.spec.containers
+    assert containers, "Pod must have at least one container"
+    mounts = containers[0].volume_mounts or []
+    mount_paths = {getattr(m, "mount_path", None) for m in mounts}
+
+    for required_path in ["/workspace", "/dev/fuse", "/root/.kube"]:
+        assert required_path in mount_paths, (
+            f"Enabling kvm_enabled=True must NOT remove the existing mount at {required_path} "
+            f"(spec RUNNER-AE-S3). Present mount paths: {sorted(p for p in mount_paths if p)}"
+        )
+
+
+# ── RUNNER-AE-S4: emulator boot helper script ────────────────────────────────
+
+
+def test_runner_ae_s4_script_exists():
+    """S4: scripts/sisyphus-android-emulator.sh must exist."""
+    assert EMULATOR_SCRIPT.exists(), (
+        f"scripts/sisyphus-android-emulator.sh not found at {EMULATOR_SCRIPT}. "
+        "Spec RUNNER-AE-S4 requires this helper to ship in /opt/sisyphus/scripts/ "
+        "inside the runner image."
+    )
+
+
+def test_runner_ae_s4_script_supports_boot_subcommand():
+    """S4: The script MUST implement a 'boot' sub-command."""
+    content = _read(EMULATOR_SCRIPT)
+    assert "boot" in content, (
+        "sisyphus-android-emulator.sh must implement a 'boot' sub-command "
+        "(spec RUNNER-AE-S4: `sisyphus-android-emulator.sh boot --timeout 300`)."
+    )
+
+
+def test_runner_ae_s4_script_headless_no_window():
+    """S4: boot sub-command MUST pass -no-window to emulator for headless operation."""
+    content = _read(EMULATOR_SCRIPT)
+    assert "-no-window" in content, (
+        "sisyphus-android-emulator.sh must pass '-no-window' to the emulator "
+        "(spec RUNNER-AE-S4: headless boot inside a privileged pod without X server)."
+    )
+
+
+def test_runner_ae_s4_script_headless_no_audio():
+    """S4: boot sub-command MUST pass -no-audio to emulator."""
+    content = _read(EMULATOR_SCRIPT)
+    assert "-no-audio" in content, (
+        "sisyphus-android-emulator.sh must pass '-no-audio' to the emulator "
+        "(spec RUNNER-AE-S4: headless mode flags)."
+    )
+
+
+def test_runner_ae_s4_script_headless_no_snapshot():
+    """S4: boot sub-command MUST pass -no-snapshot to emulator."""
+    content = _read(EMULATOR_SCRIPT)
+    assert "-no-snapshot" in content, (
+        "sisyphus-android-emulator.sh must pass '-no-snapshot' to the emulator "
+        "(spec RUNNER-AE-S4: headless mode flags)."
+    )
+
+
+def test_runner_ae_s4_script_uses_swiftshader_gpu():
+    """S4: boot sub-command MUST use -gpu swiftshader_indirect for headless GPU rendering."""
+    content = _read(EMULATOR_SCRIPT)
+    assert "swiftshader_indirect" in content, (
+        "sisyphus-android-emulator.sh must pass '-gpu swiftshader_indirect' to the emulator "
+        "(spec RUNNER-AE-S4: required for headless rendering without a GPU)."
+    )
+
+
+def test_runner_ae_s4_script_polls_boot_completed():
+    """S4: boot sub-command MUST poll 'adb shell getprop sys.boot_completed' for '1'."""
+    content = _read(EMULATOR_SCRIPT)
+    assert "sys.boot_completed" in content, (
+        "sisyphus-android-emulator.sh must poll 'adb shell getprop sys.boot_completed' "
+        "to detect when the Android emulator has fully booted (spec RUNNER-AE-S4)."
+    )
+
+
+def test_runner_ae_s4_script_prints_completion_message():
+    """S4: On successful boot, the script MUST print '[android-emulator] boot completed in <N>s'."""
+    content = _read(EMULATOR_SCRIPT)
+    assert "[android-emulator] boot completed in" in content, (
+        "sisyphus-android-emulator.sh must print '[android-emulator] boot completed in <N>s' "
+        "on successful boot (spec RUNNER-AE-S4)."
+    )
+
+
+def test_runner_ae_s4_script_has_configurable_timeout():
+    """S4: boot sub-command MUST support a configurable timeout (default 300s)."""
+    content = _read(EMULATOR_SCRIPT)
+    has_timeout = any(
+        kw in content for kw in ["--timeout", "TIMEOUT", "timeout", "300"]
+    )
+    assert has_timeout, (
+        "sisyphus-android-emulator.sh must support a configurable timeout with "
+        "default 300s (spec RUNNER-AE-S4: `--timeout 300` flag)."
+    )
+
+
+def test_runner_ae_s4_script_exits_nonzero_on_timeout():
+    """S4: On timeout, the script MUST exit non-zero so calling Makefile targets fail loudly."""
+    content = _read(EMULATOR_SCRIPT)
+    lines = content.splitlines()
+    nonzero_exit_re = re.compile(r"exit\s+[1-9]")
+    has_nonzero_exit = any(nonzero_exit_re.search(ln) for ln in lines)
+    assert has_nonzero_exit, (
+        "sisyphus-android-emulator.sh must exit with a non-zero code when the boot "
+        "timeout elapses, so calling Makefile targets fail loudly rather than silently "
+        "proceeding against a half-booted emulator (spec RUNNER-AE-S4)."
+    )

--- a/orchestrator/tests/test_k8s_runner.py
+++ b/orchestrator/tests/test_k8s_runner.py
@@ -112,6 +112,62 @@ def test_build_pod_with_image_pull_secrets():
     assert pod.spec.image_pull_secrets[0].name == "ghcr-creds"
 
 
+def test_build_pod_no_kvm_mount_by_default():
+    """默认 kvm_enabled=False：Pod spec 不含 /dev/kvm 卷或挂载（兼容老部署）。"""
+    rc = _make_controller()
+    pod = rc.build_pod("REQ-1")
+    c = pod.spec.containers[0]
+    mount_paths = [m.mount_path for m in c.volume_mounts]
+    assert "/dev/kvm" not in mount_paths
+    volume_names = [v.name for v in pod.spec.volumes]
+    assert "kvm" not in volume_names
+
+
+def _make_controller_with_kvm() -> RunnerController:
+    return RunnerController(
+        namespace="sisyphus-runners",
+        runner_image="ghcr.io/phona/sisyphus-runner:main",
+        runner_sa="sisyphus-runner-sa",
+        storage_class="local-path",
+        workspace_size="10Gi",
+        runner_secret_name="sisyphus-runner-secrets",
+        image_pull_secrets=[],
+        ready_timeout_sec=5,
+        kvm_enabled=True,
+        core_v1=MagicMock(),
+    )
+
+
+def test_build_pod_mounts_kvm_when_enabled():
+    """kvm_enabled=True：挂宿主 /dev/kvm CharDevice 进 runner pod（emulator 硬件加速）。"""
+    rc = _make_controller_with_kvm()
+    pod = rc.build_pod("REQ-1")
+    c = pod.spec.containers[0]
+
+    mount_paths = [m.mount_path for m in c.volume_mounts]
+    assert "/dev/kvm" in mount_paths
+
+    kvm_vol = next(v for v in pod.spec.volumes if v.name == "kvm")
+    assert kvm_vol.host_path is not None
+    assert kvm_vol.host_path.path == "/dev/kvm"
+    assert kvm_vol.host_path.type == "CharDevice"
+
+
+def test_build_pod_existing_mounts_unchanged_with_kvm_enabled():
+    """开启 kvm 不能影响 /workspace, /dev/fuse, /root/.kube 三个老挂载。"""
+    rc = _make_controller_with_kvm()
+    pod = rc.build_pod("REQ-1")
+    c = pod.spec.containers[0]
+    mount_paths = [m.mount_path for m in c.volume_mounts]
+    assert "/workspace" in mount_paths
+    assert "/dev/fuse" in mount_paths
+    assert "/root/.kube" in mount_paths
+
+    # fuse hostPath 仍指向 /dev/fuse，没被 kvm 覆盖
+    fuse_vol = next(v for v in pod.spec.volumes if v.name == "fuse")
+    assert fuse_vol.host_path.path == "/dev/fuse"
+
+
 def test_kubeconfig_mounts_from_same_secret():
     """verify kubeconfig is mounted from the same runner_secret_name (not a separate secret)。"""
     rc = _make_controller()

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -16,13 +16,17 @@ LABEL org.opencontainers.image.source=https://github.com/phona/sisyphus
 LABEL org.opencontainers.image.description="Sisyphus per-REQ runner: Flutter + Go + Docker DinD + openspec"
 LABEL org.opencontainers.image.licenses=MIT
 
-# ─── 1. 基础工具 + Docker 官方仓库（含 docker-compose-plugin v2） ──────
+# ─── 1. 基础工具 + Docker 官方仓库（含 docker-compose-plugin v2） + KVM userland ──
 # Debian/Ubuntu 自带 docker.io 是 20.10，缺 docker-compose-plugin。
 # 走官方源装 docker-ce + compose plugin + buildx。
+# 同步装 qemu-kvm + cpu-checker：Android emulator 在 KVM 加速下冷启 ~30s（vs 软 CPU
+# 5-10min），需要宿主 /dev/kvm 挂入容器（k8s_runner.py kvm_enabled=true 启用）。
+# cpu-checker 提供 kvm-ok 用于 emulator 启动前自检。
 RUN install -m 0755 -d /etc/apt/keyrings \
     && apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates gnupg curl iptables \
         git gh jq make bash sudo nodejs npm ssh-client \
+        qemu-kvm cpu-checker \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
         -o /etc/apt/keyrings/docker.asc \
     && chmod a+r /etc/apt/keyrings/docker.asc \
@@ -62,12 +66,33 @@ RUN npm install -g @fission-ai/openspec@latest && openspec --version
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
     && uv --version
 
+# ─── 4c. Android emulator + system image + 默认 AVD ──────────────────────
+# Cirrus flutter base 已带 Android SDK + sdkmanager + platform-tools (adb)，但默认
+# 没装 emulator package 也没装 system-image。这里补齐：
+#   - emulator (QEMU 包装)
+#   - system-images;android-34;google_apis;x86_64 (~1GB)
+#   - 预创建 AVD `sisyphus-default` (跳过运行时 ~10s 部署延迟)
+# 选型理由见 openspec/changes/REQ-runner-android-emulator-1777189159/design.md §2/§4。
+# yes | sdkmanager 自动同意 license；ANDROID_SDK_ROOT 由 cirrus base 设好。
+ARG ANDROID_API_LEVEL=34
+ARG ANDROID_SYSTEM_IMAGE=system-images;android-34;google_apis;x86_64
+RUN yes | sdkmanager --install \
+        "emulator" \
+        "${ANDROID_SYSTEM_IMAGE}" \
+    && echo "no" | avdmanager create avd \
+        --name sisyphus-default \
+        --package "${ANDROID_SYSTEM_IMAGE}" \
+        --device "pixel" \
+        --force \
+    && emulator -list-avds | grep -q sisyphus-default
+
 # ─── 5. sisyphus 合约脚本 ──────────────────
 # build context 必须是 sisyphus repo 根（CI workflow 已配 context: .）
 COPY scripts/check-scenario-refs.sh \
      scripts/check-tasks-section-ownership.sh \
      scripts/pre-commit-acl.sh \
      scripts/sisyphus-clone-repos.sh \
+     scripts/sisyphus-android-emulator.sh \
      /opt/sisyphus/scripts/
 RUN chmod +x /opt/sisyphus/scripts/*.sh
 ENV PATH="/opt/sisyphus/scripts:$PATH"

--- a/runner/README.md
+++ b/runner/README.md
@@ -5,6 +5,8 @@
 ## 镜像内容
 
 - Flutter SDK + Android SDK + Java（来自 `cirruslabs/flutter:stable`）
+- Android emulator + system image `android-34;google_apis;x86_64` + AVD `sisyphus-default`（仅 full flavor）
+- KVM userland (`qemu-kvm`, `cpu-checker`) — 配合 orchestrator `runner.kvmEnabled=true` 跑 emulator 硬件加速
 - Go 1.22
 - Node + npm
 - Docker DinD（contract test 跑 docker compose 用）
@@ -46,6 +48,22 @@ docker exec $CONTAINER bash -c "docker compose -f tests/contract/docker-compose.
 | `go` | `runner/go.Dockerfile` | `ghcr.io/phona/sisyphus-runner-go` | ~1GB | Go 项目（如 ubox-crosser），不带 Flutter |
 
 prompt `runner_container.md.j2` 默认用 `:go`。Flutter 项目要切成 `:main`（full flavor）。
+
+## Android emulator (full flavor only)
+
+`runner/Dockerfile` 装了 emulator + 一个 API 34 system image，并预创建 AVD `sisyphus-default`。
+业务 Makefile 一行起：
+
+```bash
+/opt/sisyphus/scripts/sisyphus-android-emulator.sh boot --timeout 300   # headless 启动并等 boot_completed=1
+/opt/sisyphus/scripts/sisyphus-android-emulator.sh halt                  # 停掉
+```
+
+硬件加速依赖宿主 `/dev/kvm` 挂入 pod（orchestrator helm value `runner.kvmEnabled=true`，
+默认 false）。没 KVM 时 emulator 退回软 CPU 仍能跑但慢 5-10x；脚本会打 warning 不 fail。
+
+`go.Dockerfile` 没装 emulator/avdmanager（保持 ~1GB 体积），调用脚本会立即报
+`emulator: command not found`——业务 Makefile 该切到 `:main` 标签。
 
 ## 构建
 

--- a/runner/go.Dockerfile
+++ b/runner/go.Dockerfile
@@ -65,10 +65,14 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/b
     && uv --version
 
 # ─── 4. sisyphus 合约脚本 ──────────────────
+# sisyphus-android-emulator.sh 也 COPY 进来：Go runner 缺 emulator/avdmanager 二进制，
+# 调用立即报 "emulator: command not found" 是预期行为（业务 Makefile 该切到 full 镜像）。
+# 路径统一比 PATH 不一致更省疑惑。
 COPY scripts/check-scenario-refs.sh \
      scripts/check-tasks-section-ownership.sh \
      scripts/pre-commit-acl.sh \
      scripts/sisyphus-clone-repos.sh \
+     scripts/sisyphus-android-emulator.sh \
      /opt/sisyphus/scripts/
 RUN chmod +x /opt/sisyphus/scripts/*.sh
 ENV PATH="/opt/sisyphus/scripts:$PATH"

--- a/scripts/sisyphus-android-emulator.sh
+++ b/scripts/sisyphus-android-emulator.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# sisyphus-android-emulator.sh — boot/halt the default Android AVD inside a runner pod.
+#
+# 只在 full Flutter runner image 里有用（go.Dockerfile 同样 COPY 了这个文件，但缺
+# emulator/avdmanager 二进制 → 调用即 fail-fast 报 "emulator: command not found"，
+# 让 caller 看到清楚错误而不是被埋）。
+#
+# 业务 Makefile 一行调用：
+#   /opt/sisyphus/scripts/sisyphus-android-emulator.sh boot           # 默认 300s timeout
+#   /opt/sisyphus/scripts/sisyphus-android-emulator.sh boot --timeout 600
+#   /opt/sisyphus/scripts/sisyphus-android-emulator.sh halt
+#
+# 依赖宿主 /dev/kvm 已挂入 pod（orchestrator runner.kvmEnabled=true）。
+# /dev/kvm 缺失 → emulator 自动退回软 CPU，仍能跑但慢 5-10x；脚本会 warning 不
+# fail，让没装 KVM 的 dev 环境也可以验功能。
+set -euo pipefail
+
+AVD_NAME="${AVD_NAME:-sisyphus-default}"
+TIMEOUT_SEC=300
+PID_FILE="/tmp/sisyphus-android-emulator.pid"
+
+usage() {
+  cat >&2 <<EOF
+Usage: $(basename "$0") <command> [options]
+
+Commands:
+  boot [--timeout N]   Start AVD '${AVD_NAME}' headless and wait until boot_completed=1
+  halt                 Kill the running emulator started by this script
+
+Env overrides:
+  AVD_NAME             AVD name to boot (default: sisyphus-default)
+EOF
+}
+
+cmd_boot() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --timeout) TIMEOUT_SEC="$2"; shift 2 ;;
+      *) echo "[android-emulator] unknown option: $1" >&2; usage; exit 2 ;;
+    esac
+  done
+
+  if ! command -v emulator >/dev/null 2>&1; then
+    echo "[android-emulator] emulator: command not found — this image is the Go-only flavor; switch to ghcr.io/phona/sisyphus-runner:main" >&2
+    exit 127
+  fi
+  if ! command -v adb >/dev/null 2>&1; then
+    echo "[android-emulator] adb: command not found (Android platform-tools missing from image)" >&2
+    exit 127
+  fi
+
+  if [[ -c /dev/kvm && -r /dev/kvm && -w /dev/kvm ]]; then
+    echo "[android-emulator] /dev/kvm available — will use KVM acceleration"
+  else
+    echo "[android-emulator] WARNING: /dev/kvm not accessible — falling back to software CPU (5-10x slower). Set runner.kvmEnabled=true in helm values to fix." >&2
+  fi
+
+  if [[ -f "${PID_FILE}" ]] && kill -0 "$(cat "${PID_FILE}")" 2>/dev/null; then
+    echo "[android-emulator] emulator already running (pid=$(cat "${PID_FILE}"))"
+  else
+    echo "[android-emulator] starting AVD '${AVD_NAME}'…"
+    nohup emulator -avd "${AVD_NAME}" \
+      -no-window -no-audio -no-snapshot \
+      -gpu swiftshader_indirect \
+      -no-boot-anim -accel on \
+      >/var/log/android-emulator.log 2>&1 &
+    echo $! > "${PID_FILE}"
+  fi
+
+  echo "[android-emulator] adb wait-for-device (timeout ${TIMEOUT_SEC}s)…"
+  adb start-server >/dev/null 2>&1 || true
+
+  local started end
+  started="$(date +%s)"
+  end=$(( started + TIMEOUT_SEC ))
+
+  # adb wait-for-device 自身没有 timeout 选项，包一层
+  while [[ "$(date +%s)" -lt "${end}" ]]; do
+    if adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' | grep -q '^1$'; then
+      local elapsed=$(( $(date +%s) - started ))
+      echo "[android-emulator] boot completed in ${elapsed}s"
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "[android-emulator] timed out after ${TIMEOUT_SEC}s waiting for sys.boot_completed=1" >&2
+  echo "[android-emulator] last 30 lines of /var/log/android-emulator.log:" >&2
+  tail -n 30 /var/log/android-emulator.log >&2 || true
+  return 1
+}
+
+cmd_halt() {
+  if [[ -f "${PID_FILE}" ]]; then
+    local pid
+    pid="$(cat "${PID_FILE}")"
+    if kill -0 "${pid}" 2>/dev/null; then
+      echo "[android-emulator] killing emulator pid=${pid}"
+      kill "${pid}" || true
+      # 等最多 10s 让 emulator 干净退（QEMU 收 SIGTERM 后还要 flush）
+      for _ in $(seq 1 10); do
+        kill -0 "${pid}" 2>/dev/null || break
+        sleep 1
+      done
+      kill -9 "${pid}" 2>/dev/null || true
+    fi
+    rm -f "${PID_FILE}"
+  fi
+  adb kill-server 2>/dev/null || true
+}
+
+case "${1:-}" in
+  boot) shift; cmd_boot "$@" ;;
+  halt) shift; cmd_halt ;;
+  -h|--help|help|"") usage; exit 0 ;;
+  *) echo "unknown command: $1" >&2; usage; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

REQ-runner-android-emulator-1777189159 — make the full Flutter runner image capable of booting an Android emulator inside the per-REQ pod, with optional `/dev/kvm` host passthrough for hardware acceleration.

- Full runner ships `emulator` + `system-images;android-34;google_apis;x86_64` + AVD `sisyphus-default`; cold boot drops from 5–10 min (software CPU) to ~30–60 s (KVM).
- New helper `scripts/sisyphus-android-emulator.sh` boots headless and blocks on `getprop sys.boot_completed=1`.
- Orchestrator gains opt-in `runner.kvmEnabled` (default `false`); when on, runner pods mount host `/dev/kvm` (mirrors the existing `/dev/fuse` pattern). Default off keeps existing deployments unaffected.
- Go-only runner is unchanged in size; the helper script is shipped there too for path uniformity but fails fast (`emulator: command not found`).

## Why opt-in

Some K8s installs run on nodes without `/dev/kvm` (nested virt, dev environments). Defaulting on would make Pod creation fail with `MountVolume.SetUp failed`. Operators flip `runner.kvmEnabled=true` after running `kvm-ok` on each runner-eligible node; comment in `helm/values.yaml` documents the prerequisite.

See [openspec/changes/REQ-runner-android-emulator-1777189159/design.md](openspec/changes/REQ-runner-android-emulator-1777189159/design.md) for decisions on system image variant (api 34 google_apis x86_64, no playstore), AVD pre-creation policy, and why hostPath beats a device plugin in our single-node K3s.

## Test plan

- [x] `openspec validate REQ-runner-android-emulator-1777189159 --strict` passes
- [x] `scripts/check-scenario-refs.sh` passes (237 scenario defs reachable)
- [x] `make ci-lint` clean
- [x] `cd orchestrator && uv run pytest -q` — 742 passed (3 new `build_pod` cases)
- [x] `bash -n scripts/sisyphus-android-emulator.sh` clean
- [ ] Image build (CI workflow `runner-image.yml`) — both flavors will rebuild from this PR's `runner/**` + `scripts/**` changes; verify full image size growth (~+1.5 GB) and that `emulator -list-avds` prints `sisyphus-default`.
- [ ] Smoke test on vm-node04 (post-merge): `kubectl exec runner-<req> -- /opt/sisyphus/scripts/sisyphus-android-emulator.sh boot --timeout 300` after flipping `runner.kvmEnabled=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)