### PR TITLE
feat: 1 REQ = 1 PR (incident comment-on-PR) (REQ-one-pr-per-req-1777218057)

### DIFF
--- a/openspec/changes/REQ-one-pr-per-req-1777218057/design.md
+++ b/openspec/changes/REQ-one-pr-per-req-1777218057/design.md
@@ -1,0 +1,93 @@
+# Design: incident comment-on-PR
+
+## Decision: comment first, fall back to fresh issue
+
+For each `(repo, feat/{REQ})` pair the escalate action handles per the existing
+layered involved-repos resolver, the new flow is:
+
+```
+for repo in incident_repos:
+    if repo in ctx.gh_incident_urls: continue          # idempotent
+    pr_number = await gh_incident.find_pr_for_branch(repo, f"feat/{req_id}")
+    if pr_number is not None:
+        url = await gh_incident.comment_on_pr(repo, pr_number, ...)
+        kind = "comment"
+    else:
+        url = await gh_incident.open_incident(repo, ...)  # legacy
+        kind = "issue"
+    if url:
+        new_urls[repo] = url
+        new_kinds[repo] = kind
+```
+
+Why fall back rather than skip when no PR exists: escalations can fire from
+INTAKING / early ANALYZING (intake-fail, analyze action-error before any push)
+where there is no `feat/{REQ}` branch on GitHub yet. In those states the human
+still needs a triage surface; an opened issue is the only one available.
+
+Why not always do both: the PR comment alone covers the "1 REQ = 1 PR"
+invariant; doubling up just re-introduces the noise the change is meant to
+eliminate.
+
+## API: GitHub PR comments
+
+PR comments are issue-level comments (PR is an issue subtype). The endpoint is
+`POST /repos/{owner}/{repo}/issues/{pr_number}/comments` with body
+`{"body": "..."}`. Required PAT scope: `repo` / `issues: write`. The same PAT
+already used by `open_incident` is sufficient — no new permission ask. Response
+`html_url` is the comment permalink; that's what we persist to
+`ctx.gh_incident_urls[repo]`.
+
+## API: PR lookup
+
+`GET /repos/{owner}/{repo}/pulls?head={owner}:{branch}&state=all&per_page=5`.
+We accept any state (open / closed / merged) — escalations can land after a PR
+is merged (e.g., archive crash) and the comment is still useful audit. We take
+the first PR returned (GitHub orders by newest).
+
+If the API errors (network, 5xx, 403 from PAT scope mismatch), we treat the
+result as "PR not found" and fall through to `open_incident` rather than
+failing the escalate path. The escalate action's contract — "GitHub failures
+never block the state transition" — is preserved.
+
+## Idempotency model
+
+Unchanged from existing behavior: per-repo idempotency on `ctx.gh_incident_urls`.
+If the same `(repo, REQ)` pair already has a URL recorded, skip everything
+(both PR lookup and comment) regardless of whether the prior URL was a comment
+or an issue. This means a REQ that escalates → admin-resumes → re-escalates
+posts at most one GitHub artifact per repo for its lifetime, matching today.
+A future REQ can extend to per-(repo, escalation-round) if reviewers want a
+timeline; out of scope here.
+
+## ctx schema additions
+
+| field | shape | notes |
+|---|---|---|
+| `gh_incident_urls` | `dict[str, str]` | unchanged; URL is comment permalink **or** issue url |
+| `gh_incident_kinds` | `dict[str, "comment"\|"issue"]` | **new**; per-repo, set to whichever path landed |
+| `gh_incident_url` | `str` | unchanged legacy single-URL field; first newly minted URL of the call |
+| `gh_incident_opened_at` | ISO8601 string | unchanged |
+
+`gh_incident_kinds` is purely additive — admin and dashboard read `context`
+opaquely so no consumers need updates. Optional for downstream tools to use.
+
+## Failure modes and what's preserved
+
+- GitHub PR-lookup network error → fall through to `open_incident` (issue
+  fallback). Same behavior as today (no PR found = always issue).
+- Comment POST 4xx / 5xx → log warning, return None, escalate continues; no
+  retry inside the escalate boundary (matches `open_incident` policy).
+- All-empty involved repos + no `gh_incident_repo` → skip entirely (no
+  comment, no issue, no `github-incident` tag). Unchanged from today.
+- `github_token` empty → both `find_pr_for_branch` and `comment_on_pr` short-
+  circuit (return None); fall through gives empty result; escalate proceeds
+  with no GitHub artifact and no `github-incident` tag. Matches today.
+
+## What this does NOT change
+
+- `open_incident()` signature, body shape, headers, label list — untouched.
+- BKD tags (`escalated`, `reason:*`, `github-incident`) — semantics unchanged.
+- Auto-resume path — still no GitHub interaction.
+- PR-merged shortcut — runs before this code path; unaffected.
+- Per-involved-repo loop, layered fallback resolver — both reused as-is.

