### PR TITLE
feat(orch): tag every sisyphus issue with pr:owner/repo#N (REQ-issue-link-pr-quality-base-1777218242)

### DIFF
--- a/openspec/changes/REQ-issue-link-pr-quality-base-1777218242/proposal.md
+++ b/openspec/changes/REQ-issue-link-pr-quality-base-1777218242/proposal.md
@@ -1,0 +1,133 @@
+# REQ-issue-link-pr-quality-base-1777218242: feat: every sisyphus issue must link the REQ PR
+
+## Why
+
+为一条 REQ，sisyphus 在 BKD 里会创建一连串 issue：analyze（intent issue 改名）、
+staging-test（legacy path）、pr-ci-watch（legacy path）、accept、done-archive、
+challenger、verifier、fixer。人在 BKD UI 看 sub-issue 时，**没有任何线索**指向
+GitHub 上跑着的实际 PR —— 必须翻 ctx / open verifier / 看 prompt 渲染才能挖出
+PR 号。
+
+这是 quality-base 类的体感问题：每条 sisyphus 创的 BKD issue 都应该带 `pr:<owner>/<repo>#<N>`
+tag（一个 PR 一个 tag，多仓 REQ 多个 tag），让人在 UI 里"一跳到 PR"。
+
+## What Changes
+
+新增一个轻 helper `pr_links` + 在每个 sisyphus 创 BKD issue 的 callsite 注入
+PR-link tag。
+
+```
+pr_links.ensure_pr_links_in_ctx(req_id, branch, ctx)
+  ↓
+1. ctx.pr_links 已缓存？→ 直接返回（O(1)）
+2. 缓存 miss：
+   - runner pod 里 ls /workspace/source/*/ 拿仓清单（复用 create_pr_ci_watch 的同款 helper 逻辑）
+   - 每个仓 GET /repos/{repo}/pulls?head={owner}:{branch}&state=open 取 PR
+   - 失败 best-effort：log warning，返空 list（**不**阻断 issue 创建）
+   - 成功 → ctx.pr_links = [{repo, number, url}, ...]，update_context 落 jsonb
+   - 第一次成功后顺手回填 ctx 已知 sisyphus issue id 的 tag（典型场景：analyze
+     issue 在创建时 PR 还不存在 → 第一次 verifier 创建时回填 analyze issue tag）
+
+pr_links.pr_link_tags(links) -> ["pr:owner/repo#42", ...]
+```
+
+每个 callsite（`start_challenger`、`_verifier.invoke_verifier`、`_verifier.start_fixer`、
+`create_staging_test._dispatch_bkd_agent`、`create_pr_ci_watch._dispatch_bkd_agent`、
+`create_accept`、`done_archive`）创 issue 前调一次 `ensure_pr_links_in_ctx`，把
+返回的 tag 数组拼进 `tags=`。
+
+`start_analyze` / `start_analyze_with_finalized_intent` 不调 helper（创 issue
+时 PR 还不存在），但 stash `analyze_issue_id` 进 ctx —— 这样后续 helper 第一次
+discover 成功时能回填 analyze issue 的 tag。
+
+### 行为契约
+
+```
+ensure_pr_links_in_ctx(req_id, branch, ctx) called from any action
+  ↓
+1. cached := from_ctx(ctx)  # parses ctx.pr_links list[dict]
+2. if cached: return cached
+3. repos := discover_repos_via_runner(req_id)  # ls /workspace/source/*/ + git remote
+   if no controller / exec error: return []
+4. for repo in repos:
+     GET /repos/{repo}/pulls?head={owner}:{branch}&state=open
+     on httpx error or empty: skip, log warning
+     else: links.append(PrLink(repo, pr.number, pr.html_url))
+5. if not links: return []
+6. update_context(req_id, {pr_links: [l.to_dict() for l in links]})
+7. backfill_ids := gather_issue_ids_from_ctx(ctx)  # analyze_issue_id, etc.
+   for iid in backfill_ids:
+     bkd.merge_tags_and_update(project, iid, add=pr_link_tags(links))
+     on error: log warning, continue
+8. return links
+```
+
+### Tag 形式
+
+`pr:<owner>/<repo>#<number>` —— 跟现有 sisyphus tag 命名约定一致：
+`parent-id:`、`verify:`、`trigger:`、`fixer:`、`repo:`、`round:`、`reason:`，
+都是 `<key>:<value>` 形式。`#` 在 BKD tag 里没特殊含义（free-form 字符串），
+但人眼能立刻识别"是个 PR 编号"。
+
+### 不动什么
+
+- 不改 state.py / engine.py / migrations / router 匹配规则
+- 不动现有 webhook / verifier-decision schema
+- 不改 BKD intake / analyze prompt（agent 仍按当前 prompt 行事）
+- 不引入新 Postgres 表（pr_links 走现有 ctx.jsonb）
+- intake issue / 已 archive 的旧 REQ 不回填（不在 active context 里）
+
+## Tradeoffs
+
+- **为什么 tag 不是 description / follow-up message** —— BKD tag 在列表 UI
+  里直接显示，且 router 已用 tag 做结构化 metadata（`parent-id:` 等）。description
+  是非结构化富文本，follow-up 沉到聊天历史里看不到。
+- **为什么 lazy discover 而不是 push-to-ctx 在 PR 开的时候** —— 没人主动告诉
+  sisyphus "PR 开了"。analyze-agent 在 prompt 里 push branch + gh pr create，但
+  不会回写 ctx（agent 只填 result tag）。Lazy discover 是只 GH REST 1-N 次
+  per first-time call 的事，比改 prompt 强约束 agent 写回更稳。
+- **为什么 in-memory cache 而非每次都查 GH** —— GH PAT 有 5000/h 配额，每个
+  REQ 4-8 个 issue 创建窗口，无 cache 会吃 8 × N(repo) 次/REQ；in-ctx cache
+  让第一次成功之后所有后续 callsite O(1)。
+- **为什么不区分 closed/merged PR 的 tag** —— `pr:owner/repo#42` 永远指向同一
+  个 GH 资源 URL，open / closed / merged 状态在 GH 一查便知，sisyphus tag
+  没必要镜像。
+- **为什么 best-effort（discover 失败不阻断）** —— issue 创建是热路径（pipeline
+  推进每个 stage 都过），GH API 抖动 / runner 没起来 / 0 PR（极早期）任何一种
+  都不能让 sisyphus 卡住。tag 缺了下次 callsite 还有机会补上。
+- **为什么 backfill 只覆盖 analyze_issue_id（+ 路径上其他已知 issue）** —— 只
+  backfill ctx 里能直接读到的 id；不主动扫所有 BKD issue。简单 + 正确：第一次
+  helper 命中时已知的就是 analyze issue（intent → analyze）。
+- **为什么不自动回填已 archive 的 REQ** —— archive 完成 = REQ 终态，回填没人
+  看。本 REQ 只覆盖 active REQ 的"还在跑的"issue。
+
+## Impact
+
+- 新文件 `orchestrator/src/orchestrator/pr_links.py`：
+  - `PrLink` dataclass
+  - `from_ctx(ctx)` / `pr_link_tags(links)` helpers
+  - `discover_pr_links(req_id, branch, repos=None)`（含 `_discover_repos_via_runner`）
+  - `ensure_pr_links_in_ctx(req_id, branch, ctx, project_id)`（缓存 + 持久化 + 回填）
+- 改 `orchestrator/src/orchestrator/actions/start_analyze.py`：
+  stash `analyze_issue_id` 到 ctx（让后续 backfill 能找到）
+- 改 `orchestrator/src/orchestrator/actions/_verifier.py`：
+  `invoke_verifier` / `start_fixer` 在 create_issue 前调 helper，注入 tag
+- 改 `orchestrator/src/orchestrator/actions/create_staging_test.py`：
+  `_dispatch_bkd_agent` 调 helper
+- 改 `orchestrator/src/orchestrator/actions/create_pr_ci_watch.py`：
+  `_dispatch_bkd_agent` 调 helper
+- 改 `orchestrator/src/orchestrator/actions/create_accept.py`：
+  调 helper（注：accept agent issue 创建时 PR 一定存在，应能命中 cache）
+- 改 `orchestrator/src/orchestrator/actions/done_archive.py`：
+  调 helper
+- 改 `orchestrator/src/orchestrator/actions/start_challenger.py`：
+  调 helper
+- 新测试 `orchestrator/tests/test_pr_links.py`：
+  - LP-S1 cache hit returns cached, no GH call
+  - LP-S2 discover via runner + GH API on cache miss + persists ctx
+  - LP-S3 discover failure (runner exec error) returns empty list
+  - LP-S4 GH API HTTP error per repo skips that repo, returns whatever succeeded
+  - LP-S5 first-time discover backfills known issue ids in ctx
+  - LP-S6 pr_link_tags renders `pr:owner/repo#N` format
+  - LP-S7 from_ctx tolerates malformed entries
+- 不改 docs/state-machine.md / migrations / router schema

