### PR TITLE
chore(code): drop dead derive_event param + mark __aexit__ slurp args (REQ-code-quality-cleanup-1777220568)

### DIFF
--- a/openspec/changes/REQ-code-quality-cleanup-1777220568/proposal.md
+++ b/openspec/changes/REQ-code-quality-cleanup-1777220568/proposal.md
@@ -1,0 +1,63 @@
+# chore(code): unused imports / dead code / lint
+
+## Why
+
+Routine hygiene sweep on `orchestrator/`. Two small but real findings the
+project's existing `ruff` + `vulture` scans surface that have no behaviour
+attached to them:
+
+1. **`router.derive_event` carries a dead parameter.**
+   `def derive_event(event_type, tags, result_tags_only: bool = False)` —
+   `result_tags_only` was never wired up. No caller in `src/` or `tests/`
+   passes it; the function body never reads it. `git log -S` traces it back
+   to the initial Python orchestrator commit (`d5e791b`) and it has been
+   unused since. Vulture flags it at 100 % confidence.
+
+2. **`__aexit__(self, *exc)` in two BKD client classes.**
+   Both `BKDMcpClient` and `BKDRestClient` close their `httpx` client in
+   `__aexit__` and ignore the exception triple. The current `*exc` name
+   reads like a real variable; vulture flags it as "unused variable" with
+   100 % confidence. The rest of the codebase already uses the
+   `*_exc` / `*_a` / `*_` convention to signal "deliberately swallowed
+   protocol args" (see e.g. `tests/test_webhook_upstream_done.py:27`,
+   `tests/test_contract_escalate_pr_merged_override_challenger.py:73`).
+
+Both are pure cleanup — no caller observes a behaviour change.
+
+## What Changes
+
+- **`orchestrator/src/orchestrator/router.py`** — drop the unused
+  `result_tags_only` keyword parameter from `derive_event`. The function
+  signature becomes `def derive_event(event_type: str, tags: Iterable[str])
+  -> Event | None`. All existing call sites already pass two positional
+  arguments only, so this is signature-narrowing without any caller fix-up.
+
+- **`orchestrator/src/orchestrator/bkd_mcp.py`** and
+  **`orchestrator/src/orchestrator/bkd_rest.py`** — rename the
+  `__aexit__(self, *exc)` slurp to `__aexit__(self, *_exc)` so the
+  intent ("absorb and discard the protocol triple") is explicit and
+  vulture stops flagging it.
+
+No tests need to change: the unit suite (`pytest -m "not integration"`,
+925 tests) keeps passing as-is.
+
+## Impact
+
+- **Affected specs**: new capability `code-quality` (ADDED).
+- **Affected code**: three source files in `orchestrator/src/orchestrator/`
+  (`router.py`, `bkd_mcp.py`, `bkd_rest.py`). No tests, no migrations,
+  no helm / runner / docs changes.
+- **Deployment / migration**: zero-ops. Standard orchestrator rollout
+  picks up the change with no schema or config touch.
+- **Risk**: trivially low. The dropped parameter never had a reader; the
+  `*exc` → `*_exc` rename is a parameter-name change in a private slot
+  of the async-context-manager protocol and Python never inspects the
+  name.
+- **Out of scope**: every other vulture finding. The remaining 60 %-
+  confidence hits (FastAPI route handlers, `@register`-decorated action
+  handlers, pydantic config fields, pytest fixtures, mock attribute
+  assignments) are framework-driven false positives. The `ARG001` /
+  `ARG002` flags on action-handler parameters are similarly out of scope:
+  the `*, body, req_id, tags, ctx` quartet is the registered handler
+  contract documented at `actions/__init__.py` top-of-file and individual
+  handlers may legitimately ignore some of them.

