### PR TITLE
feat(mcp): sisyphus-dispatch MCP server M0 (REQ-mcp-sisyphus-dispatch-m0-1777220172)

### DIFF
--- a/openspec/changes/REQ-mcp-sisyphus-dispatch-m0-1777220172/design.md
+++ b/openspec/changes/REQ-mcp-sisyphus-dispatch-m0-1777220172/design.md
@@ -1,0 +1,104 @@
+# Design: sisyphus-dispatch MCP server M0
+
+## Interpretation of the intent
+
+Title-only intent: `feat(mcp): sisyphus-dispatch MCP server M0`. We
+read this as **server-side**, because the only existing MCP code path
+in the repo is `orchestrator/src/orchestrator/bkd_mcp.py` which is
+already a *client*, and the project philosophy in CLAUDE.md is "走 BKD
+REST，不走 MCP". So sisyphus is not consuming MCP — it would be
+*producing* MCP, exposing its orchestration surface to other MCP
+clients. The "dispatch" name aligns with the verb sisyphus already uses
+in spec text ("sisyphus-dispatched sub-agents"): an external MCP client
+asking the orchestrator about, and eventually directing, REQ flow.
+
+If the reviewer disagrees with this read, M1's only sunk cost is the
+package name — the queries / tests are useful regardless.
+
+## Why FastMCP, not handrolled JSON-RPC
+
+Two reasons:
+
+1. **MCP handshake is non-trivial.** The protocol requires a stateful
+   initialize → notifications/initialized → tools/list → tools/call
+   sequence over either stdio or HTTP-SSE, with capability
+   negotiation. Hand-coding this for M0 means rebuilding it in M1 when
+   we add HTTP transport. FastMCP gives both transports for free.
+2. **Tool schema generation.** FastMCP introspects type hints and
+   docstrings to publish JSON-Schema for each tool. Hand-rolling
+   schemas is error-prone and would diverge from the Python signatures.
+
+The cost is one new dep (`mcp`). The orchestrator runner image already
+caches uv wheels on PVC (REQ-runner-cache-on-pvc-1777198512), so this
+is an install-once hit.
+
+## Why stdio only in M0
+
+The two transports MCP supports are stdio (one client per process,
+parent launches child) and Streamable HTTP / SSE (long-running
+server, multiple clients).
+
+- stdio fits the "developer launches `python -m
+  orchestrator.dispatch_mcp` from Claude Code config" use case
+  with zero deployment work — Claude Code already knows how to spawn
+  stdio MCP servers.
+- HTTP needs a port, a service, an ingress, and an auth model. Doing
+  any of those in M0 forces decisions (port number, token store,
+  multi-tenant isolation) that we don't yet have signal on.
+
+So M0 ships stdio. M1 adds Streamable HTTP for an in-cluster sidecar.
+
+## Why two tools and not more
+
+- `get_req_state` answers "what's REQ X doing?" — the single most
+  common question.
+- `list_reqs` answers "what's running right now?" — the second most
+  common.
+
+Together they cover ~all read-only inspection an interactive operator
+needs from an IDE. `stage_runs` / `verifier_decisions` views require
+deciding which columns to surface and how to render them, which is its
+own design conversation; we defer rather than guess.
+
+## Why redact `context` to keys-only
+
+`req_state.context` is a free-form JSONB blob holding agent prompts,
+finalized intent JSON, escalate reasons, and (for some past REQs) raw
+agent output text. An MCP tool result is shown directly to the IDE
+client. Returning the full context unconditionally:
+
+- bloats tool results past sane sizes (some contexts run >50 KB),
+- could leak prompts the user didn't intend to share with whoever is
+  attached to the MCP server,
+- and ships unstructured text where the M0 contract is "JSON-shaped
+  state".
+
+Keys-only gives the agent enough hint to ask follow-up tools in later
+milestones (e.g. `get_req_context_field(req_id, key)`). Cheap to
+return, predictable shape, no leakage.
+
+## Why no FastMCP test harness
+
+`@mcp.tool()` registers the function in FastMCP's internal tool dict
+without modifying it. The Python function is still callable directly
+with the same signature. Our tests therefore call the **queries**
+module — pure async functions — and skip the registration layer
+entirely. This:
+
+- avoids depending on `mcp` SDK internals in tests,
+- keeps tests fast (no SDK init, no transport boot),
+- and means a future SDK upgrade that changes the decorator
+  internals doesn't break our unit suite.
+
+A future integration test (M18 challenger) can drive the full
+stdio transport end-to-end if we want black-box coverage.
+
+## DB pool ownership
+
+The MCP server runs as a **separate process** from the orchestrator
+FastAPI app. It has its own asyncpg pool. We don't reach into
+`store.db._pool` because that singleton is owned by the FastAPI
+lifecycle. Instead `run_stdio()` calls `init_pool(settings.pg_dsn)`
+itself before invoking `mcp.run("stdio")`, and `close_pool()` on
+shutdown. Tests pass a fake pool directly into the queries — they
+never touch the singleton.

--- a/openspec/changes/REQ-mcp-sisyphus-dispatch-m0-1777220172/proposal.md
+++ b/openspec/changes/REQ-mcp-sisyphus-dispatch-m0-1777220172/proposal.md
@@ -1,0 +1,90 @@
+# feat(mcp): sisyphus-dispatch MCP server M0
+
+## Why
+
+Operators and Claude-Code IDE agents inspect REQ state today by either
+hitting `orchestrator.admin` HTTP endpoints by hand or shelling into the
+Postgres pod and writing SQL. Neither is ergonomic for an interactive
+agent loop, and both require credentials wired up case-by-case.
+
+The medium-term goal is a stable **MCP** surface — `sisyphus-dispatch` —
+that any MCP-speaking client (Claude Code, custom dev tooling) can
+attach to and call tools like "what's REQ X doing right now?", "list
+in-flight REQs", and (in later milestones) "force-resume", "open a fresh
+intake". M0 is the foundation milestone: ship the package shape, the
+server entrypoint, and **read-only inspection tools** so future
+milestones can layer mutating operations on top without re-litigating
+package layout, transport choice, or DB-pool wiring.
+
+> **Assumption flagged for reviewer.** The intent issue title is the
+> entire spec we received. We are interpreting "sisyphus-dispatch MCP
+> server M0" as "a server-side MCP that exposes sisyphus orchestrator
+> state to MCP clients, scaffolded with the smallest useful read-only
+> tool set". If the intent was different (e.g. an MCP **client** for
+> dispatching to other systems, or a replacement for `bkd_mcp.py` which
+> is BKD's old MCP **client**), call this out on the PR — the package
+> name `dispatch_mcp` is the only thing M1 would need to rename.
+
+## What Changes
+
+- **New Python package** `orchestrator/src/orchestrator/dispatch_mcp/`
+  with three modules:
+  - `queries.py` — pure async DB-read helpers
+    (`fetch_req_state(pool, req_id)`,
+    `fetch_reqs(pool, *, state, limit)`) returning JSON-serialisable
+    dicts. No FastMCP coupling so unit tests stay fast.
+  - `server.py` — constructs a `mcp.server.fastmcp.FastMCP` instance,
+    registers two `@mcp.tool()` wrappers around the queries, and
+    exposes `run_stdio()` that lazily inits the asyncpg pool from
+    `settings.pg_dsn` before handing control to the SDK's stdio
+    transport.
+  - `__main__.py` — `python -m orchestrator.dispatch_mcp` entrypoint
+    that calls `run_stdio()`. M0 ships **stdio only**; HTTP/SSE
+    transport and auth are explicitly deferred to M1+.
+
+- **New dep** `mcp>=1.2` in `orchestrator/pyproject.toml`. We use
+  FastMCP because handcrafting JSON-RPC + tool-list + initialize
+  handshakes for M0 just to throw it away in M1 has zero upside.
+
+- **Two read-only tools** exposed by the M0 server:
+  - `get_req_state(req_id: str)` — returns
+    `{req_id, project_id, state, created_at, updated_at, last_event,
+    context_keys}`. We return `context_keys` (top-level keys list) not
+    full `context` because contexts hold tokens / prompts / agent
+    output that an IDE agent has no reason to slurp wholesale.
+  - `list_reqs(state: str | None = None, limit: int = 50)` — returns a
+    list of `{req_id, project_id, state, updated_at}`. `limit`
+    clamped to `[1, 200]` server-side; `state` validated against the
+    `ReqState` enum so a typo gets a clean error instead of silently
+    returning everything.
+
+- **Unit tests** `orchestrator/tests/test_dispatch_mcp.py` covering
+  the queries module against a fake asyncpg pool (same pattern as
+  `tests/test_admission.py`). No FastMCP harness — the queries are
+  plain async functions and that's where the logic lives.
+
+## Impact
+
+- **Affected specs**: new capability `dispatch-mcp` (purely additive).
+- **Affected code**: new package + tests; one-line dep bump in
+  `pyproject.toml`. No existing module modified.
+- **Deployment / migration**: zero ops. The MCP server is **not**
+  auto-started by the orchestrator FastAPI app — operators who want it
+  run `python -m orchestrator.dispatch_mcp` next to the orchestrator
+  pod (or locally, given `SISYPHUS_PG_DSN`). M1 wires this into a Helm
+  sidecar / second deployment with HTTP transport.
+- **Risk**: very low. Server is isolated (separate process, separate
+  asyncpg pool, never imported by `webhook` / `engine` / `actions`).
+  Only read paths against `req_state`. If `mcp` SDK install fails on
+  the runner, dev_cross_check / staging_test fail loudly — which is
+  what we want.
+- **Out of scope (deferred to M1+)**:
+  - HTTP / SSE transport, OAuth / token auth.
+  - Mutating tools (force-resume, cancel, open-intake, follow-up).
+  - Reading from `stage_runs` / `verifier_decisions` (M0 sticks to
+    `req_state` so we don't have to make UX decisions about which
+    columns to surface).
+  - Helm chart / sidecar deployment.
+  - Resource (`mcp.resource`) URIs — we go tool-only for M0 because
+    every IDE client today understands tools; resource support
+    varies.

--- a/openspec/changes/REQ-mcp-sisyphus-dispatch-m0-1777220172/specs/dispatch-mcp/spec.md
+++ b/openspec/changes/REQ-mcp-sisyphus-dispatch-m0-1777220172/specs/dispatch-mcp/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: sisyphus-dispatch MCP server exposes read-only REQ inspection tools over stdio
+
+The sisyphus orchestrator codebase SHALL ship a Python package
+`orchestrator.dispatch_mcp` providing an MCP server, runnable as
+`python -m orchestrator.dispatch_mcp`, that connects to the
+orchestrator's Postgres `req_state` table and MUST register exactly
+two read-only tools — `get_req_state` and `list_reqs` — over the
+stdio transport defined in the Model Context Protocol specification.
+The server MUST NOT register any tool that mutates `req_state`,
+`event_log`, `stage_runs`, or `verifier_decisions`; mutating
+operations are deferred to later milestones.
+
+The server MUST initialise its own asyncpg pool via
+`orchestrator.store.db.init_pool(settings.pg_dsn)` before accepting
+requests, and SHALL close that pool when the stdio session ends. The
+server MUST NOT reuse the orchestrator FastAPI process's singleton
+pool — the MCP server runs as an independent process whose lifecycle
+is decoupled from the webhook handler.
+
+#### Scenario: DISPATCH-MCP-S1 get_req_state returns shape for an existing REQ
+
+- **GIVEN** the `req_state` row for `REQ-x` has
+  `state=ANALYZING`, `project_id=p1`, `context={"a":1,"b":2}`,
+  `history=[{"to":"analyzing","ts":"2026-04-26T10:00:00Z"}]`
+- **WHEN** `fetch_req_state(pool, "REQ-x")` is awaited
+- **THEN** the returned dict contains keys
+  `req_id`, `project_id`, `state`, `created_at`, `updated_at`,
+  `last_event`, `context_keys` and `state == "analyzing"` and
+  `sorted(context_keys) == ["a", "b"]`
+
+#### Scenario: DISPATCH-MCP-S2 get_req_state returns None for a missing REQ
+
+- **GIVEN** the `req_state` table has no row for `REQ-missing`
+- **WHEN** `fetch_req_state(pool, "REQ-missing")` is awaited
+- **THEN** the returned value is `None`
+
+#### Scenario: DISPATCH-MCP-S3 list_reqs default limit is 50 and clamped to [1, 200]
+
+- **GIVEN** the caller passes `limit=999`
+- **WHEN** `fetch_reqs(pool, state=None, limit=999)` is awaited
+- **THEN** the SQL `LIMIT` parameter passed to the pool MUST equal `200`
+
+  AND **GIVEN** the caller passes `limit=0`
+- **WHEN** the same function is awaited
+- **THEN** the SQL `LIMIT` parameter MUST equal `1`
+
+#### Scenario: DISPATCH-MCP-S4 list_reqs with explicit state filters by ReqState value
+
+- **GIVEN** the caller passes `state="analyzing"`
+- **WHEN** `fetch_reqs(pool, state="analyzing", limit=50)` is awaited
+- **THEN** the SQL `WHERE` clause MUST filter on `state = $1` and the
+  bound `$1` value MUST be the literal string `analyzing`
+
+#### Scenario: DISPATCH-MCP-S5 list_reqs raises ValueError on unknown state
+
+- **GIVEN** the caller passes `state="banana"`
+- **WHEN** `fetch_reqs(pool, state="banana", limit=50)` is awaited
+- **THEN** the call MUST raise `ValueError` whose message contains
+  the substring `unknown state` and the list of valid values
+
+#### Scenario: DISPATCH-MCP-S6 get_req_state redacts context body to keys-only
+
+- **GIVEN** the `req_state.context` for `REQ-redact` contains
+  `{"prompt":"<long secret text>","intent":{"k":"v"}}`
+- **WHEN** `fetch_req_state(pool, "REQ-redact")` is awaited
+- **THEN** the result MUST contain `context_keys` equal to
+  `["prompt","intent"]` (in any order) and MUST NOT contain a top-level
+  `context` field nor any string value from the original context body

--- a/openspec/changes/REQ-mcp-sisyphus-dispatch-m0-1777220172/tasks.md
+++ b/openspec/changes/REQ-mcp-sisyphus-dispatch-m0-1777220172/tasks.md
@@ -1,0 +1,28 @@
+# tasks: REQ-mcp-sisyphus-dispatch-m0-1777220172
+
+## Stage: contract / spec
+
+- [x] author `specs/dispatch-mcp/spec.md` with delta `## ADDED Requirements`
+- [x] write 6 scenarios `DISPATCH-MCP-S{1..6}` covering: get_req_state
+      happy / get_req_state missing / list_reqs default limit /
+      list_reqs filtered by state / list_reqs invalid state error /
+      get_req_state redacts context to keys-only
+
+## Stage: implementation
+
+- [x] add `mcp>=1.2` to `orchestrator/pyproject.toml` dependencies
+- [x] `orchestrator/src/orchestrator/dispatch_mcp/__init__.py`: package marker
+- [x] `orchestrator/src/orchestrator/dispatch_mcp/queries.py`:
+      `fetch_req_state(pool, req_id)` and
+      `fetch_reqs(pool, *, state, limit)` returning JSON-serialisable dicts
+- [x] `orchestrator/src/orchestrator/dispatch_mcp/server.py`:
+      FastMCP instance + two `@mcp.tool()` wrappers + `run_stdio()`
+- [x] `orchestrator/src/orchestrator/dispatch_mcp/__main__.py`:
+      stdio entrypoint
+- [x] `orchestrator/tests/test_dispatch_mcp.py`: unit tests for the
+      6 scenarios against a fake asyncpg pool
+
+## Stage: PR
+
+- [x] git push `feat/REQ-mcp-sisyphus-dispatch-m0-1777220172`
+- [x] gh pr create

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "kubernetes>=31.0",      # v0.2 K8s runner（pod/pvc/exec）
     "jsonschema>=4.0",       # M3 manifest/openspec admission（schema validate）
     "pyyaml>=6.0",           # M3 读 PVC 上 manifest.yaml