--- a/openspec/changes/REQ-issue-link-pr-quality-base-1777218242/specs/issue-pr-link/contract.spec.yaml
+++ b/openspec/changes/REQ-issue-link-pr-quality-base-1777218242/specs/issue-pr-link/contract.spec.yaml
@@ -1,0 +1,96 @@
+spec: issue-pr-link
+version: 1
+description: >-
+  Every BKD issue sisyphus creates for a REQ MUST carry a `pr:<owner>/<repo>#<N>`
+  tag (one per repo PR) so that humans viewing the issue in BKD UI can navigate
+  directly to the GitHub PR. Discovery is lazy + cached in req_state.context;
+  the analyze issue (created before PRs exist) is backfilled the first time PRs
+  are discovered.
+
+inputs:
+  - name: req_id
+    type: string
+    description: REQ identifier; branch convention is feat/{req_id}
+  - name: branch
+    type: string
+    description: feat/{req_id} normally; callers MAY pass override
+  - name: ctx
+    type: object
+    description: req_state.context jsonb — read pr_links cache, stashed sisyphus issue ids
+  - name: project_id
+    type: string
+    description: BKD project id, needed for backfill tag PATCHes
+  - name: github_token
+    type: string
+    description: settings.github_token. Empty token MUST NOT block; helper sends unauthenticated GH requests (low rate cap, but fallback is empty list — same effect as no token)
+
+side_effects_on_first_discovery:
+  - context_patch_keys:
+      - pr_links             # value MUST be list[{repo, number, url}]
+  - bkd_issue_tags_added_via_backfill:
+      # Iterate over known issue ids in ctx (analyze_issue_id, staging_test_issue_id,
+      # pr_ci_watch_issue_id, accept_issue_id, archive_issue_id) and PATCH each with
+      # `pr:owner/repo#N` for every found PR.
+      - "pr:<owner>/<repo>#<N>"
+
+side_effects_on_cache_hit:
+  - "no GH HTTP request"
+  - "no ctx update"
+  - "no BKD PATCH (callers receive cached PrLink list and inject tags into freshly-created issues themselves)"
+
+discovery_logic:
+  - cached := from_ctx(ctx)
+  - if cached: return cached  # O(1) cache hit, no GH call
+  - repos := _discover_repos_via_runner(req_id)
+      command: `for d in /workspace/source/*/; do [ -d "$d/.git" ] && git -C "$d" remote get-url origin; done`
+      filter: parse owner/repo from `git@github.com:OWNER/REPO(.git)?` or `https://github.com/OWNER/REPO(.git)?`
+      on RuntimeError / exec error: return []
+  - if no repos: return []
+  - for repo in repos:
+      GET /repos/{repo}/pulls?head={owner}:{branch}&state=open
+      on httpx error: log warning + skip this repo
+      else if first PR exists: links.append(PrLink(repo, pr.number, pr.html_url))
+  - if not links: return []
+  - update_context(req_id, {pr_links: [l.to_dict() for l in links]})
+  - backfill known sisyphus issue ids in ctx via bkd.merge_tags_and_update
+  - return links
+
+tag_format:
+  - PrLink(repo="phona/sisyphus", number=42).tag() == "pr:phona/sisyphus#42"
+  - pr_link_tags([l1, l2, ...]) == ["pr:.../#N1", "pr:.../#N2", ...]
+
+callsite_obligations:
+  # Each action that invokes bkd.create_issue for a sisyphus-managed REQ issue
+  # MUST call ensure_pr_links_in_ctx and concat pr_link_tags(...) into its
+  # base tags list.
+  required_actions:
+    - actions/_verifier.invoke_verifier
+    - actions/_verifier.start_fixer
+    - actions/create_staging_test._dispatch_bkd_agent
+    - actions/create_pr_ci_watch._dispatch_bkd_agent
+    - actions/create_accept (BKD agent dispatch, phase 2)
+    - actions/done_archive
+    - actions/start_challenger
+  # actions/start_analyze and start_analyze_with_finalized_intent do NOT call
+  # ensure_pr_links_in_ctx (PRs do not exist yet at create time), but MUST
+  # stash analyze_issue_id into ctx so backfill can find the analyze issue
+  # later.
+
+failure_modes:
+  - runner controller not available -> _discover_repos_via_runner returns [] -> ensure returns [] -> caller proceeds without pr:* tags (issue creation NOT blocked)
+  - runner exec error -> same as above
+  - GH API HTTP error per repo -> log warning, that repo skipped, others still tagged
+  - 0 open PR for any repo -> ensure returns [] -> ctx NOT updated, retry next callsite
+  - BKD merge_tags_and_update error during backfill -> log warning, continue (other backfill ids attempted)
+
+idempotency:
+  - Cache hit returns cached list verbatim; no side effects
+  - Backfill uses bkd.merge_tags_and_update (additive merge); calling twice with
+    same tags is a no-op (existing tag preserved, no duplicate inserted)
+  - First successful discovery writes ctx.pr_links once; subsequent calls skip
+    discovery branch entirely
+
+audit:
+  - ctx.pr_links is the durable record of "what PRs sisyphus knows belong to this REQ"
+    (queryable from observability dashboards; no separate table)
+  - tag `pr:owner/repo#N` is the visible record on each BKD issue

