### PR TITLE
feat(orch): in-flight REQ cap + disk pressure precheck (REQ-orch-rate-limit-1777202974)

### DIFF
--- a/openspec/changes/REQ-orch-rate-limit-1777202974/proposal.md
+++ b/openspec/changes/REQ-orch-rate-limit-1777202974/proposal.md
@@ -1,0 +1,92 @@
+# feat(orch): in-flight REQ cap + disk pressure precheck
+
+## Why
+
+Sisyphus today admits every `intent:intake` / `intent:analyze` webhook into a
+running REQ unconditionally. Two failure modes follow on the single-node K3s
+deployment (vm-node04, ~6 GiB RAM, ~50 GB ephemeral):
+
+1. **Concurrent runner storm.** A burst of new REQs (e.g. an analyze-agent
+   creating multiple sub-issues, or a user pasting a batch of intents) creates
+   a per-REQ runner Pod for each. Each Pod requests `512Mi` and limits to
+   `8Gi`; the K8s scheduler eventually `FailedScheduling: Insufficient memory`
+   and the pile-up wedges existing in-flight REQs.
+2. **PVC creation on a full disk.** `runner_gc.gc_once` already does an
+   *emergency* purge when the node crosses
+   `runner_gc_disk_pressure_threshold` (default `0.8`), but it runs on a
+   15-minute interval (`runner_gc_interval_sec`). Between ticks, sisyphus
+   happily creates more `workspace-<req-id>` PVCs and the node tips into
+   `DiskPressure` eviction, killing healthy runners.
+
+Both problems share the same root: there is no admission gate. The
+orchestrator never asks "should I take this work right now?" — it just
+ensures the runner Pod and dispatches the BKD agent.
+
+## What Changes
+
+Add a single admission gate that runs at the **fresh-entry actions only**
+(`start_intake`, `start_analyze`). When a check fails, the action emits
+`VERIFY_ESCALATE` with a specific `escalated_reason`, and the existing
+state-machine path puts the REQ into `ESCALATED` so a human can re-trigger
+once capacity frees up. We do not retry automatically — that matches the
+project philosophy ("sisyphus 不机制性兜 retry"), keeps the gate simple,
+and makes the rejection visible on the BKD board.
+
+- **New module** `orchestrator/src/orchestrator/admission.py` exposing one
+  async function `check_admission(pool, *, req_id) -> AdmissionDecision`.
+  - Counts non-terminal REQs in `req_state` (`state NOT IN
+    ('init','done','escalated','gh-incident-open') AND req_id <> $1`) and
+    rejects when `count >= settings.inflight_req_cap`.
+  - Asks `RunnerController.node_disk_usage_ratio()` and rejects when
+    `ratio >= settings.admission_disk_pressure_threshold`. Reuses the
+    existing `runner_gc._DISK_CHECK_DISABLED` short-circuit so RBAC-denied
+    clusters are not re-probed forever; any other exception is treated as
+    fail-open (admit + log).
+  - Both checks are independent: a failure short-circuits, but an
+    individually-disabled check (`cap == 0` or disk-check off) does not
+    block admission.
+
+- **`orchestrator/src/orchestrator/config.py`** adds two settings:
+  - `inflight_req_cap: int = 10` — `0` disables the cap entirely.
+  - `admission_disk_pressure_threshold: float = 0.75` — set lower than the
+    GC's `0.8` so admission trips first and we stop accepting new work
+    before the GC starts evicting PVCs.
+
+- **`orchestrator/src/orchestrator/actions/start_intake.py`** and
+  **`start_analyze.py`** — at the very top, before `ensure_runner` /
+  `ensure_runner` + clone, call `check_admission`. On rejection set
+  `ctx.escalated_reason` (`rate-limit:inflight-cap-exceeded` or
+  `rate-limit:disk-pressure`) and return `{"emit": "verify.escalate",
+  "reason": "..."}`. `start_analyze_with_finalized_intent` is **not**
+  gated — it is a continuation of an already-admitted intake REQ; gating
+  it would punish a REQ for capacity arriving between intake and analyze.
+
+- **Tests**:
+  - new `orchestrator/tests/test_admission.py` covering the decision
+    function (cap on/off, count just below / at / above cap, disk under /
+    over threshold, disk RBAC-denied, no-controller in dev).
+  - `orchestrator/tests/test_actions_start_analyze.py` gains a denial test
+    that locks in the escalate emit for `start_analyze`.
+  - `orchestrator/tests/test_intake.py` gains the same for `start_intake`.
+
+## Impact
+
+- **Affected specs**: new capability `orch-rate-limit` (purely additive).
+- **Affected code**: `orchestrator/src/orchestrator/admission.py` (new),
+  `config.py`, `actions/start_intake.py`, `actions/start_analyze.py`, the
+  three test modules above.
+- **Deployment / migration**: zero ops — orchestrator rollout-restart picks
+  up the new module. Defaults (`cap=10`, `disk=0.75`) are chosen so an
+  existing healthy cluster sees no behavior change. Operators who want a
+  different policy override via env (`SISYPHUS_INFLIGHT_REQ_CAP`,
+  `SISYPHUS_ADMISSION_DISK_PRESSURE_THRESHOLD`) or helm values.
+- **Risk**: low. Both checks fail-open on infrastructure errors (DB query
+  fails → admit; disk probe raises non-403 → admit). The strictest path
+  (DB succeeds + disk probe succeeds + above threshold) escalates the new
+  REQ with a clear reason tag, which is how we already handle "this REQ
+  can't proceed right now".
+- **Out of scope**: queueing rejected REQs for later auto-retry,
+  per-project quotas, weighted admission (e.g. cap excludes
+  `REVIEW_RUNNING`). All deferred — the simple "escalate + human
+  re-trigger" loop is the project's standing answer to capacity-class
+  problems.