+    "mcp>=1.2",              # sisyphus-dispatch MCP server（dispatch_mcp/，stdio transport，M0）
 ]
 
 [project.optional-dependencies]

--- a/orchestrator/src/orchestrator/dispatch_mcp/__init__.py
+++ b/orchestrator/src/orchestrator/dispatch_mcp/__init__.py
@@ -1,0 +1,5 @@
+"""sisyphus-dispatch MCP server.
+
+M0：read-only REQ 状态查询，stdio transport。后续 milestone 加 HTTP/SSE +
+mutating tools（force-resume / open-intake / cancel）。
+"""

--- a/orchestrator/src/orchestrator/dispatch_mcp/__main__.py
+++ b/orchestrator/src/orchestrator/dispatch_mcp/__main__.py
@@ -1,0 +1,14 @@
+"""`python -m orchestrator.dispatch_mcp` → run the stdio MCP server."""
+from __future__ import annotations
+
+import asyncio
+
+from .server import run_stdio
+
+
+def main() -> None:
+    asyncio.run(run_stdio())
+
+
+if __name__ == "__main__":
+    main()

--- a/orchestrator/src/orchestrator/dispatch_mcp/queries.py
+++ b/orchestrator/src/orchestrator/dispatch_mcp/queries.py
@@ -1,0 +1,151 @@
+"""DB-read helpers backing the dispatch_mcp tools.
+
+Pure async functions; no FastMCP / MCP SDK coupling so unit tests can
+exercise them against a fake asyncpg pool the same way as
+`tests/test_admission.py`.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any
+
+import asyncpg
+
+from ..state import ReqState
+
+LIST_LIMIT_MIN = 1
+LIST_LIMIT_MAX = 200
+LIST_LIMIT_DEFAULT = 50
+
+
+def _decode_jsonb(value: Any) -> Any:
+    """asyncpg returns jsonb as either str (default) or already-parsed
+    object (when a custom codec is registered). Match the same dual
+    handling store/req_state.py uses."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return None
+    return value
+
+
+def _serialise_dt(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _last_event(history: Any) -> dict | None:
+    """Last entry of req_state.history (chronological append-only list).
+    Returns the raw dict or None if history is empty / missing."""
+    decoded = _decode_jsonb(history)
+    if isinstance(decoded, list) and decoded:
+        last = decoded[-1]
+        if isinstance(last, dict):
+            return last
+    return None
+
+
+def _context_keys(context: Any) -> list[str]:
+    decoded = _decode_jsonb(context)
+    if isinstance(decoded, dict):
+        return list(decoded.keys())
+    return []
+
+
+async def fetch_req_state(pool: asyncpg.Pool, req_id: str) -> dict | None:
+    """Return a JSON-shaped projection of req_state for `req_id`, or
+    None if the row doesn't exist.
+
+    Top-level `context` is intentionally redacted to `context_keys`
+    (top-level keys only) — see design.md "Why redact context to
+    keys-only".
+    """
+    row = await pool.fetchrow(
+        "SELECT req_id, project_id, state, history, context, "
+        "created_at, updated_at "
+        "FROM req_state WHERE req_id = $1",
+        req_id,
+    )
+    if row is None:
+        return None
+    return {
+        "req_id": row["req_id"],
+        "project_id": row["project_id"],
+        "state": row["state"],
+        "created_at": _serialise_dt(row["created_at"]),
+        "updated_at": _serialise_dt(row["updated_at"]),
+        "last_event": _last_event(row["history"]),
+        "context_keys": _context_keys(row["context"]),
+    }
+
+
+def _clamp_limit(limit: int) -> int:
+    if limit < LIST_LIMIT_MIN:
+        return LIST_LIMIT_MIN
+    if limit > LIST_LIMIT_MAX:
+        return LIST_LIMIT_MAX
+    return limit
+
+
+def _validate_state(state: str | None) -> str | None:
+    if state is None:
+        return None
+    valid = {s.value for s in ReqState}
+    if state not in valid:
+        raise ValueError(
+            f"unknown state {state!r}; expected one of "
+            f"{sorted(valid)}"
+        )
+    return state
+
+
+async def fetch_reqs(
+    pool: asyncpg.Pool,
+    *,
+    state: str | None = None,
+    limit: int = LIST_LIMIT_DEFAULT,
+) -> list[dict]:
+    """List most-recently-updated REQs, optionally filtered by state.
+
+    `limit` is clamped server-side to `[1, 200]` so a malformed client
+    can't exfiltrate the whole table in one shot. `state` is
+    validated against `ReqState`; an unknown value raises
+    `ValueError`.
+    """
+    validated_state = _validate_state(state)
+    bound_limit = _clamp_limit(limit)
+
+    if validated_state is None:
+        rows = await pool.fetch(
+            "SELECT req_id, project_id, state, updated_at "
+            "FROM req_state "
+            "ORDER BY updated_at DESC "
+            "LIMIT $1",
+            bound_limit,
+        )
+    else:
+        rows = await pool.fetch(
+            "SELECT req_id, project_id, state, updated_at "
+            "FROM req_state "
+            "WHERE state = $1 "
+            "ORDER BY updated_at DESC "
+            "LIMIT $2",
+            validated_state,
+            bound_limit,
+        )
+    return [
+        {
+            "req_id": r["req_id"],
+            "project_id": r["project_id"],
+            "state": r["state"],
+            "updated_at": _serialise_dt(r["updated_at"]),
+        }
+        for r in rows
+    ]

--- a/orchestrator/src/orchestrator/dispatch_mcp/server.py
+++ b/orchestrator/src/orchestrator/dispatch_mcp/server.py
@@ -1,0 +1,50 @@
+"""FastMCP wiring for the sisyphus-dispatch server (stdio transport, M0).
+
+Tool implementations live in `queries.py` so unit tests can exercise
+them without booting the MCP SDK. This module just glues the queries
+to FastMCP `@tool()` registration and owns the stdio runtime.
+"""
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+from ..config import settings
+from ..store.db import close_pool, get_pool, init_pool
+from . import queries
+
+mcp = FastMCP("sisyphus-dispatch")
+
+
+@mcp.tool()
+async def get_req_state(req_id: str) -> dict | None:
+    """Return current state of a REQ, or null if it doesn't exist.
+
+    The returned object exposes `req_id`, `project_id`, `state`,
+    `created_at`, `updated_at`, the last `history` entry as
+    `last_event`, and `context_keys` (top-level keys of the JSONB
+    context — body intentionally redacted).
+    """
+    return await queries.fetch_req_state(get_pool(), req_id)
+
+
+@mcp.tool()
+async def list_reqs(
+    state: str | None = None,
+    limit: int = queries.LIST_LIMIT_DEFAULT,
+) -> list[dict]:
+    """List the most-recently-updated REQs, optionally filtered by state.
+
+    `limit` is clamped to [1, 200] server-side. `state`, when supplied,
+    must be a valid `ReqState` value (e.g. "analyzing", "pr-ci-running",
+    "done"); an unknown value raises an error.
+    """
+    return await queries.fetch_reqs(get_pool(), state=state, limit=limit)
+
+
+async def run_stdio() -> None:
+    """Init the asyncpg pool, run the MCP stdio loop, then tear down."""
+    await init_pool(settings.pg_dsn)
+    try:
+        await mcp.run_stdio_async()
+    finally:
+        await close_pool()

--- a/orchestrator/tests/test_contract_dispatch_mcp_challenger.py
+++ b/orchestrator/tests/test_contract_dispatch_mcp_challenger.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import pytest
 
-
 # ── Fake pool ────────────────────────────────────────────────────────────────
 
 

--- a/orchestrator/tests/test_contract_dispatch_mcp_challenger.py
+++ b/orchestrator/tests/test_contract_dispatch_mcp_challenger.py
@@ -1,0 +1,325 @@
+"""Challenger contract tests for REQ-mcp-sisyphus-dispatch-m0-1777220172.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-mcp-sisyphus-dispatch-m0-1777220172/specs/dispatch-mcp/spec.md
+
+Scenarios covered:
+  DISPATCH-MCP-M0  queries/server/__main__ modules importable + symbols exposed
+  DISPATCH-MCP-S1  fetch_req_state returns dict with required keys, correct state, correct context_keys
+  DISPATCH-MCP-S2  fetch_req_state returns None for missing REQ
+  DISPATCH-MCP-S3  fetch_reqs limit clamped to [1, 200] — SQL param verified
+  DISPATCH-MCP-S4  fetch_reqs state filter binds 'analyzing' as $N SQL param
+  DISPATCH-MCP-S5  fetch_reqs raises ValueError on unknown state with message listing valid values
+  DISPATCH-MCP-S6  fetch_req_state redacts context body: only keys returned, no raw body exposed
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ── Fake pool ────────────────────────────────────────────────────────────────
+
+
+class _FakePool:
+    """Captures fetchrow / fetch calls; returns configured data."""
+
+    def __init__(self, row: dict | None = None, rows: list | None = None):
+        self._row = row
+        self._rows = rows or []
+        self.last_sql: str | None = None
+        self.last_args: tuple = ()
+
+    async def fetchrow(self, sql: str, *args):
+        self.last_sql = sql
+        self.last_args = args
+        return self._row
+
+    async def fetch(self, sql: str, *args):
+        self.last_sql = sql
+        self.last_args = args
+        return self._rows
+
+
+# ── M0: module + symbol importability ───────────────────────────────────────
+
+
+def test_DISPATCH_MCP_M0_queries_module_importable() -> None:
+    """orchestrator.dispatch_mcp.queries must be importable with no side effects."""
+    import orchestrator.dispatch_mcp.queries  # noqa: F401
+
+
+def test_DISPATCH_MCP_M0_fetch_req_state_callable() -> None:
+    """queries must expose fetch_req_state callable."""
+    from orchestrator.dispatch_mcp.queries import fetch_req_state
+
+    assert callable(fetch_req_state)
+
+
+def test_DISPATCH_MCP_M0_fetch_reqs_callable() -> None:
+    """queries must expose fetch_reqs callable."""
+    from orchestrator.dispatch_mcp.queries import fetch_reqs
+
+    assert callable(fetch_reqs)
+
+
+def test_DISPATCH_MCP_M0_server_module_importable() -> None:
+    """orchestrator.dispatch_mcp.server must be importable (FastMCP instance creation)."""
+    import orchestrator.dispatch_mcp.server  # noqa: F401
+
+
+def test_DISPATCH_MCP_M0_main_module_importable() -> None:
+    """orchestrator.dispatch_mcp.__main__ must be importable without triggering run_stdio()."""
+    import orchestrator.dispatch_mcp.__main__  # noqa: F401
+
+
+# ── S1 helpers ───────────────────────────────────────────────────────────────
+
+
+def _s1_row() -> dict:
+    return {
+        "req_id": "REQ-x",
+        "project_id": "p1",
+        "state": "analyzing",
+        "created_at": "2026-04-26T10:00:00Z",
+        "updated_at": "2026-04-26T10:00:00Z",
+        "last_event": "analyzing",
+        "context": {"a": 1, "b": 2},
+        "history": [{"to": "analyzing", "ts": "2026-04-26T10:00:00Z"}],
+    }
+
+
+# ── S1: correct shape for existing REQ ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_DISPATCH_MCP_S1_result_not_none() -> None:
+    """fetch_req_state must return a non-None dict for an existing REQ row."""
+    from orchestrator.dispatch_mcp.queries import fetch_req_state
+
+    pool = _FakePool(row=_s1_row())
+    result = await fetch_req_state(pool, "REQ-x")
+
+    assert result is not None, "Expected dict for existing REQ, got None"
+
+
+@pytest.mark.asyncio
+async def test_DISPATCH_MCP_S1_all_required_keys_present() -> None:
+    """fetch_req_state result must contain all 7 required keys from spec."""
+    from orchestrator.dispatch_mcp.queries import fetch_req_state
+
+    pool = _FakePool(row=_s1_row())
+    result = await fetch_req_state(pool, "REQ-x")
+
+    assert result is not None
+    required = {"req_id", "project_id", "state", "created_at", "updated_at", "last_event", "context_keys"}
+    missing = required - set(result.keys())
+    assert not missing, f"Result missing required keys: {missing}"
+
+
+@pytest.mark.asyncio
+async def test_DISPATCH_MCP_S1_state_is_analyzing() -> None:
+    """fetch_req_state result must have state == 'analyzing'."""
+    from orchestrator.dispatch_mcp.queries import fetch_req_state
+
+    pool = _FakePool(row=_s1_row())
+    result = await fetch_req_state(pool, "REQ-x")
+
+    assert result is not None
+    assert result["state"] == "analyzing", (
+        f"Expected state='analyzing', got {result['state']!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_DISPATCH_MCP_S1_context_keys_are_a_and_b() -> None:
+    """fetch_req_state result must have sorted(context_keys) == ['a', 'b']."""
+    from orchestrator.dispatch_mcp.queries import fetch_req_state
+
+    pool = _FakePool(row=_s1_row())
+    result = await fetch_req_state(pool, "REQ-x")
+
+    assert result is not None
+    assert sorted(result["context_keys"]) == ["a", "b"], (
+        f"Expected sorted context_keys=['a','b'], got {sorted(result['context_keys'])!r}"
+    )
+
+
+# ── S2: None for missing REQ ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_DISPATCH_MCP_S2_returns_none_for_missing_req() -> None:
+    """fetch_req_state returns None when pool returns no row."""
+    from orchestrator.dispatch_mcp.queries import fetch_req_state
+
+    pool = _FakePool(row=None)
+    result = await fetch_req_state(pool, "REQ-missing")
+
+    assert result is None, f"Expected None for missing REQ, got {result!r}"
+
+
+# ── S3: limit clamping ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_DISPATCH_MCP_S3_limit_999_clamped_to_200() -> None:
+    """fetch_reqs(limit=999) must pass SQL LIMIT param = 200."""
+    from orchestrator.dispatch_mcp.queries import fetch_reqs
+
+    pool = _FakePool()
+    await fetch_reqs(pool, state=None, limit=999)
+
+    assert 200 in pool.last_args, (
+        f"Expected SQL LIMIT param=200 in pool args, got args={pool.last_args}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_DISPATCH_MCP_S3_limit_0_clamped_to_1() -> None:
+    """fetch_reqs(limit=0) must pass SQL LIMIT param = 1."""
+    from orchestrator.dispatch_mcp.queries import fetch_reqs
+
+    pool = _FakePool()
+    await fetch_reqs(pool, state=None, limit=0)
+
+    assert 1 in pool.last_args, (
+        f"Expected SQL LIMIT param=1 in pool args, got args={pool.last_args}"
+    )
+
+
+# ── S4: state filter bound as $N param ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_DISPATCH_MCP_S4_state_value_bound_as_sql_param() -> None:
+    """fetch_reqs(state='analyzing') must bind 'analyzing' as a $N SQL parameter."""
+    from orchestrator.dispatch_mcp.queries import fetch_reqs
+
+    pool = _FakePool()
+    await fetch_reqs(pool, state="analyzing", limit=50)
+
+    assert "analyzing" in pool.last_args, (
+        f"Expected bound param 'analyzing' in SQL args, got {pool.last_args}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_DISPATCH_MCP_S4_sql_uses_dollar_placeholder() -> None:
+    """SQL with state filter must use $N parameterized placeholder, not string interpolation."""
+    from orchestrator.dispatch_mcp.queries import fetch_reqs
+
+    pool = _FakePool()
+    await fetch_reqs(pool, state="analyzing", limit=50)
+
+    assert pool.last_sql is not None
+    assert "$" in pool.last_sql, (
+        f"SQL must use $N params (not interpolation), got SQL: {pool.last_sql!r}"
+    )
+
+
+# ── S5: ValueError on unknown state ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_DISPATCH_MCP_S5_unknown_state_raises_value_error() -> None:
+    """fetch_reqs with unknown state must raise ValueError before touching pool."""
+    from orchestrator.dispatch_mcp.queries import fetch_reqs
+
+    pool = _FakePool()
+    with pytest.raises(ValueError):
+        await fetch_reqs(pool, state="banana", limit=50)
+
+
+@pytest.mark.asyncio
+async def test_DISPATCH_MCP_S5_error_message_contains_unknown_state() -> None:
+    """ValueError message must contain the substring 'unknown state'."""
+    from orchestrator.dispatch_mcp.queries import fetch_reqs
+
+    pool = _FakePool()
+    with pytest.raises(ValueError) as exc_info:
+        await fetch_reqs(pool, state="banana", limit=50)
+
+    msg = str(exc_info.value)
+    assert "unknown state" in msg, (
+        f"ValueError must contain 'unknown state', got: {msg!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_DISPATCH_MCP_S5_error_lists_valid_state_values() -> None:
+    """ValueError message must include a list of valid ReqState values."""
+    from orchestrator.dispatch_mcp.queries import fetch_reqs
+
+    pool = _FakePool()
+    with pytest.raises(ValueError) as exc_info:
+        await fetch_reqs(pool, state="banana", limit=50)
+
+    msg = str(exc_info.value)
+    known_valid = ["analyzing", "done", "escalated"]
+    found = any(v in msg for v in known_valid)
+    assert found, (
+        f"ValueError must list valid state values (e.g. 'analyzing', 'done', 'escalated'), "
+        f"got: {msg!r}"
+    )
+
+
+# ── S6: context redacted to keys-only ────────────────────────────────────────
+
+
+def _s6_row() -> dict:
+    return {
+        "req_id": "REQ-redact",
+        "project_id": "p1",
+        "state": "analyzing",
+        "created_at": "2026-04-26T10:00:00Z",
+        "updated_at": "2026-04-26T10:00:00Z",
+        "last_event": "analyzing",
+        "context": {"prompt": "<long secret text>", "intent": {"k": "v"}},
+        "history": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_DISPATCH_MCP_S6_context_keys_contains_correct_keys() -> None:
+    """context_keys must equal ['intent', 'prompt'] in any order."""
+    from orchestrator.dispatch_mcp.queries import fetch_req_state
+
+    pool = _FakePool(row=_s6_row())
+    result = await fetch_req_state(pool, "REQ-redact")
+
+    assert result is not None
+    assert "context_keys" in result, "Result must contain 'context_keys'"
+    assert sorted(result["context_keys"]) == sorted(["prompt", "intent"]), (
+        f"Expected context_keys=['intent','prompt'] (any order), "
+        f"got {sorted(result['context_keys'])!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_DISPATCH_MCP_S6_no_top_level_context_field() -> None:
+    """Result must NOT contain a top-level 'context' field."""
+    from orchestrator.dispatch_mcp.queries import fetch_req_state
+
+    pool = _FakePool(row=_s6_row())
+    result = await fetch_req_state(pool, "REQ-redact")
+
+    assert result is not None
+    assert "context" not in result, (
+        f"Result must NOT expose top-level 'context', got keys: {list(result.keys())}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_DISPATCH_MCP_S6_context_body_values_not_leaked() -> None:
+    """Result must NOT contain any string value from the original context body."""
+    from orchestrator.dispatch_mcp.queries import fetch_req_state
+
+    secret = "<long secret text>"
+    pool = _FakePool(row=_s6_row())
+    result = await fetch_req_state(pool, "REQ-redact")
+
+    assert result is not None
+    result_repr = str(result)
+    assert secret not in result_repr, (
+        f"Secret context value must not appear anywhere in result, got: {result_repr!r}"
+    )

--- a/orchestrator/tests/test_dispatch_mcp.py
+++ b/orchestrator/tests/test_dispatch_mcp.py
@@ -1,0 +1,218 @@
+"""dispatch_mcp.queries 单测：fake asyncpg pool（同 test_admission.py 的 pattern）。
+
+覆盖 6 个 scenario（DISPATCH-MCP-S1..S6）+ 边界 limit / state 校验。
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from orchestrator.dispatch_mcp import queries
+
+
+class _FakePool:
+    """Minimal asyncpg-like pool: only fetchrow / fetch are wired."""
+
+    def __init__(
+        self,
+        *,
+        single_row: dict | None = None,
+        many_rows: list[dict] | None = None,
+        single_raise: Exception | None = None,
+    ):
+        self._single = single_row
+        self._many = many_rows or []
+        self._single_raise = single_raise
+        self.last_sql: str | None = None
+        self.last_args: tuple | None = None
+
+    async def fetchrow(self, sql, *args):
+        self.last_sql = sql
+        self.last_args = args
+        if self._single_raise is not None:
+            raise self._single_raise
+        return self._single
+
+    async def fetch(self, sql, *args):
+        self.last_sql = sql
+        self.last_args = args
+        return self._many
+
+
+# ─── Scenario S1: get_req_state happy path ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_s1_get_req_state_returns_expected_shape():
+    created = datetime(2026, 4, 26, 9, 0, 0, tzinfo=UTC)
+    updated = datetime(2026, 4, 26, 10, 0, 0, tzinfo=UTC)
+    history = [
+        {"to": "init", "ts": "2026-04-26T09:00:00Z"},
+        {"to": "analyzing", "ts": "2026-04-26T10:00:00Z"},
+    ]
+    context = {"a": 1, "b": 2}
+    pool = _FakePool(single_row={
+        "req_id": "REQ-x",
+        "project_id": "p1",
+        "state": "analyzing",
+        "history": history,
+        "context": context,
+        "created_at": created,
+        "updated_at": updated,
+    })
+
+    result = await queries.fetch_req_state(pool, "REQ-x")
+
+    assert result is not None
+    assert result["req_id"] == "REQ-x"
+    assert result["project_id"] == "p1"
+    assert result["state"] == "analyzing"
+    assert result["created_at"] == created.isoformat()
+    assert result["updated_at"] == updated.isoformat()
+    assert result["last_event"] == {"to": "analyzing", "ts": "2026-04-26T10:00:00Z"}
+    assert sorted(result["context_keys"]) == ["a", "b"]
+    # The query MUST bind req_id as $1
+    assert pool.last_args == ("REQ-x",)
+
+
+@pytest.mark.asyncio
+async def test_s1_history_string_jsonb_is_decoded():
+    """asyncpg without a json codec returns jsonb as str — handle that."""
+    history_str = json.dumps([{"to": "done", "ts": "2026-04-26T11:00:00Z"}])
+    context_str = json.dumps({"k": "v"})
+    pool = _FakePool(single_row={
+        "req_id": "REQ-y",
+        "project_id": "p1",
+        "state": "done",
+        "history": history_str,
+        "context": context_str,
+        "created_at": None,
+        "updated_at": None,
+    })
+
+    result = await queries.fetch_req_state(pool, "REQ-y")
+    assert result is not None
+    assert result["last_event"] == {"to": "done", "ts": "2026-04-26T11:00:00Z"}
+    assert result["context_keys"] == ["k"]
+
+
+# ─── Scenario S2: get_req_state returns None for missing REQ ───────────────
+
+
+@pytest.mark.asyncio
+async def test_s2_get_req_state_returns_none_when_missing():
+    pool = _FakePool(single_row=None)
+
+    result = await queries.fetch_req_state(pool, "REQ-missing")
+
+    assert result is None
+
+
+# ─── Scenario S3: list_reqs limit clamping ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_s3_list_reqs_clamps_limit_high():
+    pool = _FakePool(many_rows=[])
+    await queries.fetch_reqs(pool, state=None, limit=999)
+    assert pool.last_args == (queries.LIST_LIMIT_MAX,)
+
+
+@pytest.mark.asyncio
+async def test_s3_list_reqs_clamps_limit_low():
+    pool = _FakePool(many_rows=[])
+    await queries.fetch_reqs(pool, state=None, limit=0)
+    assert pool.last_args == (queries.LIST_LIMIT_MIN,)
+
+
+@pytest.mark.asyncio
+async def test_s3_list_reqs_in_range_limit_passes_through():
+    pool = _FakePool(many_rows=[])
+    await queries.fetch_reqs(pool, state=None, limit=42)
+    assert pool.last_args == (42,)
+
+
+# ─── Scenario S4: list_reqs filters by state ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_s4_list_reqs_with_state_binds_state_and_limit():
+    pool = _FakePool(many_rows=[
+        {"req_id": "REQ-a", "project_id": "p1", "state": "analyzing",
+         "updated_at": datetime(2026, 4, 26, 10, 0, 0, tzinfo=UTC)},
+    ])
+
+    result = await queries.fetch_reqs(pool, state="analyzing", limit=50)
+
+    assert pool.last_args == ("analyzing", 50)
+    assert "WHERE state = $1" in (pool.last_sql or "")
+    assert len(result) == 1
+    assert result[0]["req_id"] == "REQ-a"
+    assert result[0]["state"] == "analyzing"
+    assert result[0]["updated_at"] == "2026-04-26T10:00:00+00:00"
+
+
+# ─── Scenario S5: list_reqs raises ValueError on unknown state ─────────────
+
+
+@pytest.mark.asyncio
+async def test_s5_list_reqs_unknown_state_raises():
+    pool = _FakePool(many_rows=[])
+    with pytest.raises(ValueError) as exc:
+        await queries.fetch_reqs(pool, state="banana", limit=50)
+    msg = str(exc.value)
+    assert "unknown state" in msg
+    # Some valid value must appear in the message so the IDE agent can
+    # immediately see the expected enum.
+    assert "analyzing" in msg
+    # And the pool was never touched.
+    assert pool.last_sql is None
+
+
+# ─── Scenario S6: get_req_state redacts context body ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_s6_get_req_state_redacts_context_body():
+    secret = "<long secret prompt text that must not leak>"
+    pool = _FakePool(single_row={
+        "req_id": "REQ-redact",
+        "project_id": "p1",
+        "state": "intaking",
+        "history": [],
+        "context": {"prompt": secret, "intent": {"k": "v"}},
+        "created_at": None,
+        "updated_at": None,
+    })
+
+    result = await queries.fetch_req_state(pool, "REQ-redact")
+
+    assert result is not None
+    assert "context" not in result
+    assert sorted(result["context_keys"]) == ["intent", "prompt"]
+    # No string value from the context body should leak into the
+    # serialised result.
+    assert secret not in json.dumps(result)
+
+
+# ─── Edge: empty history ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_req_state_empty_history_yields_none_last_event():
+    pool = _FakePool(single_row={
+        "req_id": "REQ-empty",
+        "project_id": "p1",
+        "state": "init",
+        "history": [],
+        "context": {},
+        "created_at": None,
+        "updated_at": None,
+    })
+
+    result = await queries.fetch_req_state(pool, "REQ-empty")
+    assert result is not None
+    assert result["last_event"] is None
+    assert result["context_keys"] == []

--- a/orchestrator/uv.lock
+++ b/orchestrator/uv.lock
@@ -96,6 +96,63 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -190,6 +247,59 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "47.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0", size = 7912214, upload-time = "2026-04-24T19:53:03.864Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ed/5f524db1fade9c013aa618e1c99c6ed05e8ffc9ceee6cda22fed22dda3f4/cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203", size = 3258581, upload-time = "2026-04-24T19:53:31.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/1b901990b174786569029f67542b3edf72ac068b6c3c8683c17e6a2f5363/cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa", size = 3775309, upload-time = "2026-04-24T19:53:33.054Z" },
+    { url = "https://files.pythonhosted.org/packages/14/88/7aa18ad9c11bc87689affa5ce4368d884b517502d75739d475fc6f4a03c7/cryptography-47.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0", size = 7904299, upload-time = "2026-04-24T19:53:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/07/55/c18f75724544872f234678fdedc871391722cb34a2aee19faa9f63100bb2/cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7", size = 4631180, upload-time = "2026-04-24T19:53:37.517Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/65/31a5cc0eaca99cec5bafffe155d407115d96136bb161e8b49e0ef73f09a7/cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1", size = 4653529, upload-time = "2026-04-24T19:53:39.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/bc/641c0519a495f3bfd0421b48d7cd325c4336578523ccd76ea322b6c29c7a/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c", size = 4638570, upload-time = "2026-04-24T19:53:42.129Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f2/300327b0a47f6dc94dd8b71b57052aefe178bb51745073d73d80604f11ab/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829", size = 5238019, upload-time = "2026-04-24T19:53:44.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/5b5cf994391d4bf9d9c7efd4c66aabe4d95227256627f8fea6cff7dfadbd/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7", size = 4686832, upload-time = "2026-04-24T19:53:47.015Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2c/ae950e28fd6475c852fc21a44db3e6b5bcc1261d1e370f2b6e42fa800fef/cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923", size = 4269301, upload-time = "2026-04-24T19:53:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/67/fb/6a39782e150ffe5cc1b0018cb6ddc48bf7ca62b498d7539ffc8a758e977d/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab", size = 4638110, upload-time = "2026-04-24T19:53:51.011Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d7/0b3c71090a76e5c203164a47688b697635ece006dcd2499ab3a4dbd3f0bd/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736", size = 5194988, upload-time = "2026-04-24T19:53:52.962Z" },
+    { url = "https://files.pythonhosted.org/packages/63/33/63a961498a9df51721ab578c5a2622661411fc520e00bd83b0cc64eb20c4/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7", size = 4686563, upload-time = "2026-04-24T19:53:55.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/5ee5b145248f92250de86145d1c1d6edebbd57a7fe7caa4dedb5d4cf06a1/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52", size = 4770094, upload-time = "2026-04-24T19:53:57.753Z" },
+    { url = "https://files.pythonhosted.org/packages/92/43/21d220b2da5d517773894dacdcdb5c682c28d3fffce65548cb06e87d5501/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd", size = 4913811, upload-time = "2026-04-24T19:54:00.236Z" },
+    { url = "https://files.pythonhosted.org/packages/31/98/dc4ad376ac5f1a1a7d4a83f7b0c6f2bcad36b5d2d8f30aeb482d3a7d9582/cryptography-47.0.0-cp314-cp314t-win32.whl", hash = "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63", size = 3237158, upload-time = "2026-04-24T19:54:02.606Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/da/97f62d18306b5133468bc3f8cc73a3111e8cdc8cf8d3e69474d6e5fd2d1b/cryptography-47.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b", size = 3758706, upload-time = "2026-04-24T19:54:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4", size = 7904072, upload-time = "2026-04-24T19:54:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
+    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bd/0a9d3edbf5eadbac926d7b9b3cd0c4be584eeeae4a003d24d9eda4affbbd/cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310", size = 3248487, upload-time = "2026-04-24T19:54:33.494Z" },
+    { url = "https://files.pythonhosted.org/packages/60/80/5681af756d0da3a599b7bdb586fac5a1540f1bcefd2717a20e611ddade45/cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769", size = 3755737, upload-time = "2026-04-24T19:54:35.408Z" },
+]
+
+[[package]]
 name = "durationpy"
 version = "0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -278,6 +388,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]