--- a/openspec/changes/REQ-issue-link-pr-quality-base-1777218242/specs/issue-pr-link/spec.md
+++ b/openspec/changes/REQ-issue-link-pr-quality-base-1777218242/specs/issue-pr-link/spec.md
@@ -1,0 +1,144 @@
+# issue-pr-link
+
+## ADDED Requirements
+
+### Requirement: ensure_pr_links_in_ctx MUST return cached PrLink list when ctx.pr_links is set
+
+The helper MUST first parse the cached pr_links list out of ctx and SHALL
+return that parsed PrLink list directly without issuing any GitHub HTTP
+request, runner exec call, or BKD PATCH whenever the list is non-empty and
+contains at least one well-formed entry. The cache-hit short-circuit keeps
+repeat calls O(1) and avoids ratepressing the GitHub PAT — sisyphus creates
+4-8 BKD issues per REQ, so an uncached fan-out would multiply the GH calls
+per stage transition.
+
+#### Scenario: LP-S1 cache hit returns cached without GH call
+
+- **GIVEN** `ctx = {"pr_links": [{"repo":"phona/sisyphus","number":42,"url":"https://github.com/phona/sisyphus/pull/42"}]}`
+- **AND** an `httpx.AsyncClient` mock that fails the test if any HTTP request is made
+- **WHEN** `ensure_pr_links_in_ctx(req_id="REQ-x", branch="feat/REQ-x", ctx=ctx, project_id="p")` is invoked
+- **THEN** the return value MUST equal `[PrLink(repo="phona/sisyphus", number=42, url="https://github.com/phona/sisyphus/pull/42")]`
+- **AND** no `httpx` request, no `k8s_runner.exec_in_runner` call, and no `req_state.update_context` call MUST occur
+
+
+### Requirement: ensure_pr_links_in_ctx MUST discover via runner + GH REST and persist to ctx on cache miss
+
+When `ctx.pr_links` is missing or empty, the helper SHALL run repo discovery
+in the runner pod (`for d in /workspace/source/*/; do git -C "$d" remote get-url origin; done`),
+parse the stdout into `owner/repo` slugs, and for each slug issue
+`GET /repos/{owner}/{repo}/pulls?head={owner}:{branch}&state=open` against
+`https://api.github.com`. The first PR returned per repo MUST be wrapped into
+a `PrLink(repo, pr.number, pr.html_url)`. If at least one `PrLink` is collected,
+the helper MUST persist the list as `ctx.pr_links = [link.to_dict(), ...]`
+via `req_state.update_context` so subsequent callsites hit the cache.
+
+#### Scenario: LP-S2 cache miss runs discovery and stashes ctx
+
+- **GIVEN** `ctx = {}` and `_discover_repos_via_runner` returns `["phona/sisyphus"]`
+- **AND** GH `/repos/phona/sisyphus/pulls?head=phona:feat/REQ-x&state=open` returns
+  `[{"number": 42, "html_url": "https://github.com/phona/sisyphus/pull/42"}]`
+- **WHEN** `ensure_pr_links_in_ctx(req_id="REQ-x", branch="feat/REQ-x", ctx={}, project_id="p")` is invoked
+- **THEN** the return value MUST equal `[PrLink(repo="phona/sisyphus", number=42, url="https://github.com/phona/sisyphus/pull/42")]`
+- **AND** `req_state.update_context` MUST be called once with patch
+  `{"pr_links": [{"repo":"phona/sisyphus","number":42,"url":"https://github.com/phona/sisyphus/pull/42"}]}`
+
+
+### Requirement: ensure_pr_links_in_ctx MUST tolerate runner discovery failure
+
+The helper MUST NOT propagate exceptions from the runner exec path. When
+`k8s_runner.get_controller()` raises `RuntimeError` (no controller in dev env),
+or when `exec_in_runner` raises any exception, the helper SHALL log a warning
+and return an empty list. The caller MUST be able to continue creating BKD
+issues without `pr:*` tags this round; a subsequent callsite gets another
+chance once the runner is back.
+
+#### Scenario: LP-S3 runner exec error returns empty without raising
+
+- **GIVEN** `ctx = {}` and `k8s_runner.get_controller().exec_in_runner` raises
+  `RuntimeError("pod not found")`
+- **WHEN** `ensure_pr_links_in_ctx` is invoked
+- **THEN** no exception MUST propagate
+- **AND** the return value MUST equal `[]`
+- **AND** `req_state.update_context` MUST NOT be called
+- **AND** a warning MUST be logged with `req_id` and `error` fields
+
+
+### Requirement: discover_pr_links MUST tolerate per-repo GH API errors
+
+The helper MUST NOT abort multi-repo discovery when a single repo's GitHub
+request fails. For each repo, `httpx.HTTPError` (5xx, 404, network errors)
+SHALL be caught locally and logged at WARNING level, the helper SHALL continue
+to the next repo, and the final return value SHALL contain only the PR links
+that were successfully collected. An empty result is allowed (caller treats
+as no-op).
+
+#### Scenario: LP-S4 one repo errors, another succeeds
+
+- **GIVEN** `_discover_repos_via_runner` returns `["phona/repo-a", "phona/repo-b"]`
+- **AND** GH `/repos/phona/repo-a/pulls` returns HTTP 503
+- **AND** GH `/repos/phona/repo-b/pulls` returns
+  `[{"number": 7, "html_url": "https://github.com/phona/repo-b/pull/7"}]`
+- **WHEN** `discover_pr_links(req_id="REQ-x", branch="feat/REQ-x")` is invoked
+- **THEN** the return value MUST contain exactly one `PrLink` for `phona/repo-b#7`
+- **AND** no entry for `phona/repo-a` MUST be present
+- **AND** a warning log MUST be emitted with `repo="phona/repo-a"`
+
+
+### Requirement: ensure_pr_links_in_ctx MUST backfill known issue ids on first discovery
+
+The helper SHALL backfill `pr:*` tags onto every sisyphus-tracked BKD issue id
+present in ctx the first time it transitions from cache-miss to a non-empty
+discovered list. The helper SHALL inspect the keys `analyze_issue_id`,
+`staging_test_issue_id`, `pr_ci_watch_issue_id`, `accept_issue_id`, and
+`archive_issue_id`, and for each non-empty string id MUST call
+`bkd.merge_tags_and_update(project_id, issue_id, add=pr_link_tags(links))`.
+The backfill MUST tolerate per-issue PATCH errors by logging a warning and
+continuing to the next id. This covers the analyze issue (created before
+PRs exist) and any earlier sub-issue that was created before the first
+successful discovery window.
+
+#### Scenario: LP-S5 first discovery backfills analyze issue
+
+- **GIVEN** `ctx = {"analyze_issue_id": "abc123"}`
+- **AND** discovery yields `[PrLink("phona/sisyphus", 42, "https://github.com/phona/sisyphus/pull/42")]`
+- **WHEN** `ensure_pr_links_in_ctx` is invoked
+- **THEN** `bkd.merge_tags_and_update` MUST be called once with arguments
+  `(project_id="p", issue_id="abc123", add=["pr:phona/sisyphus#42"])`
+- **AND** `req_state.update_context` MUST be called with `pr_links` patch
+- **AND** the return value MUST equal `[PrLink("phona/sisyphus", 42, ...)]`
+
+
+### Requirement: pr_link_tags MUST render PrLinks as pr:owner/repo#N strings
+
+`pr_link_tags(links)` MUST emit a list whose order matches the input list and
+whose i-th entry equals `f"pr:{links[i].repo}#{links[i].number}"`. The format
+is the public contract callers depend on for tag construction; changing it
+breaks existing BKD issue tag schemes.
+
+#### Scenario: LP-S6 pr_link_tags formats two repos
+
+- **GIVEN** `links = [PrLink("phona/sisyphus", 42, "..."), PrLink("phona/runner", 7, "...")]`
+- **WHEN** `pr_link_tags(links)` is invoked
+- **THEN** the return value MUST equal `["pr:phona/sisyphus#42", "pr:phona/runner#7"]`
+
+
+### Requirement: from_ctx MUST tolerate malformed cached entries
+
+The `pr_links.from_ctx(ctx)` parser MUST defensively skip entries that are not
+dicts or are missing required keys (`repo`, `number`), or whose `number` field
+cannot coerce to int. Malformed entries MUST NOT raise — the parser SHALL
+return whatever well-formed entries it could read. This guards against ctx
+written by an older sisyphus version drifting forward.
+
+#### Scenario: LP-S7 from_ctx returns only well-formed entries
+
+- **GIVEN** `ctx = {"pr_links": [
+    {"repo":"phona/sisyphus","number":42,"url":"u1"},
+    {"repo":"missing-num"},
+    "not-a-dict",
+    {"repo":"phona/runner","number":"7","url":"u2"}
+  ]}`
+- **WHEN** `from_ctx(ctx)` is invoked
+- **THEN** the return value MUST equal
+  `[PrLink("phona/sisyphus", 42, "u1"), PrLink("phona/runner", 7, "u2")]`
+- **AND** no exception MUST propagate

--- a/openspec/changes/REQ-issue-link-pr-quality-base-1777218242/tasks.md
+++ b/openspec/changes/REQ-issue-link-pr-quality-base-1777218242/tasks.md
@@ -1,0 +1,35 @@
+# tasks: REQ-issue-link-pr-quality-base-1777218242
+
+## Stage: spec
+- [x] 写 proposal.md（动机 / 方案 / 取舍 / 影响面）
+- [x] 写 specs/issue-pr-link/contract.spec.yaml（black-box 契约）
+- [x] 写 specs/issue-pr-link/spec.md（ADDED Requirements + Scenarios LP-S1..S7）
+
+## Stage: implementation
+- [x] orchestrator/src/orchestrator/pr_links.py 新文件：
+      `PrLink` dataclass、`from_ctx` / `pr_link_tags` helpers、
+      `_discover_repos_via_runner` / `discover_pr_links` /
+      `ensure_pr_links_in_ctx`（缓存 + 持久化 + 回填 ctx 里已知 issue id 的 tag）
+- [x] orchestrator/src/orchestrator/actions/start_analyze.py：
+      stash `analyze_issue_id = body.issueId` 到 ctx（backfill 用）
+- [x] orchestrator/src/orchestrator/actions/start_analyze_with_finalized_intent.py：
+      stash `analyze_issue_id = issue.id`（同上）
+- [x] orchestrator/src/orchestrator/actions/_verifier.py：
+      `invoke_verifier` / `start_fixer` create_issue 前调 helper 注入 `pr:*` tag
+- [x] orchestrator/src/orchestrator/actions/create_staging_test.py：
+      `_dispatch_bkd_agent` 注入 tag
+- [x] orchestrator/src/orchestrator/actions/create_pr_ci_watch.py：
+      `_dispatch_bkd_agent` 注入 tag
+- [x] orchestrator/src/orchestrator/actions/create_accept.py：注入 tag
+- [x] orchestrator/src/orchestrator/actions/done_archive.py：注入 tag
+- [x] orchestrator/src/orchestrator/actions/start_challenger.py：注入 tag
+
+## Stage: tests
+- [x] orchestrator/tests/test_pr_links.py 新文件，覆盖 LP-S1..S7（+ 额外补充用例）
+- [x] 跑 `make ci-unit-test`（943 测试全过，新加 18 条 / 改造 2 条 fixture）
+- [x] 跑 `make ci-lint`（ruff 通过）
+- [x] 跑 `openspec validate REQ-issue-link-pr-quality-base-1777218242 --strict` 通过
+
+## Stage: PR
+- [ ] git push origin feat/REQ-issue-link-pr-quality-base-1777218242
+- [ ] gh pr create

