### PR TITLE
fix(runner): add iproute2 + net-tools (REQ-runner-net-tools-1777202552)

### DIFF
--- a/openspec/changes/REQ-runner-net-tools-1777202552/proposal.md
+++ b/openspec/changes/REQ-runner-net-tools-1777202552/proposal.md
@@ -1,0 +1,49 @@
+# fix(runner): add iproute2 + net-tools
+
+## Why
+
+Both runner images (`runner/Dockerfile` Flutter flavor and `runner/go.Dockerfile`
+Go flavor) are missing the basic IPv4 networking userland: no `ip`, no `ss`, no
+`netstat`, no `ifconfig`, no `route`. These tools are routinely needed during
+`accept-env-up` / acceptance scenarios to:
+
+- inspect what `docker compose up` actually wired (`ip addr`, `ip route`,
+  `ip -br link`),
+- check whether a service port is listening before probing it
+  (`ss -ltn` / `netstat -ltn`),
+- diagnose DNS / routing issues from inside the per-REQ Pod when an integration
+  scenario can't reach a sibling container (`ip route get <ip>`).
+
+Currently every `accept-env-*` author who wants to debug from the runner Pod
+hits `bash: ip: command not found` and has to either install on the fly (slow,
+non-deterministic, lost on Pod restart) or shell out to `docker exec` round-trips
+that make Makefile probes brittle. Both packages are tiny (`iproute2` ~1.5 MB,
+`net-tools` <1 MB compressed) and stable Debian/Ubuntu apt names — there is no
+ongoing maintenance cost to baking them in.
+
+## What Changes
+
+- **`runner/Dockerfile`** (Flutter flavor, Ubuntu base) — section §1 `apt-get
+  install` list gains `iproute2 net-tools`.
+- **`runner/go.Dockerfile`** (Go flavor, Debian bookworm base) — section §1
+  `apt-get install` list gains `iproute2 net-tools`.
+
+That's the whole change. Nothing else: same `apt-get` invocation, same layer,
+same `--no-install-recommends`, same `rm -rf /var/lib/apt/lists/*`.
+
+## Impact
+
+- **Affected specs**: new capability `runner-net-tools` (purely additive, names
+  the four binaries the runner image guarantees).
+- **Affected code**: `runner/Dockerfile`, `runner/go.Dockerfile`. No
+  orchestrator, helm chart, scripts, or Pod spec changes.
+- **Image size**: <3 MB added per flavor (tiny vs. existing ~1 GB Go and ~5 GB
+  Flutter images).
+- **Risk**: trivial. Both packages are part of every Debian/Ubuntu base; apt
+  resolution is deterministic on the pinned base images already in use. No
+  runtime behavior of the runner changes — these are user-invoked diagnostic
+  binaries only, not wired into entrypoint or any sisyphus checker.
+- **Out of scope**: `tcpdump`, `traceroute`, `nmap`, `dig`, `bind9-host`,
+  `mtr`. Each of those is bigger and only sometimes useful — add them per-REQ
+  if a specific scenario actually needs them. This REQ stays narrow on the
+  daily-use IPv4 toolkit.