--- a/openspec/changes/REQ-orch-rate-limit-1777202974/specs/orch-rate-limit/spec.md
+++ b/openspec/changes/REQ-orch-rate-limit-1777202974/specs/orch-rate-limit/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: orchestrator gates fresh REQ entry on in-flight count and node disk pressure
+
+The sisyphus orchestrator SHALL run an admission check at the start of the
+two fresh-entry actions — `start_intake` and `start_analyze` — and MUST
+reject the REQ before any runner Pod / PVC creation when either
+condition holds:
+
+1. The number of REQs whose state is not in
+   `{init, done, escalated, gh-incident-open}` (excluding the calling
+   REQ itself) is greater than or equal to
+   `settings.inflight_req_cap`. A cap value of `0` SHALL disable this
+   check unconditionally.
+2. The K8s node's disk usage ratio reported by
+   `RunnerController.node_disk_usage_ratio()` is greater than or equal
+   to `settings.admission_disk_pressure_threshold`.
+
+Rejection MUST be expressed by returning
+`{"emit": "verify.escalate", "reason": <human-readable string>}` from
+the action handler, after writing
+`ctx.escalated_reason = "rate-limit:inflight-cap-exceeded"` or
+`"rate-limit:disk-pressure"` so the existing escalate pathway tags the
+REQ with the correct reason. The continuation action
+`start_analyze_with_finalized_intent` MUST NOT run the gate — that REQ
+already passed admission at intake time.
+
+The disk-pressure check SHALL fail open (admit + log warning) when:
+- the runner controller is not initialised (development without K8s),
+- the existing `runner_gc._DISK_CHECK_DISABLED` short-circuit flag is
+  set (cluster-scoped `nodes:list` denied by RBAC), or
+- the underlying `node_disk_usage_ratio()` raises any exception other
+  than what the GC loop already handles.
+
+#### Scenario: ORCH-RATE-S1 cap=0 disables the in-flight gate
+
+- **GIVEN** `settings.inflight_req_cap = 0` and 50 active REQs in
+  `req_state`
+- **WHEN** `check_admission(pool, req_id="REQ-new")` runs
+- **THEN** the result's `admit` is `True` regardless of the count
+
+#### Scenario: ORCH-RATE-S2 in-flight count under cap admits
+
+- **GIVEN** `settings.inflight_req_cap = 10` and the SQL count of
+  non-terminal REQs other than `REQ-new` is `9`
+- **WHEN** `check_admission(pool, req_id="REQ-new")` runs
+- **THEN** the result's `admit` is `True` and `reason` is `None`
+
+#### Scenario: ORCH-RATE-S3 in-flight count at cap rejects
+
+- **GIVEN** `settings.inflight_req_cap = 10` and the SQL count of
+  non-terminal REQs other than `REQ-new` is `10`
+- **WHEN** `check_admission(pool, req_id="REQ-new")` runs
+- **THEN** the result's `admit` is `False` and `reason` MUST contain
+  the substring `inflight-cap-exceeded`
+
+#### Scenario: ORCH-RATE-S4 disk usage under threshold admits
+
+- **GIVEN** `settings.admission_disk_pressure_threshold = 0.75` and
+  `node_disk_usage_ratio()` returns `0.50`
+- **WHEN** `check_admission(pool, req_id="REQ-new")` runs with the
+  in-flight count well below the cap
+- **THEN** the result's `admit` is `True`
+
+#### Scenario: ORCH-RATE-S5 disk usage above threshold rejects
+
+- **GIVEN** `settings.admission_disk_pressure_threshold = 0.75` and
+  `node_disk_usage_ratio()` returns `0.80`
+- **WHEN** `check_admission(pool, req_id="REQ-new")` runs with the
+  in-flight count well below the cap
+- **THEN** the result's `admit` is `False` and `reason` MUST contain
+  the substring `disk-pressure`
+
+#### Scenario: ORCH-RATE-S6 missing runner controller fails open
+
+- **GIVEN** `k8s_runner.get_controller()` raises `RuntimeError`
+  (development environment without K8s)
+- **WHEN** `check_admission(pool, req_id="REQ-new")` runs
+- **THEN** the result's `admit` is `True` (fail open) and disk check
+  is skipped without raising