--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -28,7 +28,7 @@ from typing import Literal
 
 import structlog
 
-from .. import k8s_runner
+from .. import k8s_runner, pr_links
 from ..bkd import BKDClient
 from ..config import settings
 from ..prompts import render
@@ -103,6 +103,15 @@ async def invoke_verifier(
         project_alias=project_id,
     )
 
+    # PR-link tag 注入（REQ-issue-link-pr-quality-base-1777218242）：
+    # verifier issue 在 dev 之后才创建，PR 已存在 → 第一次成功 discover 时
+    # 同时回填 ctx 里 analyze_issue_id 等已有 sisyphus issue 的 tag。
+    branch = (ctx or {}).get("branch") or f"feat/{req_id}"
+    links = await pr_links.ensure_pr_links_in_ctx(
+        req_id=req_id, branch=branch, ctx=ctx, project_id=project_id,
+    )
+    extra_tags = pr_links.pr_link_tags(links)
+
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         issue = await bkd.create_issue(
             project_id=project_id,
@@ -112,6 +121,7 @@ async def invoke_verifier(
                 req_id,
                 f"verify:{stage}",
                 f"trigger:{trigger}",
+                *extra_tags,
             ],
             status_id="todo",
             use_worktree=True,   # 并行 verifier 互不抢 working tree
@@ -269,6 +279,13 @@ async def start_fixer(*, body, req_id, tags, ctx):
             "cap": cap,
         }
 
+    # PR-link tag 注入（REQ-issue-link-pr-quality-base-1777218242）
+    branch_for_links = (ctx or {}).get("branch") or f"feat/{req_id}"
+    links = await pr_links.ensure_pr_links_in_ctx(
+        req_id=req_id, branch=branch_for_links, ctx=ctx, project_id=proj,
+    )
+    extra_tags = pr_links.pr_link_tags(links)
+
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         issue = await bkd.create_issue(
             project_id=proj,
@@ -280,6 +297,7 @@ async def start_fixer(*, body, req_id, tags, ctx):
                 f"parent-stage:{stage}",
                 f"parent-id:{ctx.get('verifier_issue_id', '')}",
                 f"round:{next_round}",
+                *extra_tags,
             ],
             status_id="todo",
             use_worktree=True,

--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -16,7 +16,7 @@ import json
 
 import structlog
 
-from .. import k8s_runner
+from .. import k8s_runner, pr_links
 from ..bkd import BKDClient
 from ..config import settings
 from ..prompts import render
@@ -111,11 +111,18 @@ async def create_accept(*, body, req_id, tags, ctx):
         }
 
     # Phase 2: dispatch accept-agent
+    # PR-link tag 注入（REQ-issue-link-pr-quality-base-1777218242）
+    branch_for_links = (ctx or {}).get("branch") or f"feat/{req_id}"
+    links = await pr_links.ensure_pr_links_in_ctx(
+        req_id=req_id, branch=branch_for_links, ctx=ctx, project_id=proj,
+    )
+    extra_tags = pr_links.pr_link_tags(links)
+
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         issue = await bkd.create_issue(
             project_id=proj,
             title=f"[{req_id}] [ACCEPT] AI-QA{short_title(ctx)}",
-            tags=["accept", req_id, f"parent-id:{source_issue_id}"],
+            tags=["accept", req_id, f"parent-id:{source_issue_id}", *extra_tags],
             status_id="todo",
             model=settings.agent_model,
         )

--- a/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
@@ -23,7 +23,7 @@ import re
 
 import structlog
 
-from .. import k8s_runner
+from .. import k8s_runner, pr_links
 from ..bkd import BKDClient
 from ..checkers import pr_ci_watch as checker
 from ..config import settings
@@ -140,11 +140,18 @@ async def _dispatch_bkd_agent(*, body, req_id: str, ctx: dict) -> dict:
     proj = body.projectId
     source_issue_id = body.issueId   # 上游 staging-test issue
 
+    # PR-link tag 注入（REQ-issue-link-pr-quality-base-1777218242）
+    branch_for_links = (ctx or {}).get("branch") or f"feat/{req_id}"
+    links = await pr_links.ensure_pr_links_in_ctx(
+        req_id=req_id, branch=branch_for_links, ctx=ctx, project_id=proj,
+    )
+    extra_tags = pr_links.pr_link_tags(links)
+
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         issue = await bkd.create_issue(
             project_id=proj,
             title=f"[{req_id}] [pr-ci-watch]{short_title(ctx)}",
-            tags=["pr-ci", req_id, f"parent-id:{source_issue_id}"],
+            tags=["pr-ci", req_id, f"parent-id:{source_issue_id}", *extra_tags],
             status_id="todo",
             model=settings.agent_model,
         )

--- a/orchestrator/src/orchestrator/actions/create_staging_test.py
+++ b/orchestrator/src/orchestrator/actions/create_staging_test.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import structlog
 
+from .. import pr_links
 from ..bkd import BKDClient
 from ..checkers import staging_test as checker
 from ..config import settings
@@ -95,11 +96,18 @@ async def _dispatch_bkd_agent(*, body, req_id: str, ctx: dict) -> dict:
     proj = body.projectId
     source_issue_id = body.issueId
 
+    # PR-link tag 注入（REQ-issue-link-pr-quality-base-1777218242）
+    branch_for_links = (ctx or {}).get("branch") or f"feat/{req_id}"
+    links = await pr_links.ensure_pr_links_in_ctx(
+        req_id=req_id, branch=branch_for_links, ctx=ctx, project_id=proj,
+    )
+    extra_tags = pr_links.pr_link_tags(links)
+
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         issue = await bkd.create_issue(
             project_id=proj,
             title=f"[{req_id}] [staging-test]{short_title(ctx)}",
-            tags=["staging-test", req_id, f"parent-id:{source_issue_id}"],
+            tags=["staging-test", req_id, f"parent-id:{source_issue_id}", *extra_tags],
             status_id="todo",
             model=settings.agent_model,
         )

--- a/orchestrator/src/orchestrator/actions/done_archive.py
+++ b/orchestrator/src/orchestrator/actions/done_archive.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import structlog
 
+from .. import pr_links
 from ..bkd import BKDClient
 from ..config import settings
 from ..prompts import render
@@ -23,11 +24,17 @@ async def done_archive(*, body, req_id, tags, ctx):
     workdir = (ctx or {}).get("workdir") or f"{settings.workdir_root}/feat-{req_id}"
     accept_issue_id = (ctx or {}).get("accept_issue_id") or body.issueId
 
+    # PR-link tag 注入（REQ-issue-link-pr-quality-base-1777218242）
+    links = await pr_links.ensure_pr_links_in_ctx(
+        req_id=req_id, branch=branch, ctx=ctx, project_id=proj,
+    )
+    extra_tags = pr_links.pr_link_tags(links)
+
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         issue = await bkd.create_issue(
             project_id=proj,
             title=f"[{req_id}] [DONE] archive & PR{short_title(ctx)}",
-            tags=["done-archive", req_id, f"parent-id:{accept_issue_id}"],
+            tags=["done-archive", req_id, f"parent-id:{accept_issue_id}", *extra_tags],
             status_id="todo",
             model=settings.agent_model,
         )

--- a/orchestrator/src/orchestrator/actions/start_analyze.py
+++ b/orchestrator/src/orchestrator/actions/start_analyze.py
@@ -99,6 +99,13 @@ async def start_analyze(*, body, req_id, tags, ctx):
         await bkd.follow_up_issue(project_id=proj, issue_id=issue_id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue_id, status_id="working")
 
+    # stash analyze_issue_id 进 ctx：让后续 pr_links.ensure_pr_links_in_ctx 第一次
+    # discover 成功时能 backfill 这条 analyze issue 的 pr:* tag
+    # （REQ-issue-link-pr-quality-base-1777218242）
+    await req_state.update_context(db.get_pool(), req_id, {
+        "analyze_issue_id": issue_id,
+    })
+
     log.info("start_analyze.done", req_id=req_id, issue_id=issue_id,
              cloned_repos=cloned_repos)
     return {"issue_id": issue_id, "req_id": req_id, "cloned_repos": cloned_repos}

--- a/orchestrator/src/orchestrator/actions/start_analyze_with_finalized_intent.py
+++ b/orchestrator/src/orchestrator/actions/start_analyze_with_finalized_intent.py
@@ -25,6 +25,7 @@ from ..bkd import BKDClient
 from ..config import settings
 from ..prompts import render
 from ..state import Event
+from ..store import db, req_state
 from . import register, short_title
 from ._clone import clone_involved_repos_into_runner
 