@@ -493,6 +612,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.20.2"
 source = { registry = "https://pypi.org/simple" }
@@ -622,6 +766,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.3"
 source = { registry = "https://pypi.org/simple" }
@@ -735,6 +888,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -795,6 +962,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -1002,6 +1194,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "kubernetes" },
+    { name = "mcp" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1035,6 +1228,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1" },
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "kubernetes", specifier = ">=31.0" },
+    { name = "mcp", specifier = ">=1.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
     { name = "psycopg2-binary", specifier = ">=2.9" },
     { name = "pydantic", specifier = ">=2.9" },
@@ -1073,6 +1267,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/9a/f35932a8c0eb6b2287b66fa65a0321df8c84e4e355a659c1841a37c39fdb/sse_starlette-3.4.1.tar.gz", hash = "sha256:f780bebcf6c8997fe514e3bd8e8c648d8284976b391c8bed0bcb1f611632b555", size = 35127, upload-time = "2026-04-26T13:32:32.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/07/45c21ed03d708c477367305726b89919b020a3a2a01f72aaf5ad941caf35/sse_starlette-3.4.1-py3-none-any.whl", hash = "sha256:6b43cf21f1d574d582a6e1b0cfbde1c94dc86a32a701a7168c99c4475c6bd1d0", size = 16487, upload-time = "2026-04-26T13:32:30.819Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Scaffold server-side MCP package `orchestrator.dispatch_mcp`: stdio
  transport via FastMCP, two read-only tools (`get_req_state`,
  `list_reqs`) over the `req_state` table.
- `queries.py` keeps the actual logic pure-async + decoupled from the
  MCP SDK so unit tests run against a fake asyncpg pool with no
  transport boot.
- M0 deliberately ships read-only tools and stdio only; HTTP/SSE
  transport, auth, mutating tools, and helm sidecar are deferred to
  later milestones.

## Why

Operators / Claude-Code IDE agents currently inspect REQ state by
hitting `orchestrator.admin` HTTP endpoints by hand or SQLing the
Postgres pod. M0 lays down a stable MCP surface so that workflow
becomes one tool call — and so future milestones don't have to
re-litigate package layout, transport choice, or DB-pool wiring.

> Reviewer note: the intent issue title is the entire spec we
> received. We interpreted "sisyphus-dispatch MCP server M0" as
> server-side (since `bkd_mcp.py` is already a *client* and project
> philosophy is "走 BKD REST，不走 MCP"). If the intent was different,
> only the package name `dispatch_mcp` is sunk cost. Captured in
> `openspec/changes/REQ-mcp-sisyphus-dispatch-m0-1777220172/proposal.md`
> and `design.md`.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `BASE_REV=$(git merge-base HEAD origin/main) make ci-lint` — clean
- [x] `uv run pytest -m "not integration"` — 935 passed (including 10
      new tests covering all 6 spec scenarios + edge cases)
- [x] `openspec validate REQ-mcp-sisyphus-dispatch-m0-1777220172
      --type=change` — valid
- [x] `./scripts/check-scenario-refs.sh ...` — all scenario refs found
- [x] Smoke: `python -m orchestrator.dispatch_mcp` boots FastMCP with
      both tools registered (`get_req_state`, `list_reqs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)