### PR TITLE
fix(checkers): run make ci-setup before ci-* + bump dev_cross_check timeout

### DIFF
--- a/orchestrator/src/orchestrator/checkers/dev_cross_check.py
+++ b/orchestrator/src/orchestrator/checkers/dev_cross_check.py
@@ -84,6 +84,11 @@ def _build_cmd(req_id: str) -> str:
         '              || git merge-base HEAD origin/develop 2>/dev/null '
         '              || git merge-base HEAD origin/dev 2>/dev/null '
         '              || echo "")); '
+        # 先跑 ci-setup 拉 deps（per ttpos-ci 契约，对齐 ci-go.yml 流：ci-setup → ci-lint）。
+        # 实证 ttpos v9：ci-lint 第一次跑触发 go mod download 大量 alibabacloud SDK，
+        # 没 ci-setup 预热 → 5min timeout (-1)。`|| true` 不让 setup 失败拦 lint。
+        '    echo "=== dev_cross_check (ci-setup): $name ==="; '
+        '    (cd "$repo" && make ci-setup) || true; '
         '    echo "=== dev_cross_check (ci-lint): $name (BASE_REV=$base_rev) ==="; '
         '    if ! (cd "$repo" && BASE_REV="$base_rev" make ci-lint); then '
         '      echo "=== FAIL: $name ===" >&2; '
@@ -105,7 +110,7 @@ def _build_cmd(req_id: str) -> str:
 async def run_dev_cross_check(
     req_id: str,
     *,
-    timeout_sec: int = 300,
+    timeout_sec: int = 900,
 ) -> CheckResult:
     """kubectl exec runner -- <for-each-repo make ci-lint>。"""
     rc = k8s_runner.get_controller()

--- a/orchestrator/src/orchestrator/checkers/staging_test.py
+++ b/orchestrator/src/orchestrator/checkers/staging_test.py
@@ -92,6 +92,9 @@ def _build_cmd(req_id: str) -> str:
         # 实证：ttpos v8 dev_cross_check 同款卡，根因 make exit 非零。
         '  if [ -f "$repo/Makefile" ] && (cd "$repo" && (make -p -n 2>/dev/null || true) | grep -qE \'^ci-unit-test:\') '
         '       && (cd "$repo" && (make -p -n 2>/dev/null || true) | grep -qE \'^ci-integration-test:\'); then '
+        # 先 ci-setup 拉 deps，跟 dev_cross_check / ttpos-ci ci-go.yml 流对齐。
+        '    echo "=== staging_test (ci-setup): $name ==="; '
+        '    (cd "$repo" && make ci-setup) || true; '
         "    ( "
         '      echo "=== staging_test (unit): $name ==="; '
         '      cd "$repo" && make ci-unit-test > "/tmp/staging-test-logs/$name-unit.log" 2>&1 '


### PR DESCRIPTION
## Summary
- Insert `make ci-setup || true` before `make ci-lint` (dev_cross_check) and before `make ci-unit-test` / `ci-integration-test` (staging_test) — honors the ttpos-ci contract (ci-setup → ci-lint pattern, see ttpos-ci ci-go.yml)
- Bump dev_cross_check default timeout 300 → 900s (large Go repo first-run setup needs 2-5min)

## Why
ttpos v9 (REQ-ttpos-pipefail-fix-validate-1777192030, post #129) finally ran real `make ci-lint` on ttpos-server-go but exit_code=-1 in 301s — stderr shows alibabacloud SDK + many Go modules still downloading when timeout hit. Without ci-setup, lint has to fetch all deps inline.

## Test plan
- [x] `uv run pytest tests/test_checkers_*.py -x -q` → 21 passed
- [ ] Post-merge: re-dispatch ttpos REQ; dev_cross_check should pass within timeout (or fail with real lint findings, not timeout)