### PR TITLE
fix(runner): redirect Go/npm/uv cache to PVC (REQ-runner-cache-on-pvc-1777198512)

### DIFF
--- a/openspec/changes/REQ-runner-cache-on-pvc-1777198512/proposal.md
+++ b/openspec/changes/REQ-runner-cache-on-pvc-1777198512/proposal.md
@@ -1,0 +1,63 @@
+# fix(runner): redirect Go/npm/uv cache to PVC
+
+## Why
+
+The runner Pod's toolchain caches default to paths that live on the container's
+writable layer (ephemeral storage), not on the per-REQ PVC mounted at
+`/workspace`:
+
+- Go modules: `$GOPATH/pkg/mod` — `/root/go/pkg/mod` (image baked `GOPATH=/root/go`).
+- Go build cache: `~/.cache/go-build`.
+- npm: `~/.npm`.
+- uv: `~/.cache/uv`.
+
+Two operational pains follow:
+
+1. **Cache lost on Pod restart.** A K8s OOMKill / node migration / `runner.pause()`
+   destroys the container; the PVC at `/workspace` survives but the caches don't.
+   Every subsequent `dev_cross_check` / `staging_test` re-downloads modules and
+   re-compiles from cold, padding minutes onto each retry.
+2. **Node ephemeral-storage pressure.** Caches accumulate on `/var/lib/kubelet`
+   (or the docker overlay) and aren't visible to `runner_gc` because they're not
+   in any PVC. On vm-node04 (single-node K3s, ~50 GB ephemeral) several
+   concurrent runners can push the node to disk-pressure eviction.
+
+Redirecting the four big toolchain caches into `/workspace/.cache/...` makes
+them PVC-resident: they survive Pod restarts within the same REQ, get GCd along
+with the PVC at REQ done/escalate, and stop bleeding into shared node storage.
+
+## What Changes
+
+- **`orchestrator/src/orchestrator/k8s_runner.py`** — `build_pod()` injects four
+  new env vars on every runner container:
+  - `GOMODCACHE=/workspace/.cache/go/mod`
+  - `GOCACHE=/workspace/.cache/go/build`
+  - `npm_config_cache=/workspace/.cache/npm`
+  - `UV_CACHE_DIR=/workspace/.cache/uv`
+
+  No volume / mount changes — `/workspace` is already mounted from the per-REQ
+  PVC.
+- **`orchestrator/tests/test_k8s_runner.py`** — new
+  `test_build_pod_redirects_toolchain_caches_to_pvc` assertion locking the four
+  env values down so a future refactor can't silently revert them.
+
+Image, Dockerfile, helm chart, CLI tools, and `sisyphus-clone-repos.sh` are
+**not** touched: the convention lives entirely in the Pod spec.
+
+## Impact
+
+- **Affected specs**: new capability `runner-cache-on-pvc` (purely additive).
+- **Affected code**: `orchestrator/src/orchestrator/k8s_runner.py`,
+  `orchestrator/tests/test_k8s_runner.py`.
+- **Deployment / migration**: zero ops — orchestrator rollout-restart picks up
+  the new Pod template; existing in-flight Pods keep running with the old
+  (ephemeral) cache layout until their REQ ends. PVC size requests are
+  unchanged (default `10Gi`); cache footprint for a typical REQ is well under
+  1 GB across all four toolchains, so existing PVCs comfortably absorb it.
+- **Risk**: low. Env vars are honored by every supported version of `go`,
+  `npm`, and `uv`; they take precedence over default paths, so the change is
+  purely "where do bytes land" with no behavioral side-effects on the tools
+  themselves.
+- **Out of scope**: cross-REQ cache sharing (would need a separate RWX
+  PV / something like a node-local hostPath cache) — different design, larger
+  blast radius, deferred.