--- a/openspec/changes/REQ-one-pr-per-req-1777218057/proposal.md
+++ b/openspec/changes/REQ-one-pr-per-req-1777218057/proposal.md
@@ -1,0 +1,54 @@
+# REQ-one-pr-per-req-1777218057 — feat: 1 REQ = 1 PR (incident comment-on-PR)
+
+## Why
+
+Today every REQ that escalates leaves behind two GitHub artifacts per
+involved-repo:
+
+1. The `feat/{REQ}` PR (opened by the analyze-agent), and
+2. A separate **incident issue** opened by `gh_incident.open_incident()`
+   (`https://api.github.com/repos/{repo}/issues`).
+
+The invariant "1 REQ = 1 PR" — single point of truth on GitHub — is broken: the
+human reviewer triaging an escalation has to context-switch between a PR (where
+the diff lives) and a parallel incident issue (where the failure metadata
+lives). With per-involved-repo escalation (REQ-gh-incident-per-involved-repo),
+multi-repo REQs spawn N issues + N PRs, multiplying the noise.
+
+## What changes
+
+The `escalate` action posts the incident metadata as a **PR comment** on the
+existing `feat/{REQ}` PR for each involved-repo, instead of creating a fresh
+GitHub issue.
+
+The legacy issue-creation path is preserved as a **fallback**: when there is no
+PR for `feat/{REQ}` on a given repo (escalations during INTAKING / early
+ANALYZING that fire before the analyze-agent has pushed any branch, or
+deployments that point `gh_incident_repo` at a triage inbox repo with no per-REQ
+PR), the action falls through to `gh_incident.open_incident()` exactly as
+today. This keeps "human always sees something" as the strict guarantee while
+eliminating the duplicate artifact in the common steady-state path.
+
+`ctx.gh_incident_urls` continues to be the persisted record of what was opened
+on GitHub. URLs may now point to either an issue-comment URL
+(`/repos/{repo}/issues/{pr_number}#issuecomment-{id}`) or a fresh-issue
+`html_url`; ctx.gh_incident_kinds (new field) records `"comment" | "issue"` per
+repo so the admin view / dashboards can distinguish the two paths.
+
+## Impact
+
+- **`orchestrator/src/orchestrator/gh_incident.py`** — adds `find_pr_for_branch`
+  + `comment_on_pr`; keeps `open_incident` unchanged for the fallback path.
+- **`orchestrator/src/orchestrator/actions/escalate.py`** — for each
+  incident-target repo, looks up the `feat/{REQ}` PR via REST; when found,
+  posts a comment; when not found, falls through to `open_incident` as today.
+- **`ctx`** — adds `gh_incident_kinds: dict[str, "comment" | "issue"]`
+  alongside the existing `gh_incident_urls` / `gh_incident_url` /
+  `gh_incident_opened_at`. The BKD tag `github-incident` is appended in both
+  the comment and the issue path (semantics unchanged: "humans should look at
+  GitHub for this REQ").
+- **Settings** — no new knobs; the existing `github_token` PAT already needs
+  Issues:Write (which covers PR comments — they're issues under the hood).
+- **Backwards compat** — no migrations; `gh_incident_url` /
+  `gh_incident_urls` field shapes are unchanged. Existing escalated REQs
+  with an `gh_incident_url` field set are still readable.

--- a/openspec/changes/REQ-one-pr-per-req-1777218057/specs/gh-incident-open/spec.md
+++ b/openspec/changes/REQ-one-pr-per-req-1777218057/specs/gh-incident-open/spec.md
@@ -1,0 +1,246 @@
+# gh-incident-open delta — REQ-one-pr-per-req-1777218057
+
+## ADDED Requirements
+
+### Requirement: comment_on_pr posts a comment on a specific PR when called
+
+The orchestrator SHALL expose a `gh_incident.comment_on_pr` async function that
+accepts explicit `repo: str`, `pr_number: int`, plus the same identification
+kwargs as `open_incident` (`req_id`, `reason`, `retry_count`,
+`intent_issue_id`, `failed_issue_id`, `project_id`, `state`). When `repo` and
+`settings.github_token` are both non-empty and `pr_number` is positive, the
+function MUST POST to
+`https://api.github.com/repos/{repo}/issues/{pr_number}/comments` with a Bearer
+token and a JSON body whose `body` field contains the same `_format_body`
+metadata `open_incident` uses (REQ id, reason, retry count, BKD project,
+intent issue id, failed sub-issue id, opened-at). The function MUST return the
+response `html_url` on success and `None` (without raising) on any HTTP error,
+on 2xx without `html_url`, or when `repo` / `pr_number` / `github_token` is
+missing.
+
+#### Scenario: COP-S1 disabled when repo argument is empty
+- **GIVEN** `settings.github_token = "ghp_xxx"`
+- **WHEN** `comment_on_pr(repo="", pr_number=42, req_id="REQ-1", reason="x", retry_count=0, intent_issue_id="i", failed_issue_id="i", project_id="p")` is called
+- **THEN** no HTTP request is made
+- **AND** the return value is `None`
+
+#### Scenario: COP-S2 disabled when github_token is empty
+- **GIVEN** `settings.github_token = ""`
+- **WHEN** `comment_on_pr(repo="phona/sisyphus", pr_number=42, ...)` is called
+- **THEN** no HTTP request is made
+- **AND** the return value is `None`
+
+#### Scenario: COP-S3 disabled when pr_number is zero or negative
+- **GIVEN** `settings.github_token = "ghp_xxx"`
+- **WHEN** `comment_on_pr(repo="phona/sisyphus", pr_number=0, ...)` is called
+- **THEN** no HTTP request is made
+- **AND** the return value is `None`
+
+#### Scenario: COP-S4 success returns the comment html_url
+- **GIVEN** `settings.github_token` is set and the GH API returns 201 with `{"html_url": "https://github.com/phona/sisyphus/pull/42#issuecomment-99"}`
+- **WHEN** `comment_on_pr(repo="phona/sisyphus", pr_number=42, ...)` is called
+- **THEN** the POST URL MUST equal `https://api.github.com/repos/phona/sisyphus/issues/42/comments`
+- **AND** the request headers MUST include `Authorization: Bearer ghp_xxx` and `Accept: application/vnd.github+json`
+- **AND** the return value MUST equal `"https://github.com/phona/sisyphus/pull/42#issuecomment-99"`
+
+#### Scenario: COP-S5 request body contains REQ id, reason, and BKD cross-references
+- **GIVEN** the GH API is mocked to record the POST body
+- **WHEN** `comment_on_pr(repo="phona/sisyphus", pr_number=42, req_id="REQ-9", reason="fixer-round-cap", retry_count=1, intent_issue_id="intent-1", failed_issue_id="vfy-3", project_id="proj-A", state="fixer-running")` is called
+- **THEN** the JSON `body` field MUST contain the substrings `REQ-9`, `fixer-round-cap`, `intent-1`, `vfy-3`, `proj-A`, and `fixer-running`
+
+#### Scenario: COP-S6 HTTP failure returns None and does not raise
+- **GIVEN** the GH API returns HTTP 503 for `repo="phona/sisyphus"` `pr_number=42`
+- **WHEN** `comment_on_pr(...)` is called
+- **THEN** the call MUST NOT raise
+- **AND** the return value MUST be `None`
+
+#### Scenario: COP-S7 network error returns None and does not raise
+- **GIVEN** the underlying httpx client raises `ConnectError`
+- **WHEN** `comment_on_pr(...)` is called
+- **THEN** the call MUST NOT raise
+- **AND** the return value MUST be `None`
+
+### Requirement: find_pr_for_branch resolves a PR number for a (repo, branch)
+
+The orchestrator SHALL expose a `gh_incident.find_pr_for_branch` async
+function that, given a `repo` slug and `branch` name, queries
+`GET https://api.github.com/repos/{repo}/pulls?head={owner}:{branch}&state=all&per_page=5`
+and returns the `number` of the first PR returned, or `None` when the API
+returns an empty list. The function MUST return `None` (without raising) when
+`repo` or `settings.github_token` is empty, and MUST return `None` on any HTTP
+error.
+
+#### Scenario: FPR-S1 disabled when repo or token is empty
+- **GIVEN** `settings.github_token = ""` (or `repo = ""`)
+- **WHEN** `find_pr_for_branch(repo="phona/sisyphus", branch="feat/REQ-x")` is called
+- **THEN** no HTTP request is made
+- **AND** the return value is `None`
+
+#### Scenario: FPR-S2 returns first PR number when API responds with at least one PR
+- **GIVEN** the GH API returns 200 with `[{"number": 42, "html_url": "..."}, {"number": 39}]` for `head=phona:feat/REQ-x`
+- **WHEN** `find_pr_for_branch(repo="phona/sisyphus", branch="feat/REQ-x")` is called
+- **THEN** the GET URL MUST equal `https://api.github.com/repos/phona/sisyphus/pulls` with query `head=phona:feat/REQ-x`, `state=all`, `per_page=5`
+- **AND** the return value MUST equal `42`
+
+#### Scenario: FPR-S3 returns None when API returns empty list
+- **GIVEN** the GH API returns 200 with `[]`
+- **WHEN** `find_pr_for_branch(repo="phona/sisyphus", branch="feat/REQ-x")` is called
+- **THEN** the return value MUST be `None`
+
+#### Scenario: FPR-S4 returns None on HTTP error
+- **GIVEN** the GH API returns HTTP 503
+- **WHEN** `find_pr_for_branch(...)` is called
+- **THEN** the call MUST NOT raise
+- **AND** the return value MUST be `None`
+
+## MODIFIED Requirements
+
+### Requirement: escalate action opens an incident on real-escalate and is idempotent under resume cycles
+
+The `escalate` action MUST resolve the list of incident-target repos via the
+ordered fallback documented in "Requirement: incident repo resolution layers"
+and, for every repo not already present as a key in `ctx.gh_incident_urls`,
+MUST first call `gh_incident.find_pr_for_branch(repo=..., branch="feat/{REQ}")`
+to look up the existing PR number for the REQ's feat branch. When a PR number
+is returned, the action MUST call
+`gh_incident.comment_on_pr(repo=..., pr_number=...)` to post the incident
+metadata as a PR comment. When `find_pr_for_branch` returns `None` (no PR yet
+for this REQ on this repo), the action MUST fall back to
+`gh_incident.open_incident(repo=...)` exactly as before. Successfully returned
+URLs MUST be persisted to `ctx.gh_incident_urls` (a `dict[str, str]` mapping
+repo slug to `html_url`); the kind of artifact landed (`"comment"` or
+`"issue"`) MUST be persisted to a sibling `ctx.gh_incident_kinds` dict. The
+first newly minted URL in the call MUST also be written to the legacy
+`ctx.gh_incident_url` for backward compatibility. The auto-resume branch MUST
+NOT call `find_pr_for_branch`, `comment_on_pr`, or `open_incident`. Per-repo
+HTTP failures MUST NOT abort the loop or the escalate flow. The
+`github-incident` BKD tag MUST be appended when at least one URL was opened or
+already present in `ctx.gh_incident_urls`, regardless of whether the URL is a
+PR comment or a fresh issue.
+
+#### Scenario: GHI-S6 real-escalate single involved repo posts a PR comment when PR exists
+- **GIVEN** `settings.github_token` is set, `ctx.involved_repos = ["phona/sisyphus"]`, `settings.gh_incident_repo = ""`
+- **AND** `gh_incident.find_pr_for_branch(repo="phona/sisyphus", branch="feat/REQ-9")` is mocked to return `42`
+- **AND** `gh_incident.comment_on_pr` is mocked to return `"https://github.com/phona/sisyphus/pull/42#issuecomment-99"`
+- **AND** the escalate input is `body.event = "verify.escalate"` with `ctx.escalated_reason = "verifier-decision-escalate"` (non-transient)
+- **WHEN** `escalate(...)` runs
+- **THEN** `gh_incident.find_pr_for_branch` MUST be awaited exactly once with `repo="phona/sisyphus"`, `branch="feat/REQ-9"`
+- **AND** `gh_incident.comment_on_pr` MUST be awaited exactly once with `repo="phona/sisyphus"`, `pr_number=42`, `req_id="REQ-9"`, `reason="verifier-decision-escalate"`, `intent_issue_id`, and `failed_issue_id` matching the input
+- **AND** `gh_incident.open_incident` MUST NOT be awaited
+- **AND** `req_state.update_context` MUST be invoked with `gh_incident_urls = {"phona/sisyphus": "https://github.com/phona/sisyphus/pull/42#issuecomment-99"}`, `gh_incident_kinds = {"phona/sisyphus": "comment"}`, `gh_incident_url = "https://github.com/phona/sisyphus/pull/42#issuecomment-99"`, and a non-empty `gh_incident_opened_at`
+- **AND** `bkd.merge_tags_and_update` MUST be called with `add` containing `escalated`, `reason:verifier-decision-escalate`, AND `github-incident`
+
+#### Scenario: GHI-S7 idempotent: pre-existing ctx.gh_incident_urls skips the second POST
+- **GIVEN** the same setup as GHI-S6
+- **AND** `ctx.gh_incident_urls = {"phona/sisyphus": "https://github.com/phona/sisyphus/pull/42#issuecomment-99"}` is already set
+- **WHEN** `escalate(...)` runs again (e.g. resume → re-escalate cycle)
+- **THEN** `gh_incident.find_pr_for_branch` MUST NOT be awaited
+- **AND** `gh_incident.comment_on_pr` MUST NOT be awaited
+- **AND** `gh_incident.open_incident` MUST NOT be awaited
+- **AND** `ctx.gh_incident_urls` MUST be preserved unchanged in the update
+- **AND** the BKD tag merge MUST still include `github-incident`
+
+#### Scenario: GHI-S8 auto-resume branch does not interact with GitHub
+- **GIVEN** the input is `body.event = "session.failed"`, `auto_retry_count = 0` (transient with budget remaining)
+- **WHEN** `escalate(...)` runs
+- **THEN** `gh_incident.find_pr_for_branch`, `gh_incident.comment_on_pr`, and `gh_incident.open_incident` MUST NOT be awaited
+- **AND** `bkd.follow_up_issue` MUST be awaited (auto-resume continues as today)
+
+#### Scenario: GHI-S9 GH failure does not abort the escalate flow
+- **GIVEN** the same setup as GHI-S6 except `gh_incident.comment_on_pr` returns `None` (GH outage / 4xx / 5xx)
+- **WHEN** `escalate(...)` runs
+- **THEN** `bkd.merge_tags_and_update` MUST still be awaited
+- **AND** the action MUST return `{"escalated": True, ...}` as before
+- **AND** the persisted ctx MUST NOT include `gh_incident_url` or a non-empty `gh_incident_urls`
+- **AND** the BKD tag merge MUST NOT include `github-incident`
+
+#### Scenario: GHI-S10 disabled (no involved repos and no fallback) does not break escalate
+- **GIVEN** `ctx.involved_repos` is unset, all other layers are empty, and `settings.gh_incident_repo = ""`
+- **WHEN** `escalate(...)` runs through the real-escalate branch
+- **THEN** `gh_incident.find_pr_for_branch`, `gh_incident.comment_on_pr`, and `gh_incident.open_incident` MUST NOT be awaited
+- **AND** the action MUST return `{"escalated": True, ...}` exactly as before this change
+- **AND** ctx MUST NOT be mutated with `gh_incident_url`, `gh_incident_urls`, `gh_incident_kinds`, or `gh_incident_opened_at`
+- **AND** the BKD tag merge MUST NOT include `github-incident`
+
+#### Scenario: GHI-S11 multi-repo REQ posts one comment per involved repo
+- **GIVEN** `settings.github_token` is set, `ctx.involved_repos = ["phona/repo-a", "phona/repo-b"]`, `settings.gh_incident_repo = ""`
+- **AND** `gh_incident.find_pr_for_branch` returns `7` for `repo="phona/repo-a"` and `3` for `repo="phona/repo-b"`
+- **AND** `gh_incident.comment_on_pr` returns `"https://github.com/phona/repo-a/pull/7#issuecomment-1"` for `(repo="phona/repo-a", pr_number=7)` and `"https://github.com/phona/repo-b/pull/3#issuecomment-2"` for `(repo="phona/repo-b", pr_number=3)`
+- **AND** the escalate input is `body.event = "verify.escalate"` with `ctx.escalated_reason = "verifier-decision-escalate"`
+- **WHEN** `escalate(...)` runs
+- **THEN** `gh_incident.comment_on_pr` MUST be awaited exactly twice — once with `repo="phona/repo-a"`, `pr_number=7`, and once with `repo="phona/repo-b"`, `pr_number=3`
+- **AND** `gh_incident.open_incident` MUST NOT be awaited
+- **AND** `req_state.update_context` MUST be invoked with `gh_incident_urls` containing both `"phona/repo-a"` and `"phona/repo-b"` keys mapped to their respective `html_url`
+- **AND** `gh_incident_kinds` MUST be `{"phona/repo-a": "comment", "phona/repo-b": "comment"}`
+- **AND** the BKD tag merge MUST include `github-incident` exactly once
+
+#### Scenario: GHI-S12 partial failure isolated: one repo fails, the other succeeds
+- **GIVEN** `ctx.involved_repos = ["phona/repo-a", "phona/repo-b"]`
+- **AND** `gh_incident.find_pr_for_branch` returns `7` for `repo="phona/repo-a"` and `3` for `repo="phona/repo-b"`
+- **AND** `gh_incident.comment_on_pr` returns `None` for `(repo="phona/repo-a", pr_number=7)` (e.g. 403 — PAT lacks Issues:Write) but returns `"https://github.com/phona/repo-b/pull/3#issuecomment-2"` for `(repo="phona/repo-b", pr_number=3)`
+- **WHEN** `escalate(...)` runs
+- **THEN** the action MUST return `{"escalated": True, ...}`
+- **AND** `ctx.gh_incident_urls` MUST equal `{"phona/repo-b": "https://github.com/phona/repo-b/pull/3#issuecomment-2"}` (failed repo absent)
+- **AND** `ctx.gh_incident_kinds` MUST equal `{"phona/repo-b": "comment"}` (failed repo absent)
+- **AND** the BKD tag merge MUST include `github-incident` (one success suffices)
+
+#### Scenario: GHI-S13 idempotent across multi-repo: only missing repos POSTed on re-entry
+- **GIVEN** `ctx.involved_repos = ["phona/repo-a", "phona/repo-b"]` and `ctx.gh_incident_urls = {"phona/repo-a": "https://github.com/phona/repo-a/pull/7#issuecomment-1"}` (repo-a already commented in a prior escalate call)
+- **AND** `gh_incident.find_pr_for_branch` returns `3` for `repo="phona/repo-b"`
+- **AND** `gh_incident.comment_on_pr` returns `"https://github.com/phona/repo-b/pull/3#issuecomment-2"` for `(repo="phona/repo-b", pr_number=3)`
+- **WHEN** `escalate(...)` runs again
+- **THEN** `gh_incident.find_pr_for_branch` MUST be awaited exactly once with `repo="phona/repo-b"` (NOT for `phona/repo-a`)
+- **AND** `gh_incident.comment_on_pr` MUST be awaited exactly once with `repo="phona/repo-b"`, `pr_number=3`
+- **AND** the persisted `gh_incident_urls` MUST contain both `phona/repo-a` (existing) and `phona/repo-b` (newly added) keys
+
+## ADDED Requirements
+
+### Requirement: escalate falls back to opening a fresh issue when no PR exists for the feat branch
+
+The escalate action MUST fall back to `gh_incident.open_incident(repo=..., ...)`
+to create a fresh GitHub issue when the layered involved-repos resolver yields
+a repo for which `gh_incident.find_pr_for_branch(repo=..., branch="feat/{REQ}")`
+returns `None` (no PR has been opened yet — typical for escalations during
+INTAKING / early ANALYZING that fire before the analyze-agent has pushed a
+branch, or for deployments whose `gh_incident_repo` fallback points at a
+triage-inbox repo without per-REQ PRs). The persisted `ctx.gh_incident_kinds`
+entry for that repo MUST be `"issue"`, and the URL persisted in
+`ctx.gh_incident_urls` MUST be the issue `html_url` returned by
+`open_incident`. The fallback MUST NOT swallow exceptions thrown by the
+resolver layers above it — only PR-lookup and comment-POST HTTP errors are
+absorbed by returning `None`. The `github-incident` BKD tag semantics are
+unchanged: appended when at least one URL (comment or issue) was minted or
+already present in ctx.
+
+#### Scenario: ICP-S1 falls back to issue when no PR exists for feat/{REQ}
+- **GIVEN** `settings.github_token` is set, `ctx.involved_repos = ["phona/sisyphus"]`
+- **AND** `gh_incident.find_pr_for_branch(repo="phona/sisyphus", branch="feat/REQ-9")` is mocked to return `None`
+- **AND** `gh_incident.open_incident` is mocked to return `"https://github.com/phona/sisyphus/issues/42"`
+- **AND** the escalate input is `body.event = "verify.escalate"` with `ctx.escalated_reason = "verifier-decision-escalate"`
+- **WHEN** `escalate(...)` runs
+- **THEN** `gh_incident.find_pr_for_branch` MUST be awaited exactly once
+- **AND** `gh_incident.comment_on_pr` MUST NOT be awaited
+- **AND** `gh_incident.open_incident` MUST be awaited exactly once with `repo="phona/sisyphus"`, `req_id="REQ-9"`, `reason="verifier-decision-escalate"`
+- **AND** `req_state.update_context` MUST be invoked with `gh_incident_urls = {"phona/sisyphus": "https://github.com/phona/sisyphus/issues/42"}` and `gh_incident_kinds = {"phona/sisyphus": "issue"}`
+- **AND** the BKD tag merge MUST include `github-incident`
+
+#### Scenario: ICP-S2 mixed multi-repo: comment for one repo, issue fallback for another
+- **GIVEN** `settings.github_token` is set, `ctx.involved_repos = ["phona/repo-a", "phona/repo-b"]`
+- **AND** `gh_incident.find_pr_for_branch` returns `7` for `repo="phona/repo-a"` and `None` for `repo="phona/repo-b"` (no feat branch pushed yet on repo-b)
+- **AND** `gh_incident.comment_on_pr(repo="phona/repo-a", pr_number=7, ...)` returns `"https://github.com/phona/repo-a/pull/7#issuecomment-1"`
+- **AND** `gh_incident.open_incident(repo="phona/repo-b", ...)` returns `"https://github.com/phona/repo-b/issues/42"`
+- **WHEN** `escalate(...)` runs
+- **THEN** `gh_incident.comment_on_pr` MUST be awaited exactly once with `repo="phona/repo-a"`
+- **AND** `gh_incident.open_incident` MUST be awaited exactly once with `repo="phona/repo-b"`
+- **AND** `ctx.gh_incident_urls` MUST equal `{"phona/repo-a": "https://github.com/phona/repo-a/pull/7#issuecomment-1", "phona/repo-b": "https://github.com/phona/repo-b/issues/42"}`
+- **AND** `ctx.gh_incident_kinds` MUST equal `{"phona/repo-a": "comment", "phona/repo-b": "issue"}`
+- **AND** the BKD tag merge MUST include `github-incident` exactly once
+
+#### Scenario: ICP-S3 PR-lookup HTTP error treated as no-PR (falls back to issue)
+- **GIVEN** `settings.github_token` is set, `ctx.involved_repos = ["phona/sisyphus"]`
+- **AND** `gh_incident.find_pr_for_branch(repo="phona/sisyphus", ...)` returns `None` (the function absorbs the underlying HTTP error and reports "not found")
+- **AND** `gh_incident.open_incident` returns `"https://github.com/phona/sisyphus/issues/42"`
+- **WHEN** `escalate(...)` runs
+- **THEN** `gh_incident.open_incident` MUST be awaited exactly once with `repo="phona/sisyphus"`
+- **AND** `ctx.gh_incident_kinds["phona/sisyphus"]` MUST equal `"issue"`
+- **AND** the action MUST return `{"escalated": True, ...}`

--- a/openspec/changes/REQ-one-pr-per-req-1777218057/tasks.md
+++ b/openspec/changes/REQ-one-pr-per-req-1777218057/tasks.md
@@ -1,0 +1,21 @@
+# Tasks — REQ-one-pr-per-req-1777218057
+
+## Stage: contract / spec
+- [x] author `specs/gh-incident-open/spec.md` delta (MODIFIED Requirements + ADDED comment-on-pr Requirement) — `openspec/changes/REQ-one-pr-per-req-1777218057/specs/gh-incident-open/spec.md`
+- [x] author `proposal.md` (motivation + impact summary)
+- [x] author `design.md` (decision tree, ctx schema, failure modes)
+
+## Stage: implementation
+- [x] add `gh_incident.find_pr_for_branch(repo, branch) -> int | None` (httpx GET `/repos/{repo}/pulls?head=...&state=all`)
+- [x] add `gh_incident.comment_on_pr(*, repo, pr_number, ...) -> str | None` (httpx POST `/repos/{repo}/issues/{pr_number}/comments`, returns `html_url`)
+- [x] update `actions/escalate.py` per-repo loop: try PR comment first, fall through to `open_incident` when no PR
+- [x] persist `ctx.gh_incident_kinds: dict[str, "comment" | "issue"]` alongside existing `ctx.gh_incident_urls`
+- [x] preserve existing per-repo idempotency on `ctx.gh_incident_urls`
+- [x] preserve existing `github-incident` BKD tag semantics
+- [x] unit tests: `find_pr_for_branch` happy path / 404 / network error / token-empty short-circuit
+- [x] unit tests: `comment_on_pr` happy path / 4xx / network error / token-empty short-circuit
+- [x] integration tests in `test_gh_incident.py`: escalate posts comment when PR exists; falls back to issue when PR missing; multi-repo mixed (one comment, one issue); per-repo idempotency
+
+## Stage: PR
+- [x] `git push origin feat/REQ-one-pr-per-req-1777218057`
+- [x] `gh pr create` (one PR on phona/sisyphus, the only involved repo)

--- a/orchestrator/src/orchestrator/actions/escalate.py
+++ b/orchestrator/src/orchestrator/actions/escalate.py
@@ -14,12 +14,18 @@
    → 在 intent issue 上加 `escalated` + `reason:<细分>` tag
    → 落 ctx 标记 escalated_reason
    → 解析 incident-target repos（involved_repos 5 层 fallback，layer 5 是
-     legacy settings.gh_incident_repo）；对每个 repo 独立 POST GH issue，
-     idempotent on ctx.gh_incident_urls；至少一条成功 → 加 `github-incident` BKD tag
+     legacy settings.gh_incident_repo）；对每个 repo:
+       a. 优先 `find_pr_for_branch(feat/{REQ})` → 找到 → `comment_on_pr`
+          （保 1 REQ = 1 PR 不变量；REQ-one-pr-per-req-1777218057）
+       b. 没 PR → fall back `open_incident` 开新 issue（INTAKING / 早期
+          ANALYZING / triage-inbox 部署）
+     idempotent on ctx.gh_incident_urls；ctx.gh_incident_kinds 记录每个
+     repo 是 "comment" 还是 "issue"；至少一条成功 → 加 `github-incident` BKD tag
    → state 进 ESCALATED
 
 不在 BKD 开新 issue（避免污染列表）；不 cancel 当前 issue（让人工有现场）。
-GH issue 是给人看的事故面板，不在 BKD 里复制；REST 失败不阻塞 escalate。
+GH 一面（PR comment / fallback issue）是给人看的事故面板，不在 BKD 里复制；
+REST 失败不阻塞 escalate。
 """
 from __future__ import annotations
 
@@ -356,38 +362,65 @@ async def escalate(*, body, req_id, tags, ctx):
 
     pool = db.get_pool()
 
-    # ─── GH 事故 issue（per-involved-repo loop, idempotent on ctx.gh_incident_urls） ─
-    # 仅在 real-escalate 路径开 issue（auto-resume 不开，会刷屏）。Layer 1-4 是
-    # involved_repos（跟 clone helper 对齐：哪几个仓被 clone，事故就在那几个仓里
-    # 落 issue）；Layer 5 是 settings.gh_incident_repo（legacy single-inbox fallback，
-    # intake 阶段失败 pre-clone / 集中三角部署）。
+    # ─── GH 事故落地（per-involved-repo loop, idempotent on ctx.gh_incident_urls） ─
+    # REQ-one-pr-per-req-1777218057: 优先在 feat/{REQ} PR 上加评论（保 1 REQ = 1 PR
+    # 不变量）；只有该 repo 上还没 PR（escalation in INTAKING / 早期 ANALYZING / triage
+    # inbox 部署）才 fall back 开新 issue（legacy open_incident）。
+    #
+    # 仅在 real-escalate 路径写 GH（auto-resume 不写，会刷屏）。Layer 1-4 是
+    # involved_repos（跟 clone helper 对齐：哪几个仓被 clone，事故就在那几个仓里）；
+    # Layer 5 是 settings.gh_incident_repo（legacy single-inbox fallback）。
     existing_urls = dict((ctx or {}).get("gh_incident_urls") or {})
+    existing_kinds = dict((ctx or {}).get("gh_incident_kinds") or {})
     incident_repos = _resolve_incident_repos(ctx, tags)
     new_urls: dict[str, str] = {}
+    new_kinds: dict[str, str] = {}
     if incident_repos:
-        # 取当前 state 给 issue body（best-effort，None 也能继续）
+        # 取当前 state 给 body（best-effort，None 也能继续）
         try:
             row = await req_state.get(pool, req_id)
             state_str = row.state.value if row else None
         except Exception:
             state_str = None
+        feat_branch = f"feat/{req_id}"
         for incident_repo in incident_repos:
             if incident_repo in existing_urls:
-                continue  # idempotent: 此 repo 已开过 issue
-            url = await gh_incident.open_incident(
-                repo=incident_repo,
-                req_id=req_id,
-                reason=final_reason,
-                retry_count=retry_count,
-                intent_issue_id=intent_issue_id,
-                failed_issue_id=failed_issue_id,
-                project_id=proj,
-                state=state_str,
+                continue  # idempotent: 此 repo 已 comment / open 过
+            pr_number = await gh_incident.find_pr_for_branch(
+                repo=incident_repo, branch=feat_branch,
             )
+            if pr_number:
+                url = await gh_incident.comment_on_pr(
+                    repo=incident_repo,
+                    pr_number=pr_number,
+                    req_id=req_id,
+                    reason=final_reason,
+                    retry_count=retry_count,
+                    intent_issue_id=intent_issue_id,
+                    failed_issue_id=failed_issue_id,
+                    project_id=proj,
+                    state=state_str,
+                )
+                kind = "comment"
+            else:
+                # 没 PR → 兜底开 issue（legacy 行为）
+                url = await gh_incident.open_incident(
+                    repo=incident_repo,
+                    req_id=req_id,
+                    reason=final_reason,
+                    retry_count=retry_count,
+                    intent_issue_id=intent_issue_id,
+                    failed_issue_id=failed_issue_id,
+                    project_id=proj,
+                    state=state_str,
+                )
+                kind = "issue"
             if url:
                 new_urls[incident_repo] = url
+                new_kinds[incident_repo] = kind
 
     merged_urls = {**existing_urls, **new_urls}
+    merged_kinds = {**existing_kinds, **new_kinds}
 
     add_tags = ["escalated", f"reason:{final_reason}"]
     if merged_urls:
@@ -411,6 +444,9 @@ async def escalate(*, body, req_id, tags, ctx):
     if new_urls:
         # 全量替换 dict（merge of existing_urls + new_urls 已在 merged_urls）
         ctx_patch["gh_incident_urls"] = merged_urls
+        # gh_incident_kinds 跟 gh_incident_urls 对齐：每个 repo 一个 "comment" | "issue"
+        # 标记，让 admin / dashboard 能区分两条路径。
+        ctx_patch["gh_incident_kinds"] = merged_kinds
         # legacy single-URL field：保留首次成功 POST 的 URL，让 admin view /
         # Metabase 旧 query 继续工作。优先 existing（保持旧值），否则取新 URL 第一条。
         legacy_url = (ctx or {}).get("gh_incident_url") or next(iter(new_urls.values()))

--- a/orchestrator/src/orchestrator/gh_incident.py
+++ b/orchestrator/src/orchestrator/gh_incident.py
@@ -1,17 +1,25 @@
-"""Open a GitHub issue when a REQ enters ESCALATED.
+"""GitHub-side incident surfacing for escalated REQs.
 
-Called from `actions/escalate.py` in the "real escalate" branch (auto-resume does not
-open an incident — that would be noise). The GH issue is the canonical surface humans
-use to triage sisyphus failures (`gh issue list --label sisyphus:incident`); BKD tags
-remain the agent-facing signal.
+Two paths, both called from `actions/escalate.py` in the real-escalate branch
+(auto-resume never opens any GH artifact — that would be noise):
 
-Disabled when `repo` (explicit kwarg, resolved by escalate from involved_repos /
-settings.gh_incident_repo fallback) OR `settings.github_token` is empty — both return
-None without making any HTTP request.
+1. `find_pr_for_branch` + `comment_on_pr` — preferred. Posts the incident
+   metadata as a comment on the existing `feat/{REQ}` PR. Keeps the "1 REQ =
+   1 PR" invariant: humans triage on the same PR they'd review the diff on.
 
-Failure mode: any exception or non-2xx HTTP response logs a warning and returns None.
-The escalate action is the retry boundary for the failure path; we do not re-enter
-GH retry from inside escalate.
+2. `open_incident` — legacy fallback. Creates a fresh GitHub issue when no PR
+   exists for the REQ on this repo (escalations during INTAKING / early
+   ANALYZING that fire pre-push, or `gh_incident_repo` triage-inbox
+   deployments). The issue is the canonical surface humans use to triage in
+   that fallback case (`gh issue list --label sisyphus:incident`); BKD tags
+   remain the agent-facing signal regardless of which path landed.
+
+All three functions are disabled (return `None` without HTTP) when their
+required input is missing — `repo`/`pr_number`/`branch` empty or
+`settings.github_token` empty. Failure mode is uniform: any exception or non-2xx
+HTTP response logs a warning and returns `None`. The escalate action is the
+retry boundary for the failure path; we do not re-enter GH retry from inside
+the helpers.
 """
 from __future__ import annotations
 
@@ -25,6 +33,7 @@ from .config import settings
 log = structlog.get_logger(__name__)
 
 _GH_API = "https://api.github.com"
+_TIMEOUT = 15.0
 
 
 def _format_body(
@@ -53,8 +62,126 @@ def _format_body(
         "2. Decide pass / fix / escalate; if recoverable, use the admin resume endpoint:\n"
         f"   `POST /admin/req/{req_id}/resume` with body "
         '`{"action": "pass" | "fix-needed", "stage"?: "...", "reason"?: "..."}`.\n'
-        "3. Close this issue once the REQ is resolved.\n"
+        "3. Close this incident once the REQ is resolved.\n"
     )
+
+
+def _auth_headers() -> dict[str, str]:
+    return {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Authorization": f"Bearer {settings.github_token.strip()}",
+    }
+
+
+async def find_pr_for_branch(*, repo: str, branch: str) -> int | None:
+    """Look up the PR number for a (repo, branch) pair.
+
+    Queries `GET /repos/{repo}/pulls?head={owner}:{branch}&state=all&per_page=5`
+    and returns the first PR's `number`, or `None` when the response is empty.
+
+    Accepts any state (open / closed / merged) — escalations can land after a
+    PR is merged (e.g., archive crash) and a comment is still useful audit.
+
+    Disabled (returns `None` without HTTP) when `repo` or
+    `settings.github_token` is empty. Returns `None` on any HTTP error or when
+    the response shape is unexpected.
+    """
+    repo = (repo or "").strip()
+    branch = (branch or "").strip()
+    token = settings.github_token.strip()
+    if not repo or not branch or not token or "/" not in repo:
+        log.debug("gh_incident.find_pr.disabled", repo=repo, branch=branch,
+                  has_token=bool(token))
+        return None
+    owner = repo.split("/", 1)[0]
+    url = f"{_GH_API}/repos/{repo}/pulls"
+    params = {
+        "head": f"{owner}:{branch}",
+        "state": "all",
+        "per_page": 5,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.get(url, headers=_auth_headers(), params=params)
+        if resp.status_code >= 300:
+            log.warning("gh_incident.find_pr.http_error", repo=repo, branch=branch,
+                        status=resp.status_code, body_tail=resp.text[-200:])
+            return None
+        pulls = resp.json()
+        if not isinstance(pulls, list) or not pulls:
+            return None
+        number = pulls[0].get("number")
+        if not isinstance(number, int) or number <= 0:
+            log.warning("gh_incident.find_pr.bad_number", repo=repo, branch=branch,
+                        body_tail=resp.text[-200:])
+            return None
+        return number
+    except Exception as e:
+        log.warning("gh_incident.find_pr.failed", repo=repo, branch=branch, error=str(e))
+        return None
+
+
+async def comment_on_pr(
+    *,
+    repo: str,
+    pr_number: int,
+    req_id: str,
+    reason: str,
+    retry_count: int,
+    intent_issue_id: str,
+    failed_issue_id: str,
+    project_id: str,
+    state: str | None = None,
+) -> str | None:
+    """POST a comment to `repo`'s PR `pr_number`. Returns html_url or None.
+
+    Endpoint: `POST /repos/{repo}/issues/{pr_number}/comments` (PR comments are
+    issue-level comments — the PR is an issue subtype). Body shape mirrors the
+    `_format_body` metadata `open_incident` writes.
+
+    Returns None (without HTTP) when `repo` / `pr_number` / `settings.github_token`
+    is missing or invalid. Returns None on any HTTP error — never raises, so
+    the escalate flow can proceed even if GitHub is unreachable / per-repo PAT
+    scope is missing.
+    """
+    repo = (repo or "").strip()
+    token = settings.github_token.strip()
+    if not repo or not token or pr_number <= 0:
+        log.debug("gh_incident.comment.disabled", req_id=req_id, repo=repo,
+                  pr_number=pr_number, has_token=bool(token))
+        return None
+
+    body = _format_body(
+        req_id=req_id, reason=reason, retry_count=retry_count,
+        intent_issue_id=intent_issue_id, failed_issue_id=failed_issue_id,
+        project_id=project_id, state=state,
+    )
+    payload = {"body": body}
+    url = f"{_GH_API}/repos/{repo}/issues/{pr_number}/comments"
+
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.post(url, headers=_auth_headers(), json=payload)
+        if resp.status_code >= 300:
+            log.warning("gh_incident.comment.http_error",
+                        req_id=req_id, repo=repo, pr_number=pr_number,
+                        status=resp.status_code, body_tail=resp.text[-200:])
+            return None
+        html_url = resp.json().get("html_url")
+        if not html_url:
+            log.warning("gh_incident.comment.no_html_url",
+                        req_id=req_id, repo=repo, pr_number=pr_number,
+                        body_tail=resp.text[-200:])
+            return None
+        log.info("gh_incident.commented",
+                 req_id=req_id, repo=repo, pr_number=pr_number,
+                 url=html_url, reason=reason)
+        return html_url
+    except Exception as e:
+        log.warning("gh_incident.comment.failed",
+                    req_id=req_id, repo=repo, pr_number=pr_number, error=str(e))
+        return None
 
 
 async def open_incident(
@@ -90,17 +217,11 @@ async def open_incident(
     )
     labels = [*settings.gh_incident_labels, f"reason:{reason}"]
     payload = {"title": title, "body": body, "labels": labels}
-
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        "Authorization": f"Bearer {token}",
-    }
     url = f"{_GH_API}/repos/{repo}/issues"
 
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            resp = await client.post(url, headers=headers, json=payload)
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.post(url, headers=_auth_headers(), json=payload)
         if resp.status_code >= 300:
             log.warning("gh_incident.http_error",
                         req_id=req_id, repo=repo, status=resp.status_code,

--- a/orchestrator/tests/test_contract_gh_incident_open.py
+++ b/orchestrator/tests/test_contract_gh_incident_open.py
@@ -1,8 +1,16 @@
-"""Contract tests for REQ-gh-incident-per-involved-repo-1777180551:
-feat(orchestrator): open one GitHub incident per involved source repo.
+"""Contract tests for the gh-incident-open capability.
 
 Black-box behavioral contracts derived exclusively from:
-  openspec/specs/gh-incident-open/spec.md (post REQ-gh-incident-per-involved-repo)
+  openspec/specs/gh-incident-open/spec.md
++ openspec/changes/REQ-one-pr-per-req-1777218057/specs/gh-incident-open/spec.md
+
+History:
+  - REQ-gh-incident-per-involved-repo-1777180551: original per-involved-repo
+    issue creation behavior (GHI-S1..GHI-S15).
+  - REQ-one-pr-per-req-1777218057: escalate now comments on the existing
+    feat/{REQ} PR via comment_on_pr; falls back to open_incident only when
+    no PR exists for the REQ on this repo. open_incident's own unit-level
+    behavior (GHI-S1..GHI-S5) is unchanged.
 
 Scenarios covered:
   GHI-S1   open_incident disabled when repo='' → None, no HTTP
@@ -10,18 +18,27 @@ Scenarios covered:
   GHI-S3   open_incident success → POST correct URL + headers, returns html_url
   GHI-S4   open_incident POST body contains required fields and labels array
   GHI-S5   open_incident HTTP failure (503) → None, does not raise
-  GHI-S6   escalate single involved-repo: one POST, ctx.gh_incident_urls has the entry
-  GHI-S7   escalate idempotent: ctx.gh_incident_urls already covers all involved repos → no POST
-  GHI-S8   escalate auto-resume branch → no POST
-  GHI-S9   escalate: GH failure (open_incident→None) does not abort the flow
-  GHI-S10  escalate: no involved_repos and no settings.gh_incident_repo → no POST, no tag
-  GHI-S11  escalate multi-involved-repo → one POST per repo, urls dict has both keys
+  GHI-S6   escalate single involved-repo: PR found → comment_on_pr (not open_incident);
+            ctx.gh_incident_urls + ctx.gh_incident_kinds populated
+  GHI-S7   escalate idempotent: ctx.gh_incident_urls covers all repos → no GH calls
+  GHI-S8   escalate auto-resume branch → no GH calls
+  GHI-S9   escalate: comment_on_pr returns None → no fallback to open_incident
+            (PR was found; no point trying issue), no tag, flow continues
+  GHI-S10  escalate: no involved_repos and no settings.gh_incident_repo → no calls, no tag
+  GHI-S11  escalate multi-involved-repo → one comment per repo
   GHI-S12  escalate partial failure isolated → only successful repo persisted
-  GHI-S13  escalate idempotent across multi-repo: only missing repos POSTed on re-entry
-  GHI-S14  escalate falls back to settings.gh_incident_repo when involved_repos empty
+  GHI-S13  escalate idempotent across multi-repo: only missing repos commented on re-entry
+  GHI-S14  escalate falls back to settings.gh_incident_repo when involved_repos empty;
+            since the inbox repo has no per-REQ PR, falls through to open_incident
   GHI-S15  ctx.involved_repos beats settings.gh_incident_repo (layers 1-4 win)
+  ICP-S1   no PR for feat/{REQ} → falls back to open_incident; gh_incident_kinds = "issue"
+  ICP-S2   mixed multi-repo: comment for repo with PR, issue for repo without
+  ICP-S3   PR-lookup error (find_pr returns None) treated as "no PR" → falls back to issue
 
 Function signatures verified at test design time:
+  find_pr_for_branch(*, repo, branch) -> int | None
+  comment_on_pr(*, repo, pr_number, req_id, reason, retry_count, intent_issue_id,
+                failed_issue_id, project_id, state=None) -> str | None
   open_incident(*, repo, req_id, reason, retry_count, intent_issue_id, failed_issue_id,
                 project_id, state=None) -> str | None
   escalate(*, body, req_id, tags, ctx) -> dict
@@ -68,7 +85,7 @@ def _make_body(event: str = "verify.escalate", project_id: str = "proj-test") ->
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Part 1: open_incident — GHI-S1 and GHI-S2 (no HTTP)
+# Part 1: open_incident unit-level (GHI-S1..GHI-S5) — unchanged by REQ-one-pr-per-req
 # ─────────────────────────────────────────────────────────────────────────────
 
 
@@ -76,9 +93,7 @@ class TestOpenIncidentDisabled:
     """Spec: open_incident returns None when either input is empty."""
 
     async def test_ghi_s1_disabled_when_repo_arg_empty(self):
-        """
-        GHI-S1: open_incident(repo="") → returns None without any HTTP request.
-        """
+        """GHI-S1: open_incident(repo="") → returns None without any HTTP request."""
         import orchestrator.gh_incident as ghi
 
         s = _make_settings()
@@ -98,9 +113,7 @@ class TestOpenIncidentDisabled:
         )
 
     async def test_ghi_s2_disabled_when_github_token_empty(self):
-        """
-        GHI-S2: github_token='' → open_incident returns None without any HTTP request.
-        """
+        """GHI-S2: github_token='' → open_incident returns None without any HTTP request."""
         import orchestrator.gh_incident as ghi
 
         s = _make_settings(github_token="")
@@ -120,21 +133,11 @@ class TestOpenIncidentDisabled:
         )
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Part 2: open_incident success — GHI-S3 and GHI-S4
-# ─────────────────────────────────────────────────────────────────────────────
-
-
 class TestOpenIncidentSuccess:
     """Spec: on 201, open_incident returns the html_url, uses correct URL and headers."""
 
     async def test_ghi_s3_success_returns_html_url_with_correct_request(self, httpx_mock):
-        """
-        GHI-S3: GH API returns 201 + html_url →
-        POST hits https://api.github.com/repos/phona/sisyphus/issues with
-        Authorization: Bearer <token> and Accept: application/vnd.github+json.
-        Return value equals the html_url string.
-        """
+        """GHI-S3"""
         import orchestrator.gh_incident as ghi
 
         httpx_mock.add_response(
@@ -155,33 +158,16 @@ class TestOpenIncidentSuccess:
                 project_id="proj-1",
             )
 
-        assert result == "https://github.com/phona/sisyphus/issues/42", (
-            f"open_incident MUST return the html_url from GH 201 response; got {result!r}"
-        )
-
+        assert result == "https://github.com/phona/sisyphus/issues/42"
         request = httpx_mock.get_request()
-        assert request is not None, (
-            "open_incident MUST send an HTTP POST request when both inputs are non-empty"
-        )
-        assert str(request.url) == "https://api.github.com/repos/phona/sisyphus/issues", (
-            f"POST URL must be 'https://api.github.com/repos/phona/sisyphus/issues'; "
-            f"got {request.url!r}"
-        )
-        assert request.headers.get("authorization") == "Bearer ghp_test_token", (
-            f"Authorization header must be 'Bearer ghp_test_token'; "
-            f"got {request.headers.get('authorization')!r}"
-        )
+        assert request is not None
+        assert str(request.url) == "https://api.github.com/repos/phona/sisyphus/issues"
+        assert request.headers.get("authorization") == "Bearer ghp_test_token"
         accept_header = request.headers.get("accept", "")
-        assert "vnd.github" in accept_header, (
-            f"Accept header must contain 'vnd.github'; got {accept_header!r}"
-        )
+        assert "vnd.github" in accept_header
 
     async def test_ghi_s4_post_body_contains_required_fields_and_correct_labels(self, httpx_mock):
-        """
-        GHI-S4: POST body must contain all cross-reference substrings:
-        REQ-9, fixer-round-cap, intent-1, vfy-3, proj-A, fixer-running.
-        labels array must contain 'sisyphus:incident' and 'reason:fixer-round-cap'.
-        """
+        """GHI-S4"""
         import orchestrator.gh_incident as ghi
 
         httpx_mock.add_response(
@@ -204,7 +190,7 @@ class TestOpenIncidentSuccess:
             )
 
         request = httpx_mock.get_request()
-        assert request is not None, "Must have sent a POST request"
+        assert request is not None
         body = json.loads(request.content)
         body_str = json.dumps(body)
 
@@ -214,26 +200,15 @@ class TestOpenIncidentSuccess:
             )
 
         labels = body.get("labels", [])
-        assert "sisyphus:incident" in labels, (
-            f"labels MUST contain 'sisyphus:incident'; got: {labels!r}"
-        )
-        assert "reason:fixer-round-cap" in labels, (
-            f"labels MUST contain 'reason:fixer-round-cap'; got: {labels!r}"
-        )
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Part 3: open_incident HTTP failure — GHI-S5
-# ─────────────────────────────────────────────────────────────────────────────
+        assert "sisyphus:incident" in labels
+        assert "reason:fixer-round-cap" in labels
 
 
 class TestOpenIncidentHTTPFailure:
     """Spec: non-2xx response → None, never raises."""
 
     async def test_ghi_s5_http_503_returns_none_and_does_not_raise(self, httpx_mock):
-        """
-        GHI-S5: GH API returns 503 → open_incident MUST return None and MUST NOT raise.
-        """
+        """GHI-S5"""
         import orchestrator.gh_incident as ghi
 
         httpx_mock.add_response(
@@ -261,13 +236,11 @@ class TestOpenIncidentHTTPFailure:
                     f"got {type(exc).__name__}: {exc}"
                 )
 
-        assert result is None, (
-            f"open_incident MUST return None on HTTP 503 error; got {result!r}"
-        )
+        assert result is None
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Part 4: escalate action integration — GHI-S6 .. GHI-S15
+# Part 2: escalate integration — REQ-one-pr-per-req comment-first behavior
 # ─────────────────────────────────────────────────────────────────────────────
 
 
@@ -283,32 +256,55 @@ def _collect_dict_args(*args, **kwargs) -> dict:
     return collected
 
 
+def _resolve_table(spec: Any, *, key: Any, kwargs: dict) -> Any:
+    """Resolve a return spec from per-helper mock config.
+
+    spec may be: a literal value, a dict keyed on `key`, or a callable(**kwargs).
+    """
+    if callable(spec):
+        return spec(**kwargs)
+    if isinstance(spec, dict):
+        return spec.get(key)
+    return spec
+
+
 def _make_escalate_mocks(
-    open_incident_calls: list,
+    *,
+    find_pr_calls: list,
+    comment_calls: list,
+    open_inc_calls: list,
     merge_tags_calls: list,
     update_ctx_calls: list,
-    gh_return: Any = "https://github.com/phona/sisyphus/issues/42",
+    find_pr_return: Any = None,
+    comment_return: Any = None,
+    open_inc_return: Any = None,
 ) -> tuple[Any, Any, Any, Any]:
-    """Build mock objects for escalate's module-level imports.
+    """Build mock objects for escalate's three gh_incident helpers + BKD/db plumbing.
 
-    `gh_return` may be:
-      - a string  → all open_incident calls return that string
-      - None      → all calls return None (GH outage)
-      - a dict    → keyed by repo arg; missing keys → None
-      - a callable → called with kwargs, must return str | None
+    Each *_return may be: a literal value, a dict (keyed on repo or (repo, pr_number)),
+    or a callable(**kwargs). Calls are recorded into the corresponding *_calls list.
     """
-
     mock_gh = MagicMock()
 
-    async def _capture_open_incident(**kwargs):
-        open_incident_calls.append(dict(kwargs))
-        if callable(gh_return):
-            return gh_return(**kwargs)
-        if isinstance(gh_return, dict):
-            return gh_return.get(kwargs.get("repo"))
-        return gh_return
+    async def _capture_find_pr(**kwargs):
+        find_pr_calls.append(dict(kwargs))
+        return _resolve_table(find_pr_return, key=kwargs.get("repo"), kwargs=kwargs)
 
-    mock_gh.open_incident = _capture_open_incident
+    async def _capture_comment(**kwargs):
+        comment_calls.append(dict(kwargs))
+        return _resolve_table(
+            comment_return,
+            key=(kwargs.get("repo"), kwargs.get("pr_number")),
+            kwargs=kwargs,
+        )
+
+    async def _capture_open(**kwargs):
+        open_inc_calls.append(dict(kwargs))
+        return _resolve_table(open_inc_return, key=kwargs.get("repo"), kwargs=kwargs)
+
+    mock_gh.find_pr_for_branch = _capture_find_pr
+    mock_gh.comment_on_pr = _capture_comment
+    mock_gh.open_incident = _capture_open
 
     mock_bkd_inner = MagicMock()
 
@@ -350,6 +346,13 @@ def _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s):
         patch("orchestrator.actions.escalate.req_state", mock_rs),
         patch("orchestrator.actions.escalate.k8s_runner", mock_k8s),
         patch("orchestrator.actions.escalate.db", MagicMock()),
+        # PR-merged shortcut sometimes preempts the real-escalate branch when
+        # GH stubs return unexpected truthy values; force-disable it so all
+        # contract tests below exercise the real-escalate path deterministically.
+        patch(
+            "orchestrator.actions.escalate._all_prs_merged_for_req",
+            AsyncMock(return_value=False),
+        ),
     ]
 
 
@@ -371,20 +374,35 @@ def _last_url_update(update_ctx_calls: list) -> dict | None:
     return matches[-1] if matches else None
 
 
-class TestEscalateRealEscalateGHIS6:
-    """GHI-S6: real-escalate single involved repo → one POST, ctx.gh_incident_urls populated."""
+def _run_with_patches(patches: list, coro_fn):
+    """Run `coro_fn()` inside the stack of patches. Returns the coroutine result."""
+    # Local helper to avoid contextlib.ExitStack noise across many tests.
+    p0, p1, p2, p3, p4, p5, p6 = patches
+    with p0, p1, p2, p3, p4, p5, p6:
+        return coro_fn()
 
-    async def test_ghi_s6_single_involved_repo_opens_one_incident(self):
+
+class TestEscalateRealEscalateGHIS6:
+    """GHI-S6: real-escalate single involved repo with PR found → comment_on_pr."""
+
+    async def test_ghi_s6_single_involved_repo_comments_on_pr(self):
         from orchestrator.actions.escalate import escalate
 
-        open_incident_calls: list = []
+        find_pr_calls: list = []
+        comment_calls: list = []
+        open_inc_calls: list = []
         merge_tags_calls: list = []
         update_ctx_calls: list = []
 
         settings = _make_settings()
         mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
-            open_incident_calls, merge_tags_calls, update_ctx_calls,
-            gh_return="https://github.com/phona/sisyphus/issues/42",
+            find_pr_calls=find_pr_calls,
+            comment_calls=comment_calls,
+            open_inc_calls=open_inc_calls,
+            merge_tags_calls=merge_tags_calls,
+            update_ctx_calls=update_ctx_calls,
+            find_pr_return=42,
+            comment_return="https://github.com/phona/sisyphus/pull/42#issuecomment-99",
         )
 
         body = _make_body("verify.escalate")
@@ -396,7 +414,7 @@ class TestEscalateRealEscalateGHIS6:
         }
 
         patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
             await escalate(
                 body=body,
                 req_id="REQ-test-ghi",
@@ -404,31 +422,32 @@ class TestEscalateRealEscalateGHIS6:
                 ctx=ctx,
             )
 
-        assert len(open_incident_calls) == 1, (
-            f"open_incident MUST be awaited exactly once for a single involved repo; "
-            f"got {len(open_incident_calls)} calls: {open_incident_calls!r}"
+        assert len(find_pr_calls) == 1
+        assert find_pr_calls[0]["repo"] == "phona/sisyphus"
+        assert find_pr_calls[0]["branch"] == "feat/REQ-test-ghi"
+
+        assert len(comment_calls) == 1, (
+            f"comment_on_pr MUST be awaited exactly once when PR is found; "
+            f"got {comment_calls!r}"
         )
-        call = open_incident_calls[0]
-        assert call.get("repo") == "phona/sisyphus", (
-            f"open_incident must be called with repo='phona/sisyphus'; got {call!r}"
+        c = comment_calls[0]
+        assert c["repo"] == "phona/sisyphus"
+        assert c["pr_number"] == 42
+        assert c["req_id"] == "REQ-test-ghi"
+        assert c["reason"] == "verifier-decision-escalate"
+
+        assert len(open_inc_calls) == 0, (
+            f"open_incident MUST NOT be awaited when PR is found; got {open_inc_calls!r}"
         )
-        assert call.get("req_id") == "REQ-test-ghi"
-        assert call.get("reason") == "verifier-decision-escalate"
 
         u = _last_url_update(update_ctx_calls)
-        assert u is not None, (
-            f"update_context MUST be called with gh_incident_urls; "
-            f"all updates: {update_ctx_calls!r}"
-        )
+        assert u is not None
         assert u.get("gh_incident_urls") == {
-            "phona/sisyphus": "https://github.com/phona/sisyphus/issues/42",
-        }, f"gh_incident_urls dict mismatch: {u!r}"
-        assert u.get("gh_incident_url") == "https://github.com/phona/sisyphus/issues/42", (
-            f"legacy gh_incident_url must equal the first URL: {u!r}"
-        )
-        assert u.get("gh_incident_opened_at"), (
-            f"gh_incident_opened_at MUST be non-empty: {u!r}"
-        )
+            "phona/sisyphus": "https://github.com/phona/sisyphus/pull/42#issuecomment-99",
+        }
+        assert u.get("gh_incident_kinds") == {"phona/sisyphus": "comment"}
+        assert u.get("gh_incident_url") == "https://github.com/phona/sisyphus/pull/42#issuecomment-99"
+        assert u.get("gh_incident_opened_at")
 
         assert merge_tags_calls
         add_list = _get_add_list(merge_tags_calls[-1])
@@ -438,19 +457,27 @@ class TestEscalateRealEscalateGHIS6:
 
 
 class TestEscalateIdempotentGHIS7:
-    """GHI-S7: ctx.gh_incident_urls already covers the involved repo → no POST."""
+    """GHI-S7: ctx.gh_incident_urls already covers the involved repo → no GH calls."""
 
     async def test_ghi_s7_idempotent_when_urls_dict_covers_all(self):
         from orchestrator.actions.escalate import escalate
 
-        open_incident_calls: list = []
+        find_pr_calls: list = []
+        comment_calls: list = []
+        open_inc_calls: list = []
         merge_tags_calls: list = []
         update_ctx_calls: list = []
 
         settings = _make_settings()
         mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
-            open_incident_calls, merge_tags_calls, update_ctx_calls,
-            gh_return="https://example/should/not/be/called",
+            find_pr_calls=find_pr_calls,
+            comment_calls=comment_calls,
+            open_inc_calls=open_inc_calls,
+            merge_tags_calls=merge_tags_calls,
+            update_ctx_calls=update_ctx_calls,
+            find_pr_return=42,
+            comment_return="https://example/should/not/be/called",
+            open_inc_return="https://example/should/not/be/called",
         )
 
         body = _make_body("verify.escalate")
@@ -460,12 +487,12 @@ class TestEscalateIdempotentGHIS7:
             "auto_retry_count": 5,
             "involved_repos": ["phona/sisyphus"],
             "gh_incident_urls": {
-                "phona/sisyphus": "https://github.com/phona/sisyphus/issues/42",
+                "phona/sisyphus": "https://github.com/phona/sisyphus/pull/42#issuecomment-99",
             },
         }
 
         patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
             await escalate(
                 body=body,
                 req_id="REQ-test-ghi",
@@ -473,40 +500,46 @@ class TestEscalateIdempotentGHIS7:
                 ctx=ctx,
             )
 
-        assert len(open_incident_calls) == 0, (
-            f"open_incident MUST NOT be called when ctx.gh_incident_urls covers "
-            f"every involved repo; got {open_incident_calls!r}"
-        )
-        # github-incident tag still emitted (existing URLs justify it)
+        assert len(find_pr_calls) == 0
+        assert len(comment_calls) == 0
+        assert len(open_inc_calls) == 0
         add_list = _get_add_list(merge_tags_calls[-1])
         assert "github-incident" in add_list
 
 
 class TestEscalateAutoResumeGHIS8:
-    """GHI-S8: auto-resume branch → no POST."""
+    """GHI-S8: auto-resume branch → no GH calls of any kind."""
 
-    async def test_ghi_s8_auto_resume_does_not_call_open_incident(self):
+    async def test_ghi_s8_auto_resume_does_not_call_gh_helpers(self):
         from orchestrator.actions.escalate import escalate
 
-        open_incident_calls: list = []
+        find_pr_calls: list = []
+        comment_calls: list = []
+        open_inc_calls: list = []
         merge_tags_calls: list = []
         update_ctx_calls: list = []
 
         settings = _make_settings()
         mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
-            open_incident_calls, merge_tags_calls, update_ctx_calls,
-            gh_return="https://example/should/not/be/called",
+            find_pr_calls=find_pr_calls,
+            comment_calls=comment_calls,
+            open_inc_calls=open_inc_calls,
+            merge_tags_calls=merge_tags_calls,
+            update_ctx_calls=update_ctx_calls,
+            find_pr_return=42,
+            comment_return="x",
+            open_inc_return="x",
         )
 
         body = _make_body("session.failed")
         ctx = {
             "escalated_reason": "session-failed",
-            "auto_retry_count": 0,  # budget remaining
+            "auto_retry_count": 0,
             "involved_repos": ["phona/sisyphus"],
         }
 
         patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
             await escalate(
                 body=body,
                 req_id="REQ-test-ghi",
@@ -514,25 +547,33 @@ class TestEscalateAutoResumeGHIS8:
                 ctx=ctx,
             )
 
-        assert len(open_incident_calls) == 0, (
-            f"open_incident MUST NOT be called in auto-resume; got {open_incident_calls!r}"
-        )
+        assert len(find_pr_calls) == 0
+        assert len(comment_calls) == 0
+        assert len(open_inc_calls) == 0
 
 
 class TestEscalateGHFailureGHIS9:
-    """GHI-S9: GH outage → open_incident returns None; flow continues, no tag, no URL ctx fields."""
+    """GHI-S9: PR found but comment_on_pr returns None → no fallback to issue, no tag."""
 
-    async def test_ghi_s9_gh_failure_does_not_abort_escalate(self):
+    async def test_ghi_s9_comment_failure_does_not_abort_escalate(self):
         from orchestrator.actions.escalate import escalate
 
-        open_incident_calls: list = []
+        find_pr_calls: list = []
+        comment_calls: list = []
+        open_inc_calls: list = []
         merge_tags_calls: list = []
         update_ctx_calls: list = []
 
         settings = _make_settings()
         mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
-            open_incident_calls, merge_tags_calls, update_ctx_calls,
-            gh_return=None,  # outage
+            find_pr_calls=find_pr_calls,
+            comment_calls=comment_calls,
+            open_inc_calls=open_inc_calls,
+            merge_tags_calls=merge_tags_calls,
+            update_ctx_calls=update_ctx_calls,
+            find_pr_return=42,
+            comment_return=None,
+            open_inc_return=None,
         )
 
         body = _make_body("verify.escalate")
@@ -545,7 +586,7 @@ class TestEscalateGHFailureGHIS9:
 
         result = None
         patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
             result = await escalate(
                 body=body,
                 req_id="REQ-test-ghi",
@@ -553,38 +594,43 @@ class TestEscalateGHFailureGHIS9:
                 ctx=ctx,
             )
 
-        assert merge_tags_calls, (
-            "bkd.merge_tags_and_update MUST still be called even when open_incident returns None"
+        assert len(comment_calls) == 1
+        assert len(open_inc_calls) == 0, (
+            "PR was found, so escalate must NOT fall through to open_incident "
+            "even when comment_on_pr fails"
         )
+        assert merge_tags_calls
         url_updates = [u for u in update_ctx_calls
                        if u.get("gh_incident_url") or u.get("gh_incident_urls")]
-        assert not url_updates, (
-            f"ctx MUST NOT receive gh_incident_url(s) when GH POSTs all returned None; "
-            f"found: {url_updates!r}"
-        )
+        assert not url_updates, f"no URL ctx fields when no GH artifact landed: {url_updates!r}"
         add_list = _get_add_list(merge_tags_calls[-1])
-        assert "github-incident" not in add_list, (
-            f"'github-incident' tag MUST NOT be added when no URL was opened; "
-            f"got: {add_list!r}"
-        )
+        assert "github-incident" not in add_list
         if isinstance(result, dict):
             assert result.get("escalated") is True
 
 
 class TestEscalateDisabledGHIS10:
-    """GHI-S10: no involved_repos and no settings.gh_incident_repo → no POST, no tag."""
+    """GHI-S10: no involved_repos and no settings.gh_incident_repo → no calls, no tag."""
 
     async def test_ghi_s10_disabled_default_keeps_old_behavior(self):
         from orchestrator.actions.escalate import escalate
 
-        open_incident_calls: list = []
+        find_pr_calls: list = []
+        comment_calls: list = []
+        open_inc_calls: list = []
         merge_tags_calls: list = []
         update_ctx_calls: list = []
 
         settings = _make_settings(gh_incident_repo="")
         mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
-            open_incident_calls, merge_tags_calls, update_ctx_calls,
-            gh_return="https://example/should/not/be/called",
+            find_pr_calls=find_pr_calls,
+            comment_calls=comment_calls,
+            open_inc_calls=open_inc_calls,
+            merge_tags_calls=merge_tags_calls,
+            update_ctx_calls=update_ctx_calls,
+            find_pr_return="https://example/should/not/be/called",
+            comment_return="https://example/should/not/be/called",
+            open_inc_return="https://example/should/not/be/called",
         )
 
         body = _make_body("verify.escalate")
@@ -592,11 +638,10 @@ class TestEscalateDisabledGHIS10:
             "escalated_reason": "verifier-decision-escalate",
             "escalated_source_issue_id": "fail-issue-ghi",
             "auto_retry_count": 5,
-            # NO involved_repos
         }
 
         patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
             result = await escalate(
                 body=body,
                 req_id="REQ-test-ghi",
@@ -604,42 +649,45 @@ class TestEscalateDisabledGHIS10:
                 ctx=ctx,
             )
 
-        assert len(open_incident_calls) == 0, (
-            f"open_incident MUST NOT be called when all 5 layers are empty; "
-            f"got: {open_incident_calls!r}"
-        )
+        assert len(find_pr_calls) == 0
+        assert len(comment_calls) == 0
+        assert len(open_inc_calls) == 0
         if merge_tags_calls:
             add_list = _get_add_list(merge_tags_calls[-1])
-            assert "github-incident" not in add_list, (
-                f"'github-incident' tag MUST NOT appear; got: {add_list!r}"
-            )
+            assert "github-incident" not in add_list
         url_updates = [u for u in update_ctx_calls
                        if u.get("gh_incident_url") or u.get("gh_incident_urls")]
-        assert not url_updates, (
-            f"ctx MUST NOT receive gh_incident_url(s); found: {url_updates!r}"
-        )
+        assert not url_updates
         if isinstance(result, dict):
             assert result.get("escalated") is True
 
 
 class TestEscalateMultiRepoGHIS11:
-    """GHI-S11: multi-repo REQ → one POST per involved repo."""
+    """GHI-S11: multi-repo REQ → one comment per involved repo."""
 
-    async def test_ghi_s11_multi_repo_one_incident_per_repo(self):
+    async def test_ghi_s11_multi_repo_one_comment_per_repo(self):
         from orchestrator.actions.escalate import escalate
 
-        open_incident_calls: list = []
+        find_pr_calls: list = []
+        comment_calls: list = []
+        open_inc_calls: list = []
         merge_tags_calls: list = []
         update_ctx_calls: list = []
 
         settings = _make_settings()
-        gh_table = {
-            "phona/repo-a": "https://github.com/phona/repo-a/issues/7",
-            "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
+        pr_table = {"phona/repo-a": 7, "phona/repo-b": 3}
+        comment_table = {
+            ("phona/repo-a", 7): "https://github.com/phona/repo-a/pull/7#issuecomment-1",
+            ("phona/repo-b", 3): "https://github.com/phona/repo-b/pull/3#issuecomment-2",
         }
         mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
-            open_incident_calls, merge_tags_calls, update_ctx_calls,
-            gh_return=gh_table,
+            find_pr_calls=find_pr_calls,
+            comment_calls=comment_calls,
+            open_inc_calls=open_inc_calls,
+            merge_tags_calls=merge_tags_calls,
+            update_ctx_calls=update_ctx_calls,
+            find_pr_return=pr_table,
+            comment_return=comment_table,
         )
 
         body = _make_body("verify.escalate")
@@ -650,7 +698,7 @@ class TestEscalateMultiRepoGHIS11:
         }
 
         patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
             await escalate(
                 body=body,
                 req_id="REQ-test-ghi",
@@ -658,16 +706,21 @@ class TestEscalateMultiRepoGHIS11:
                 ctx=ctx,
             )
 
-        assert len(open_incident_calls) == 2, (
-            f"open_incident MUST be called once per involved repo (2 expected); "
-            f"got: {open_incident_calls!r}"
-        )
-        called_repos = sorted(c["repo"] for c in open_incident_calls)
+        assert len(comment_calls) == 2
+        called_repos = sorted(c["repo"] for c in comment_calls)
         assert called_repos == ["phona/repo-a", "phona/repo-b"]
+        assert len(open_inc_calls) == 0
 
         u = _last_url_update(update_ctx_calls)
         assert u is not None
-        assert u["gh_incident_urls"] == gh_table
+        assert u["gh_incident_urls"] == {
+            "phona/repo-a": "https://github.com/phona/repo-a/pull/7#issuecomment-1",
+            "phona/repo-b": "https://github.com/phona/repo-b/pull/3#issuecomment-2",
+        }
+        assert u["gh_incident_kinds"] == {
+            "phona/repo-a": "comment",
+            "phona/repo-b": "comment",
+        }
 
         add_list = _get_add_list(merge_tags_calls[-1])
         assert add_list.count("github-incident") == 1
@@ -679,18 +732,26 @@ class TestEscalatePartialFailureGHIS12:
     async def test_ghi_s12_partial_failure_isolated(self):
         from orchestrator.actions.escalate import escalate
 
-        open_incident_calls: list = []
+        find_pr_calls: list = []
+        comment_calls: list = []
+        open_inc_calls: list = []
         merge_tags_calls: list = []
         update_ctx_calls: list = []
 
         settings = _make_settings()
-        gh_table = {
-            "phona/repo-a": None,  # 403 / outage
-            "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
+        pr_table = {"phona/repo-a": 7, "phona/repo-b": 3}
+        comment_table = {
+            ("phona/repo-a", 7): None,  # 4xx / outage
+            ("phona/repo-b", 3): "https://github.com/phona/repo-b/pull/3#issuecomment-2",
         }
         mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
-            open_incident_calls, merge_tags_calls, update_ctx_calls,
-            gh_return=gh_table,
+            find_pr_calls=find_pr_calls,
+            comment_calls=comment_calls,
+            open_inc_calls=open_inc_calls,
+            merge_tags_calls=merge_tags_calls,
+            update_ctx_calls=update_ctx_calls,
+            find_pr_return=pr_table,
+            comment_return=comment_table,
         )
 
         body = _make_body("verify.escalate")
@@ -702,7 +763,7 @@ class TestEscalatePartialFailureGHIS12:
 
         result = None
         patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
             result = await escalate(
                 body=body,
                 req_id="REQ-test-ghi",
@@ -716,8 +777,9 @@ class TestEscalatePartialFailureGHIS12:
         u = _last_url_update(update_ctx_calls)
         assert u is not None
         assert u["gh_incident_urls"] == {
-            "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
-        }, f"Only the successful repo MUST be persisted; got {u!r}"
+            "phona/repo-b": "https://github.com/phona/repo-b/pull/3#issuecomment-2",
+        }
+        assert u["gh_incident_kinds"] == {"phona/repo-b": "comment"}
 
         add_list = _get_add_list(merge_tags_calls[-1])
         assert "github-incident" in add_list
@@ -729,14 +791,25 @@ class TestEscalateMultiRepoIdempotentGHIS13:
     async def test_ghi_s13_only_missing_repos_posted_on_reentry(self):
         from orchestrator.actions.escalate import escalate
 
-        open_incident_calls: list = []
+        find_pr_calls: list = []
+        comment_calls: list = []
+        open_inc_calls: list = []
         merge_tags_calls: list = []
         update_ctx_calls: list = []
 
         settings = _make_settings()
+        pr_table = {"phona/repo-b": 3}
+        comment_table = {
+            ("phona/repo-b", 3): "https://github.com/phona/repo-b/pull/3#issuecomment-2",
+        }
         mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
-            open_incident_calls, merge_tags_calls, update_ctx_calls,
-            gh_return="https://github.com/phona/repo-b/issues/3",
+            find_pr_calls=find_pr_calls,
+            comment_calls=comment_calls,
+            open_inc_calls=open_inc_calls,
+            merge_tags_calls=merge_tags_calls,
+            update_ctx_calls=update_ctx_calls,
+            find_pr_return=pr_table,
+            comment_return=comment_table,
         )
 
         body = _make_body("verify.escalate")
@@ -745,12 +818,12 @@ class TestEscalateMultiRepoIdempotentGHIS13:
             "auto_retry_count": 5,
             "involved_repos": ["phona/repo-a", "phona/repo-b"],
             "gh_incident_urls": {
-                "phona/repo-a": "https://github.com/phona/repo-a/issues/7",
+                "phona/repo-a": "https://github.com/phona/repo-a/pull/7#issuecomment-1",
             },
         }
 
         patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
             await escalate(
                 body=body,
                 req_id="REQ-test-ghi",
@@ -758,44 +831,55 @@ class TestEscalateMultiRepoIdempotentGHIS13:
                 ctx=ctx,
             )
 
-        assert len(open_incident_calls) == 1, (
-            f"Only the missing repo MUST be re-POSTed; got: {open_incident_calls!r}"
-        )
-        assert open_incident_calls[0]["repo"] == "phona/repo-b"
+        assert len(comment_calls) == 1
+        assert comment_calls[0]["repo"] == "phona/repo-b"
+        assert comment_calls[0]["pr_number"] == 3
+        assert len(open_inc_calls) == 0
 
         u = _last_url_update(update_ctx_calls)
         assert u is not None
         assert u["gh_incident_urls"] == {
-            "phona/repo-a": "https://github.com/phona/repo-a/issues/7",
-            "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
-        }, f"merged urls dict mismatch: {u!r}"
+            "phona/repo-a": "https://github.com/phona/repo-a/pull/7#issuecomment-1",
+            "phona/repo-b": "https://github.com/phona/repo-b/pull/3#issuecomment-2",
+        }
 
 
 class TestEscalateLegacyFallbackGHIS14:
-    """GHI-S14: no involved_repos → fall back to settings.gh_incident_repo."""
+    """GHI-S14: no involved_repos → fall back to settings.gh_incident_repo.
 
-    async def test_ghi_s14_falls_back_to_settings_gh_incident_repo(self):
+    The triage-inbox repo has no per-REQ PR, so find_pr_for_branch returns
+    None and escalate falls through to open_incident (issue creation).
+    """
+
+    async def test_ghi_s14_falls_back_to_settings_gh_incident_repo_via_issue(self):
         from orchestrator.actions.escalate import escalate
 
-        open_incident_calls: list = []
+        find_pr_calls: list = []
+        comment_calls: list = []
+        open_inc_calls: list = []
         merge_tags_calls: list = []
         update_ctx_calls: list = []
 
         settings = _make_settings(gh_incident_repo="phona/sisyphus")
         mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
-            open_incident_calls, merge_tags_calls, update_ctx_calls,
-            gh_return="https://github.com/phona/sisyphus/issues/99",
+            find_pr_calls=find_pr_calls,
+            comment_calls=comment_calls,
+            open_inc_calls=open_inc_calls,
+            merge_tags_calls=merge_tags_calls,
+            update_ctx_calls=update_ctx_calls,
+            find_pr_return=None,
+            comment_return=None,
+            open_inc_return="https://github.com/phona/sisyphus/issues/99",
         )
 
         body = _make_body("verify.escalate")
         ctx = {
             "escalated_reason": "verifier-decision-escalate",
             "auto_retry_count": 5,
-            # No involved_repos / no repo: tags / no default_involved_repos
         }
 
         patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
             await escalate(
                 body=body,
                 req_id="REQ-test-ghi",
@@ -803,17 +887,18 @@ class TestEscalateLegacyFallbackGHIS14:
                 ctx=ctx,
             )
 
-        assert len(open_incident_calls) == 1, (
-            f"open_incident MUST be called once with the legacy fallback repo; "
-            f"got: {open_incident_calls!r}"
-        )
-        assert open_incident_calls[0]["repo"] == "phona/sisyphus"
+        assert len(find_pr_calls) == 1
+        assert find_pr_calls[0]["repo"] == "phona/sisyphus"
+        assert len(comment_calls) == 0
+        assert len(open_inc_calls) == 1
+        assert open_inc_calls[0]["repo"] == "phona/sisyphus"
 
         u = _last_url_update(update_ctx_calls)
         assert u is not None
         assert u["gh_incident_urls"] == {
             "phona/sisyphus": "https://github.com/phona/sisyphus/issues/99",
         }
+        assert u["gh_incident_kinds"] == {"phona/sisyphus": "issue"}
         add_list = _get_add_list(merge_tags_calls[-1])
         assert "github-incident" in add_list
 
@@ -824,25 +909,32 @@ class TestEscalateLayerPrecedenceGHIS15:
     async def test_ghi_s15_involved_repos_take_precedence(self):
         from orchestrator.actions.escalate import escalate
 
-        open_incident_calls: list = []
+        find_pr_calls: list = []
+        comment_calls: list = []
+        open_inc_calls: list = []
         merge_tags_calls: list = []
         update_ctx_calls: list = []
 
-        settings = _make_settings(gh_incident_repo="phona/sisyphus")  # layer 5 also set
+        settings = _make_settings(gh_incident_repo="phona/sisyphus")
         mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
-            open_incident_calls, merge_tags_calls, update_ctx_calls,
-            gh_return="https://github.com/phona/repo-a/issues/1",
+            find_pr_calls=find_pr_calls,
+            comment_calls=comment_calls,
+            open_inc_calls=open_inc_calls,
+            merge_tags_calls=merge_tags_calls,
+            update_ctx_calls=update_ctx_calls,
+            find_pr_return=1,
+            comment_return="https://github.com/phona/repo-a/pull/1#issuecomment-1",
         )
 
         body = _make_body("verify.escalate")
         ctx = {
             "escalated_reason": "verifier-decision-escalate",
             "auto_retry_count": 5,
-            "involved_repos": ["phona/repo-a"],  # layer 2
+            "involved_repos": ["phona/repo-a"],
         }
 
         patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
             await escalate(
                 body=body,
                 req_id="REQ-test-ghi",
@@ -850,15 +942,194 @@ class TestEscalateLayerPrecedenceGHIS15:
                 ctx=ctx,
             )
 
-        assert len(open_incident_calls) == 1, (
-            f"Only the layer-2 repo MUST be POSTed; got: {open_incident_calls!r}"
-        )
-        assert open_incident_calls[0]["repo"] == "phona/repo-a", (
-            f"layer 2 MUST beat layer 5; got repo={open_incident_calls[0]['repo']!r}"
-        )
+        assert len(comment_calls) == 1
+        assert comment_calls[0]["repo"] == "phona/repo-a"
+        assert len(open_inc_calls) == 0
 
         u = _last_url_update(update_ctx_calls)
         assert u is not None
-        assert set(u["gh_incident_urls"].keys()) == {"phona/repo-a"}, (
-            f"Only the layer-2 repo MUST appear in gh_incident_urls; got: {u!r}"
+        assert set(u["gh_incident_urls"].keys()) == {"phona/repo-a"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Part 3: REQ-one-pr-per-req fallback paths — ICP-S1..ICP-S3
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestEscalateFallsBackToIssueICPS1:
+    """ICP-S1: no PR for feat/{REQ} → falls back to open_incident."""
+
+    async def test_icp_s1_falls_back_to_issue_when_no_pr(self):
+        from orchestrator.actions.escalate import escalate
+
+        find_pr_calls: list = []
+        comment_calls: list = []
+        open_inc_calls: list = []
+        merge_tags_calls: list = []
+        update_ctx_calls: list = []
+
+        settings = _make_settings()
+        mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
+            find_pr_calls=find_pr_calls,
+            comment_calls=comment_calls,
+            open_inc_calls=open_inc_calls,
+            merge_tags_calls=merge_tags_calls,
+            update_ctx_calls=update_ctx_calls,
+            find_pr_return=None,
+            comment_return=None,
+            open_inc_return="https://github.com/phona/sisyphus/issues/42",
         )
+
+        body = _make_body("verify.escalate")
+        ctx = {
+            "escalated_reason": "verifier-decision-escalate",
+            "auto_retry_count": 5,
+            "involved_repos": ["phona/sisyphus"],
+        }
+
+        patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+            await escalate(
+                body=body,
+                req_id="REQ-test-ghi",
+                tags=["REQ-test-ghi", "verifier"],
+                ctx=ctx,
+            )
+
+        assert len(find_pr_calls) == 1
+        assert find_pr_calls[0]["repo"] == "phona/sisyphus"
+        assert find_pr_calls[0]["branch"] == "feat/REQ-test-ghi"
+        assert len(comment_calls) == 0
+        assert len(open_inc_calls) == 1
+        assert open_inc_calls[0]["repo"] == "phona/sisyphus"
+        assert open_inc_calls[0]["req_id"] == "REQ-test-ghi"
+        assert open_inc_calls[0]["reason"] == "verifier-decision-escalate"
+
+        u = _last_url_update(update_ctx_calls)
+        assert u is not None
+        assert u["gh_incident_urls"] == {
+            "phona/sisyphus": "https://github.com/phona/sisyphus/issues/42",
+        }
+        assert u["gh_incident_kinds"] == {"phona/sisyphus": "issue"}
+        add_list = _get_add_list(merge_tags_calls[-1])
+        assert "github-incident" in add_list
+
+
+class TestEscalateMixedMultiRepoICPS2:
+    """ICP-S2: comment for repo with PR, issue for repo without."""
+
+    async def test_icp_s2_mixed_multi_repo_comment_and_issue(self):
+        from orchestrator.actions.escalate import escalate
+
+        find_pr_calls: list = []
+        comment_calls: list = []
+        open_inc_calls: list = []
+        merge_tags_calls: list = []
+        update_ctx_calls: list = []
+
+        settings = _make_settings()
+        pr_table = {"phona/repo-a": 7}  # repo-b absent → no PR
+        comment_table = {
+            ("phona/repo-a", 7): "https://github.com/phona/repo-a/pull/7#issuecomment-1",
+        }
+        open_table = {
+            "phona/repo-b": "https://github.com/phona/repo-b/issues/42",
+        }
+        mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
+            find_pr_calls=find_pr_calls,
+            comment_calls=comment_calls,
+            open_inc_calls=open_inc_calls,
+            merge_tags_calls=merge_tags_calls,
+            update_ctx_calls=update_ctx_calls,
+            find_pr_return=pr_table,
+            comment_return=comment_table,
+            open_inc_return=open_table,
+        )
+
+        body = _make_body("verify.escalate")
+        ctx = {
+            "escalated_reason": "verifier-decision-escalate",
+            "auto_retry_count": 5,
+            "involved_repos": ["phona/repo-a", "phona/repo-b"],
+        }
+
+        patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+            await escalate(
+                body=body,
+                req_id="REQ-test-ghi",
+                tags=["REQ-test-ghi", "verifier"],
+                ctx=ctx,
+            )
+
+        assert len(comment_calls) == 1
+        assert comment_calls[0]["repo"] == "phona/repo-a"
+        assert len(open_inc_calls) == 1
+        assert open_inc_calls[0]["repo"] == "phona/repo-b"
+
+        u = _last_url_update(update_ctx_calls)
+        assert u is not None
+        assert u["gh_incident_urls"] == {
+            "phona/repo-a": "https://github.com/phona/repo-a/pull/7#issuecomment-1",
+            "phona/repo-b": "https://github.com/phona/repo-b/issues/42",
+        }
+        assert u["gh_incident_kinds"] == {
+            "phona/repo-a": "comment",
+            "phona/repo-b": "issue",
+        }
+        add_list = _get_add_list(merge_tags_calls[-1])
+        assert add_list.count("github-incident") == 1
+
+
+class TestEscalateFindPRErrorICPS3:
+    """ICP-S3: find_pr_for_branch returns None on HTTP error → falls back to issue."""
+
+    async def test_icp_s3_find_pr_error_treated_as_no_pr(self):
+        from orchestrator.actions.escalate import escalate
+
+        find_pr_calls: list = []
+        comment_calls: list = []
+        open_inc_calls: list = []
+        merge_tags_calls: list = []
+        update_ctx_calls: list = []
+
+        settings = _make_settings()
+        # find_pr_for_branch absorbs HTTP errors internally and yields None;
+        # the contract here is "None ⇒ escalate falls through to open_incident".
+        mock_gh, mock_BKDClient, mock_rs, mock_k8s = _make_escalate_mocks(
+            find_pr_calls=find_pr_calls,
+            comment_calls=comment_calls,
+            open_inc_calls=open_inc_calls,
+            merge_tags_calls=merge_tags_calls,
+            update_ctx_calls=update_ctx_calls,
+            find_pr_return=None,
+            comment_return=None,
+            open_inc_return="https://github.com/phona/sisyphus/issues/42",
+        )
+
+        body = _make_body("verify.escalate")
+        ctx = {
+            "escalated_reason": "verifier-decision-escalate",
+            "auto_retry_count": 5,
+            "involved_repos": ["phona/sisyphus"],
+        }
+
+        result = None
+        patches = _escalate_patches(settings, mock_gh, mock_BKDClient, mock_rs, mock_k8s)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+            result = await escalate(
+                body=body,
+                req_id="REQ-test-ghi",
+                tags=["REQ-test-ghi", "verifier"],
+                ctx=ctx,
+            )
+
+        assert len(comment_calls) == 0
+        assert len(open_inc_calls) == 1
+
+        u = _last_url_update(update_ctx_calls)
+        assert u is not None
+        assert u["gh_incident_kinds"]["phona/sisyphus"] == "issue"
+
+        if isinstance(result, dict):
+            assert result.get("escalated") is True

--- a/orchestrator/tests/test_gh_incident.py
+++ b/orchestrator/tests/test_gh_incident.py
@@ -1,7 +1,17 @@
-"""Unit tests for orchestrator.gh_incident.open_incident + escalate integration.
+"""Unit tests for orchestrator.gh_incident + escalate integration.
 
-Covers GHI-S1..GHI-S15 from openspec/specs/gh-incident-open/spec.md (the
-per-involved-repo loop introduced by REQ-gh-incident-per-involved-repo-1777180551).
+Coverage:
+- GHI-S1..GHI-S5    open_incident unit tests (legacy issue-creation path) —
+                    behavior preserved by the comment-on-pr refactor.
+- COP-S1..COP-S7    comment_on_pr unit tests
+                    (REQ-one-pr-per-req-1777218057).
+- FPR-S1..FPR-S4    find_pr_for_branch unit tests
+                    (REQ-one-pr-per-req-1777218057).
+- GHI-S6..GHI-S15   escalate integration: comment-first happy paths,
+                    idempotency, multi-repo, partial failure, layered
+                    fallback resolver.
+- ICP-S1..ICP-S3    escalate falls back to open_incident when no PR exists
+                    (REQ-one-pr-per-req-1777218057).
 """
 from __future__ import annotations
 
@@ -30,27 +40,40 @@ def _set_settings(monkeypatch, *, token: str = "ghp_xxx", labels=None,
     )
 
 
-def _patch_client(monkeypatch, *, status_code: int = 201,
-                  json_body: dict | None = None,
-                  raise_exc: Exception | None = None):
-    """Replace httpx.AsyncClient with a stub whose .post returns / raises predictably.
+def _patch_client(monkeypatch, *,
+                  post_status: int = 201,
+                  post_json: dict | None = None,
+                  post_raise: Exception | None = None,
+                  get_status: int = 200,
+                  get_json: list | dict | None = None,
+                  get_raise: Exception | None = None):
+    """Replace httpx.AsyncClient with a stub supporting GET (find_pr) + POST.
 
-    Captures the (url, headers, json) of the last call on the returned `recorder` dict.
+    Captures the (url, headers, params/json) of the last call on the returned
+    `recorder` dict under keys `last_post` / `last_get`.
     """
     from orchestrator import gh_incident
 
     recorder: dict = {}
 
     async def _post(self, url, headers=None, json=None):
-        recorder["url"] = url
-        recorder["headers"] = headers
-        recorder["json"] = json
-        if raise_exc:
-            raise raise_exc
+        recorder["last_post"] = {"url": url, "headers": headers, "json": json}
+        if post_raise:
+            raise post_raise
         resp = MagicMock(spec=httpx.Response)
-        resp.status_code = status_code
-        resp.text = "" if json_body is None else str(json_body)
-        resp.json = MagicMock(return_value=json_body or {})
+        resp.status_code = post_status
+        resp.text = "" if post_json is None else str(post_json)
+        resp.json = MagicMock(return_value=post_json or {})
+        return resp
+
+    async def _get(self, url, headers=None, params=None):
+        recorder["last_get"] = {"url": url, "headers": headers, "params": params}
+        if get_raise:
+            raise get_raise
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = get_status
+        resp.text = "" if get_json is None else str(get_json)
+        resp.json = MagicMock(return_value=get_json if get_json is not None else [])
         return resp
 
     class _FakeClient:
@@ -58,17 +81,21 @@ def _patch_client(monkeypatch, *, status_code: int = 201,
         async def __aenter__(self): return self
         async def __aexit__(self, *exc): return None
         post = _post
+        get = _get
 
     monkeypatch.setattr(gh_incident.httpx, "AsyncClient", _FakeClient)
     return recorder
 
 
-# ─── GHI-S1: disabled when repo argument is empty ─────────────────────────
+# ─── GHI-S1..GHI-S5: open_incident unit tests (legacy path, unchanged) ─────
+
+
 @pytest.mark.asyncio
 async def test_open_incident_disabled_when_repo_empty(monkeypatch):
+    """GHI-S1"""
     from orchestrator import gh_incident
     _set_settings(monkeypatch, token="ghp_xxx")
-    rec = _patch_client(monkeypatch)  # would record if called
+    rec = _patch_client(monkeypatch)
 
     out = await gh_incident.open_incident(
         repo="", req_id="REQ-1", reason="x", retry_count=0,
@@ -78,9 +105,9 @@ async def test_open_incident_disabled_when_repo_empty(monkeypatch):
     assert rec == {}, "no HTTP request should be made when repo is empty"
 
 
-# ─── GHI-S2: disabled when github_token empty ────────────────────────────
 @pytest.mark.asyncio
 async def test_open_incident_disabled_when_token_empty(monkeypatch):
+    """GHI-S2"""
     from orchestrator import gh_incident
     _set_settings(monkeypatch, token="")
     rec = _patch_client(monkeypatch)
@@ -93,14 +120,14 @@ async def test_open_incident_disabled_when_token_empty(monkeypatch):
     assert rec == {}
 
 
-# ─── GHI-S3: success returns html_url + uses correct URL/headers ─────────
 @pytest.mark.asyncio
 async def test_open_incident_success_returns_html_url(monkeypatch):
+    """GHI-S3"""
     from orchestrator import gh_incident
     _set_settings(monkeypatch, token="ghp_xxx")
     rec = _patch_client(
-        monkeypatch, status_code=201,
-        json_body={"html_url": "https://github.com/phona/sisyphus/issues/42"},
+        monkeypatch, post_status=201,
+        post_json={"html_url": "https://github.com/phona/sisyphus/issues/42"},
     )
 
     out = await gh_incident.open_incident(
@@ -110,19 +137,20 @@ async def test_open_incident_success_returns_html_url(monkeypatch):
         state="executing",
     )
     assert out == "https://github.com/phona/sisyphus/issues/42"
-    assert rec["url"] == "https://api.github.com/repos/phona/sisyphus/issues"
-    assert rec["headers"]["Authorization"] == "Bearer ghp_xxx"
-    assert rec["headers"]["Accept"] == "application/vnd.github+json"
+    last = rec["last_post"]
+    assert last["url"] == "https://api.github.com/repos/phona/sisyphus/issues"
+    assert last["headers"]["Authorization"] == "Bearer ghp_xxx"
+    assert last["headers"]["Accept"] == "application/vnd.github+json"
 
 
-# ─── GHI-S4: request body contains REQ id, reason, BKD cross-references ──
 @pytest.mark.asyncio
 async def test_open_incident_body_contains_context(monkeypatch):
+    """GHI-S4"""
     from orchestrator import gh_incident
     _set_settings(monkeypatch, token="ghp_xxx")
     rec = _patch_client(
-        monkeypatch, status_code=201,
-        json_body={"html_url": "https://github.com/phona/sisyphus/issues/42"},
+        monkeypatch, post_status=201,
+        post_json={"html_url": "https://github.com/phona/sisyphus/issues/42"},
     )
 
     await gh_incident.open_incident(
@@ -131,24 +159,23 @@ async def test_open_incident_body_contains_context(monkeypatch):
         intent_issue_id="intent-1", failed_issue_id="vfy-3", project_id="proj-A",
         state="fixer-running",
     )
-    payload = rec["json"]
+    payload = rec["last_post"]["json"]
     assert "REQ-9" in payload["title"]
     assert "fixer-round-cap" in payload["title"]
     body = payload["body"]
     for needle in ("REQ-9", "fixer-round-cap", "intent-1", "vfy-3", "proj-A", "fixer-running"):
         assert needle in body, f"body should contain {needle!r}"
-    # labels: base + reason:*
     assert "sisyphus:incident" in payload["labels"]
     assert "reason:fixer-round-cap" in payload["labels"]
 
 
-# ─── GHI-S5: HTTP failure returns None and does not raise ─────────────────
 @pytest.mark.asyncio
 async def test_open_incident_http_503_returns_none(monkeypatch):
+    """GHI-S5 — HTTP failure"""
     from orchestrator import gh_incident
     _set_settings(monkeypatch, token="ghp_xxx")
-    _patch_client(monkeypatch, status_code=503,
-                  json_body={"message": "service unavailable"})
+    _patch_client(monkeypatch, post_status=503,
+                  post_json={"message": "service unavailable"})
 
     out = await gh_incident.open_incident(
         repo="phona/sisyphus",
@@ -162,7 +189,7 @@ async def test_open_incident_http_503_returns_none(monkeypatch):
 async def test_open_incident_network_error_returns_none(monkeypatch):
     from orchestrator import gh_incident
     _set_settings(monkeypatch, token="ghp_xxx")
-    _patch_client(monkeypatch, raise_exc=httpx.ConnectError("DNS failure"))
+    _patch_client(monkeypatch, post_raise=httpx.ConnectError("DNS failure"))
 
     out = await gh_incident.open_incident(
         repo="phona/sisyphus",
@@ -176,7 +203,7 @@ async def test_open_incident_network_error_returns_none(monkeypatch):
 async def test_open_incident_2xx_without_html_url_returns_none(monkeypatch):
     from orchestrator import gh_incident
     _set_settings(monkeypatch, token="ghp_xxx")
-    _patch_client(monkeypatch, status_code=200, json_body={"unexpected": "shape"})
+    _patch_client(monkeypatch, post_status=200, post_json={"unexpected": "shape"})
 
     out = await gh_incident.open_incident(
         repo="phona/sisyphus",
@@ -186,9 +213,209 @@ async def test_open_incident_2xx_without_html_url_returns_none(monkeypatch):
     assert out is None
 
 
-# ─── escalate-integration tests (GHI-S6..GHI-S15) ─────────────────────────
-# Sister tests to test_actions_smoke.py — kept here to keep gh-incident
-# scenarios in one file. The fixtures mirror the smoke-test style.
+# ─── COP-S1..COP-S7: comment_on_pr unit tests ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_comment_on_pr_disabled_when_repo_empty(monkeypatch):
+    """COP-S1"""
+    from orchestrator import gh_incident
+    _set_settings(monkeypatch, token="ghp_xxx")
+    rec = _patch_client(monkeypatch)
+
+    out = await gh_incident.comment_on_pr(
+        repo="", pr_number=42, req_id="REQ-1", reason="x", retry_count=0,
+        intent_issue_id="i", failed_issue_id="i", project_id="p",
+    )
+    assert out is None
+    assert rec == {}
+
+
+@pytest.mark.asyncio
+async def test_comment_on_pr_disabled_when_token_empty(monkeypatch):
+    """COP-S2"""
+    from orchestrator import gh_incident
+    _set_settings(monkeypatch, token="")
+    rec = _patch_client(monkeypatch)
+
+    out = await gh_incident.comment_on_pr(
+        repo="phona/sisyphus", pr_number=42, req_id="REQ-1", reason="x",
+        retry_count=0, intent_issue_id="i", failed_issue_id="i", project_id="p",
+    )
+    assert out is None
+    assert rec == {}
+
+
+@pytest.mark.asyncio
+async def test_comment_on_pr_disabled_when_pr_number_zero(monkeypatch):
+    """COP-S3"""
+    from orchestrator import gh_incident
+    _set_settings(monkeypatch, token="ghp_xxx")
+    rec = _patch_client(monkeypatch)
+
+    out = await gh_incident.comment_on_pr(
+        repo="phona/sisyphus", pr_number=0, req_id="REQ-1", reason="x",
+        retry_count=0, intent_issue_id="i", failed_issue_id="i", project_id="p",
+    )
+    assert out is None
+    assert rec == {}
+
+
+@pytest.mark.asyncio
+async def test_comment_on_pr_success_returns_html_url(monkeypatch):
+    """COP-S4"""
+    from orchestrator import gh_incident
+    _set_settings(monkeypatch, token="ghp_xxx")
+    rec = _patch_client(
+        monkeypatch, post_status=201,
+        post_json={"html_url": "https://github.com/phona/sisyphus/pull/42#issuecomment-99"},
+    )
+
+    out = await gh_incident.comment_on_pr(
+        repo="phona/sisyphus", pr_number=42,
+        req_id="REQ-9", reason="verifier-decision-escalate", retry_count=0,
+        intent_issue_id="intent-1", failed_issue_id="vfy-3", project_id="proj-A",
+        state="executing",
+    )
+    assert out == "https://github.com/phona/sisyphus/pull/42#issuecomment-99"
+    last = rec["last_post"]
+    assert last["url"] == "https://api.github.com/repos/phona/sisyphus/issues/42/comments"
+    assert last["headers"]["Authorization"] == "Bearer ghp_xxx"
+    assert last["headers"]["Accept"] == "application/vnd.github+json"
+
+
+@pytest.mark.asyncio
+async def test_comment_on_pr_body_contains_context(monkeypatch):
+    """COP-S5"""
+    from orchestrator import gh_incident
+    _set_settings(monkeypatch, token="ghp_xxx")
+    rec = _patch_client(
+        monkeypatch, post_status=201,
+        post_json={"html_url": "https://github.com/phona/sisyphus/pull/42#issuecomment-99"},
+    )
+
+    await gh_incident.comment_on_pr(
+        repo="phona/sisyphus", pr_number=42,
+        req_id="REQ-9", reason="fixer-round-cap", retry_count=1,
+        intent_issue_id="intent-1", failed_issue_id="vfy-3", project_id="proj-A",
+        state="fixer-running",
+    )
+    payload = rec["last_post"]["json"]
+    body = payload["body"]
+    for needle in ("REQ-9", "fixer-round-cap", "intent-1", "vfy-3", "proj-A", "fixer-running"):
+        assert needle in body, f"body should contain {needle!r}"
+
+
+@pytest.mark.asyncio
+async def test_comment_on_pr_http_503_returns_none(monkeypatch):
+    """COP-S6"""
+    from orchestrator import gh_incident
+    _set_settings(monkeypatch, token="ghp_xxx")
+    _patch_client(monkeypatch, post_status=503, post_json={"message": "boom"})
+
+    out = await gh_incident.comment_on_pr(
+        repo="phona/sisyphus", pr_number=42,
+        req_id="REQ-9", reason="x", retry_count=0,
+        intent_issue_id="i", failed_issue_id="i", project_id="p",
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_comment_on_pr_network_error_returns_none(monkeypatch):
+    """COP-S7"""
+    from orchestrator import gh_incident
+    _set_settings(monkeypatch, token="ghp_xxx")
+    _patch_client(monkeypatch, post_raise=httpx.ConnectError("DNS failure"))
+
+    out = await gh_incident.comment_on_pr(
+        repo="phona/sisyphus", pr_number=42,
+        req_id="REQ-9", reason="x", retry_count=0,
+        intent_issue_id="i", failed_issue_id="i", project_id="p",
+    )
+    assert out is None
+
+
+# ─── FPR-S1..FPR-S4: find_pr_for_branch unit tests ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_find_pr_disabled_when_repo_or_token_empty(monkeypatch):
+    """FPR-S1"""
+    from orchestrator import gh_incident
+    _set_settings(monkeypatch, token="")
+    rec = _patch_client(monkeypatch)
+
+    out = await gh_incident.find_pr_for_branch(repo="phona/sisyphus", branch="feat/REQ-x")
+    assert out is None
+    assert rec == {}
+
+    _set_settings(monkeypatch, token="ghp_xxx")
+    rec = _patch_client(monkeypatch)
+    out = await gh_incident.find_pr_for_branch(repo="", branch="feat/REQ-x")
+    assert out is None
+    assert rec == {}
+
+
+@pytest.mark.asyncio
+async def test_find_pr_returns_first_pr_number(monkeypatch):
+    """FPR-S2"""
+    from orchestrator import gh_incident
+    _set_settings(monkeypatch, token="ghp_xxx")
+    rec = _patch_client(
+        monkeypatch, get_status=200,
+        get_json=[{"number": 42, "html_url": "https://x"}, {"number": 39}],
+    )
+
+    out = await gh_incident.find_pr_for_branch(
+        repo="phona/sisyphus", branch="feat/REQ-x",
+    )
+    assert out == 42
+    last = rec["last_get"]
+    assert last["url"] == "https://api.github.com/repos/phona/sisyphus/pulls"
+    assert last["params"] == {"head": "phona:feat/REQ-x", "state": "all", "per_page": 5}
+    assert last["headers"]["Authorization"] == "Bearer ghp_xxx"
+
+
+@pytest.mark.asyncio
+async def test_find_pr_returns_none_on_empty_list(monkeypatch):
+    """FPR-S3"""
+    from orchestrator import gh_incident
+    _set_settings(monkeypatch, token="ghp_xxx")
+    _patch_client(monkeypatch, get_status=200, get_json=[])
+
+    out = await gh_incident.find_pr_for_branch(
+        repo="phona/sisyphus", branch="feat/REQ-x",
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_find_pr_returns_none_on_http_error(monkeypatch):
+    """FPR-S4"""
+    from orchestrator import gh_incident
+    _set_settings(monkeypatch, token="ghp_xxx")
+    _patch_client(monkeypatch, get_status=503, get_json={"message": "boom"})
+
+    out = await gh_incident.find_pr_for_branch(
+        repo="phona/sisyphus", branch="feat/REQ-x",
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_find_pr_returns_none_on_network_error(monkeypatch):
+    from orchestrator import gh_incident
+    _set_settings(monkeypatch, token="ghp_xxx")
+    _patch_client(monkeypatch, get_raise=httpx.ConnectError("DNS failure"))
+
+    out = await gh_incident.find_pr_for_branch(
+        repo="phona/sisyphus", branch="feat/REQ-x",
+    )
+    assert out is None
+
+
+# ─── escalate-integration tests (GHI-S6..S15 + ICP-S1..S3) ────────────────
 
 
 @dataclass
@@ -266,19 +493,55 @@ def _stub_req_state_get(monkeypatch):
     monkeypatch.setattr(rs, "get", AsyncMock(return_value=_Row()))
 
 
+def _stub_pr_merge_probe_disabled(monkeypatch):
+    """Stub _all_prs_merged_for_req → False so PR-merged shortcut never fires."""
+    from orchestrator.actions import escalate as mod
+    monkeypatch.setattr(mod, "_all_prs_merged_for_req", AsyncMock(return_value=False))
+
+
+def _patch_gh(monkeypatch, *, find_pr=None, comment=None, open_inc=None):
+    """Mock the three gh_incident helpers escalate now uses.
+
+    `find_pr`: return value or callable(repo, branch) for per-call value.
+    `comment`: return value or callable(**kwargs) for per-call value.
+    `open_inc`: return value or callable(**kwargs) for per-call value.
+    """
+    from orchestrator.actions import escalate as mod
+
+    def _wrap(spec, default):
+        if spec is None:
+            return AsyncMock(return_value=default)
+        if callable(spec):
+            return AsyncMock(side_effect=spec)
+        return AsyncMock(return_value=spec)
+
+    fp = _wrap(find_pr, None)
+    co = _wrap(comment, None)
+    oi = _wrap(open_inc, None)
+    monkeypatch.setattr(mod.gh_incident, "find_pr_for_branch", fp)
+    monkeypatch.setattr(mod.gh_incident, "comment_on_pr", co)
+    monkeypatch.setattr(mod.gh_incident, "open_incident", oi)
+    return fp, co, oi
+
+
+# ─── GHI-S6: real-escalate single involved repo posts a PR comment ────────
 @pytest.mark.asyncio
-async def test_escalate_real_path_opens_gh_incident(monkeypatch):
-    """GHI-S6: real-escalate single involved repo → one POST + ctx.gh_incident_urls."""
+async def test_escalate_real_path_comments_on_pr(monkeypatch):
+    """GHI-S6"""
     from orchestrator.actions import escalate as mod
 
     fake_bkd = _make_fake_bkd()
     _patch_bkd(monkeypatch, fake_bkd)
     patches = _patch_db(monkeypatch)
     _stub_req_state_get(monkeypatch)
+    _stub_pr_merge_probe_disabled(monkeypatch)
     _patch_settings(monkeypatch)
 
-    open_inc = AsyncMock(return_value="https://github.com/phona/sisyphus/issues/42")
-    monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
+    fp, co, oi = _patch_gh(
+        monkeypatch,
+        find_pr=42,
+        comment="https://github.com/phona/sisyphus/pull/42#issuecomment-99",
+    )
 
     body = _make_body(issue_id="vfy-3", event="verify.escalate")
     out = await mod.escalate(
@@ -291,20 +554,29 @@ async def test_escalate_real_path_opens_gh_incident(monkeypatch):
     )
     assert out["escalated"] is True
 
-    open_inc.assert_awaited_once()
-    kw = open_inc.await_args.kwargs
-    assert kw["repo"] == "phona/sisyphus"
-    assert kw["req_id"] == "REQ-9"
-    assert kw["reason"] == "verifier-decision-escalate"
-    assert kw["intent_issue_id"] == "intent-1"
-    assert kw["failed_issue_id"] == "vfy-3"
-    assert kw["project_id"] == "p"
+    fp.assert_awaited_once()
+    fp_kw = fp.await_args.kwargs
+    assert fp_kw["repo"] == "phona/sisyphus"
+    assert fp_kw["branch"] == "feat/REQ-9"
+
+    co.assert_awaited_once()
+    co_kw = co.await_args.kwargs
+    assert co_kw["repo"] == "phona/sisyphus"
+    assert co_kw["pr_number"] == 42
+    assert co_kw["req_id"] == "REQ-9"
+    assert co_kw["reason"] == "verifier-decision-escalate"
+    assert co_kw["intent_issue_id"] == "intent-1"
+    assert co_kw["failed_issue_id"] == "vfy-3"
+    assert co_kw["project_id"] == "p"
+
+    oi.assert_not_awaited()
 
     final = patches[-1]
     assert final["gh_incident_urls"] == {
-        "phona/sisyphus": "https://github.com/phona/sisyphus/issues/42",
+        "phona/sisyphus": "https://github.com/phona/sisyphus/pull/42#issuecomment-99",
     }
-    assert final["gh_incident_url"] == "https://github.com/phona/sisyphus/issues/42"
+    assert final["gh_incident_kinds"] == {"phona/sisyphus": "comment"}
+    assert final["gh_incident_url"] == "https://github.com/phona/sisyphus/pull/42#issuecomment-99"
     assert "gh_incident_opened_at" in final
     assert final["escalated_reason"] == "verifier-decision-escalate"
 
@@ -315,19 +587,22 @@ async def test_escalate_real_path_opens_gh_incident(monkeypatch):
     assert "github-incident" in add
 
 
+# ─── GHI-S7: idempotent: pre-existing url skips lookup + comment ──────────
 @pytest.mark.asyncio
 async def test_escalate_idempotent_when_ctx_has_url(monkeypatch):
-    """GHI-S7: ctx.gh_incident_urls already covers all involved repos → no second POST."""
+    """GHI-S7"""
     from orchestrator.actions import escalate as mod
 
     fake_bkd = _make_fake_bkd()
     _patch_bkd(monkeypatch, fake_bkd)
     patches = _patch_db(monkeypatch)
     _stub_req_state_get(monkeypatch)
+    _stub_pr_merge_probe_disabled(monkeypatch)
     _patch_settings(monkeypatch)
 
-    open_inc = AsyncMock(return_value="https://example/should/not/be/called")
-    monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
+    fp, co, oi = _patch_gh(monkeypatch, find_pr=42,
+                            comment="https://example/should/not/be/called",
+                            open_inc="https://example/should/not/be/called")
 
     body = _make_body(issue_id="vfy-3", event="verify.escalate")
     await mod.escalate(
@@ -337,33 +612,37 @@ async def test_escalate_idempotent_when_ctx_has_url(monkeypatch):
             "escalated_reason": "verifier-decision-escalate",
             "involved_repos": ["phona/sisyphus"],
             "gh_incident_urls": {
-                "phona/sisyphus": "https://github.com/phona/sisyphus/issues/42",
+                "phona/sisyphus": "https://github.com/phona/sisyphus/pull/42#issuecomment-99",
             },
         },
     )
 
-    open_inc.assert_not_awaited()
+    fp.assert_not_awaited()
+    co.assert_not_awaited()
+    oi.assert_not_awaited()
+
     final = patches[-1]
     # No new URL → ctx_patch must not REWRITE gh_incident_urls / gh_incident_url
     assert "gh_incident_urls" not in final
     assert "gh_incident_url" not in final
-    # Tag still includes github-incident (existing URLs → still annotate BKD)
+    assert "gh_incident_kinds" not in final
     add = fake_bkd.merge_tags_and_update.await_args.kwargs["add"]
     assert "github-incident" in add
 
 
+# ─── GHI-S8: auto-resume branch does not interact with GitHub ─────────────
 @pytest.mark.asyncio
 async def test_escalate_auto_resume_does_not_open_incident(monkeypatch):
-    """GHI-S8: transient + budget remaining → auto-resume; no GH POST."""
+    """GHI-S8"""
     from orchestrator.actions import escalate as mod
 
     fake_bkd = _make_fake_bkd()
     _patch_bkd(monkeypatch, fake_bkd)
     _patch_db(monkeypatch)
+    _stub_pr_merge_probe_disabled(monkeypatch)
     _patch_settings(monkeypatch)
 
-    open_inc = AsyncMock(return_value="https://example/should/not/be/called")
-    monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
+    fp, co, oi = _patch_gh(monkeypatch, find_pr=42, comment="x", open_inc="x")
 
     body = _make_body(issue_id="src-1", event="session.failed")
     out = await mod.escalate(
@@ -371,24 +650,27 @@ async def test_escalate_auto_resume_does_not_open_incident(monkeypatch):
         ctx={"intent_issue_id": "intent-1", "auto_retry_count": 0},
     )
     assert out["auto_resumed"] is True
-    open_inc.assert_not_awaited()
+    fp.assert_not_awaited()
+    co.assert_not_awaited()
+    oi.assert_not_awaited()
     fake_bkd.follow_up_issue.assert_awaited_once()
     fake_bkd.merge_tags_and_update.assert_not_awaited()
 
 
+# ─── GHI-S9: GH comment failure does not abort escalate ───────────────────
 @pytest.mark.asyncio
-async def test_escalate_gh_failure_does_not_abort(monkeypatch):
-    """GHI-S9: open_incident returns None → escalate still completes; no URL ctx fields."""
+async def test_escalate_gh_comment_failure_does_not_abort(monkeypatch):
+    """GHI-S9"""
     from orchestrator.actions import escalate as mod
 
     fake_bkd = _make_fake_bkd()
     _patch_bkd(monkeypatch, fake_bkd)
     patches = _patch_db(monkeypatch)
     _stub_req_state_get(monkeypatch)
+    _stub_pr_merge_probe_disabled(monkeypatch)
     _patch_settings(monkeypatch)
 
-    open_inc = AsyncMock(return_value=None)  # GH outage / disabled
-    monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
+    _fp, co, oi = _patch_gh(monkeypatch, find_pr=42, comment=None, open_inc=None)
 
     body = _make_body(issue_id="vfy-3", event="verify.escalate")
     out = await mod.escalate(
@@ -400,26 +682,31 @@ async def test_escalate_gh_failure_does_not_abort(monkeypatch):
         },
     )
     assert out["escalated"] is True
+    co.assert_awaited_once()
+    oi.assert_not_awaited()  # PR was found → no fallback to issue
     fake_bkd.merge_tags_and_update.assert_awaited_once()
     final = patches[-1]
     assert "gh_incident_url" not in final
     assert "gh_incident_urls" not in final
+    assert "gh_incident_kinds" not in final
     add = fake_bkd.merge_tags_and_update.await_args.kwargs["add"]
     assert "github-incident" not in add
 
 
+# ─── GHI-S10: disabled (no involved repos and no fallback) ────────────────
 @pytest.mark.asyncio
 async def test_escalate_disabled_default_keeps_old_behavior(monkeypatch):
-    """GHI-S10: no involved_repos and no settings.gh_incident_repo → behavior unchanged."""
+    """GHI-S10"""
     from orchestrator.actions import escalate as mod
 
     fake_bkd = _make_fake_bkd()
     _patch_bkd(monkeypatch, fake_bkd)
     patches = _patch_db(monkeypatch)
     _stub_req_state_get(monkeypatch)
+    _stub_pr_merge_probe_disabled(monkeypatch)
     _patch_settings(monkeypatch)
 
-    # Don't mock open_incident — let it run with real (empty) settings
+    fp, co, oi = _patch_gh(monkeypatch)
     monkeypatch.setattr(mod.gh_incident.settings, "github_token", "")
 
     body = _make_body(issue_id="vfy-3", event="verify.escalate")
@@ -431,34 +718,45 @@ async def test_escalate_disabled_default_keeps_old_behavior(monkeypatch):
         },
     )
     assert out["escalated"] is True
+    fp.assert_not_awaited()
+    co.assert_not_awaited()
+    oi.assert_not_awaited()
     final = patches[-1]
     assert "gh_incident_url" not in final
     assert "gh_incident_urls" not in final
+    assert "gh_incident_kinds" not in final
     add = fake_bkd.merge_tags_and_update.await_args.kwargs["add"]
     assert "github-incident" not in add
     assert "escalated" in add
     assert "reason:verifier-decision-escalate" in add
 
 
+# ─── GHI-S11: multi-repo REQ posts one comment per involved repo ──────────
 @pytest.mark.asyncio
-async def test_escalate_multi_repo_opens_incident_per_repo(monkeypatch):
-    """GHI-S11: multi-repo REQ → one POST per involved repo."""
+async def test_escalate_multi_repo_comments_per_repo(monkeypatch):
+    """GHI-S11"""
     from orchestrator.actions import escalate as mod
 
     fake_bkd = _make_fake_bkd()
     _patch_bkd(monkeypatch, fake_bkd)
     patches = _patch_db(monkeypatch)
     _stub_req_state_get(monkeypatch)
+    _stub_pr_merge_probe_disabled(monkeypatch)
     _patch_settings(monkeypatch)
 
-    async def _open(*, repo, **_):
-        return {
-            "phona/repo-a": "https://github.com/phona/repo-a/issues/7",
-            "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
-        }.get(repo)
+    pr_lookup = {"phona/repo-a": 7, "phona/repo-b": 3}
+    comments = {
+        ("phona/repo-a", 7): "https://github.com/phona/repo-a/pull/7#issuecomment-1",
+        ("phona/repo-b", 3): "https://github.com/phona/repo-b/pull/3#issuecomment-2",
+    }
 
-    open_inc = AsyncMock(side_effect=_open)
-    monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
+    async def _find(*, repo, branch):
+        return pr_lookup.get(repo)
+
+    async def _comment(*, repo, pr_number, **_):
+        return comments.get((repo, pr_number))
+
+    _fp, co, oi = _patch_gh(monkeypatch, find_pr=_find, comment=_comment)
 
     body = _make_body(issue_id="vfy-3", event="verify.escalate")
     await mod.escalate(
@@ -470,35 +768,46 @@ async def test_escalate_multi_repo_opens_incident_per_repo(monkeypatch):
         },
     )
 
-    assert open_inc.await_count == 2
-    repos_called = sorted(c.kwargs["repo"] for c in open_inc.await_args_list)
+    assert co.await_count == 2
+    repos_called = sorted(c.kwargs["repo"] for c in co.await_args_list)
     assert repos_called == ["phona/repo-a", "phona/repo-b"]
+    oi.assert_not_awaited()
 
     final = patches[-1]
     assert final["gh_incident_urls"] == {
-        "phona/repo-a": "https://github.com/phona/repo-a/issues/7",
-        "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
+        "phona/repo-a": "https://github.com/phona/repo-a/pull/7#issuecomment-1",
+        "phona/repo-b": "https://github.com/phona/repo-b/pull/3#issuecomment-2",
+    }
+    assert final["gh_incident_kinds"] == {
+        "phona/repo-a": "comment",
+        "phona/repo-b": "comment",
     }
     add = fake_bkd.merge_tags_and_update.await_args.kwargs["add"]
     assert add.count("github-incident") == 1
 
 
+# ─── GHI-S12: partial failure isolated ────────────────────────────────────
 @pytest.mark.asyncio
 async def test_escalate_partial_failure_isolated(monkeypatch):
-    """GHI-S12: one repo POST fails (None), the other succeeds → only the success persists."""
+    """GHI-S12"""
     from orchestrator.actions import escalate as mod
 
     fake_bkd = _make_fake_bkd()
     _patch_bkd(monkeypatch, fake_bkd)
     patches = _patch_db(monkeypatch)
     _stub_req_state_get(monkeypatch)
+    _stub_pr_merge_probe_disabled(monkeypatch)
     _patch_settings(monkeypatch)
 
-    async def _open(*, repo, **_):
-        return None if repo == "phona/repo-a" else "https://github.com/phona/repo-b/issues/3"
+    pr_lookup = {"phona/repo-a": 7, "phona/repo-b": 3}
 
-    open_inc = AsyncMock(side_effect=_open)
-    monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
+    async def _find(*, repo, branch):
+        return pr_lookup.get(repo)
+
+    async def _comment(*, repo, pr_number, **_):
+        return None if repo == "phona/repo-a" else "https://github.com/phona/repo-b/pull/3#issuecomment-2"
+
+    _fp, _co, _oi = _patch_gh(monkeypatch, find_pr=_find, comment=_comment)
 
     body = _make_body(issue_id="vfy-3", event="verify.escalate")
     out = await mod.escalate(
@@ -513,25 +822,30 @@ async def test_escalate_partial_failure_isolated(monkeypatch):
 
     final = patches[-1]
     assert final["gh_incident_urls"] == {
-        "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
+        "phona/repo-b": "https://github.com/phona/repo-b/pull/3#issuecomment-2",
     }
+    assert final["gh_incident_kinds"] == {"phona/repo-b": "comment"}
     add = fake_bkd.merge_tags_and_update.await_args.kwargs["add"]
-    assert "github-incident" in add  # one success suffices
+    assert "github-incident" in add
 
 
+# ─── GHI-S13: idempotent across multi-repo on re-entry ────────────────────
 @pytest.mark.asyncio
 async def test_escalate_idempotent_per_repo_only_missing_posted(monkeypatch):
-    """GHI-S13: existing URLs preserved; only missing repos POSTed on re-entry."""
+    """GHI-S13"""
     from orchestrator.actions import escalate as mod
 
     fake_bkd = _make_fake_bkd()
     _patch_bkd(monkeypatch, fake_bkd)
     patches = _patch_db(monkeypatch)
     _stub_req_state_get(monkeypatch)
+    _stub_pr_merge_probe_disabled(monkeypatch)
     _patch_settings(monkeypatch)
 
-    open_inc = AsyncMock(return_value="https://github.com/phona/repo-b/issues/3")
-    monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
+    _fp, co, oi = _patch_gh(
+        monkeypatch, find_pr=3,
+        comment="https://github.com/phona/repo-b/pull/3#issuecomment-2",
+    )
 
     body = _make_body(issue_id="vfy-3", event="verify.escalate")
     await mod.escalate(
@@ -541,34 +855,42 @@ async def test_escalate_idempotent_per_repo_only_missing_posted(monkeypatch):
             "escalated_reason": "verifier-decision-escalate",
             "involved_repos": ["phona/repo-a", "phona/repo-b"],
             "gh_incident_urls": {
-                "phona/repo-a": "https://github.com/phona/repo-a/issues/7",
+                "phona/repo-a": "https://github.com/phona/repo-a/pull/7#issuecomment-1",
             },
         },
     )
 
-    open_inc.assert_awaited_once()
-    assert open_inc.await_args.kwargs["repo"] == "phona/repo-b"
+    co.assert_awaited_once()
+    assert co.await_args.kwargs["repo"] == "phona/repo-b"
+    assert co.await_args.kwargs["pr_number"] == 3
+    oi.assert_not_awaited()
 
     final = patches[-1]
     assert final["gh_incident_urls"] == {
-        "phona/repo-a": "https://github.com/phona/repo-a/issues/7",
-        "phona/repo-b": "https://github.com/phona/repo-b/issues/3",
+        "phona/repo-a": "https://github.com/phona/repo-a/pull/7#issuecomment-1",
+        "phona/repo-b": "https://github.com/phona/repo-b/pull/3#issuecomment-2",
     }
 
 
+# ─── GHI-S14: falls back to settings.gh_incident_repo (legacy single inbox) ─
 @pytest.mark.asyncio
 async def test_escalate_falls_back_to_settings_gh_incident_repo(monkeypatch):
-    """GHI-S14: no involved_repos → fall back to settings.gh_incident_repo (legacy single-inbox)."""
+    """GHI-S14"""
     from orchestrator.actions import escalate as mod
 
     fake_bkd = _make_fake_bkd()
     _patch_bkd(monkeypatch, fake_bkd)
     patches = _patch_db(monkeypatch)
     _stub_req_state_get(monkeypatch)
+    _stub_pr_merge_probe_disabled(monkeypatch)
     _patch_settings(monkeypatch, gh_incident_repo="phona/sisyphus")
 
-    open_inc = AsyncMock(return_value="https://github.com/phona/sisyphus/issues/99")
-    monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
+    # gh_incident_repo is a triage-inbox repo with no per-REQ PR — find_pr returns None,
+    # falls through to open_incident.
+    fp, co, oi = _patch_gh(
+        monkeypatch, find_pr=None, comment=None,
+        open_inc="https://github.com/phona/sisyphus/issues/99",
+    )
 
     body = _make_body(issue_id="vfy-3", event="verify.escalate")
     await mod.escalate(
@@ -579,30 +901,38 @@ async def test_escalate_falls_back_to_settings_gh_incident_repo(monkeypatch):
         },
     )
 
-    open_inc.assert_awaited_once()
-    assert open_inc.await_args.kwargs["repo"] == "phona/sisyphus"
+    fp.assert_awaited_once()
+    assert fp.await_args.kwargs["repo"] == "phona/sisyphus"
+    co.assert_not_awaited()
+    oi.assert_awaited_once()
+    assert oi.await_args.kwargs["repo"] == "phona/sisyphus"
 
     final = patches[-1]
     assert final["gh_incident_urls"] == {
         "phona/sisyphus": "https://github.com/phona/sisyphus/issues/99",
     }
+    assert final["gh_incident_kinds"] == {"phona/sisyphus": "issue"}
     add = fake_bkd.merge_tags_and_update.await_args.kwargs["add"]
     assert "github-incident" in add
 
 
+# ─── GHI-S15: layers 1-4 take precedence over settings.gh_incident_repo ───
 @pytest.mark.asyncio
 async def test_escalate_involved_repos_take_precedence_over_fallback(monkeypatch):
-    """GHI-S15: ctx.involved_repos beats settings.gh_incident_repo."""
+    """GHI-S15"""
     from orchestrator.actions import escalate as mod
 
     fake_bkd = _make_fake_bkd()
     _patch_bkd(monkeypatch, fake_bkd)
     patches = _patch_db(monkeypatch)
     _stub_req_state_get(monkeypatch)
+    _stub_pr_merge_probe_disabled(monkeypatch)
     _patch_settings(monkeypatch, gh_incident_repo="phona/sisyphus")
 
-    open_inc = AsyncMock(return_value="https://github.com/phona/repo-a/issues/1")
-    monkeypatch.setattr(mod.gh_incident, "open_incident", open_inc)
+    _fp, co, oi = _patch_gh(
+        monkeypatch, find_pr=1,
+        comment="https://github.com/phona/repo-a/pull/1#issuecomment-1",
+    )
 
     body = _make_body(issue_id="vfy-3", event="verify.escalate")
     await mod.escalate(
@@ -614,8 +944,152 @@ async def test_escalate_involved_repos_take_precedence_over_fallback(monkeypatch
         },
     )
 
-    open_inc.assert_awaited_once()
-    assert open_inc.await_args.kwargs["repo"] == "phona/repo-a"
+    co.assert_awaited_once()
+    assert co.await_args.kwargs["repo"] == "phona/repo-a"
+    oi.assert_not_awaited()
 
     final = patches[-1]
     assert set(final["gh_incident_urls"].keys()) == {"phona/repo-a"}
+
+
+# ─── ICP-S1: falls back to issue when no PR exists for feat/{REQ} ─────────
+@pytest.mark.asyncio
+async def test_escalate_falls_back_to_issue_when_no_pr(monkeypatch):
+    """ICP-S1"""
+    from orchestrator.actions import escalate as mod
+
+    fake_bkd = _make_fake_bkd()
+    _patch_bkd(monkeypatch, fake_bkd)
+    patches = _patch_db(monkeypatch)
+    _stub_req_state_get(monkeypatch)
+    _stub_pr_merge_probe_disabled(monkeypatch)
+    _patch_settings(monkeypatch)
+
+    fp, co, oi = _patch_gh(
+        monkeypatch, find_pr=None, comment=None,
+        open_inc="https://github.com/phona/sisyphus/issues/42",
+    )
+
+    body = _make_body(issue_id="vfy-3", event="verify.escalate")
+    await mod.escalate(
+        body=body, req_id="REQ-9", tags=["verifier"],
+        ctx={
+            "intent_issue_id": "intent-1",
+            "escalated_reason": "verifier-decision-escalate",
+            "involved_repos": ["phona/sisyphus"],
+        },
+    )
+
+    fp.assert_awaited_once()
+    assert fp.await_args.kwargs["repo"] == "phona/sisyphus"
+    assert fp.await_args.kwargs["branch"] == "feat/REQ-9"
+    co.assert_not_awaited()
+    oi.assert_awaited_once()
+    oi_kw = oi.await_args.kwargs
+    assert oi_kw["repo"] == "phona/sisyphus"
+    assert oi_kw["req_id"] == "REQ-9"
+    assert oi_kw["reason"] == "verifier-decision-escalate"
+
+    final = patches[-1]
+    assert final["gh_incident_urls"] == {
+        "phona/sisyphus": "https://github.com/phona/sisyphus/issues/42",
+    }
+    assert final["gh_incident_kinds"] == {"phona/sisyphus": "issue"}
+    add = fake_bkd.merge_tags_and_update.await_args.kwargs["add"]
+    assert "github-incident" in add
+
+
+# ─── ICP-S2: mixed multi-repo: comment for one, issue fallback for other ──
+@pytest.mark.asyncio
+async def test_escalate_mixed_multi_repo_comment_and_issue(monkeypatch):
+    """ICP-S2"""
+    from orchestrator.actions import escalate as mod
+
+    fake_bkd = _make_fake_bkd()
+    _patch_bkd(monkeypatch, fake_bkd)
+    patches = _patch_db(monkeypatch)
+    _stub_req_state_get(monkeypatch)
+    _stub_pr_merge_probe_disabled(monkeypatch)
+    _patch_settings(monkeypatch)
+
+    pr_lookup = {"phona/repo-a": 7}  # repo-b absent → no PR
+
+    async def _find(*, repo, branch):
+        return pr_lookup.get(repo)
+
+    async def _comment(*, repo, pr_number, **_):
+        if repo == "phona/repo-a" and pr_number == 7:
+            return "https://github.com/phona/repo-a/pull/7#issuecomment-1"
+        return None
+
+    async def _open(*, repo, **_):
+        if repo == "phona/repo-b":
+            return "https://github.com/phona/repo-b/issues/42"
+        return None
+
+    _fp, co, oi = _patch_gh(monkeypatch, find_pr=_find, comment=_comment, open_inc=_open)
+
+    body = _make_body(issue_id="vfy-3", event="verify.escalate")
+    await mod.escalate(
+        body=body, req_id="REQ-9", tags=["verifier"],
+        ctx={
+            "intent_issue_id": "intent-1",
+            "escalated_reason": "verifier-decision-escalate",
+            "involved_repos": ["phona/repo-a", "phona/repo-b"],
+        },
+    )
+
+    co.assert_awaited_once()
+    assert co.await_args.kwargs["repo"] == "phona/repo-a"
+    oi.assert_awaited_once()
+    assert oi.await_args.kwargs["repo"] == "phona/repo-b"
+
+    final = patches[-1]
+    assert final["gh_incident_urls"] == {
+        "phona/repo-a": "https://github.com/phona/repo-a/pull/7#issuecomment-1",
+        "phona/repo-b": "https://github.com/phona/repo-b/issues/42",
+    }
+    assert final["gh_incident_kinds"] == {
+        "phona/repo-a": "comment",
+        "phona/repo-b": "issue",
+    }
+    add = fake_bkd.merge_tags_and_update.await_args.kwargs["add"]
+    assert add.count("github-incident") == 1
+
+
+# ─── ICP-S3: PR-lookup HTTP error (find_pr returns None) → falls back to issue ─
+@pytest.mark.asyncio
+async def test_escalate_find_pr_none_falls_back_to_issue(monkeypatch):
+    """ICP-S3"""
+    from orchestrator.actions import escalate as mod
+
+    fake_bkd = _make_fake_bkd()
+    _patch_bkd(monkeypatch, fake_bkd)
+    patches = _patch_db(monkeypatch)
+    _stub_req_state_get(monkeypatch)
+    _stub_pr_merge_probe_disabled(monkeypatch)
+    _patch_settings(monkeypatch)
+
+    # find_pr returning None covers both the "really no PR" and "API error"
+    # cases — find_pr_for_branch absorbs HTTP errors internally and yields None.
+    _fp, co, oi = _patch_gh(
+        monkeypatch, find_pr=None, comment=None,
+        open_inc="https://github.com/phona/sisyphus/issues/42",
+    )
+
+    body = _make_body(issue_id="vfy-3", event="verify.escalate")
+    out = await mod.escalate(
+        body=body, req_id="REQ-9", tags=["verifier"],
+        ctx={
+            "intent_issue_id": "intent-1",
+            "escalated_reason": "verifier-decision-escalate",
+            "involved_repos": ["phona/sisyphus"],
+        },
+    )
+    assert out["escalated"] is True
+
+    co.assert_not_awaited()
+    oi.assert_awaited_once()
+
+    final = patches[-1]
+    assert final["gh_incident_kinds"]["phona/sisyphus"] == "issue"


### PR DESCRIPTION
## Summary

Today every escalated REQ leaves behind two GitHub artifacts per involved-repo: the `feat/{REQ}` PR and a separate **incident issue** opened by `gh_incident.open_incident()`. The reviewer triaging an escalation has to context-switch between the PR (where the diff lives) and a parallel issue (where the failure metadata lives). With per-involved-repo escalation, multi-repo REQs spawn N issues + N PRs, multiplying the noise.

This change posts the incident metadata as a **PR comment** on the existing `feat/{REQ}` PR for each involved-repo instead of opening a fresh issue. The legacy issue path is preserved as a **fallback** for the cases where no PR exists yet (escalations during INTAKING / early ANALYZING that fire pre-push, `gh_incident_repo` triage-inbox deployments).

## Why

- Restores the "1 REQ = 1 PR" invariant: a single point of truth on GitHub per (repo, REQ).
- Puts incident metadata where humans already are (the PR they'd review the diff on).
- Multi-repo REQs no longer fan out to N parallel issues.

## Implementation

- **`gh_incident.py`** — adds `find_pr_for_branch(repo, branch) -> int | None` (GET `/repos/{repo}/pulls?head={owner}:{branch}&state=all`) and `comment_on_pr(*, repo, pr_number, ...) -> str | None` (POST `/repos/{repo}/issues/{pr_number}/comments`). `open_incident()` is unchanged.
- **`actions/escalate.py`** — per-repo loop: `find_pr_for_branch` first; if PR found, `comment_on_pr`; else fall through to `open_incident`. Per-repo idempotency on `ctx.gh_incident_urls` preserved. New `ctx.gh_incident_kinds: dict[str, "comment" | "issue"]` records which path landed for admin/dashboard distinction. `gh_incident_url` / `gh_incident_urls` / `gh_incident_opened_at` field shapes unchanged (no migrations; existing escalated REQs still readable).
- **Settings** — no new knobs; the existing `github_token` PAT already needs Issues:Write (which covers PR comments — they're issues under the hood).

## Spec

- `openspec/changes/REQ-one-pr-per-req-1777218057/specs/gh-incident-open/spec.md`
- 3 ADDED requirements: `comment_on_pr`, `find_pr_for_branch`, `escalate falls back to opening a fresh issue when no PR exists for the feat branch`
- 1 MODIFIED requirement: `escalate action opens an incident on real-escalate and is idempotent under resume cycles`
- New scenarios: COP-S1..S7, FPR-S1..S4, GHI-S6..S15 (rewritten for comment-first), ICP-S1..S3 (fallback)

## Test plan

- [x] `make ci-unit-test` (943 tests passing locally including new COP/FPR/ICP tests + rewritten contract suite)
- [x] `openspec validate REQ-one-pr-per-req-1777218057 --strict` passes
- [x] `scripts/check-scenario-refs.sh` passes (301 scenarios discovered)
- [ ] sisyphus `spec_lint` + `dev_cross_check` + `staging_test` + `pr_ci` per the standard pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)