--- a/openspec/changes/REQ-orch-rate-limit-1777202974/tasks.md
+++ b/openspec/changes/REQ-orch-rate-limit-1777202974/tasks.md
@@ -1,0 +1,31 @@
+# tasks: REQ-orch-rate-limit-1777202974
+
+## Stage: contract / spec
+
+- [x] author `specs/orch-rate-limit/spec.md` with delta `## ADDED Requirements`
+- [x] write 6 scenarios `ORCH-RATE-S{1..6}` covering cap-disabled,
+      under-cap admit, at-cap reject, disk under threshold admit, disk
+      over threshold reject, controller-missing dev fallback
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/admission.py`: new module with
+      `AdmissionDecision` dataclass and `check_admission(pool, *, req_id)`
+- [x] `orchestrator/src/orchestrator/config.py`: add
+      `inflight_req_cap` (default 10) and
+      `admission_disk_pressure_threshold` (default 0.75)
+- [x] `orchestrator/src/orchestrator/actions/start_intake.py`: call
+      `check_admission` first; on reject patch `ctx.escalated_reason` +
+      emit `VERIFY_ESCALATE`
+- [x] `orchestrator/src/orchestrator/actions/start_analyze.py`: same
+- [x] `orchestrator/tests/test_admission.py`: unit tests for
+      `check_admission` covering all 6 scenarios
+- [x] `orchestrator/tests/test_intake.py`: integration test that
+      `start_intake` escalates when admission denies
+- [x] `orchestrator/tests/test_actions_start_analyze.py`: same for
+      `start_analyze`
+
+## Stage: PR
+
+- [x] git push `feat/REQ-orch-rate-limit-1777202974`
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/actions/start_analyze.py
+++ b/orchestrator/src/orchestrator/actions/start_analyze.py
@@ -25,10 +25,12 @@ from __future__ import annotations
 import structlog
 
 from .. import k8s_runner
+from ..admission import check_admission
 from ..bkd import BKDClient
 from ..config import settings
 from ..prompts import render
 from ..state import Event
+from ..store import db, req_state
 from . import register, short_title
 from ._clone import clone_involved_repos_into_runner
 from ._skip import skip_if_enabled
@@ -42,6 +44,18 @@ async def start_analyze(*, body, req_id, tags, ctx):
         return rv
     proj = body.projectId
     issue_id = body.issueId
+
+    # 0. Admission gate（in-flight cap + disk pressure）。拒了直接 escalate，
+    # 不浪费 PVC / Pod 的资源。fail-open by design：DB / disk 探测异常仍 admit。
+    decision = await check_admission(db.get_pool(), req_id=req_id)
+    if not decision.admit:
+        await req_state.update_context(db.get_pool(), req_id, {
+            "escalated_reason": f"rate-limit:{decision.reason}",
+        })
+        return {
+            "emit": Event.VERIFY_ESCALATE.value,
+            "reason": f"admission denied: {decision.reason}",
+        }
 
     # 1. 拉 K8s Pod + PVC（幂等；已存在就跳）
     try:

--- a/orchestrator/src/orchestrator/actions/start_intake.py
+++ b/orchestrator/src/orchestrator/actions/start_intake.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 import structlog
 
 from .. import k8s_runner
+from ..admission import check_admission
 from ..bkd import BKDClient
 from ..config import settings
 from ..prompts import render
+from ..state import Event
+from ..store import db, req_state
 from . import register, short_title
 
 log = structlog.get_logger(__name__)
@@ -23,6 +26,18 @@ log = structlog.get_logger(__name__)
 async def start_intake(*, body, req_id, tags, ctx):
     proj = body.projectId
     issue_id = body.issueId
+
+    # 0. Admission gate（in-flight cap + disk pressure）。拒了直接 escalate，
+    # 不浪费 PVC / Pod 的资源。fail-open by design：DB / disk 探测异常仍 admit。
+    decision = await check_admission(db.get_pool(), req_id=req_id)
+    if not decision.admit:
+        await req_state.update_context(db.get_pool(), req_id, {
+            "escalated_reason": f"rate-limit:{decision.reason}",
+        })
+        return {
+            "emit": Event.VERIFY_ESCALATE.value,
+            "reason": f"admission denied: {decision.reason}",
+        }
 
     # 1. 拉 K8s Pod + PVC（幂等；已存在就跳）
     try:

--- a/orchestrator/src/orchestrator/admission.py
+++ b/orchestrator/src/orchestrator/admission.py
@@ -1,0 +1,124 @@
+"""Admission gate for fresh REQ entry.
+
+Two checks at the door of `start_intake` / `start_analyze` (the two actions
+that turn an incoming `intent:*` webhook into a runner Pod + PVC):
+
+1. **In-flight cap** — refuse new work when the count of non-terminal REQs
+   would push past `settings.inflight_req_cap`. Without this, a webhook
+   burst can pile up enough runner Pods to wedge the K8s scheduler.
+2. **Disk pressure** — refuse new work when
+   `RunnerController.node_disk_usage_ratio()` is at or above
+   `settings.admission_disk_pressure_threshold`. `runner_gc` already
+   does an *emergency* purge above 0.8, but it polls on a 15-min loop;
+   without this gate, sisyphus keeps creating PVCs in the gap.
+
+Rejection is expressed as `AdmissionDecision(admit=False, reason=...)`. The
+caller writes `ctx.escalated_reason` and returns `{"emit": "verify.escalate"}`,
+so the existing state-machine path puts the REQ in ESCALATED for human
+re-trigger. We deliberately do not auto-retry — that matches the project
+philosophy ("sisyphus 不机制性兜 retry") and keeps the gate simple.
+
+Both checks fail open: a DB error or a transient disk probe failure admits
+the REQ rather than blocking healthy entries on infra noise.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import asyncpg
+import structlog
+from kubernetes.client import ApiException
+
+from . import k8s_runner, runner_gc
+from .config import settings
+
+log = structlog.get_logger(__name__)
+
+
+# Non-terminal states for the in-flight cap. Excluding `init` keeps brand-new
+# rows that haven't dispatched yet from being counted as work-in-progress;
+# excluding `gh-incident-open` keeps escalated-but-waiting-for-human REQs out
+# of the cap (they consume no runner Pod). Done / escalated are terminal.
+_INFLIGHT_EXCLUDE_STATES: tuple[str, ...] = (
+    "init", "done", "escalated", "gh-incident-open",
+)
+
+
+@dataclass(frozen=True)
+class AdmissionDecision:
+    """Result of `check_admission`.
+
+    `admit=True` → caller proceeds with `ensure_runner` + agent dispatch.
+    `admit=False` → caller writes `ctx.escalated_reason = reason` and emits
+    `VERIFY_ESCALATE`.
+    """
+    admit: bool
+    reason: str | None = None
+
+
+async def check_admission(
+    pool: asyncpg.Pool, *, req_id: str,
+) -> AdmissionDecision:
+    """Run both gates; first failure short-circuits."""
+    cap_decision = await _check_inflight_cap(pool, req_id=req_id)
+    if not cap_decision.admit:
+        return cap_decision
+    return await _check_disk_pressure()
+
+
+async def _check_inflight_cap(
+    pool: asyncpg.Pool, *, req_id: str,
+) -> AdmissionDecision:
+    cap = settings.inflight_req_cap
+    if cap <= 0:
+        return AdmissionDecision(admit=True)
+    try:
+        row = await pool.fetchrow(
+            "SELECT COUNT(*)::BIGINT AS n FROM req_state "
+            "WHERE state <> ALL($1::text[]) AND req_id <> $2",
+            list(_INFLIGHT_EXCLUDE_STATES), req_id,
+        )
+    except Exception as e:
+        log.warning("admission.cap_query_failed", req_id=req_id, error=str(e))
+        return AdmissionDecision(admit=True)
+    count = int(row["n"]) if row else 0
+    if count >= cap:
+        reason = f"inflight-cap-exceeded:{count}/{cap}"
+        log.warning("admission.cap_rejected", req_id=req_id,
+                    inflight=count, cap=cap)
+        return AdmissionDecision(admit=False, reason=reason)
+    return AdmissionDecision(admit=True)
+
+
+async def _check_disk_pressure() -> AdmissionDecision:
+    threshold = settings.admission_disk_pressure_threshold
+    # Reuse the GC's RBAC short-circuit so admission stops probing once the
+    # cluster has told us nodes:list is denied.
+    if runner_gc._DISK_CHECK_DISABLED:
+        return AdmissionDecision(admit=True)
+    try:
+        rc = k8s_runner.get_controller()
+    except RuntimeError:
+        # No controller (dev / unit test). Fail open.
+        return AdmissionDecision(admit=True)
+    try:
+        ratio = await rc.node_disk_usage_ratio()
+    except ApiException as e:
+        if e.status == 403:
+            runner_gc._DISK_CHECK_DISABLED = True
+            log.info("admission.disk_check_rbac_denied",
+                     hint="ServiceAccount lacks cluster-scoped nodes:list; "
+                          "admission disk gate disabled until restart")
+        else:
+            log.debug("admission.disk_check_failed",
+                      error=str(e), status=e.status)
+        return AdmissionDecision(admit=True)
+    except Exception as e:
+        log.debug("admission.disk_check_failed", error=str(e))
+        return AdmissionDecision(admit=True)
+    if ratio >= threshold:
+        reason = f"disk-pressure:{ratio:.2f}/{threshold:.2f}"
+        log.warning("admission.disk_rejected",
+                    ratio=round(ratio, 2), threshold=threshold)
+        return AdmissionDecision(admit=False, reason=reason)
+    return AdmissionDecision(admit=True)

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -53,6 +53,16 @@ class Settings(BaseSettings):
     # 磁盘压力阈值：超过此比例 GC 强清所有非 active PVC（不论 retention）
     runner_gc_disk_pressure_threshold: float = 0.8
 
+    # ─── Admission gate（fresh REQ entry rate-limit）────────────────────────
+    # 同时跑的 REQ 上限：start_intake / start_analyze 进门时数 req_state 里非
+    # 终态行（exclude init/done/escalated/gh-incident-open + 自身），>= cap 直接
+    # escalate。0 = 关闭。默认 10：vm-node04 6 GiB RAM、runner request 512Mi，
+    # 10 个并发是调度器开始挤兑前的舒适上限。
+    inflight_req_cap: int = 10
+    # admission 阶段独立的磁盘阈值，比 runner_gc_disk_pressure_threshold(0.8) 更严：
+    # 让"不收新活"先于"紧急清 PVC"触发，避免 GC tick 间隔（15 min）里继续建 PVC。
+    admission_disk_pressure_threshold: float = 0.75
+
     # GitHub token（烘进 runner Pod env，给 agent 用 gh CLI / docker login ghcr.io）
     # scope: repo + read:packages
     # 注意：当 gh_incident_repo 非空时，本 PAT 必须额外有 Issues: Read-and-write

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -70,6 +70,7 @@ async def test_start_analyze(monkeypatch):
     from orchestrator.actions import start_analyze as mod
     fake = make_fake_bkd()
     patch_bkd(monkeypatch, "start_analyze", fake)
+    patch_db(monkeypatch, "start_analyze")  # admission gate reads pool
     body = make_body(issue_id="intent-1", title="加个登录")
     out = await mod.start_analyze(body=body, req_id="REQ-9", tags=["intent:analyze"], ctx={})
     # cloned_repos=None: 直接 analyze 路径无 involved_repos，跳过 server-side clone
@@ -86,6 +87,7 @@ async def test_start_analyze_title_format(monkeypatch):
     from orchestrator.actions import start_analyze as mod
     fake = make_fake_bkd()
     patch_bkd(monkeypatch, "start_analyze", fake)
+    patch_db(monkeypatch, "start_analyze")  # admission gate reads pool
 
     # 场景1：有 intent_title，长度正常
     body = make_body(issue_id="intent-1", title="加个登录端点")

--- a/orchestrator/tests/test_actions_start_analyze.py
+++ b/orchestrator/tests/test_actions_start_analyze.py
@@ -14,7 +14,18 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from orchestrator.actions import _clone, start_analyze, start_analyze_with_finalized_intent
+from orchestrator.admission import AdmissionDecision
 from orchestrator.state import Event
+
+
+@pytest.fixture(autouse=True)
+def _admit_by_default(monkeypatch):
+    """Admission gate 默认 admit=True 通过；个别 case 要 deny 自己再 patch。"""
+    monkeypatch.setattr(
+        start_analyze, "check_admission",
+        AsyncMock(return_value=AdmissionDecision(admit=True)),
+    )
+    monkeypatch.setattr(start_analyze.db, "get_pool", lambda: object())
 
 
 @dataclass
@@ -472,3 +483,65 @@ async def test_start_analyze_skip_remains_when_all_layers_empty(monkeypatch):
     exec_fn.assert_not_awaited()
     follow_up.assert_awaited_once()
     assert rv["cloned_repos"] is None
+
+
+# ── REQ-orch-rate-limit-1777202974: admission gate ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_analyze_admission_denied_emits_escalate(monkeypatch):
+    """admission deny → emit VERIFY_ESCALATE，不调 ensure_runner / clone / BKD。"""
+    monkeypatch.setattr(
+        start_analyze, "check_admission",
+        AsyncMock(return_value=AdmissionDecision(
+            admit=False, reason="inflight-cap-exceeded:10/10",
+        )),
+    )
+    update_ctx = AsyncMock()
+    monkeypatch.setattr(start_analyze.req_state, "update_context", update_ctx)
+
+    exec_fn = AsyncMock(return_value=FakeExec(exit_code=0))
+    fake_rc = _patch_runner(monkeypatch, exec_fn=exec_fn)
+    follow_up, _, _ = _patch_bkd_client(monkeypatch, target_module=start_analyze)
+
+    rv = await start_analyze.start_analyze(
+        body=_make_body(), req_id="REQ-X",
+        tags=["intent:analyze"], ctx={},
+    )
+
+    assert rv["emit"] == Event.VERIFY_ESCALATE.value
+    assert "admission denied" in rv["reason"]
+    assert "inflight-cap-exceeded" in rv["reason"]
+    # ctx.escalated_reason 必须落 ctx
+    update_ctx.assert_awaited_once()
+    patch = update_ctx.await_args.args[2]
+    assert patch["escalated_reason"] == "rate-limit:inflight-cap-exceeded:10/10"
+    # 不能花 runner / clone / agent 的成本
+    fake_rc.ensure_runner.assert_not_awaited()
+    exec_fn.assert_not_awaited()
+    follow_up.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_analyze_admission_disk_pressure_escalates(monkeypatch):
+    """disk-pressure 拒绝同样 escalate；reason 标 disk-pressure。"""
+    monkeypatch.setattr(
+        start_analyze, "check_admission",
+        AsyncMock(return_value=AdmissionDecision(
+            admit=False, reason="disk-pressure:0.85/0.75",
+        )),
+    )
+    update_ctx = AsyncMock()
+    monkeypatch.setattr(start_analyze.req_state, "update_context", update_ctx)
+    exec_fn = AsyncMock()
+    _patch_runner(monkeypatch, exec_fn=exec_fn)
+    _patch_bkd_client(monkeypatch, target_module=start_analyze)
+
+    rv = await start_analyze.start_analyze(
+        body=_make_body(), req_id="REQ-X", tags=[], ctx={},
+    )
+
+    assert rv["emit"] == Event.VERIFY_ESCALATE.value
+    assert "disk-pressure" in rv["reason"]
+    patch = update_ctx.await_args.args[2]
+    assert "disk-pressure" in patch["escalated_reason"]

--- a/orchestrator/tests/test_admission.py
+++ b/orchestrator/tests/test_admission.py
@@ -1,0 +1,250 @@
+"""admission.check_admission 单测：mock pool + k8s_runner controller。
+
+覆盖 6 个 scenario（ORCH-RATE-S1..S6）+ fail-open 路径。
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from kubernetes.client import ApiException
+
+from orchestrator import admission, k8s_runner, runner_gc
+
+
+class _FakePool:
+    def __init__(self, count: int = 0, raise_exc: Exception | None = None):
+        self._count = count
+        self._raise = raise_exc
+        self.last_args: tuple | None = None
+
+    async def fetchrow(self, sql, *args):
+        self.last_args = args
+        if self._raise is not None:
+            raise self._raise
+        return {"n": self._count}
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    """每 case 还原 _DISK_CHECK_DISABLED + 卸掉 controller。"""
+    runner_gc._DISK_CHECK_DISABLED = False
+    k8s_runner.set_controller(None)
+    yield
+    runner_gc._DISK_CHECK_DISABLED = False
+    k8s_runner.set_controller(None)
+
+
+def _install_controller(*, ratio: float | None = None,
+                        raise_exc: Exception | None = None) -> MagicMock:
+    fake = MagicMock()
+    if raise_exc is not None:
+        fake.node_disk_usage_ratio = AsyncMock(side_effect=raise_exc)
+    else:
+        fake.node_disk_usage_ratio = AsyncMock(return_value=ratio if ratio is not None else 0.0)
+    k8s_runner.set_controller(fake)
+    return fake
+
+
+# ─── Scenario S1: cap=0 disables in-flight gate ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inflight_cap_disabled_admits_any_count(monkeypatch):
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 0)
+    pool = _FakePool(count=999)
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+    assert decision.admit is True
+    assert decision.reason is None
+
+
+# ─── Scenario S2: count under cap admits ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inflight_count_under_cap_admits(monkeypatch):
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    monkeypatch.setattr(admission.settings, "admission_disk_pressure_threshold", 0.75)
+    _install_controller(ratio=0.10)
+    pool = _FakePool(count=9)
+
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+
+    assert decision.admit is True
+    assert decision.reason is None
+    # Verify SQL params: state list + req_id excluded
+    assert pool.last_args is not None
+    state_list, excluded_req_id = pool.last_args
+    assert excluded_req_id == "REQ-new"
+    assert "init" in state_list
+    assert "done" in state_list
+    assert "escalated" in state_list
+    assert "gh-incident-open" in state_list
+
+
+# ─── Scenario S3: count at cap rejects ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inflight_count_at_cap_rejects(monkeypatch):
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    pool = _FakePool(count=10)
+
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+
+    assert decision.admit is False
+    assert decision.reason is not None
+    assert "inflight-cap-exceeded" in decision.reason
+    assert "10/10" in decision.reason
+
+
+@pytest.mark.asyncio
+async def test_inflight_count_above_cap_rejects(monkeypatch):
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    pool = _FakePool(count=15)
+
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+
+    assert decision.admit is False
+    assert "inflight-cap-exceeded" in decision.reason
+    assert "15/10" in decision.reason
+
+
+# ─── Scenario S4: disk under threshold admits ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_disk_under_threshold_admits(monkeypatch):
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    monkeypatch.setattr(admission.settings, "admission_disk_pressure_threshold", 0.75)
+    _install_controller(ratio=0.50)
+    pool = _FakePool(count=0)
+
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+    assert decision.admit is True
+
+
+# ─── Scenario S5: disk above threshold rejects ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_disk_above_threshold_rejects(monkeypatch):
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    monkeypatch.setattr(admission.settings, "admission_disk_pressure_threshold", 0.75)
+    _install_controller(ratio=0.80)
+    pool = _FakePool(count=0)
+
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+
+    assert decision.admit is False
+    assert "disk-pressure" in decision.reason
+    assert "0.80" in decision.reason
+    assert "0.75" in decision.reason
+
+
+@pytest.mark.asyncio
+async def test_disk_at_threshold_rejects(monkeypatch):
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    monkeypatch.setattr(admission.settings, "admission_disk_pressure_threshold", 0.75)
+    _install_controller(ratio=0.75)
+    pool = _FakePool(count=0)
+
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+    assert decision.admit is False
+    assert "disk-pressure" in decision.reason
+
+
+# ─── Scenario S6: missing controller fails open ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_controller_fails_open(monkeypatch):
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    # do NOT install controller; get_controller raises RuntimeError
+    pool = _FakePool(count=0)
+
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+    assert decision.admit is True
+
+
+# ─── Fail-open: DB error on cap query ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_db_error_fails_open(monkeypatch):
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    _install_controller(ratio=0.10)
+    pool = _FakePool(count=0, raise_exc=RuntimeError("pg down"))
+
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+    assert decision.admit is True
+
+
+# ─── Fail-open: disk probe RBAC 403 disables flag + admits ───────────────
+
+
+@pytest.mark.asyncio
+async def test_disk_rbac_denied_admits_and_disables_flag(monkeypatch):
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    _install_controller(raise_exc=ApiException(status=403, reason="Forbidden"))
+    pool = _FakePool(count=0)
+
+    assert runner_gc._DISK_CHECK_DISABLED is False
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+
+    assert decision.admit is True
+    assert runner_gc._DISK_CHECK_DISABLED is True
+
+
+# ─── Fail-open: disk probe 500 admits but keeps flag alive ───────────────
+
+
+@pytest.mark.asyncio
+async def test_disk_probe_5xx_admits(monkeypatch):
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    _install_controller(raise_exc=ApiException(status=500, reason="Internal"))
+    pool = _FakePool(count=0)
+
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+    assert decision.admit is True
+    assert runner_gc._DISK_CHECK_DISABLED is False
+
+
+@pytest.mark.asyncio
+async def test_disk_probe_other_exception_admits(monkeypatch):
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    _install_controller(raise_exc=RuntimeError("no node info"))
+    pool = _FakePool(count=0)
+
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+    assert decision.admit is True
+
+
+# ─── Disk check short-circuits when GC flag already set ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_disk_check_skipped_when_gc_flag_disabled(monkeypatch):
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    fake = _install_controller(ratio=0.99)
+    runner_gc._DISK_CHECK_DISABLED = True
+    pool = _FakePool(count=0)
+
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+    assert decision.admit is True
+    fake.node_disk_usage_ratio.assert_not_awaited()
+
+
+# ─── Cap rejection short-circuits disk probe ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cap_rejection_short_circuits_disk_probe(monkeypatch):
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    fake = _install_controller(ratio=0.10)
+    pool = _FakePool(count=10)
+
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+    assert decision.admit is False
+    assert "inflight-cap-exceeded" in decision.reason
+    fake.node_disk_usage_ratio.assert_not_awaited()

--- a/orchestrator/tests/test_intake.py
+++ b/orchestrator/tests/test_intake.py
@@ -169,6 +169,9 @@ async def test_start_intake(monkeypatch):
     from orchestrator.actions import start_intake as mod
     fake = make_fake_bkd()
     patch_bkd(monkeypatch, "orchestrator.actions.start_intake.BKDClient", fake)
+    monkeypatch.setattr(mod, "check_admission",
+                        AsyncMock(return_value=_admit()))
+    monkeypatch.setattr(mod.db, "get_pool", lambda: object())
 
     out = await mod.start_intake(body=make_body(issue_id="intent-1"), req_id="REQ-9", tags=[], ctx={})
     assert out == {"issue_id": "intent-1", "req_id": "REQ-9"}
@@ -180,6 +183,42 @@ async def test_start_intake(monkeypatch):
     assert "[INTAKE]" in kwargs["title"]
     assert "intake" in kwargs["tags"]
     assert "REQ-9" in kwargs["tags"]
+
+
+def _admit():
+    from orchestrator.admission import AdmissionDecision
+    return AdmissionDecision(admit=True)
+
+
+def _deny(reason="inflight-cap-exceeded:10/10"):
+    from orchestrator.admission import AdmissionDecision
+    return AdmissionDecision(admit=False, reason=reason)
+
+
+@pytest.mark.asyncio
+async def test_start_intake_admission_denied_emits_escalate(monkeypatch):
+    """admission deny → emit VERIFY_ESCALATE，不 dispatch BKD agent / 不建 runner。"""
+    from orchestrator.actions import start_intake as mod
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, "orchestrator.actions.start_intake.BKDClient", fake)
+    monkeypatch.setattr(mod, "check_admission",
+                        AsyncMock(return_value=_deny()))
+    update_ctx = AsyncMock()
+    monkeypatch.setattr(mod.req_state, "update_context", update_ctx)
+    monkeypatch.setattr(mod.db, "get_pool", lambda: object())
+
+    out = await mod.start_intake(body=make_body(issue_id="intent-1"),
+                                 req_id="REQ-9", tags=[], ctx={})
+
+    assert out["emit"] == Event.VERIFY_ESCALATE.value
+    assert "admission denied" in out["reason"]
+    assert "inflight-cap-exceeded" in out["reason"]
+    # ctx.escalated_reason 必须落 ctx，让 escalate.py 派 reason tag
+    update_ctx.assert_awaited_once()
+    patch = update_ctx.await_args.args[2]
+    assert patch["escalated_reason"].startswith("rate-limit:")
+    # 不能调到 BKD（不浪费 agent token）
+    fake.follow_up_issue.assert_not_awaited()
 
 
 # ─── 5. start_analyze_with_finalized_intent smoke test ───────────────────────


### PR DESCRIPTION
## Summary

- Adds a single admission gate at the two fresh-entry actions (`start_intake`, `start_analyze`) so sisyphus stops accepting new REQs when capacity is gone.
- **In-flight cap**: counts non-terminal REQs in `req_state` (excluding self) and rejects when `count >= settings.inflight_req_cap` (default `10`, `0` disables). Solves the runner-Pod pile-up that wedges the K8s scheduler on bursts.
- **Disk pressure precheck**: asks `RunnerController.node_disk_usage_ratio()` and rejects above `settings.admission_disk_pressure_threshold` (default `0.75`, intentionally lower than `runner_gc_disk_pressure_threshold`'s `0.8` so admission trips before GC's emergency PVC purge). Reuses `runner_gc._DISK_CHECK_DISABLED` so RBAC-denied clusters don't re-probe.
- Both checks **fail open** on infra errors (DB / K8s API non-403 / missing controller). On rejection the action writes `ctx.escalated_reason = "rate-limit:..."` and emits `VERIFY_ESCALATE`; the REQ lands in `ESCALATED` with a reason-tagged BKD card for human re-trigger.
- `start_analyze_with_finalized_intent` is **not** gated — it's a continuation of an already-admitted REQ.

## Files

- `orchestrator/src/orchestrator/admission.py` (new) — `check_admission(pool, *, req_id) -> AdmissionDecision`
- `orchestrator/src/orchestrator/config.py` — `inflight_req_cap`, `admission_disk_pressure_threshold`
- `orchestrator/src/orchestrator/actions/start_intake.py`, `start_analyze.py` — call the gate first thing
- `orchestrator/tests/test_admission.py` (new) — 14 tests covering all 6 spec scenarios + fail-open paths
- `orchestrator/tests/test_intake.py`, `test_actions_start_analyze.py`, `test_actions_smoke.py` — integration coverage
- `openspec/changes/REQ-orch-rate-limit-1777202974/` — proposal / tasks / spec delta

## Test plan

- [x] `uv run pytest -m "not integration"` — 911 passed
- [x] `uv run ruff check` on all touched files — clean
- [x] `openspec validate REQ-orch-rate-limit-1777202974` — passes
- [x] `bash scripts/check-scenario-refs.sh .` — 283 scenarios, all references resolved
- [ ] sisyphus pr-ci-watch on this PR
- [ ] sisyphus accept stage exercises the gate (manual: bump cap to 0, queue 11 REQs, confirm 11th escalates with `reason:rate-limit:inflight-cap-exceeded`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)