--- a/openspec/changes/REQ-runner-cache-on-pvc-1777198512/specs/runner-cache-on-pvc/spec.md
+++ b/openspec/changes/REQ-runner-cache-on-pvc-1777198512/specs/runner-cache-on-pvc/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: runner Pod redirects Go / npm / uv toolchain caches onto the per-REQ PVC
+
+The sisyphus orchestrator's `RunnerController.build_pod(req_id)` SHALL inject
+four cache-location environment variables into every runner container, and
+each value MUST point inside `/workspace/.cache/` so the cache is written to
+the PVC mounted at `/workspace` rather than the container's writable layer.
+Future cache lookups by `go`, `npm`, and `uv` MUST therefore land on
+PVC-backed storage that survives Pod restarts within the same REQ. The exact
+mapping is:
+
+| Env var            | Value                          | Tool covered           |
+|--------------------|--------------------------------|------------------------|
+| `GOMODCACHE`       | `/workspace/.cache/go/mod`     | Go module download cache |
+| `GOCACHE`          | `/workspace/.cache/go/build`   | Go build cache           |
+| `npm_config_cache` | `/workspace/.cache/npm`        | npm package cache        |
+| `UV_CACHE_DIR`     | `/workspace/.cache/uv`         | uv package cache         |
+
+The runner container's existing `/workspace` PVC mount MUST remain the only
+volume backing these paths — no new volume, mount, or hostPath is introduced.
+Cross-REQ cache sharing is explicitly out of scope: each REQ's PVC is its
+own cache scope and cleanup happens implicitly when the PVC is deleted at
+REQ done / escalate.
+
+#### Scenario: RUNNER-CACHE-S1 GOMODCACHE points into /workspace/.cache
+
+- **GIVEN** a `RunnerController` constructed with default settings
+- **WHEN** the controller calls `build_pod("REQ-1")`
+- **THEN** the resulting Pod's container `env` list contains an entry whose
+  `name` is `GOMODCACHE` and whose `value` is exactly `/workspace/.cache/go/mod`
+
+#### Scenario: RUNNER-CACHE-S2 GOCACHE points into /workspace/.cache
+
+- **GIVEN** a `RunnerController` constructed with default settings
+- **WHEN** the controller calls `build_pod("REQ-1")`
+- **THEN** the resulting Pod's container `env` list contains an entry whose
+  `name` is `GOCACHE` and whose `value` is exactly `/workspace/.cache/go/build`
+
+#### Scenario: RUNNER-CACHE-S3 npm_config_cache points into /workspace/.cache
+
+- **GIVEN** a `RunnerController` constructed with default settings
+- **WHEN** the controller calls `build_pod("REQ-1")`
+- **THEN** the resulting Pod's container `env` list contains an entry whose
+  `name` is `npm_config_cache` and whose `value` is exactly
+  `/workspace/.cache/npm`
+
+#### Scenario: RUNNER-CACHE-S4 UV_CACHE_DIR points into /workspace/.cache
+
+- **GIVEN** a `RunnerController` constructed with default settings
+- **WHEN** the controller calls `build_pod("REQ-1")`
+- **THEN** the resulting Pod's container `env` list contains an entry whose
+  `name` is `UV_CACHE_DIR` and whose `value` is exactly `/workspace/.cache/uv`