--- a/openspec/changes/REQ-runner-net-tools-1777202552/specs/runner-net-tools/spec.md
+++ b/openspec/changes/REQ-runner-net-tools-1777202552/specs/runner-net-tools/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: runner images guarantee iproute2 + net-tools userland
+
+Both sisyphus runner images SHALL ship with the `iproute2` and `net-tools`
+Debian/Ubuntu packages pre-installed in the base image layer, where "both"
+means the Flutter-flavored `ghcr.io/phona/sisyphus-runner` built from
+`runner/Dockerfile` and the Go-only `ghcr.io/phona/sisyphus-runner-go` built
+from `runner/go.Dockerfile`. Consequently, the binaries `ip`, `ss`, `netstat`,
+and `ifconfig` MUST be resolvable on the default `PATH` inside any runner Pod
+started from either image, without any further apt-get or runtime installation
+step. The packages MUST be installed in the same `apt-get install` invocation
+as the rest of the section §1 base utilities so they share that layer's cache
+scope and image tagging cadence.
+
+#### Scenario: RUNNER-NET-S1 ip command resolves on Flutter runner
+
+- **GIVEN** a Pod started from `ghcr.io/phona/sisyphus-runner:<tag>`
+- **WHEN** an operator runs `kubectl exec <pod> -- command -v ip`
+- **THEN** the command exits 0 and prints a path under `/usr/sbin/` or
+  `/sbin/`, demonstrating `iproute2` is on `PATH`
+
+#### Scenario: RUNNER-NET-S2 ss command resolves on Go runner
+
+- **GIVEN** a Pod started from `ghcr.io/phona/sisyphus-runner-go:<tag>`
+- **WHEN** an operator runs `kubectl exec <pod> -- command -v ss`
+- **THEN** the command exits 0 and prints a path under `/usr/sbin/` or
+  `/usr/bin/`, demonstrating `iproute2` is on `PATH`
+
+#### Scenario: RUNNER-NET-S3 netstat command resolves on both runners
+
+- **GIVEN** a Pod started from either runner image variant
+- **WHEN** an operator runs `kubectl exec <pod> -- command -v netstat`
+- **THEN** the command exits 0 and prints a path under `/bin/` or
+  `/usr/bin/`, demonstrating `net-tools` is on `PATH`
+
+#### Scenario: RUNNER-NET-S4 ifconfig command resolves on both runners
+
+- **GIVEN** a Pod started from either runner image variant
+- **WHEN** an operator runs `kubectl exec <pod> -- command -v ifconfig`
+- **THEN** the command exits 0 and prints a path under `/sbin/` or
+  `/usr/sbin/`, demonstrating `net-tools` is on `PATH`

--- a/openspec/changes/REQ-runner-net-tools-1777202552/tasks.md
+++ b/openspec/changes/REQ-runner-net-tools-1777202552/tasks.md
@@ -1,0 +1,19 @@
+# tasks: REQ-runner-net-tools-1777202552
+
+## Stage: contract / spec
+
+- [x] author `specs/runner-net-tools/spec.md` with delta `## ADDED Requirements`
+- [x] write 4 scenarios `RUNNER-NET-S{1..4}` covering `ip`, `ss`, `netstat`,
+      `ifconfig`
+
+## Stage: implementation
+
+- [x] `runner/Dockerfile`: extend §1 apt-get install list with
+      `iproute2 net-tools`
+- [x] `runner/go.Dockerfile`: extend §1 apt-get install list with
+      `iproute2 net-tools`
+
+## Stage: PR
+
+- [x] git push `feat/REQ-runner-net-tools-1777202552`
+- [x] gh pr create