@@ -87,6 +88,13 @@ async def start_analyze_with_finalized_intent(*, body, req_id, tags, ctx):
         )
         await bkd.follow_up_issue(project_id=proj, issue_id=issue.id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue.id, status_id="working")
+
+    # stash analyze_issue_id 进 ctx：让 pr_links.ensure_pr_links_in_ctx 第一次
+    # discover 成功时能 backfill 这条 analyze issue 的 pr:* tag
+    # （REQ-issue-link-pr-quality-base-1777218242）
+    await req_state.update_context(db.get_pool(), req_id, {
+        "analyze_issue_id": issue.id,
+    })
 
     log.info("start_analyze_with_finalized_intent.done", req_id=req_id,
              analyze_issue_id=issue.id, cloned_repos=cloned_repos)

--- a/orchestrator/src/orchestrator/actions/start_challenger.py
+++ b/orchestrator/src/orchestrator/actions/start_challenger.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import structlog
 
+from .. import pr_links
 from ..bkd import BKDClient
 from ..config import settings
 from ..prompts import render
@@ -41,11 +42,18 @@ async def start_challenger(*, body, req_id, tags, ctx):
     proj = body.projectId
     source_issue_id = body.issueId   # spec_lint 没 BKD agent issue，用上游 intent issue
 
+    # PR-link tag 注入（REQ-issue-link-pr-quality-base-1777218242）
+    branch_for_links = (ctx or {}).get("branch") or f"feat/{req_id}"
+    links = await pr_links.ensure_pr_links_in_ctx(
+        req_id=req_id, branch=branch_for_links, ctx=ctx, project_id=proj,
+    )
+    extra_tags = pr_links.pr_link_tags(links)
+
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         issue = await bkd.create_issue(
             project_id=proj,
             title=f"[{req_id}] [CHALLENGER]{short_title(ctx)}",
-            tags=["challenger", req_id, f"parent-id:{source_issue_id}"],
+            tags=["challenger", req_id, f"parent-id:{source_issue_id}", *extra_tags],
             status_id="todo",
             use_worktree=True,   # 黑盒，不污染主 worktree
             model=settings.agent_model,

--- a/orchestrator/src/orchestrator/pr_links.py
+++ b/orchestrator/src/orchestrator/pr_links.py
@@ -1,0 +1,282 @@
+"""PR-link discovery + tag synthesis (REQ-issue-link-pr-quality-base-1777218242).
+
+每个 sisyphus 为 REQ 创建的 BKD issue 都应带 `pr:<owner>/<repo>#<N>` tag，
+让人在 BKD UI 看 sub-issue 时能一跳跳到 GitHub PR。
+
+discover 时机：lazy。第一次 callsite 调 `ensure_pr_links_in_ctx` 时：
+1. 优先读 `ctx.pr_links` 缓存（O(1)）
+2. miss → runner pod ls /workspace/source/* + GH REST 查 open PR
+3. 失败（无 controller / GH 5xx / 0 PR）一律 best-effort 返 [],
+   **绝不**抛异常出来阻断 issue 创建
+4. 成功 → 持久化 ctx.pr_links + 顺手 backfill ctx 里已知的 sisyphus issue id
+   的 tag（典型场景：analyze issue 在创建时 PR 还没开，第一次 verifier
+   issue 创建时回填）
+
+之所以 cache 在 ctx：
+- ctx 是 jsonb，update_context append 即可，没新表
+- ctx 是 REQ 维度，刚好对应"PR 是 REQ 的产物"语义
+- observability dashboard 直接 SELECT context->'pr_links' 就能查"该 REQ 开了哪些 PR"
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+import httpx
+import structlog
+
+from . import k8s_runner
+from .config import settings
+from .store import db, req_state
+
+log = structlog.get_logger(__name__)
+
+_GH_API = "https://api.github.com"
+_DISCOVER_TIMEOUT_SEC = 30
+_GH_REQUEST_TIMEOUT = 15.0
+
+# git@github.com:owner/repo(.git) | https://github.com/owner/repo(.git)
+_REMOTE_RE = re.compile(r"github\.com[:/]([^/]+/[^/.]+?)(?:\.git)?$")
+
+# ctx 里 sisyphus 已创/记的 issue id key 集合 —— first-time discovery 时回填这些
+_KNOWN_ISSUE_ID_KEYS = (
+    "analyze_issue_id",
+    "staging_test_issue_id",
+    "pr_ci_watch_issue_id",
+    "accept_issue_id",
+    "archive_issue_id",
+)
+
+
+@dataclass(frozen=True)
+class PrLink:
+    """单条 GitHub PR 引用：owner/repo + PR 号 + html_url。"""
+
+    repo: str        # "owner/repo"
+    number: int
+    url: str
+
+    def tag(self) -> str:
+        return f"pr:{self.repo}#{self.number}"
+
+    def to_dict(self) -> dict:
+        return {"repo": self.repo, "number": self.number, "url": self.url}
+
+
+def pr_link_tags(links: list[PrLink]) -> list[str]:
+    """`[PrLink(...)]` → `["pr:owner/repo#N", ...]`，顺序保留。"""
+    return [link.tag() for link in links]
+
+
+def from_ctx(ctx: dict | None) -> list[PrLink]:
+    """解析 ctx.pr_links list[dict] → list[PrLink]。malformed entry 静默跳过。
+
+    防御老版本 sisyphus 写过的 ctx drift forward：缺 key / 类型错的条目跳过，
+    不抛异常。
+    """
+    raw = (ctx or {}).get("pr_links") or []
+    if not isinstance(raw, list):
+        return []
+    out: list[PrLink] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            link = PrLink(
+                repo=str(entry["repo"]),
+                number=int(entry["number"]),
+                url=str(entry.get("url", "")),
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+        out.append(link)
+    return out
+
+
+async def _discover_repos_via_runner(req_id: str) -> list[str]:
+    """ls /workspace/source/*/.git → ['owner/repo', ...]。失败返 []。
+
+    跟 actions/create_pr_ci_watch._discover_repos_from_runner 同样 helper 逻辑，
+    避免循环 import 自己写一遍。
+    """
+    cmd = (
+        "for d in /workspace/source/*/; do "
+        "  [ -d \"$d/.git\" ] && git -C \"$d\" remote get-url origin 2>/dev/null; "
+        "done"
+    )
+    try:
+        rc = k8s_runner.get_controller()
+    except RuntimeError as e:
+        log.debug("pr_links.no_runner_controller", req_id=req_id, error=str(e))
+        return []
+    try:
+        result = await rc.exec_in_runner(req_id, cmd, timeout_sec=_DISCOVER_TIMEOUT_SEC)
+    except Exception as e:
+        log.warning("pr_links.discover_repos_failed", req_id=req_id, error=str(e))
+        return []
+    repos: list[str] = []
+    seen: set[str] = set()
+    for line in (result.stdout or "").splitlines():
+        m = _REMOTE_RE.search(line.strip())
+        if not m:
+            continue
+        slug = m.group(1)
+        if slug in seen:
+            continue
+        seen.add(slug)
+        repos.append(slug)
+    return repos
+
+
+def _gh_headers() -> dict[str, str]:
+    h = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if settings.github_token:
+        h["Authorization"] = f"Bearer {settings.github_token}"
+    return h
+
+
+async def _get_open_pr(
+    client: httpx.AsyncClient, repo: str, branch: str,
+) -> PrLink | None:
+    """查 repo 在 head={owner}:{branch} 的第一条 open PR。
+
+    单 repo 错误 best-effort：HTTP error / 解析错误返 None + log warning，
+    上层继续遍历下一 repo。
+    """
+    if "/" not in repo:
+        return None
+    owner, _ = repo.split("/", 1)
+    try:
+        r = await client.get(
+            f"/repos/{repo}/pulls",
+            params={"head": f"{owner}:{branch}", "state": "open"},
+        )
+        r.raise_for_status()
+        pulls = r.json()
+    except httpx.HTTPError as e:
+        log.warning("pr_links.gh_api_error", repo=repo, branch=branch, error=str(e))
+        return None
+    except (ValueError, TypeError) as e:
+        log.warning("pr_links.gh_api_parse_error", repo=repo, branch=branch, error=str(e))
+        return None
+    if not pulls:
+        return None
+    pr = pulls[0]
+    try:
+        return PrLink(
+            repo=repo,
+            number=int(pr["number"]),
+            url=str(pr.get("html_url", "")),
+        )
+    except (KeyError, TypeError, ValueError) as e:
+        log.warning("pr_links.pr_payload_invalid", repo=repo, error=str(e))
+        return None
+
+
+async def discover_pr_links(
+    req_id: str,
+    branch: str,
+    repos: list[str] | None = None,
+) -> list[PrLink]:
+    """对每个 repo 查 open PR。repos=None → runner discovery 拿仓清单。
+
+    任意一步失败均不抛异常出来：返回当前已收集到的列表（best-effort）。
+    """
+    repo_list = repos if repos is not None else await _discover_repos_via_runner(req_id)
+    if not repo_list:
+        return []
+    links: list[PrLink] = []
+    async with httpx.AsyncClient(
+        base_url=_GH_API, headers=_gh_headers(), timeout=_GH_REQUEST_TIMEOUT,
+    ) as client:
+        for repo in repo_list:
+            link = await _get_open_pr(client, repo, branch)
+            if link is not None:
+                links.append(link)
+    return links
+
+
+def _gather_known_issue_ids(ctx: dict | None) -> list[str]:
+    """从 ctx 收集已知的 sisyphus issue id（去重，保留出现顺序）。"""
+    if not ctx:
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for key in _KNOWN_ISSUE_ID_KEYS:
+        v = ctx.get(key)
+        if isinstance(v, str) and v and v not in seen:
+            seen.add(v)
+            out.append(v)
+    return out
+
+
+async def _backfill_known_issues(
+    project_id: str,
+    issue_ids: list[str],
+    links: list[PrLink],
+) -> None:
+    """给 ctx 里已知的 sisyphus issue 补 pr:* tag。每条独立 try/except，单条失败不影响其他。"""
+    if not issue_ids or not links:
+        return
+    # 延迟 import 避免顶层循环（bkd_rest 导入了 bkd._to_issue → 闭环）
+    from .bkd import BKDClient
+
+    add_tags = pr_link_tags(links)
+    async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+        for iid in issue_ids:
+            try:
+                await bkd.merge_tags_and_update(project_id, iid, add=add_tags)
+            except Exception as e:
+                log.warning(
+                    "pr_links.backfill_failed", issue_id=iid, error=str(e),
+                )
+
+
+async def ensure_pr_links_in_ctx(
+    *,
+    req_id: str,
+    branch: str,
+    ctx: dict | None,
+    project_id: str,
+) -> list[PrLink]:
+    """读缓存 → 没有则 discover + 持久化 + backfill 已知 issue。
+
+    返回 PrLink 列表（可能为空）。callsite 用 `pr_link_tags(...)` 拼到
+    新建 issue 的 tags 数组里。
+
+    不抛异常：任何失败均 log warning 并返当前能拿到的列表（多数是 []）。
+    """
+    cached = from_ctx(ctx)
+    if cached:
+        return cached
+
+    links = await discover_pr_links(req_id, branch)
+    if not links:
+        return []
+
+    # 持久化 ctx.pr_links（让后续 callsite 命中 cache）
+    pool = db.get_pool()
+    try:
+        await req_state.update_context(
+            pool, req_id,
+            {"pr_links": [link.to_dict() for link in links]},
+        )
+    except Exception as e:
+        # ctx 更新失败不阻断本次 callsite —— 当前调用还是返 links，下次会再试
+        log.warning("pr_links.ctx_update_failed", req_id=req_id, error=str(e))
+
+    # 第一次 discover 成功 → 顺手 backfill ctx 里已经记下来的 sisyphus issue
+    backfill_ids = _gather_known_issue_ids(ctx)
+    if backfill_ids:
+        await _backfill_known_issues(project_id, backfill_ids, links)
+
+    log.info(
+        "pr_links.discovered",
+        req_id=req_id, branch=branch,
+        links=[link.to_dict() for link in links],
+        backfilled=backfill_ids,
+    )
+    return links