--- a/openspec/changes/REQ-runner-cache-on-pvc-1777198512/tasks.md
+++ b/openspec/changes/REQ-runner-cache-on-pvc-1777198512/tasks.md
@@ -1,0 +1,20 @@
+# tasks: REQ-runner-cache-on-pvc-1777198512
+
+## Stage: contract / spec
+
+- [x] author `specs/runner-cache-on-pvc/spec.md` with delta `## ADDED Requirements`
+- [x] write 4 scenarios `RUNNER-CACHE-S{1..4}` covering each toolchain env var
+      (`GOMODCACHE`, `GOCACHE`, `npm_config_cache`, `UV_CACHE_DIR`)
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/k8s_runner.py`: extend `build_pod` env list
+      with the four cache env vars pointing under `/workspace/.cache/`
+- [x] `orchestrator/tests/test_k8s_runner.py`: new
+      `test_build_pod_redirects_toolchain_caches_to_pvc` locking exact env names
+      and paths
+
+## Stage: PR
+
+- [x] git push `feat/REQ-runner-cache-on-pvc-1777198512`
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/k8s_runner.py
+++ b/orchestrator/src/orchestrator/k8s_runner.py
@@ -171,6 +171,19 @@ class RunnerController:
             client.V1EnvVar(name="GOMEMLIMIT", value="2GiB"),
             client.V1EnvVar(name="GOGC", value="50"),
             client.V1EnvVar(name="GOFLAGS", value="-p=2"),
+            # Toolchain 包/构建/下载 cache 全部重定向到 PVC 挂载点
+            # `/workspace/.cache/`。默认位置（GOPATH/pkg/mod = /root/go/pkg/mod、
+            # ~/.cache/go-build、~/.npm、~/.cache/uv）落在容器可写层 / ephemeral
+            # storage：pod 重启 / 节点压力下被驱逐就丢，每次重新下载 modules
+            # 又拖累 dev_cross_check / staging_test 时长，还吃 node /var/lib
+            # 空间。PVC 挂的 /workspace 跟 pod lifecycle 解耦（OOM 重启不掉），
+            # 跨 stage 的 lint/test 复用同一份 cache。
+            # 注：per-REQ PVC 仅 REQ 内共享，不跨 REQ；跨 REQ 共享 cache 是另一
+            # 个话题（需要 RWX volume），不在本次范围。
+            client.V1EnvVar(name="GOMODCACHE", value="/workspace/.cache/go/mod"),
+            client.V1EnvVar(name="GOCACHE", value="/workspace/.cache/go/build"),
+            client.V1EnvVar(name="npm_config_cache", value="/workspace/.cache/npm"),
+            client.V1EnvVar(name="UV_CACHE_DIR", value="/workspace/.cache/uv"),
         ]
         # 从 runner-secrets 注入 GitHub 凭证（optional，secret 缺了 pod 还能起）
         for env_name, secret_key in (

--- a/orchestrator/tests/test_contract_runner_cache_on_pvc.py
+++ b/orchestrator/tests/test_contract_runner_cache_on_pvc.py
@@ -1,0 +1,192 @@
+"""Contract tests for REQ-runner-cache-on-pvc-1777198512.
+
+Capability: runner-cache-on-pvc
+Author: challenger-agent (black-box, written from spec only)
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is genuinely wrong, escalate to spec_fixer to correct the spec.
+
+Scenarios covered:
+  RUNNER-CACHE-S1  GOMODCACHE points into /workspace/.cache/go/mod
+  RUNNER-CACHE-S2  GOCACHE points into /workspace/.cache/go/build
+  RUNNER-CACHE-S3  npm_config_cache points into /workspace/.cache/npm
+  RUNNER-CACHE-S4  UV_CACHE_DIR points into /workspace/.cache/uv
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def _make_controller():
+    from orchestrator.k8s_runner import RunnerController
+
+    return RunnerController(
+        core_v1=MagicMock(),
+        namespace="sisyphus-runners",
+        runner_image="ghcr.io/phona/sisyphus-runner:main",
+        runner_sa="sisyphus-runner-sa",
+        runner_secret_name="sisyphus-runner-secrets",
+        storage_class="local-path",
+        workspace_size="10Gi",
+    )
+
+
+def _env_value(pod, name: str) -> str | None:
+    """Return the value of env var `name` in the first container, or None."""
+    containers = pod.spec.containers
+    assert containers, "Pod must have at least one container"
+    for entry in containers[0].env or []:
+        if getattr(entry, "name", None) == name:
+            return getattr(entry, "value", None)
+    return None
+
+
+# ── RUNNER-CACHE-S1: GOMODCACHE ───────────────────────────────────────────────
+
+
+def test_runner_cache_s1_gomodcache_env_present():
+    """S1: build_pod MUST include env var GOMODCACHE."""
+    controller = _make_controller()
+    pod = controller.build_pod("REQ-1")
+
+    containers = pod.spec.containers
+    assert containers, "Pod must have at least one container"
+    env_names = [getattr(e, "name", None) for e in (containers[0].env or [])]
+    assert "GOMODCACHE" in env_names, (
+        "Pod's container env list must contain 'GOMODCACHE' "
+        f"(spec RUNNER-CACHE-S1). Present env names: {env_names}"
+    )
+
+
+def test_runner_cache_s1_gomodcache_value():
+    """S1: GOMODCACHE MUST equal '/workspace/.cache/go/mod'."""
+    controller = _make_controller()
+    pod = controller.build_pod("REQ-1")
+
+    value = _env_value(pod, "GOMODCACHE")
+    assert value == "/workspace/.cache/go/mod", (
+        "GOMODCACHE must be set to '/workspace/.cache/go/mod' so the Go module "
+        "download cache lands on the PVC rather than the container writable layer "
+        f"(spec RUNNER-CACHE-S1). Got: {value!r}"
+    )
+
+
+# ── RUNNER-CACHE-S2: GOCACHE ──────────────────────────────────────────────────
+
+
+def test_runner_cache_s2_gocache_env_present():
+    """S2: build_pod MUST include env var GOCACHE."""
+    controller = _make_controller()
+    pod = controller.build_pod("REQ-1")
+
+    containers = pod.spec.containers
+    assert containers, "Pod must have at least one container"
+    env_names = [getattr(e, "name", None) for e in (containers[0].env or [])]
+    assert "GOCACHE" in env_names, (
+        "Pod's container env list must contain 'GOCACHE' "
+        f"(spec RUNNER-CACHE-S2). Present env names: {env_names}"
+    )
+
+
+def test_runner_cache_s2_gocache_value():
+    """S2: GOCACHE MUST equal '/workspace/.cache/go/build'."""
+    controller = _make_controller()
+    pod = controller.build_pod("REQ-1")
+
+    value = _env_value(pod, "GOCACHE")
+    assert value == "/workspace/.cache/go/build", (
+        "GOCACHE must be set to '/workspace/.cache/go/build' so the Go build "
+        "cache lands on the PVC rather than the container writable layer "
+        f"(spec RUNNER-CACHE-S2). Got: {value!r}"
+    )
+
+
+# ── RUNNER-CACHE-S3: npm_config_cache ─────────────────────────────────────────
+
+
+def test_runner_cache_s3_npm_config_cache_env_present():
+    """S3: build_pod MUST include env var npm_config_cache."""
+    controller = _make_controller()
+    pod = controller.build_pod("REQ-1")
+
+    containers = pod.spec.containers
+    assert containers, "Pod must have at least one container"
+    env_names = [getattr(e, "name", None) for e in (containers[0].env or [])]
+    assert "npm_config_cache" in env_names, (
+        "Pod's container env list must contain 'npm_config_cache' "
+        f"(spec RUNNER-CACHE-S3). Present env names: {env_names}"
+    )
+
+
+def test_runner_cache_s3_npm_config_cache_value():
+    """S3: npm_config_cache MUST equal '/workspace/.cache/npm'."""
+    controller = _make_controller()
+    pod = controller.build_pod("REQ-1")
+
+    value = _env_value(pod, "npm_config_cache")
+    assert value == "/workspace/.cache/npm", (
+        "npm_config_cache must be set to '/workspace/.cache/npm' so the npm "
+        "package cache lands on the PVC rather than the container writable layer "
+        f"(spec RUNNER-CACHE-S3). Got: {value!r}"
+    )
+
+
+# ── RUNNER-CACHE-S4: UV_CACHE_DIR ────────────────────────────────────────────
+
+
+def test_runner_cache_s4_uv_cache_dir_env_present():
+    """S4: build_pod MUST include env var UV_CACHE_DIR."""
+    controller = _make_controller()
+    pod = controller.build_pod("REQ-1")
+
+    containers = pod.spec.containers
+    assert containers, "Pod must have at least one container"
+    env_names = [getattr(e, "name", None) for e in (containers[0].env or [])]
+    assert "UV_CACHE_DIR" in env_names, (
+        "Pod's container env list must contain 'UV_CACHE_DIR' "
+        f"(spec RUNNER-CACHE-S4). Present env names: {env_names}"
+    )
+
+
+def test_runner_cache_s4_uv_cache_dir_value():
+    """S4: UV_CACHE_DIR MUST equal '/workspace/.cache/uv'."""
+    controller = _make_controller()
+    pod = controller.build_pod("REQ-1")
+
+    value = _env_value(pod, "UV_CACHE_DIR")
+    assert value == "/workspace/.cache/uv", (
+        "UV_CACHE_DIR must be set to '/workspace/.cache/uv' so the uv "
+        "package cache lands on the PVC rather than the container writable layer "
+        f"(spec RUNNER-CACHE-S4). Got: {value!r}"
+    )
+
+
+# ── cross-cut: all four caches are under /workspace/.cache ───────────────────
+
+
+def test_runner_cache_all_four_vars_point_under_workspace_cache():
+    """S1-S4: All four cache env vars MUST have values starting with '/workspace/.cache/'."""
+    controller = _make_controller()
+    pod = controller.build_pod("REQ-1")
+
+    required = {
+        "GOMODCACHE": "/workspace/.cache/go/mod",
+        "GOCACHE": "/workspace/.cache/go/build",
+        "npm_config_cache": "/workspace/.cache/npm",
+        "UV_CACHE_DIR": "/workspace/.cache/uv",
+    }
+    for var_name, expected in required.items():
+        actual = _env_value(pod, var_name)
+        assert actual is not None, (
+            f"Env var '{var_name}' missing from Pod container spec "
+            f"(spec RUNNER-CACHE-S1..S4). "
+            "All four toolchain cache dirs must be redirected to PVC."
+        )
+        assert actual.startswith("/workspace/.cache/"), (
+            f"Env var '{var_name}'={actual!r} does not start with '/workspace/.cache/' — "
+            "all cache dirs must be PVC-resident (spec RUNNER-CACHE-S1..S4)."
+        )
+        assert actual == expected, (
+            f"Env var '{var_name}': expected {expected!r}, got {actual!r} "
+            f"(spec RUNNER-CACHE-S1..S4)."
+        )

--- a/orchestrator/tests/test_k8s_runner.py
+++ b/orchestrator/tests/test_k8s_runner.py
@@ -90,6 +90,22 @@ def test_build_pod_mounts_pvc_and_fuse():
     assert "SISYPHUS_REQ_ID" in env_names
 
 
+def test_build_pod_redirects_toolchain_caches_to_pvc():
+    """Go / npm / uv cache env vars 指向 /workspace/.cache（PVC 挂载点）。
+
+    默认位置（GOPATH/pkg/mod、~/.cache/go-build、~/.npm、~/.cache/uv）落在
+    容器可写层，pod 重启就丢；redirect 到 PVC 让 cache 跨 stage / 跨 pod
+    重启复用，避免 dev_cross_check / staging_test 每次重新下载 modules。
+    """
+    rc = _make_controller()
+    pod = rc.build_pod("REQ-1")
+    env = {e.name: e.value for e in pod.spec.containers[0].env if e.value is not None}
+    assert env.get("GOMODCACHE") == "/workspace/.cache/go/mod"
+    assert env.get("GOCACHE") == "/workspace/.cache/go/build"
+    assert env.get("npm_config_cache") == "/workspace/.cache/npm"
+    assert env.get("UV_CACHE_DIR") == "/workspace/.cache/uv"
+
+
 def test_build_pod_no_image_pull_secrets_when_empty():
     rc = _make_controller()
     pod = rc.build_pod("REQ-1")


### PR DESCRIPTION
## Summary

- Inject four toolchain cache env vars on every runner container so caches land on the per-REQ PVC instead of the container's writable layer:
  - `GOMODCACHE=/workspace/.cache/go/mod`
  - `GOCACHE=/workspace/.cache/go/build`
  - `npm_config_cache=/workspace/.cache/npm`
  - `UV_CACHE_DIR=/workspace/.cache/uv`
- Add `test_build_pod_redirects_toolchain_caches_to_pvc` to lock the four env values down.
- Author openspec change `REQ-runner-cache-on-pvc-1777198512` (proposal / tasks / `runner-cache-on-pvc` capability spec with 4 scenarios).

## Why

The runner Pod's PVC at `/workspace` already survives container restarts, but the toolchain caches default to paths on the container's writable layer (`/root/go/pkg/mod`, `~/.cache/go-build`, `~/.npm`, `~/.cache/uv`). Two pains:

1. Pod OOMKill / node migration / `runner.pause()` blows the caches away while the PVC and source repos remain — every retry of `dev_cross_check` / `staging_test` redownloads modules from cold.
2. Caches accumulate on node ephemeral storage and aren't visible to `runner_gc`, so concurrent runners can push the node toward disk-pressure eviction.

Redirecting them to `/workspace/.cache/...` puts them on the PVC: they survive Pod restarts within the same REQ, get GC'd along with the PVC at done/escalate, and stop bleeding into shared node storage.

## Test plan

- [x] `cd orchestrator && uv run pytest tests/test_k8s_runner.py` — 35 passed locally
- [x] `make ci-unit-test` — 872 passed locally
- [x] `BASE_REV=<merge-base> make ci-lint` — all checks passed
- [x] `openspec validate REQ-runner-cache-on-pvc-1777198512 --strict` — valid
- [x] `scripts/check-scenario-refs.sh --specs-search-path . .` — 0 unmatched refs
- [ ] sisyphus dev_cross_check / staging_test on this PR
- [ ] sisyphus pr_ci_watch (GitHub Actions)
- [ ] After merge: observe PVC `.cache/` populates after first `make ci-*` run inside any new REQ's runner Pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)