--- a/openspec/changes/REQ-code-quality-cleanup-1777220568/specs/code-quality/spec.md
+++ b/openspec/changes/REQ-code-quality-cleanup-1777220568/specs/code-quality/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: orchestrator src tree carries no dead parameters or unused-variable lint findings
+
+The `orchestrator/src/orchestrator/` Python tree SHALL be free of
+parameter-shaped dead code as defined by two complementary signals: ruff
+under the project's existing `pyproject.toml` selection
+(`["E", "F", "I", "B", "UP", "RUF"]` minus the project's ignore list)
+MUST report zero findings, and `vulture src/ --min-confidence 100` MUST
+report zero findings. In particular, public-facing helpers MUST NOT
+declare parameters with default values that are never read inside the
+function body and never passed by any caller; protocol slots (such as
+`__aexit__(self, *exc, ...)`) that intentionally discard their arguments
+MUST use a leading-underscore name (`*_exc`, `*_a`, `*_`) so the intent
+is explicit and the linter / vulture do not flag them.
+
+This requirement scopes only `orchestrator/src/`. Test code under
+`orchestrator/tests/` is out of scope: pytest fixtures, monkeypatched
+lambdas, and mock async-context-manager stubs routinely carry parameters
+named for protocol matching that vulture cannot see through.
+
+#### Scenario: CQ-S1 ruff under project config reports zero findings on src + tests
+
+- **GIVEN** a fresh checkout of the repository at the merge of this REQ
+- **WHEN** an operator runs `cd orchestrator && uv run ruff check src/ tests/`
+- **THEN** the command exits 0 and prints `All checks passed!` with no
+  remaining unused-noqa, unused-import, or unused-variable diagnostics
+
+#### Scenario: CQ-S2 vulture at 100 % confidence reports zero findings on src
+
+- **GIVEN** a fresh checkout of the repository at the merge of this REQ
+- **WHEN** an operator runs
+  `cd orchestrator && uv tool run vulture src/ --min-confidence 100`
+- **THEN** the command exits 0 with empty stdout, demonstrating no
+  fully-unused parameters or variables remain in the source tree
+
+#### Scenario: CQ-S3 derive_event signature accepts exactly event_type and tags
+
+- **GIVEN** the `orchestrator.router` module imported from a fresh
+  checkout at the merge of this REQ
+- **WHEN** a caller invokes
+  `inspect.signature(orchestrator.router.derive_event).parameters`
+- **THEN** the resulting mapping contains exactly two keys, `event_type`
+  and `tags`, with no `result_tags_only` parameter present, demonstrating
+  the dead parameter has been removed without breaking the two-arg call
+  sites used in `webhook.py` and the test suite

--- a/openspec/changes/REQ-code-quality-cleanup-1777220568/tasks.md
+++ b/openspec/changes/REQ-code-quality-cleanup-1777220568/tasks.md
@@ -1,0 +1,24 @@
+# Tasks — REQ-code-quality-cleanup-1777220568
+
+## Stage: contract / spec
+- [x] author `specs/code-quality/spec.md` capturing the two hygiene rules
+      (no dead parameters, no vulture-100 %-confidence findings in `src/`)
+- [x] proposal.md explains why each finding is real vs. false-positive
+
+## Stage: implementation
+- [x] `orchestrator/src/orchestrator/router.py`: drop unused
+      `result_tags_only` parameter from `derive_event`
+- [x] `orchestrator/src/orchestrator/bkd_mcp.py`: rename
+      `__aexit__(self, *exc)` → `__aexit__(self, *_exc)`
+- [x] `orchestrator/src/orchestrator/bkd_rest.py`: rename
+      `__aexit__(self, *exc)` → `__aexit__(self, *_exc)`
+
+## Stage: verification
+- [x] `make ci-lint` (`uv run ruff check src/ tests/`) — clean
+- [x] `vulture src/ --min-confidence 100` — empty (no findings)
+- [x] `make ci-unit-test` (`uv run pytest -m "not integration"`) —
+      925 passed
+
+## Stage: PR
+- [x] git push `feat/REQ-code-quality-cleanup-1777220568`
+- [x] `gh pr create` with motivation + test plan

--- a/orchestrator/src/orchestrator/bkd_mcp.py
+++ b/orchestrator/src/orchestrator/bkd_mcp.py
@@ -35,7 +35,7 @@ class BKDMcpClient:
         await self.initialize()
         return self
 
-    async def __aexit__(self, *exc) -> None:
+    async def __aexit__(self, *_exc) -> None:
         await self._http.aclose()
 
     async def initialize(self) -> None:

--- a/orchestrator/src/orchestrator/bkd_rest.py
+++ b/orchestrator/src/orchestrator/bkd_rest.py
@@ -28,7 +28,7 @@ class BKDRestClient:
     async def __aenter__(self) -> BKDRestClient:
         return self
 
-    async def __aexit__(self, *exc) -> None:
+    async def __aexit__(self, *_exc) -> None:
         await self._http.aclose()
 
     async def initialize(self) -> None:

--- a/orchestrator/src/orchestrator/router.py
+++ b/orchestrator/src/orchestrator/router.py
@@ -209,7 +209,7 @@ def extract_intake_finalized_intent(text: str | None) -> dict | None:
     return None
 
 
-def derive_event(event_type: str, tags: Iterable[str], result_tags_only: bool = False) -> Event | None:
+def derive_event(event_type: str, tags: Iterable[str]) -> Event | None:
     """根据 (event_type, tags) 推 Event 枚举。
 
     event_type: BKD webhook 的 event 字段（issue.updated / session.completed / session.failed）

--- a/orchestrator/tests/test_contract_code_quality.py
+++ b/orchestrator/tests/test_contract_code_quality.py
@@ -1,0 +1,122 @@
+"""Contract tests for REQ-code-quality-cleanup-1777220568.
+
+Black-box behavioral contracts derived from:
+  openspec/changes/REQ-code-quality-cleanup-1777220568/specs/code-quality/spec.md
+
+Scenarios covered:
+  CQ-S1   ruff under project config reports zero findings on src + tests
+  CQ-S2   vulture at 100% confidence reports zero findings on src
+  CQ-S3   derive_event signature accepts exactly event_type and tags (no result_tags_only)
+
+Testing strategy:
+  - CQ-S1: real subprocess invocation of `uv run ruff check src/ tests/`
+  - CQ-S2: real subprocess invocation of `uv tool run vulture src/ --min-confidence 100`
+  - CQ-S3: subprocess Python one-liner to import and inspect derive_event signature,
+    avoiding sys.path mutation inside the test process
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# orchestrator/tests/../../ = repo root; orchestrator/ is one level down from root
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+ORCHESTRATOR_ROOT = REPO_ROOT / "orchestrator"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        list(args),
+        cwd=str(ORCHESTRATOR_ROOT),
+        capture_output=True,
+        text=True,
+    )
+
+
+# ── CQ-S1 ───────────────────────────────────────────────────────────────────
+
+
+def test_CQ_S1_ruff_check_src_and_tests_exits_0():
+    """ruff check src/ tests/ under the project config exits 0 (all checks passed)."""
+    result = _run("uv", "run", "ruff", "check", "src/", "tests/")
+    assert result.returncode == 0, (
+        f"ruff check src/ tests/ returned {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_CQ_S1_ruff_check_prints_all_checks_passed():
+    """ruff check src/ tests/ prints 'All checks passed!' when there are no findings."""
+    result = _run("uv", "run", "ruff", "check", "src/", "tests/")
+    combined = result.stdout + result.stderr
+    assert "All checks passed" in combined, (
+        f"Expected 'All checks passed!' from ruff, got:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+# ── CQ-S2 ───────────────────────────────────────────────────────────────────
+
+
+def test_CQ_S2_vulture_100_confidence_exits_0():
+    """vulture src/ --min-confidence 100 exits 0 with no fully-unused dead code."""
+    result = _run("uv", "tool", "run", "vulture", "src/", "--min-confidence", "100")
+    assert result.returncode == 0, (
+        f"vulture src/ --min-confidence 100 returned {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_CQ_S2_vulture_100_confidence_produces_empty_stdout():
+    """vulture src/ --min-confidence 100 produces empty stdout (no findings to report)."""
+    result = _run("uv", "tool", "run", "vulture", "src/", "--min-confidence", "100")
+    assert result.stdout.strip() == "", (
+        f"Expected empty stdout from vulture at 100% confidence, got:\n{result.stdout}"
+    )
+
+
+# ── CQ-S3 ───────────────────────────────────────────────────────────────────
+
+
+def test_CQ_S3_derive_event_has_no_result_tags_only_param():
+    """derive_event signature does not contain the dead 'result_tags_only' parameter."""
+    result = _run(
+        "uv",
+        "run",
+        "python",
+        "-c",
+        (
+            "import inspect, orchestrator.router; "
+            "params = list(inspect.signature(orchestrator.router.derive_event).parameters.keys()); "
+            "print(','.join(params))"
+        ),
+    )
+    assert result.returncode == 0, (
+        f"Failed to import orchestrator.router or inspect signature:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    params = [p for p in result.stdout.strip().split(",") if p]
+    assert "result_tags_only" not in params, (
+        f"Dead parameter 'result_tags_only' still present in derive_event: {params}"
+    )
+
+
+def test_CQ_S3_derive_event_has_exactly_event_type_and_tags():
+    """derive_event signature contains exactly two params: event_type and tags."""
+    result = _run(
+        "uv",
+        "run",
+        "python",
+        "-c",
+        (
+            "import inspect, orchestrator.router; "
+            "params = list(inspect.signature(orchestrator.router.derive_event).parameters.keys()); "
+            "print(','.join(params))"
+        ),
+    )
+    assert result.returncode == 0, (
+        f"Failed to inspect derive_event:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    params = [p for p in result.stdout.strip().split(",") if p]
+    assert params == ["event_type", "tags"], (
+        f"Expected derive_event params ['event_type', 'tags'], got: {params}"
+    )


### PR DESCRIPTION
## Why

Routine hygiene sweep on `orchestrator/`. Two findings the project's existing
`ruff` + `vulture` scans surface that no behaviour depends on:

1. **`router.derive_event` carries a dead parameter.**
   `def derive_event(event_type, tags, result_tags_only: bool = False)` —
   `result_tags_only` was never wired up. No caller in `src/` or `tests/`
   passes it; the body never reads it. `git log -S` traces it back to the
   initial Python-orchestrator commit (`d5e791b`) and it has been unused
   ever since. Vulture flags it at 100 % confidence.

2. **`__aexit__(self, *exc)` in two BKD client classes.**
   Both `BKDMcpClient` and `BKDRestClient` close their `httpx` client in
   `__aexit__` and discard the exception triple. The `*exc` name reads
   like a real variable; vulture flags it at 100 %. The rest of the
   codebase already uses the `*_exc` / `*_a` / `*_` convention to signal
   "deliberately swallowed protocol args".

Both are pure cleanup — no caller observes a behaviour change.

## What changed

- `orchestrator/src/orchestrator/router.py`: drop unused
  `result_tags_only` keyword from `derive_event`. Signature becomes
  `def derive_event(event_type: str, tags: Iterable[str]) -> Event | None`.
- `orchestrator/src/orchestrator/bkd_mcp.py`,
  `orchestrator/src/orchestrator/bkd_rest.py`:
  rename `__aexit__(self, *exc)` → `__aexit__(self, *_exc)`.
- `openspec/changes/REQ-code-quality-cleanup-1777220568/`: spec for the
  hygiene rule (no dead params, no vulture-100 % findings on `src/`).

## Test plan

- [x] `cd orchestrator && uv run ruff check src/ tests/` → `All checks passed!`
- [x] `cd orchestrator && uv tool run vulture src/ --min-confidence 100`
      → empty stdout
- [x] `cd orchestrator && uv run pytest -m "not integration"` →
      `925 passed`
- [x] `openspec validate REQ-code-quality-cleanup-1777220568 --strict` →
      `Change ... is valid`
- [x] `bash scripts/check-scenario-refs.sh --specs-search-path . .` →
      `OK: 所有 scenario 引用都在 specs 中找到`

🤖 Generated with [Claude Code](https://claude.com/claude-code)