--- a/orchestrator/tests/test_actions_start_analyze.py
+++ b/orchestrator/tests/test_actions_start_analyze.py
@@ -26,6 +26,12 @@ def _admit_by_default(monkeypatch):
         AsyncMock(return_value=AdmissionDecision(admit=True)),
     )
     monkeypatch.setattr(start_analyze.db, "get_pool", lambda: object())
+    # REQ-issue-link-pr-quality-base-1777218242: success path stashes
+    # analyze_issue_id via update_context. Fixture pool is dummy object();
+    # patch update_context to no-op so existing tests don't crash.
+    # Tests that want to inspect the call can re-patch.
+    noop = AsyncMock()
+    monkeypatch.setattr(start_analyze.req_state, "update_context", noop)
 
 
 @dataclass

--- a/orchestrator/tests/test_intake.py
+++ b/orchestrator/tests/test_intake.py
@@ -230,6 +230,10 @@ async def test_start_analyze_with_finalized_intent_creates_new_issue(monkeypatch
     fake = make_fake_bkd()
     fake.create_issue = AsyncMock(return_value=FakeIssue(id="analyze-new-1"))
     patch_bkd(monkeypatch, "orchestrator.actions.start_analyze_with_finalized_intent.BKDClient", fake)
+    # REQ-issue-link-pr-quality-base-1777218242: success path stashes
+    # analyze_issue_id via update_context.
+    monkeypatch.setattr(mod.req_state, "update_context", AsyncMock())
+    monkeypatch.setattr(mod.db, "get_pool", lambda: object())
 
     ctx = {"intake_finalized_intent": _VALID_INTENT, "intent_title": "加 INTAKING stage"}
     out = await mod.start_analyze_with_finalized_intent(

--- a/orchestrator/tests/test_pr_links.py
+++ b/orchestrator/tests/test_pr_links.py
@@ -1,0 +1,461 @@
+"""pr_links 单测（REQ-issue-link-pr-quality-base-1777218242）。
+
+覆盖 LP-S1..S7：
+- LP-S1 cache hit returns cached without GH call
+- LP-S2 cache miss runs discovery and stashes ctx
+- LP-S3 runner exec error returns empty without raising
+- LP-S4 one repo errors, another succeeds (per-repo best-effort)
+- LP-S5 first discovery backfills analyze issue
+- LP-S6 pr_link_tags formats correctly
+- LP-S7 from_ctx tolerates malformed entries
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from orchestrator import pr_links
+
+# ─── 测试 fixture / helper ─────────────────────────────────────────────────
+
+
+@dataclass
+class FakeExec:
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
+
+
+def _patch_runner(monkeypatch, *, exec_return: FakeExec | Exception | None = None):
+    """patch pr_links.k8s_runner.get_controller()。
+
+    exec_return:
+      - FakeExec: exec_in_runner 返回该 stdout
+      - Exception 实例: exec_in_runner 抛该异常
+      - None: get_controller 抛 RuntimeError（无 controller）
+    """
+    if exec_return is None:
+        def raise_no_controller():
+            raise RuntimeError("RunnerController 未初始化")
+        monkeypatch.setattr(
+            pr_links.k8s_runner, "get_controller", raise_no_controller,
+        )
+        return None
+
+    if isinstance(exec_return, Exception):
+        exec_fn = AsyncMock(side_effect=exec_return)
+    else:
+        exec_fn = AsyncMock(return_value=exec_return)
+
+    class FakeRC:
+        exec_in_runner = exec_fn
+
+    monkeypatch.setattr(pr_links.k8s_runner, "get_controller", lambda: FakeRC())
+    return exec_fn
+
+
+def _patch_db(monkeypatch, *, update_ctx: AsyncMock | None = None):
+    """patch pr_links.db.get_pool + req_state.update_context。"""
+    if update_ctx is None:
+        update_ctx = AsyncMock()
+    monkeypatch.setattr(pr_links.db, "get_pool", lambda: object())
+    monkeypatch.setattr(pr_links.req_state, "update_context", update_ctx)
+    return update_ctx
+
+
+def _patch_bkd(monkeypatch, *, merge_tags_fn: AsyncMock | None = None):
+    """patch BKDClient (lazy imported in pr_links._backfill_known_issues)。"""
+    if merge_tags_fn is None:
+        merge_tags_fn = AsyncMock()
+    bkd_instance = MagicMock()
+    bkd_instance.merge_tags_and_update = merge_tags_fn
+
+    @asynccontextmanager
+    async def fake_client(*a, **kw):
+        yield bkd_instance
+
+    # bkd_links 内部 import: from .bkd import BKDClient
+    import orchestrator.bkd as bkd_mod
+    monkeypatch.setattr(bkd_mod, "BKDClient", fake_client)
+    return merge_tags_fn
+
+
+# ─── LP-S1: cache hit returns cached without GH call ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_LP_S1_cache_hit_returns_cached_without_gh(monkeypatch):
+    """ctx.pr_links 已缓存 → 直接返回，**不**触发 GH HTTP / runner exec / DB write。"""
+    # 任何一个 get_controller 调用都失败：cache hit 路径不该走到这
+    def _boom():
+        raise AssertionError("cache hit MUST NOT call get_controller")
+    monkeypatch.setattr(pr_links.k8s_runner, "get_controller", _boom)
+
+    update_ctx = _patch_db(monkeypatch)
+
+    cached_ctx = {
+        "pr_links": [
+            {"repo": "phona/sisyphus", "number": 42, "url": "https://github.com/phona/sisyphus/pull/42"},
+        ],
+    }
+
+    result = await pr_links.ensure_pr_links_in_ctx(
+        req_id="REQ-X", branch="feat/REQ-X",
+        ctx=cached_ctx, project_id="p",
+    )
+
+    assert result == [
+        pr_links.PrLink(
+            repo="phona/sisyphus", number=42,
+            url="https://github.com/phona/sisyphus/pull/42",
+        ),
+    ]
+    update_ctx.assert_not_awaited()
+
+
+# ─── LP-S2: cache miss runs discovery and stashes ctx ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_LP_S2_cache_miss_discovers_and_stashes(monkeypatch, httpx_mock):
+    """ctx 空 → runner discovery + GH REST → 返回 + 持久化 ctx.pr_links。"""
+    monkeypatch.setattr(pr_links.settings, "github_token", "ghp_xxx")
+    _patch_runner(monkeypatch, exec_return=FakeExec(
+        stdout="git@github.com:phona/sisyphus.git\n",
+    ))
+    update_ctx = _patch_db(monkeypatch)
+    _patch_bkd(monkeypatch)
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/sisyphus/pulls?head=phona:feat/REQ-X&state=open",
+        json=[{"number": 42, "html_url": "https://github.com/phona/sisyphus/pull/42"}],
+    )
+
+    result = await pr_links.ensure_pr_links_in_ctx(
+        req_id="REQ-X", branch="feat/REQ-X",
+        ctx={}, project_id="p",
+    )
+
+    assert result == [
+        pr_links.PrLink(
+            repo="phona/sisyphus", number=42,
+            url="https://github.com/phona/sisyphus/pull/42",
+        ),
+    ]
+    update_ctx.assert_awaited_once()
+    _, args, _kwargs = update_ctx.mock_calls[0]
+    # update_context(pool, req_id, patch)
+    patch = args[2]
+    assert patch == {
+        "pr_links": [
+            {"repo": "phona/sisyphus", "number": 42,
+             "url": "https://github.com/phona/sisyphus/pull/42"},
+        ],
+    }
+
+
+# ─── LP-S3: runner exec error returns empty without raising ────────────────
+
+
+@pytest.mark.asyncio
+async def test_LP_S3_runner_exec_error_returns_empty(monkeypatch):
+    """get_controller RuntimeError → 返 []，不抛、不更新 ctx、不查 GH。"""
+    _patch_runner(monkeypatch, exec_return=None)  # get_controller raises
+    update_ctx = _patch_db(monkeypatch)
+
+    result = await pr_links.ensure_pr_links_in_ctx(
+        req_id="REQ-X", branch="feat/REQ-X",
+        ctx={}, project_id="p",
+    )
+
+    assert result == []
+    update_ctx.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_LP_S3b_runner_exec_in_runner_raises_returns_empty(monkeypatch):
+    """exec_in_runner 抛异常 → 返 []，不抛。"""
+    _patch_runner(
+        monkeypatch,
+        exec_return=RuntimeError("pod not found"),
+    )
+    update_ctx = _patch_db(monkeypatch)
+
+    result = await pr_links.ensure_pr_links_in_ctx(
+        req_id="REQ-X", branch="feat/REQ-X",
+        ctx={}, project_id="p",
+    )
+
+    assert result == []
+    update_ctx.assert_not_awaited()
+
+
+# ─── LP-S4: one repo errors, another succeeds ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_LP_S4_per_repo_best_effort_on_gh_error(monkeypatch, httpx_mock):
+    """multi-repo: repo-a GH 503，repo-b 正常 → 只返 repo-b 的 link。"""
+    monkeypatch.setattr(pr_links.settings, "github_token", "ghp_xxx")
+    _patch_runner(monkeypatch, exec_return=FakeExec(
+        stdout=(
+            "git@github.com:phona/repo-a.git\n"
+            "https://github.com/phona/repo-b.git\n"
+        ),
+    ))
+    _patch_db(monkeypatch)
+    _patch_bkd(monkeypatch)
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/repo-a/pulls?head=phona:feat/REQ-X&state=open",
+        status_code=503,
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/repo-b/pulls?head=phona:feat/REQ-X&state=open",
+        json=[{"number": 7, "html_url": "https://github.com/phona/repo-b/pull/7"}],
+    )
+
+    result = await pr_links.discover_pr_links(
+        req_id="REQ-X", branch="feat/REQ-X",
+    )
+
+    assert result == [
+        pr_links.PrLink(
+            repo="phona/repo-b", number=7,
+            url="https://github.com/phona/repo-b/pull/7",
+        ),
+    ]
+
+
+# ─── LP-S5: first discovery backfills analyze issue ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_LP_S5_first_discovery_backfills_analyze_issue(monkeypatch, httpx_mock):
+    """ctx.analyze_issue_id 存在 → 第一次 discover 时调 bkd.merge_tags_and_update。"""
+    monkeypatch.setattr(pr_links.settings, "github_token", "ghp_xxx")
+    _patch_runner(monkeypatch, exec_return=FakeExec(
+        stdout="git@github.com:phona/sisyphus.git\n",
+    ))
+    _patch_db(monkeypatch)
+    merge_tags = _patch_bkd(monkeypatch)
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/sisyphus/pulls?head=phona:feat/REQ-X&state=open",
+        json=[{"number": 42, "html_url": "https://github.com/phona/sisyphus/pull/42"}],
+    )
+
+    result = await pr_links.ensure_pr_links_in_ctx(
+        req_id="REQ-X", branch="feat/REQ-X",
+        ctx={"analyze_issue_id": "abc123"},
+        project_id="p",
+    )
+
+    assert len(result) == 1
+    merge_tags.assert_awaited_once_with(
+        "p", "abc123", add=["pr:phona/sisyphus#42"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_LP_S5b_backfill_iterates_all_known_issue_ids(monkeypatch, httpx_mock):
+    """ctx 多个 *_issue_id key → 全部回填，每条独立 PATCH。"""
+    monkeypatch.setattr(pr_links.settings, "github_token", "ghp_xxx")
+    _patch_runner(monkeypatch, exec_return=FakeExec(
+        stdout="git@github.com:phona/sisyphus.git\n",
+    ))
+    _patch_db(monkeypatch)
+    merge_tags = _patch_bkd(monkeypatch)
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/sisyphus/pulls?head=phona:feat/REQ-X&state=open",
+        json=[{"number": 42, "html_url": "https://github.com/phona/sisyphus/pull/42"}],
+    )
+
+    ctx = {
+        "analyze_issue_id": "a-1",
+        "staging_test_issue_id": "s-1",
+        "accept_issue_id": "ac-1",
+        # archive_issue_id 缺：不该 panic
+        "unknown_key": "x-1",  # 不在白名单：不该被 backfill
+    }
+    await pr_links.ensure_pr_links_in_ctx(
+        req_id="REQ-X", branch="feat/REQ-X",
+        ctx=ctx, project_id="p",
+    )
+
+    assert merge_tags.await_count == 3
+    called_ids = {call.args[1] for call in merge_tags.await_args_list}
+    assert called_ids == {"a-1", "s-1", "ac-1"}
+
+
+@pytest.mark.asyncio
+async def test_LP_S5c_backfill_failure_does_not_raise(monkeypatch, httpx_mock):
+    """单条 backfill PATCH 抛异常 → 不冒泡到 caller，其他 id 继续 PATCH。"""
+    monkeypatch.setattr(pr_links.settings, "github_token", "ghp_xxx")
+    _patch_runner(monkeypatch, exec_return=FakeExec(
+        stdout="git@github.com:phona/sisyphus.git\n",
+    ))
+    _patch_db(monkeypatch)
+
+    call_log: list[str] = []
+
+    async def flaky_merge(project, issue_id, *, add):
+        call_log.append(issue_id)
+        if issue_id == "a-1":
+            raise httpx.HTTPError("boom")
+
+    _patch_bkd(monkeypatch, merge_tags_fn=AsyncMock(side_effect=flaky_merge))
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/sisyphus/pulls?head=phona:feat/REQ-X&state=open",
+        json=[{"number": 42, "html_url": "https://github.com/phona/sisyphus/pull/42"}],
+    )
+
+    ctx = {"analyze_issue_id": "a-1", "staging_test_issue_id": "s-1"}
+    result = await pr_links.ensure_pr_links_in_ctx(
+        req_id="REQ-X", branch="feat/REQ-X",
+        ctx=ctx, project_id="p",
+    )
+
+    # caller 拿到 link list（discover 成功部分仍有效）
+    assert len(result) == 1
+    # 失败的 a-1 之后还有 s-1 被尝试
+    assert call_log == ["a-1", "s-1"]
+
+
+# ─── LP-S6: pr_link_tags formats correctly ─────────────────────────────────
+
+
+def test_LP_S6_pr_link_tags_formats_correctly():
+    links = [
+        pr_links.PrLink(repo="phona/sisyphus", number=42, url="u1"),
+        pr_links.PrLink(repo="phona/runner", number=7, url="u2"),
+    ]
+    assert pr_links.pr_link_tags(links) == [
+        "pr:phona/sisyphus#42",
+        "pr:phona/runner#7",
+    ]
+
+
+def test_LP_S6b_pr_link_tags_empty_returns_empty():
+    assert pr_links.pr_link_tags([]) == []
+
+
+def test_LP_S6c_PrLink_tag_method():
+    link = pr_links.PrLink(repo="phona/sisyphus", number=42, url="...")
+    assert link.tag() == "pr:phona/sisyphus#42"
+    assert link.to_dict() == {
+        "repo": "phona/sisyphus", "number": 42, "url": "...",
+    }
+
+
+# ─── LP-S7: from_ctx tolerates malformed entries ───────────────────────────
+
+
+def test_LP_S7_from_ctx_skips_malformed_entries():
+    ctx = {
+        "pr_links": [
+            {"repo": "phona/sisyphus", "number": 42, "url": "u1"},
+            {"repo": "missing-num"},                   # missing number
+            "not-a-dict",                              # not a dict
+            {"repo": "phona/runner", "number": "7", "url": "u2"},  # str number coerces
+            {"repo": "phona/bad", "number": "abc"},    # invalid number
+            None,                                      # None entry
+        ],
+    }
+    result = pr_links.from_ctx(ctx)
+    assert result == [
+        pr_links.PrLink(repo="phona/sisyphus", number=42, url="u1"),
+        pr_links.PrLink(repo="phona/runner", number=7, url="u2"),
+    ]
+
+
+def test_LP_S7b_from_ctx_handles_missing_or_wrong_type():
+    assert pr_links.from_ctx(None) == []
+    assert pr_links.from_ctx({}) == []
+    assert pr_links.from_ctx({"pr_links": None}) == []
+    assert pr_links.from_ctx({"pr_links": "not-a-list"}) == []
+    assert pr_links.from_ctx({"pr_links": []}) == []
+
+
+# ─── 额外覆盖 ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_discover_repos_via_runner_dedupes(monkeypatch):
+    """同 origin 出现两次（fs glob 重复）→ 去重。"""
+    _patch_runner(monkeypatch, exec_return=FakeExec(
+        stdout=(
+            "git@github.com:phona/sisyphus.git\n"
+            "git@github.com:phona/sisyphus.git\n"
+            "https://github.com/phona/runner.git\n"
+        ),
+    ))
+    repos = await pr_links._discover_repos_via_runner("REQ-X")
+    assert repos == ["phona/sisyphus", "phona/runner"]
+
+
+@pytest.mark.asyncio
+async def test_get_open_pr_returns_none_when_no_open_pr(monkeypatch, httpx_mock):
+    """GH 返回空 list → None（repo 没 open PR，跳过）。"""
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/repo-x/pulls?head=phona:feat/REQ-X&state=open",
+        json=[],
+    )
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        result = await pr_links._get_open_pr(client, "phona/repo-x", "feat/REQ-X")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_open_pr_skips_invalid_repo_slug(monkeypatch):
+    """repo 字符串里没 '/' → None，不查 GH。"""
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        result = await pr_links._get_open_pr(client, "no-slash-repo", "feat/REQ-X")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_pr_links_no_repos_discovered_returns_empty(monkeypatch):
+    """runner discovery 返空 → 返 []，不查 GH，不写 ctx。"""
+    _patch_runner(monkeypatch, exec_return=FakeExec(stdout=""))
+    update_ctx = _patch_db(monkeypatch)
+
+    result = await pr_links.ensure_pr_links_in_ctx(
+        req_id="REQ-X", branch="feat/REQ-X",
+        ctx={}, project_id="p",
+    )
+
+    assert result == []
+    update_ctx.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ensure_pr_links_no_open_pr_returns_empty_no_ctx_write(
+    monkeypatch, httpx_mock,
+):
+    """repo 都查到了但都没 open PR → 返 []，不写 ctx（让下次 callsite 再试）。"""
+    monkeypatch.setattr(pr_links.settings, "github_token", "ghp_xxx")
+    _patch_runner(monkeypatch, exec_return=FakeExec(
+        stdout="git@github.com:phona/sisyphus.git\n",
+    ))
+    update_ctx = _patch_db(monkeypatch)
+    _patch_bkd(monkeypatch)
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/sisyphus/pulls?head=phona:feat/REQ-X&state=open",
+        json=[],
+    )
+
+    result = await pr_links.ensure_pr_links_in_ctx(
+        req_id="REQ-X", branch="feat/REQ-X",
+        ctx={}, project_id="p",
+    )
+
+    assert result == []
+    update_ctx.assert_not_awaited()


### PR DESCRIPTION
## Summary

每条 sisyphus 创建的 BKD sub-issue（analyze / staging-test / pr-ci-watch / accept /
done-archive / challenger / verifier / fixer）现在都带 `pr:<owner>/<repo>#<N>` tag
（一个 PR 一个 tag，多仓 REQ 多个 tag），让人在 BKD UI 里一跳跳到 GitHub PR。

PR 在 dev 阶段才落地（analyze-agent push feat/<REQ> 分支 + 开 PR）。所以
analyze issue 创建时 PR 不存在 → 第一次 helper discover 成功时 backfill 它。
后续所有 sisyphus 创的 issue 都直接读 ctx 缓存。

## What changed

- 新模块 `orchestrator/src/orchestrator/pr_links.py`：
  - `PrLink` dataclass + `from_ctx` / `pr_link_tags` helpers
  - `ensure_pr_links_in_ctx`：cache hit O(1) → cache miss runner pod
    discover + GH REST + 持久化 ctx.pr_links + 顺手 backfill ctx 里已知 issue id
  - 失败 best-effort（无 controller / GH 抖 / 0 PR）一律返 [] 不阻断 issue 创建
- 在每个 sisyphus 创 BKD issue 的 callsite 注入 PR tag：
  `_verifier.invoke_verifier` / `_verifier.start_fixer` /
  `create_staging_test` / `create_pr_ci_watch` / `create_accept` /
  `done_archive` / `start_challenger`
- `start_analyze` / `start_analyze_with_finalized_intent` 现在 stash
  `analyze_issue_id` 到 ctx（让回填能找到那条 issue）
- 18 条新单测覆盖 LP-S1..S7（cache hit / miss / runner error /
  per-repo GH error / 回填 / tag format / malformed ctx）

## Tradeoffs（从 proposal.md 摘）

- **tag 不是 description / follow-up message**：tag 在 BKD UI 列表里直接显示，
  且 router 已用 tag 做结构化 metadata（`parent-id:` 等）
- **lazy discover**：没人主动告诉 sisyphus "PR 开了"。改 prompt 强约束 agent 写回
  反而更脆，lazy discover 是 GH REST 1-N 次 per first-time call 的事
- **in-ctx cache**：jsonb merge，不引新表；observability 直接
  `SELECT context->'pr_links'` 就能查"该 REQ 开了哪些 PR"
- **best-effort discover**：issue 创建是热路径，GH 抖动 / runner 没起来 /
  极早期 0 PR 任何一种都不能让 sisyphus 卡住；tag 缺了下次 callsite 再补

## Test plan

- [x] `make ci-unit-test` —— 943 测试全过（新加 18 条 / 改 2 条 fixture）
- [x] `make ci-lint` —— ruff 通过
- [x] `make ci-integration-test` —— exit 5 = no integration tests，pass
- [x] `openspec validate REQ-issue-link-pr-quality-base-1777218242 --strict` —— pass
- [x] `scripts/check-scenario-refs.sh` —— 294 scenarios 全识别

## Spec

`openspec/changes/REQ-issue-link-pr-quality-base-1777218242/`：
- `proposal.md`：动机 + What Changes + Tradeoffs + Impact
- `specs/issue-pr-link/contract.spec.yaml`：black-box 行为契约
- `specs/issue-pr-link/spec.md`：6 条 ADDED Requirements + 11 条 Scenarios