### PR TITLE
fix(checkers): suppress make -p -n nonzero exit (pipefail dropping grep)

### DIFF
--- a/orchestrator/src/orchestrator/actions/_integration_resolver.py
+++ b/orchestrator/src/orchestrator/actions/_integration_resolver.py
@@ -40,14 +40,14 @@ set +e
 for d in /workspace/integration/*/; do
   [ -d "$d" ] || continue
   [ -f "${d}Makefile" ] || continue
-  if (cd "$d" && make -p -n 2>/dev/null | grep -qE '^accept-env-up:'); then
+  if (cd "$d" && (make -p -n 2>/dev/null || true) | grep -qE '^accept-env-up:'); then
     printf 'I:%s\n' "${d%/}"
   fi
 done
 for d in /workspace/source/*/; do
   [ -d "$d" ] || continue
   [ -f "${d}Makefile" ] || continue
-  if (cd "$d" && make -p -n 2>/dev/null | grep -qE '^accept-env-up:'); then
+  if (cd "$d" && (make -p -n 2>/dev/null || true) | grep -qE '^accept-env-up:'); then
     printf 'S:%s\n' "${d%/}"
   fi
 done

--- a/orchestrator/src/orchestrator/checkers/dev_cross_check.py
+++ b/orchestrator/src/orchestrator/checkers/dev_cross_check.py
@@ -75,7 +75,11 @@ def _build_cmd(req_id: str) -> str:
         # 而非 `grep '^ci-lint:'` 顶层（实证 ttpos-server-go：ci-* 在
         # ttpos-scripts/lint-ci-test.mk via `include`，顶层 grep 漏判 →
         # checker 误报"0 source repos eligible" silent fail）。
-        '  if [ -f "$repo/Makefile" ] && (cd "$repo" && make -p -n 2>/dev/null | grep -q \'^ci-lint:\'); then '
+        # `make -p -n || true` 抑制 Makefile 评估期错误（如 include 子 mk 缺 env / target body
+        # 求值挂）；外层 `set -o pipefail` 否则让 pipe 整体 fail → grep 看不到 → 误判"0 eligible"。
+        # 实证 ttpos v8 (REQ-ttpos-validate-end-to-end) 卡这个：ttpos-server-go Makefile 里
+        # ci-lint target 真存在 (via include) 但 make 评估时某处 exit 非零，pipefail 把 grep 吞光。
+        '  if [ -f "$repo/Makefile" ] && (cd "$repo" && (make -p -n 2>/dev/null || true) | grep -q \'^ci-lint:\'); then '
         '    base_rev=$(cd "$repo" && (git merge-base HEAD origin/main 2>/dev/null '
         '              || git merge-base HEAD origin/develop 2>/dev/null '
         '              || git merge-base HEAD origin/dev 2>/dev/null '

--- a/orchestrator/src/orchestrator/checkers/staging_test.py
+++ b/orchestrator/src/orchestrator/checkers/staging_test.py
@@ -88,8 +88,10 @@ def _build_cmd(req_id: str) -> str:
         # ci-unit-test / ci-integration-test target 检测：解析 Makefile（含 include 子 mk）
         # 而非 grep 顶层（实证 ttpos-server-go：ci-* 在 ttpos-scripts/lint-ci-test.mk via include
         # → 顶层 grep 漏判 → "0 source repos eligible" silent fail）。
-        '  if [ -f "$repo/Makefile" ] && (cd "$repo" && make -p -n 2>/dev/null | grep -qE \'^ci-unit-test:\') '
-        '       && (cd "$repo" && make -p -n 2>/dev/null | grep -qE \'^ci-integration-test:\'); then '
+        # `make -p -n || true` 抑制 Makefile 评估期错误（pipefail 否则吞 grep 输出）。
+        # 实证：ttpos v8 dev_cross_check 同款卡，根因 make exit 非零。
+        '  if [ -f "$repo/Makefile" ] && (cd "$repo" && (make -p -n 2>/dev/null || true) | grep -qE \'^ci-unit-test:\') '
+        '       && (cd "$repo" && (make -p -n 2>/dev/null || true) | grep -qE \'^ci-integration-test:\'); then '
         "    ( "
         '      echo "=== staging_test (unit): $name ==="; '
         '      cd "$repo" && make ci-unit-test > "/tmp/staging-test-logs/$name-unit.log" 2>&1 '


### PR DESCRIPTION
## Summary
PR #123 switched target detection to `make -p -n | grep` to resolve includes. Empirically still failed on ttpos v8 because pipefail + make exit non-zero (from rule body evaluation errors) → pipe fails → grep sees nothing.

Wrap make in `( ... || true )` subshell.

## Why
REQ-ttpos-validate-end-to-end-1777188536 (post #123 deploy) dev_cross_check artifact_checks:
```
=== FAIL dev_cross_check: 0 source repos eligible (no make ci-lint target on feat/...) — refusing to silent-pass ===
```
But ttpos-server-go DOES have ci-* via `include ./ttpos-scripts/lint-ci-test.mk`.

## Test plan
- [x] 739 passed
- [ ] Post-merge: re-dispatch ttpos REQ; dev_cross_check should真识别 ci-lint target