--- a/orchestrator/tests/test_contract_runner_net_tools.py
+++ b/orchestrator/tests/test_contract_runner_net_tools.py
@@ -1,0 +1,226 @@
+"""Contract tests for REQ-runner-net-tools-1777202552.
+
+Capability: runner-net-tools
+Author: challenger-agent (black-box, written from spec only)
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is genuinely wrong, escalate to spec_fixer to correct the spec.
+
+Scenarios covered:
+  RUNNER-NET-S1  ip command resolves on Flutter runner (iproute2 in Dockerfile §1 apt-get)
+  RUNNER-NET-S2  ss command resolves on Go runner (iproute2 in go.Dockerfile §1 apt-get)
+  RUNNER-NET-S3  netstat command resolves on both runners (net-tools in both Dockerfiles)
+  RUNNER-NET-S4  ifconfig command resolves on both runners (net-tools in both Dockerfiles)
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FULL_DOCKERFILE = REPO_ROOT / "runner" / "Dockerfile"
+GO_DOCKERFILE = REPO_ROOT / "runner" / "go.Dockerfile"
+
+# Regex: match an apt-get install block and everything up to the next &&-continuation
+# that starts a non-package command (curl / rm / echo / chmod / install).
+# We use this to extract only the first apt-get install invocation's package list.
+_FIRST_APT_BLOCK_RE = re.compile(
+    r"apt-get\s+install\s+-y\s+--no-install-recommends\s+(.*?)"
+    r"(?=&&\s*(?:curl|rm\s+-rf|echo|chmod|install\s+-m))",
+    re.DOTALL,
+)
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"Dockerfile not found at expected path: {path}"
+    return path.read_text()
+
+
+def _first_apt_install_block(content: str) -> str:
+    """Return the package-list text of the first apt-get install invocation."""
+    match = _FIRST_APT_BLOCK_RE.search(content)
+    return match.group(1) if match else ""
+
+
+# ── RUNNER-NET-S1: ip command on Flutter runner ──────────────────────────────
+
+
+def test_runner_net_s1_full_dockerfile_exists():
+    """S1: runner/Dockerfile must exist at the canonical path."""
+    assert FULL_DOCKERFILE.exists(), (
+        f"runner/Dockerfile not found at {FULL_DOCKERFILE}; "
+        "the Flutter runner image must be present for sisyphus accept-stage to work"
+    )
+
+
+def test_runner_net_s1_iproute2_present_in_full_dockerfile():
+    """S1: runner/Dockerfile MUST include 'iproute2' package (provides ip + ss on PATH)."""
+    content = _read(FULL_DOCKERFILE)
+    assert "iproute2" in content, (
+        "runner/Dockerfile must install 'iproute2' to make the 'ip' command "
+        "available on PATH inside the Flutter runner Pod (spec RUNNER-NET-S1). "
+        "Add 'iproute2' to the apt-get install list in section §1 of runner/Dockerfile.\n"
+        "Current apt-get install lines:\n"
+        + "\n".join(ln for ln in content.splitlines() if "apt-get install" in ln or "iproute2" in ln)
+    )
+
+
+def test_runner_net_s1_iproute2_in_section1_full_dockerfile():
+    """S1: iproute2 MUST be in the first (§1 base-tools) apt-get install — same layer as ca-certificates."""
+    content = _read(FULL_DOCKERFILE)
+    block = _first_apt_install_block(content)
+    assert block, (
+        "runner/Dockerfile: could not extract the first apt-get install block — "
+        "Dockerfile structure may have changed"
+    )
+    assert "iproute2" in block, (
+        "runner/Dockerfile: 'iproute2' must be in the SAME §1 apt-get install invocation "
+        "as base tools like 'ca-certificates'/'gnupg'/'curl', so it shares the layer "
+        "cache scope and image-tag cadence (spec RUNNER-NET-S1). "
+        "Was it accidentally placed in a later RUN block instead?\n"
+        "First apt-get install block found:\n" + block[:400]
+    )
+
+
+# ── RUNNER-NET-S2: ss command on Go runner ───────────────────────────────────
+
+
+def test_runner_net_s2_go_dockerfile_exists():
+    """S2: runner/go.Dockerfile must exist at the canonical path."""
+    assert GO_DOCKERFILE.exists(), (
+        f"runner/go.Dockerfile not found at {GO_DOCKERFILE}; "
+        "the Go-only runner image must also be present"
+    )
+
+
+def test_runner_net_s2_iproute2_present_in_go_dockerfile():
+    """S2: runner/go.Dockerfile MUST include 'iproute2' package (provides ss + ip on PATH)."""
+    content = _read(GO_DOCKERFILE)
+    assert "iproute2" in content, (
+        "runner/go.Dockerfile must install 'iproute2' to make the 'ss' command "
+        "available on PATH inside the Go runner Pod (spec RUNNER-NET-S2). "
+        "Add 'iproute2' to the apt-get install list in section §1 of runner/go.Dockerfile.\n"
+        "Current apt-get install lines:\n"
+        + "\n".join(ln for ln in content.splitlines() if "apt-get install" in ln or "iproute2" in ln)
+    )
+
+
+def test_runner_net_s2_iproute2_in_section1_go_dockerfile():
+    """S2: iproute2 MUST be in the first (§1 base-tools) apt-get install of go.Dockerfile."""
+    content = _read(GO_DOCKERFILE)
+    block = _first_apt_install_block(content)
+    assert block, (
+        "runner/go.Dockerfile: could not extract the first apt-get install block — "
+        "Dockerfile structure may have changed"
+    )
+    assert "iproute2" in block, (
+        "runner/go.Dockerfile: 'iproute2' must be in the SAME §1 apt-get install invocation "
+        "as base tools like 'ca-certificates'/'gnupg'/'curl' (spec RUNNER-NET-S2). "
+        "First apt-get install block found:\n" + block[:400]
+    )
+
+
+# ── RUNNER-NET-S3: netstat command on both runners ───────────────────────────
+
+
+def test_runner_net_s3_net_tools_present_in_full_dockerfile():
+    """S3: runner/Dockerfile MUST include 'net-tools' package (provides netstat on PATH)."""
+    content = _read(FULL_DOCKERFILE)
+    assert "net-tools" in content, (
+        "runner/Dockerfile must install 'net-tools' to make 'netstat' available "
+        "on PATH inside the Flutter runner Pod (spec RUNNER-NET-S3). "
+        "Add 'net-tools' to the apt-get install list in section §1 of runner/Dockerfile."
+    )
+
+
+def test_runner_net_s3_net_tools_in_section1_full_dockerfile():
+    """S3: net-tools MUST be in the first (§1 base-tools) apt-get install of Dockerfile."""
+    content = _read(FULL_DOCKERFILE)
+    block = _first_apt_install_block(content)
+    assert block, "runner/Dockerfile: could not extract the first apt-get install block"
+    assert "net-tools" in block, (
+        "runner/Dockerfile: 'net-tools' must be in the §1 base-tools apt-get install "
+        "so it shares the layer cache scope (spec RUNNER-NET-S3). "
+        "First apt-get install block:\n" + block[:400]
+    )
+
+
+def test_runner_net_s3_net_tools_present_in_go_dockerfile():
+    """S3: runner/go.Dockerfile MUST include 'net-tools' package (provides netstat on PATH)."""
+    content = _read(GO_DOCKERFILE)
+    assert "net-tools" in content, (
+        "runner/go.Dockerfile must install 'net-tools' to make 'netstat' available "
+        "on PATH inside the Go runner Pod (spec RUNNER-NET-S3). "
+        "Add 'net-tools' to the apt-get install list in section §1 of runner/go.Dockerfile."
+    )
+
+
+def test_runner_net_s3_net_tools_in_section1_go_dockerfile():
+    """S3: net-tools MUST be in the first (§1 base-tools) apt-get install of go.Dockerfile."""
+    content = _read(GO_DOCKERFILE)
+    block = _first_apt_install_block(content)
+    assert block, "runner/go.Dockerfile: could not extract the first apt-get install block"
+    assert "net-tools" in block, (
+        "runner/go.Dockerfile: 'net-tools' must be in the §1 base-tools apt-get install "
+        "(spec RUNNER-NET-S3). "
+        "First apt-get install block:\n" + block[:400]
+    )
+
+
+# ── RUNNER-NET-S4: ifconfig command on both runners ──────────────────────────
+# ifconfig is also provided by net-tools; these tests confirm the same net-tools
+# package declaration satisfies the ifconfig PATH requirement.
+
+
+def test_runner_net_s4_ifconfig_provided_by_net_tools_full_dockerfile():
+    """S4: runner/Dockerfile must declare net-tools; ifconfig is part of that package."""
+    content = _read(FULL_DOCKERFILE)
+    assert "net-tools" in content, (
+        "runner/Dockerfile must install 'net-tools' to make 'ifconfig' available "
+        "on PATH inside the Flutter runner Pod (spec RUNNER-NET-S4). "
+        "'ifconfig' is shipped as part of the net-tools Debian package."
+    )
+
+
+def test_runner_net_s4_ifconfig_provided_by_net_tools_go_dockerfile():
+    """S4: runner/go.Dockerfile must declare net-tools; ifconfig is part of that package."""
+    content = _read(GO_DOCKERFILE)
+    assert "net-tools" in content, (
+        "runner/go.Dockerfile must install 'net-tools' to make 'ifconfig' available "
+        "on PATH inside the Go runner Pod (spec RUNNER-NET-S4). "
+        "'ifconfig' is shipped as part of the net-tools Debian package."
+    )
+
+
+# ── cross-cut: both packages co-installed in same §1 block ───────────────────
+
+
+def test_runner_net_both_packages_colocated_in_section1_full_dockerfile():
+    """S1-S4: iproute2 AND net-tools MUST appear together in §1 of runner/Dockerfile."""
+    content = _read(FULL_DOCKERFILE)
+    block = _first_apt_install_block(content)
+    assert block, "runner/Dockerfile: could not extract the first apt-get install block"
+    missing = [pkg for pkg in ("iproute2", "net-tools") if pkg not in block]
+    assert not missing, (
+        "runner/Dockerfile §1 apt-get install is missing: "
+        + ", ".join(f"'{p}'" for p in missing)
+        + ". Both packages must be co-installed in the same §1 invocation "
+        "to share that layer's cache scope and image-tagging cadence "
+        "(spec RUNNER-NET-S1..S4).\n"
+        "First apt-get install block:\n" + block[:400]
+    )
+
+
+def test_runner_net_both_packages_colocated_in_section1_go_dockerfile():
+    """S1-S4: iproute2 AND net-tools MUST appear together in §1 of runner/go.Dockerfile."""
+    content = _read(GO_DOCKERFILE)
+    block = _first_apt_install_block(content)
+    assert block, "runner/go.Dockerfile: could not extract the first apt-get install block"
+    missing = [pkg for pkg in ("iproute2", "net-tools") if pkg not in block]
+    assert not missing, (
+        "runner/go.Dockerfile §1 apt-get install is missing: "
+        + ", ".join(f"'{p}'" for p in missing)
+        + ". Both packages must be co-installed in the same §1 invocation "
+        "(spec RUNNER-NET-S1..S4).\n"
+        "First apt-get install block:\n" + block[:400]
+    )

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -25,6 +25,7 @@ LABEL org.opencontainers.image.licenses=MIT
 RUN install -m 0755 -d /etc/apt/keyrings \
     && apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates gnupg curl iptables \
+        iproute2 net-tools \
         git gh jq make bash sudo nodejs npm ssh-client \
         qemu-kvm cpu-checker \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg \

--- a/runner/go.Dockerfile
+++ b/runner/go.Dockerfile
@@ -16,6 +16,7 @@ LABEL org.opencontainers.image.licenses=MIT
 RUN install -m 0755 -d /etc/apt/keyrings \
     && apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates gnupg curl iptables \
+        iproute2 net-tools \
         git jq make bash sudo nodejs npm ssh-client \
     && curl -fsSL https://download.docker.com/linux/debian/gpg \
         -o /etc/apt/keyrings/docker.asc \


### PR DESCRIPTION
## Summary

- Adds `iproute2` (`ip`, `ss`) and `net-tools` (`netstat`, `ifconfig`) to both
  runner image flavors (`runner/Dockerfile` Flutter, `runner/go.Dockerfile` Go).
- Packages land in the existing §1 apt-get layer — shared cache scope, no
  extra layer.
- Image-size impact <3 MB per flavor; no orchestrator / helm / Pod-spec
  changes.

## Why

`accept-env-up` and on-Pod debuggers routinely need `ip addr` / `ip route` /
`ss -ltn` / `netstat -ltn` / `ifconfig` to inspect what `docker compose up`
wired and probe sibling services. Today both runners fall through to
`bash: ip: command not found`, so authors either install on the fly (slow,
non-deterministic, lost on Pod restart) or shell out to `docker exec`. Both
packages are tiny and stable Debian/Ubuntu apt names.

## Test plan

- [ ] `runner-image` workflow builds both flavors green for this PR
- [ ] After merge + image roll, `kubectl exec runner-<req> -- command -v ip ss netstat ifconfig` resolves all four binaries on the per-REQ Pod

## Spec

`openspec/changes/REQ-runner-net-tools-1777202552/` adds capability
`runner-net-tools` (1 requirement, 4 scenarios `RUNNER-NET-S{1..4}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)