### PR TITLE
feat(obs): write BKD agent token to stage_runs (REQ-stage-runs-token-tracking-1777220172)

### DIFF
--- a/openspec/changes/REQ-stage-runs-token-tracking-1777220172/proposal.md
+++ b/openspec/changes/REQ-stage-runs-token-tracking-1777220172/proposal.md
@@ -1,0 +1,91 @@
+# feat(obs): write BKD agent token to stage_runs
+
+## Why
+
+`stage_runs` currently records who ran what stage (req_id, stage, agent_type,
+model, started/ended timestamps, outcome) but **does not record which BKD
+session actually executed it**. The Metabase dashboards driven off `stage_runs`
+(M14e + M7) can compute aggregate stats — pass rate, p50/p95 duration, fixer
+churn — but a row that says "REQ-foo's `analyze` stage ran for 12 minutes and
+escalated" gives no path to inspect what that agent was thinking. Pulling up
+the corresponding BKD chat today requires:
+
+1. Eyeballing the timestamp range
+2. Browsing `bkd_snapshot` for the right `parent_issue_id` chain
+3. Cross-referencing tags by hand to find the BKD issue
+4. Opening the BKD UI and clicking through to the session log
+
+That manual lookup is the dominant friction in the "which prompt should I
+change" feedback loop the observability stack is supposed to enable.
+
+The BKD `Issue` payload already exposes `externalSessionId` — the Claude Code
+session UUID assigned to that agent's run. Storing it on the matching
+`stage_runs` row gives:
+
+- A direct join key from `stage_runs` → BKD session log (the BKD UI URL is
+  derivable from project + session id; Metabase can render it as a link column)
+- Reverse lookup: paste a BKD session id, find which REQ / stage / outcome it
+  produced, without scrolling through chat history first
+- Audit trail: which exact agent run produced a given fixer-round / verifier
+  decision, which is the unit the "agent quality" view in
+  `agent_quality.sql` reasons about
+
+This is purely additive observability metadata — the state machine, action
+handlers, and webhook routing logic are unchanged.
+
+## What Changes
+
+- **`orchestrator/migrations/0008_stage_runs_bkd_session_id.sql`** — add
+  nullable `bkd_session_id TEXT` column to `stage_runs` plus a partial index
+  `idx_stage_runs_bkd_session ON stage_runs(bkd_session_id) WHERE bkd_session_id
+  IS NOT NULL` (mechanical stages stay NULL — the partial index avoids
+  indexing the large NULL bucket). Rollback drops both.
+- **`orchestrator/src/orchestrator/bkd.py`** — `Issue` dataclass gains
+  `external_session_id: str | None = None`; `_to_issue` populates it from the
+  BKD payload's `externalSessionId` field (kept on the shared dataclass so
+  both REST and MCP transports surface it).
+- **`orchestrator/src/orchestrator/store/stage_runs.py`** — new
+  `stamp_bkd_session_id(pool, req_id, stage, bkd_session_id)` helper. UPDATEs
+  the most-recent (req_id, stage) row whose `ended_at IS NULL AND
+  bkd_session_id IS NULL` — idempotent (won't overwrite an existing token,
+  won't touch closed rows). Returns the row id stamped, or None.
+- **`orchestrator/src/orchestrator/engine.py`** — promote the existing
+  module-private `_STATE_TO_STAGE` to public `STATE_TO_STAGE`; export new
+  `AGENT_STAGES = frozenset({"analyze", "verifier", "fixer", "accept",
+  "archive"})` so the webhook can decide whether the current stage is BKD-agent
+  driven (worth stamping) or mechanical (skip).
+- **`orchestrator/src/orchestrator/webhook.py`** — extend the existing BKD
+  fetch to also cover `session.failed` (so crashed agents are still linked to
+  their session). After resolving `cur_state`, before calling `engine.step`,
+  if the fetched `Issue.external_session_id` is non-null and `cur_stage` is in
+  `AGENT_STAGES`, call `stage_runs.stamp_bkd_session_id(...)`. Best-effort:
+  exceptions are logged and swallowed so observability writes never fail
+  webhook processing.
+- **Tests** — extend `test_store_stage_runs.py` with stamp-helper unit tests;
+  extend `test_bkd_rest.py` with `_to_issue` parsing tests; new
+  `test_contract_stage_runs_token_tracking.py` covering 4 webhook scenarios
+  (STR-S1 through STR-S4).
+
+## Impact
+
+- **Affected specs**: new capability `stage-runs-token-tracking` (purely
+  additive — no existing requirement is modified or removed).
+- **Affected code**: `orchestrator/migrations/0008_stage_runs_bkd_session_id.{sql,rollback.sql}`;
+  `orchestrator/src/orchestrator/{bkd,engine,webhook}.py`;
+  `orchestrator/src/orchestrator/store/stage_runs.py`;
+  `orchestrator/tests/{test_store_stage_runs,test_bkd_rest,test_contract_stage_runs_token_tracking}.py`.
+- **Deployment / migration**: low-risk schema delta — the column is nullable,
+  yoyo applies it on orchestrator boot. No backfill: pre-existing rows stay
+  NULL (they're already historical agent runs whose BKD sessions may be GC'd
+  anyway). Roll-forward only; rollback drops the column safely.
+- **Risk**: low. Stamp is best-effort observability — failures logged and
+  swallowed. Mechanical stages explicitly skipped via `AGENT_STAGES` so the
+  contract is "agent stages may have a token; mechanical stages never do".
+  The webhook fetch path is extended to also cover `session.failed`, costing
+  one extra HTTP round-trip per agent crash; acceptable given the diagnostic
+  value.
+- **Out of scope**: backfilling historical `stage_runs` rows (BKD session
+  retention isn't long enough to make that useful); rendering Metabase link
+  columns (separate dashboard PR using the new column); recording BKD session
+  ids for `intake` / `challenger` stages (engine doesn't currently open
+  `stage_runs` rows for them — addressing that is a separate change).

--- a/openspec/changes/REQ-stage-runs-token-tracking-1777220172/specs/stage-runs-token-tracking/spec.md
+++ b/openspec/changes/REQ-stage-runs-token-tracking-1777220172/specs/stage-runs-token-tracking/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: stage_runs records the BKD agent session token for agent stages
+
+The `stage_runs` table SHALL carry a nullable column `bkd_session_id TEXT`
+holding the BKD agent's `externalSessionId` (Claude Code session UUID) that
+executed that stage. The column MUST be populated for every stage_run whose
+stage is in the agent set `{analyze, verifier, fixer, accept, archive}` once
+the corresponding BKD session has been assigned an `externalSessionId` (i.e.
+by the time the orchestrator processes a `session.completed` or
+`session.failed` webhook for that BKD issue). For stages outside the agent
+set (`spec_lint`, `dev_cross_check`, `staging_test`, `pr_ci`,
+`accept_teardown`), the column MUST remain NULL — those stages have no BKD
+agent. A partial index `idx_stage_runs_bkd_session ON
+stage_runs(bkd_session_id) WHERE bkd_session_id IS NOT NULL` MUST exist to
+support reverse lookup (BKD session id → stage_run row) without paying index
+cost on the dominant NULL bucket.
+
+#### Scenario: STR-S1 webhook stamps BKD agent token before engine.step
+
+- **GIVEN** a REQ in state `ANALYZING` with an open `analyze` stage_run
+- **WHEN** the webhook receives a `session.completed` event whose BKD issue
+  carries `externalSessionId="sess-analyze-uuid"`
+- **THEN** `stage_runs.stamp_bkd_session_id(pool, "REQ-x", "analyze",
+  "sess-analyze-uuid")` MUST be invoked exactly once, AND the call MUST
+  precede the `engine.step` invocation (so the row is still
+  `ended_at IS NULL` and the stamp targets the right run)
+
+#### Scenario: STR-S2 mechanical stages skip the stamp
+
+- **GIVEN** a REQ in state `SPEC_LINT_RUNNING`
+- **WHEN** the webhook receives a `session.completed` event for a checker
+  issue whose BKD payload happens to carry an `externalSessionId`
+- **THEN** `stage_runs.stamp_bkd_session_id` MUST NOT be invoked, because
+  `spec_lint` is a mechanical checker (not in `AGENT_STAGES`) and writing a
+  spurious token to its row would falsely imply an agent ran it
+
+#### Scenario: STR-S3 missing externalSessionId is a no-op stamp
+
+- **GIVEN** a REQ in state `ANALYZING`
+- **WHEN** the webhook receives a `session.completed` event whose BKD issue
+  payload has `externalSessionId=null` (BKD session not yet assigned a UUID)
+- **THEN** `stage_runs.stamp_bkd_session_id` MUST NOT be invoked, so no
+  empty / NULL token is written
+
+#### Scenario: STR-S4 session.failed also stamps for crash diagnostics
+
+- **GIVEN** a REQ in state `REVIEW_RUNNING` with an open `verifier` stage_run
+- **WHEN** the webhook receives a `session.failed` event whose BKD issue
+  carries `externalSessionId="sess-verifier-crashed"`
+- **THEN** the webhook MUST fetch the BKD issue (extending the
+  session.completed-only fetch path to cover session.failed), AND
+  `stage_runs.stamp_bkd_session_id(pool, "REQ-x", "verifier",
+  "sess-verifier-crashed")` MUST be invoked, so the crashed run remains
+  linkable to its BKD chat for postmortem
+
+### Requirement: stamp_bkd_session_id is idempotent and targets the open row
+
+The `stamp_bkd_session_id` helper in `orchestrator/src/orchestrator/store/stage_runs.py` SHALL only update a stage_run row whose `req_id` and `stage` match the arguments AND whose `ended_at IS NULL` AND whose `bkd_session_id IS NULL`, ordered by `started_at DESC` LIMIT 1, so that already-closed rows are never mutated and an already-set token is never overwritten by a redelivered webhook. The helper MUST treat an empty or falsy `bkd_session_id` argument as a no-op (no SQL emitted, return value `None`).
+
+#### Scenario: STR-S5 stamp targets only ended_at IS NULL AND bkd_session_id IS NULL
+
+- **GIVEN** a `stage_runs` table with multiple rows for `(req_id="REQ-7",
+  stage="analyze")`: an older closed row with `bkd_session_id="old-sess"` and
+  a newer open row with `bkd_session_id IS NULL`
+- **WHEN** `stamp_bkd_session_id(pool, "REQ-7", "analyze", "new-sess")` runs
+- **THEN** the SQL MUST contain `ended_at IS NULL` AND `bkd_session_id IS
+  NULL` in its WHERE clause, the older closed row MUST NOT be touched, and
+  only the newer open row gets `bkd_session_id` set to `"new-sess"`
+
+#### Scenario: STR-S6 empty token is a no-op
+
+- **GIVEN** any `stage_runs` table state
+- **WHEN** `stamp_bkd_session_id(pool, "REQ-1", "analyze", "")` is called
+- **THEN** no SQL is emitted (return value is None) — saves a round-trip and
+  prevents writing an empty string
+
+### Requirement: Issue dataclass exposes externalSessionId from BKD payload
+
+The orchestrator's `Issue` dataclass (shared by REST and MCP transports) SHALL
+expose `external_session_id: str | None` populated by `_to_issue` from the
+BKD payload field `externalSessionId`. The field MUST default to `None` when
+the BKD payload omits it (e.g. immediately after `create_issue`, before BKD
+assigns a Claude Code session UUID), and MUST surface the assigned UUID on
+subsequent `get_issue` calls once the session has started.
+
+#### Scenario: STR-S7 _to_issue extracts externalSessionId
+
+- **GIVEN** a BKD issue payload dict containing `"externalSessionId":
+  "a742034b-6fb0-4047-be96-d5431dc1f252"`
+- **WHEN** `_to_issue(payload)` runs
+- **THEN** the returned `Issue.external_session_id` MUST equal
+  `"a742034b-6fb0-4047-be96-d5431dc1f252"`
+
+#### Scenario: STR-S8 _to_issue defaults external_session_id to None
+
+- **GIVEN** a BKD issue payload dict that omits the `externalSessionId` field
+  (e.g. fresh `create_issue` response before session start)
+- **WHEN** `_to_issue(payload)` runs
+- **THEN** the returned `Issue.external_session_id` MUST be `None` (no
+  KeyError)

--- a/openspec/changes/REQ-stage-runs-token-tracking-1777220172/tasks.md
+++ b/openspec/changes/REQ-stage-runs-token-tracking-1777220172/tasks.md
@@ -1,0 +1,43 @@
+# tasks: REQ-stage-runs-token-tracking-1777220172
+
+## Stage: contract / spec
+
+- [x] author `specs/stage-runs-token-tracking/spec.md` with delta
+      `## ADDED Requirements` (3 requirements, scenarios STR-S1..STR-S8)
+
+## Stage: implementation
+
+- [x] `orchestrator/migrations/0008_stage_runs_bkd_session_id.sql`: ADD COLUMN
+      `bkd_session_id TEXT` + partial index `idx_stage_runs_bkd_session`
+- [x] `orchestrator/migrations/0008_stage_runs_bkd_session_id.rollback.sql`:
+      DROP INDEX + DROP COLUMN
+- [x] `orchestrator/src/orchestrator/bkd.py`: add `external_session_id` field
+      to `Issue`; `_to_issue` populates from `d.get("externalSessionId")`
+- [x] `orchestrator/src/orchestrator/store/stage_runs.py`: new
+      `stamp_bkd_session_id(pool, req_id, stage, bkd_session_id)` helper
+      (idempotent, target ended_at IS NULL AND bkd_session_id IS NULL)
+- [x] `orchestrator/src/orchestrator/engine.py`: promote `_STATE_TO_STAGE` →
+      public `STATE_TO_STAGE`; export `AGENT_STAGES` frozenset
+- [x] `orchestrator/src/orchestrator/webhook.py`: extend BKD fetch to cover
+      `session.failed`; capture `issue.external_session_id`; before
+      `engine.step`, stamp on the open agent-stage row (best-effort,
+      try/except so observability never blocks webhook)
+
+## Stage: unit test
+
+- [x] `orchestrator/tests/test_store_stage_runs.py`: 4 new tests covering
+      stamp helper happy path, no-row-matched, empty-token no-op, and that
+      `insert_stage_run` does not inline `bkd_session_id`
+- [x] `orchestrator/tests/test_bkd_rest.py`: 3 new tests covering `_to_issue`
+      extraction, default-None, and end-to-end via REST `get_issue`
+- [x] `orchestrator/tests/test_contract_stage_runs_token_tracking.py`: 4
+      contract scenarios STR-S1..S4 covering stamp ordering, mechanical-stage
+      skip, missing-token skip, and session.failed stamping
+
+## Stage: PR
+
+- [x] `make ci-lint` clean
+- [x] `make ci-unit-test` (936 passed)
+- [x] `make ci-integration-test` (no integration tests collected → pass)
+- [x] git push `feat/REQ-stage-runs-token-tracking-1777220172`
+- [x] gh pr create

--- a/orchestrator/migrations/0008_stage_runs_bkd_session_id.rollback.sql
+++ b/orchestrator/migrations/0008_stage_runs_bkd_session_id.rollback.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_stage_runs_bkd_session;
+ALTER TABLE stage_runs DROP COLUMN IF EXISTS bkd_session_id;

--- a/orchestrator/migrations/0008_stage_runs_bkd_session_id.sql
+++ b/orchestrator/migrations/0008_stage_runs_bkd_session_id.sql
@@ -1,0 +1,19 @@
+-- 0008: stage_runs.bkd_session_id —— 把 BKD agent session token (Claude Code
+-- externalSessionId) 落进 stage_runs，方便从指标看板直接跳到对应 BKD chat 排查
+-- agent 行为，也让"哪条 prompt 该改"的反哺循环能 join agent_quality.sql 跟 BKD
+-- session log。
+--
+-- 仅 agent stage（analyze/verifier/fixer/accept/archive）会有非 NULL 值；机械
+-- checker（spec_lint/dev_cross_check/staging_test/pr_ci/accept_teardown）没 BKD
+-- 会话，列保留 NULL。
+
+ALTER TABLE stage_runs ADD COLUMN bkd_session_id TEXT;
+
+COMMENT ON COLUMN stage_runs.bkd_session_id IS
+  'BKD agent session token (Claude Code externalSessionId). Agent stage 才有；机械 checker 留 NULL';
+
+-- 走 partial index：仅给非 NULL 行建索引，覆盖反向查询
+-- (找某个 BKD session 对应的 stage_run) 而不为机械 stage 的大量 NULL 占空间。
+CREATE INDEX IF NOT EXISTS idx_stage_runs_bkd_session
+  ON stage_runs(bkd_session_id)
+  WHERE bkd_session_id IS NOT NULL;

--- a/orchestrator/src/orchestrator/bkd.py
+++ b/orchestrator/src/orchestrator/bkd.py
@@ -28,6 +28,10 @@ class Issue:
     description: str | None = None
     created_at: str | None = None     # BKD ISO timestamp
     updated_at: str | None = None
+    # BKD agent token = Claude Code externalSessionId. 仅 agent issue 有；
+    # session 起来后才被 BKD 填，create_issue 返回时常为 None，需要在
+    # session.completed/failed 时再 get_issue 拿到真值（写进 stage_runs）。
+    external_session_id: str | None = None
 
 
 def _to_issue(d: dict) -> Issue:
@@ -43,6 +47,7 @@ def _to_issue(d: dict) -> Issue:
         description=d.get("description"),
         created_at=d.get("createdAt"),
         updated_at=d.get("updatedAt") or d.get("statusUpdatedAt"),
+        external_session_id=d.get("externalSessionId"),
     )
 
 

--- a/orchestrator/src/orchestrator/engine.py
+++ b/orchestrator/src/orchestrator/engine.py
@@ -29,7 +29,7 @@ _TERMINAL_STATES = {ReqState.DONE, ReqState.ESCALATED}
 
 
 # M14e/M15：state → stage 名（用于 stage_runs 表）。
-_STATE_TO_STAGE: dict[ReqState, str] = {
+STATE_TO_STAGE: dict[ReqState, str] = {
     ReqState.ANALYZING:              "analyze",
     ReqState.SPEC_LINT_RUNNING:      "spec_lint",
     ReqState.DEV_CROSS_CHECK_RUNNING: "dev_cross_check",
@@ -41,6 +41,11 @@ _STATE_TO_STAGE: dict[ReqState, str] = {
     ReqState.FIXER_RUNNING:          "fixer",
     ReqState.ARCHIVING:              "archive",
 }
+# 仅以下 state 对应的 stage 由 BKD agent 跑；其他 state 是机械 checker / teardown，
+# 没 BKD session 可绑。webhook 用此集合决定 stamp_bkd_session_id 是否值得调用。
+AGENT_STAGES: frozenset[str] = frozenset({
+    "analyze", "verifier", "fixer", "accept", "archive",
+})
 
 # event → stage_runs.outcome 标签。escalate / session.failed 全归 fail。
 _EVENT_TO_OUTCOME: dict[Event, str] = {
@@ -100,7 +105,7 @@ async def _record_stage_transitions(
     if cur_state == next_state:
         return
     try:
-        cur_stage = _STATE_TO_STAGE.get(cur_state)
+        cur_stage = STATE_TO_STAGE.get(cur_state)
         if cur_stage:
             outcome = _EVENT_TO_OUTCOME.get(event, "cancelled")
             await stage_runs.close_latest_stage_run(
@@ -108,7 +113,7 @@ async def _record_stage_transitions(
                 outcome=outcome,
                 fail_reason=event.value if outcome != "pass" else None,
             )
-        next_stage = _STATE_TO_STAGE.get(next_state)
+        next_stage = STATE_TO_STAGE.get(next_state)
         if next_stage:
             await stage_runs.insert_stage_run(
                 pool, req_id, next_stage,

--- a/orchestrator/src/orchestrator/store/stage_runs.py
+++ b/orchestrator/src/orchestrator/store/stage_runs.py
@@ -111,3 +111,41 @@ async def close_latest_stage_run(
         req_id, stage, outcome, fail_reason,
     )
     return int(row["id"]) if row else None
+
+
+async def stamp_bkd_session_id(
+    pool: asyncpg.Pool,
+    req_id: str,
+    stage: str,
+    bkd_session_id: str,
+) -> int | None:
+    """把 BKD agent session token 写到最近开着的 (req_id, stage) stage_run。
+
+    用法：webhook 收到 session.completed/failed 时，从 BKD issue 拿到
+    externalSessionId，在 engine.step（即 close_latest_stage_run）跑前 stamp。
+    后续 close 只 UPDATE ended_at/outcome/fail_reason/duration_sec，不动
+    bkd_session_id，所以 stamp 在前 close 在后即可保留。
+
+    幂等：仅当目标行 bkd_session_id IS NULL 时写入；已写过则不覆盖（避免
+    BKD 重发 webhook 把同一 sid 反复写或被并发的 stamp 覆盖）。
+    返回被写入的 id；目标行不存在 / 已写过 → None。
+    """
+    if not bkd_session_id:
+        return None
+    row = await pool.fetchrow(
+        """
+        UPDATE stage_runs SET
+            bkd_session_id = $3
+        WHERE id = (
+            SELECT id FROM stage_runs
+             WHERE req_id = $1 AND stage = $2
+               AND ended_at IS NULL
+               AND bkd_session_id IS NULL
+             ORDER BY started_at DESC
+             LIMIT 1
+        )
+        RETURNING id
+        """,
+        req_id, stage, bkd_session_id,
+    )
+    return int(row["id"]) if row else None

--- a/orchestrator/src/orchestrator/webhook.py
+++ b/orchestrator/src/orchestrator/webhook.py
@@ -20,7 +20,7 @@ from . import router as router_lib
 from .bkd import BKDClient
 from .config import settings
 from .state import Event, ReqState
-from .store import db, dedup, req_state, verifier_decisions
+from .store import db, dedup, req_state, stage_runs, verifier_decisions
 
 log = structlog.get_logger(__name__)
 api = APIRouter()
@@ -128,11 +128,16 @@ async def webhook(request: Request) -> JSONResponse:
                     reason="previous attempt crashed mid-flight")
 
     # ─── 2. Resolve tags（session events 可能没带，从 BKD 拉）──────────────
+    # session.failed 也走 fetch 路径：除了拿 tags，还顺手抓 externalSessionId
+    # 写进 stage_runs，让 dashboard 能从崩掉的 stage_run 直接跳到对应 BKD chat
+    # 排查 agent 行为。getattr 防御式读 —— 老的 BKD payload / 测试 stub 可能没该字段。
     tags = body.tags or []
-    if not tags or body.event == "session.completed":
+    bkd_session_id: str | None = None
+    if not tags or body.event in ("session.completed", "session.failed"):
         async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
             issue = await bkd.get_issue(body.projectId, body.issueId)
             tags = issue.tags
+            bkd_session_id = getattr(issue, "external_session_id", None)
     log.info("webhook.received", evt=body.event, issue_id=body.issueId, tags=tags)
 
     # ─── 2.5 早期 noise filter ─────────────────────────────────────────────
@@ -327,6 +332,23 @@ async def webhook(request: Request) -> JSONResponse:
     if event == Event.VERIFY_ESCALATE:
         await req_state.update_context(pool, req_id, {"escalated_reason": "verifier-decision"})
         ctx = {**ctx, "escalated_reason": "verifier-decision"}
+
+    # ─── 5.9 stamp BKD session token onto 当前开着的 stage_run ───────────────
+    # 必须放在 engine.step 之前：engine 在 transition 时会 close_latest_stage_run，
+    # 之后这条 row 就不再开着了，stamp 找不到目标。close 只 UPDATE
+    # ended_at/outcome/fail_reason/duration_sec，不动 bkd_session_id，所以
+    # stamp 在前 close 在后能保留 token。机械 stage（spec_lint 等）不在
+    # AGENT_STAGES 里，跳过；fetch issue 失败 → bkd_session_id 仍是 None，跳过。
+    if bkd_session_id:
+        cur_stage = engine.STATE_TO_STAGE.get(cur_state)
+        if cur_stage in engine.AGENT_STAGES:
+            try:
+                await stage_runs.stamp_bkd_session_id(
+                    pool, req_id, cur_stage, bkd_session_id,
+                )
+            except Exception as e:
+                log.warning("webhook.stamp_bkd_session_id_failed",
+                            req_id=req_id, stage=cur_stage, error=str(e))
 
     # ─── 6. 推进状态机（engine 内部循环 emit）─────────────────────────────
     result = await engine.step(

--- a/orchestrator/tests/test_bkd_rest.py
+++ b/orchestrator/tests/test_bkd_rest.py
@@ -358,3 +358,56 @@ def test_factory_unknown_transport_raises():
     from orchestrator.bkd import BKDClient
     with pytest.raises(ValueError, match="Unknown BKD transport"):
         BKDClient("https://bkd.example/api", "tok", transport="grpc")
+
+
+# ─── REQ-stage-runs-token-tracking: BKD agent token 解析 ──────────────────
+
+
+def test_to_issue_extracts_external_session_id():
+    """BKD ≥0.0.65 issue payload 带 externalSessionId（Claude Code session UUID）。
+    _to_issue 必须把它取出，让 webhook 能 stamp 进 stage_runs。"""
+    from orchestrator.bkd import _to_issue
+
+    issue = _to_issue({
+        "id": "i1", "projectId": "p", "issueNumber": 1,
+        "title": "t", "statusId": "working", "tags": ["analyze"],
+        "externalSessionId": "a742034b-6fb0-4047-be96-d5431dc1f252",
+    })
+    assert issue.external_session_id == "a742034b-6fb0-4047-be96-d5431dc1f252"
+
+
+def test_to_issue_external_session_id_defaults_none():
+    """create_issue 刚返回时 BKD 还没分配 externalSessionId → 字段 None，
+    不抛 KeyError（_to_issue 用 .get）。"""
+    from orchestrator.bkd import _to_issue
+
+    issue = _to_issue({
+        "id": "i2", "projectId": "p", "issueNumber": 2,
+        "title": "t", "statusId": "todo", "tags": [],
+    })
+    assert issue.external_session_id is None
+
+
+@pytest.mark.asyncio
+async def test_get_issue_returns_external_session_id_via_rest():
+    """端到端：BKD REST GET /issues/{id} 返 externalSessionId → Issue 字段填上。"""
+    class FakeHttp:
+        async def get(self, url, headers=None):
+            payload = {
+                "success": True,
+                "data": {
+                    "id": "i1", "projectId": "p", "issueNumber": 1,
+                    "title": "[REQ-x] [ANALYZE]", "statusId": "working",
+                    "tags": ["analyze", "REQ-x"],
+                    "externalSessionId": "sess-abc",
+                },
+            }
+            return httpx.Response(200, text=json.dumps(payload))
+
+        async def aclose(self):
+            pass
+
+    client = BKDRestClient("https://bkd.example/api", "tok")
+    client._http = FakeHttp()  # type: ignore[assignment]
+    issue = await client.get_issue("p", "i1")
+    assert issue.external_session_id == "sess-abc"

--- a/orchestrator/tests/test_contract_docs_drift_audit.py
+++ b/orchestrator/tests/test_contract_docs_drift_audit.py
@@ -269,12 +269,12 @@ def test_docs_s6_tag_spec_not_apifox_content():
 # DOCS-S7: migration count 0001–0007 reflected in docs
 # ──────────────────────────────────────────────────────────────────────────
 
-def test_docs_s7_forward_migration_count_is_8():
+def test_docs_s7_forward_migration_count_is_9():
     """DOCS-S7: orchestrator/migrations/ has exactly 8 forward migration files
-    (0001..0007 + 0009; 0008 reserved for parallel REQ-evaluation work)."""
+    (0001..0009 contiguous; 0008 = stage_runs_bkd_session_id, 0009 = artifact_checks_flake)."""
     forward = [f for f in MIGRATIONS_DIR.glob("*.sql") if ".rollback." not in f.name]
-    assert len(forward) == 8, (
-        f"orchestrator/migrations/ has {len(forward)} forward migration(s), expected 8: "
+    assert len(forward) == 9, (
+        f"orchestrator/migrations/ has {len(forward)} forward migration(s), expected 9: "
         f"{sorted(f.name for f in forward)}"
     )
 

--- a/orchestrator/tests/test_contract_stage_runs_token_tracking.py
+++ b/orchestrator/tests/test_contract_stage_runs_token_tracking.py
@@ -1,0 +1,285 @@
+"""Contract tests for REQ-stage-runs-token-tracking-1777220172.
+
+Black-box behavioral contracts derived from
+  openspec/changes/REQ-stage-runs-token-tracking-1777220172/specs/
+    stage-runs-token-tracking/spec.md
+
+Scenarios covered:
+  STR-S1  webhook 收到 agent stage 的 session.completed → fetch issue 拿到
+          externalSessionId → stamp_bkd_session_id 在 engine.step 之前被调用，
+          stage 取自 cur_state（而非 tag 嗅探）
+  STR-S2  webhook 收到 mechanical stage 的 issue.updated（spec_lint 等）→ 不
+          stamp（cur_stage 不在 AGENT_STAGES）
+  STR-S3  BKD issue 没 externalSessionId（agent session 还没起来）→ 不 stamp
+  STR-S4  session.failed 也走 fetch + stamp 路径，让崩掉的 stage_run 也能在
+          dashboard 上跳到对应 BKD chat
+"""
+from __future__ import annotations
+
+from typing import ClassVar
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class _FakePool:
+    def __init__(self):
+        self.executed: list = []
+
+    async def fetchrow(self, sql, *args):
+        return None
+
+    async def execute(self, sql, *args):
+        self.executed.append((sql, args))
+
+
+def _make_request(
+    event: str,
+    tags: list[str] | None,
+    issue_id: str = "issue-str",
+) -> object:
+    class _Req:
+        headers: ClassVar = {"authorization": "Bearer test-webhook-token"}
+
+        async def json(self_inner):
+            return {
+                "event": event,
+                "issueId": issue_id,
+                "issueNumber": 7,
+                "projectId": "proj-str",
+                "executionId": "exec-str",
+                "tags": tags,
+            }
+
+    return _Req()
+
+
+def _mock_bkd_returning(monkeypatch, webhook_mod, *, tags, external_session_id):
+    """Stub BKDClient.get_issue → Issue 带指定 tags + externalSessionId."""
+    from orchestrator.bkd import Issue
+
+    def make_issue():
+        return Issue(
+            id="issue-str", project_id="proj-str", issue_number=7,
+            title="t", status_id="working", tags=tags,
+            session_status=None,
+            external_session_id=external_session_id,
+        )
+
+    class _BKD:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get_issue(self, *a, **kw):
+            return make_issue()
+
+        async def update_issue(self, *a, **kw):
+            pass
+
+    monkeypatch.setattr(webhook_mod, "BKDClient", _BKD)
+
+
+def _setup_passthrough(
+    monkeypatch,
+    *,
+    cur_state,
+    derive_event_val,
+    req_id: str = "REQ-x",
+):
+    """Mock dedup / db / state / engine.step / obs.record_event 让 webhook 跑到
+    stamp 那段。返回 stamp_calls + step_calls 用于断言。"""
+    import orchestrator.observability as obs
+    from orchestrator import engine
+    from orchestrator import router as router_lib
+    from orchestrator.store import db, dedup, stage_runs
+    from orchestrator.store import req_state as rs_mod
+
+    stamp_calls: list[tuple] = []
+    step_calls: list = []
+
+    monkeypatch.setattr(dedup, "check_and_record", AsyncMock(return_value="new"))
+    monkeypatch.setattr(dedup, "mark_processed", AsyncMock())
+    monkeypatch.setattr(db, "get_pool", lambda: _FakePool())
+    monkeypatch.setattr(obs, "record_event", AsyncMock())
+    monkeypatch.setattr(router_lib, "extract_req_id", lambda tags, num=None: req_id)
+    monkeypatch.setattr(router_lib, "derive_event", lambda evt, tags: derive_event_val)
+
+    class _Row:
+        state = cur_state
+        context: ClassVar = {}
+
+    monkeypatch.setattr(rs_mod, "get", AsyncMock(return_value=_Row()))
+    monkeypatch.setattr(rs_mod, "insert_init", AsyncMock())
+    monkeypatch.setattr(rs_mod, "update_context", AsyncMock())
+
+    async def _step(*a, **kw):
+        step_calls.append(("step", kw))
+        return {"action": "noop"}
+
+    monkeypatch.setattr(engine, "step", _step)
+
+    async def _stamp(pool, req, stage, sid):
+        stamp_calls.append((req, stage, sid))
+        return 1
+
+    monkeypatch.setattr(stage_runs, "stamp_bkd_session_id", _stamp)
+
+    return stamp_calls, step_calls
+
+
+# ─── STR-S1: agent stage session.completed → stamp before engine.step ────────
+
+
+@pytest.mark.asyncio
+async def test_str_s1_agent_stage_session_completed_stamps_before_step(monkeypatch):
+    """STR-S1: cur_state ANALYZING + session.completed → stamp_bkd_session_id
+    被调用 (req, "analyze", externalSessionId) 且发生在 engine.step 之前。
+    stage 来自 cur_state 映射，不嗅探 tags。
+    """
+    from orchestrator import webhook
+    from orchestrator.state import Event, ReqState
+
+    stamp_calls, step_calls = _setup_passthrough(
+        monkeypatch,
+        cur_state=ReqState.ANALYZING,
+        derive_event_val=Event.ANALYZE_DONE,
+    )
+    _mock_bkd_returning(
+        monkeypatch, webhook,
+        tags=["analyze", "REQ-x"],
+        external_session_id="sess-analyze-uuid",
+    )
+
+    # 用一个共享 list 保留调用顺序
+    order: list[str] = []
+    from orchestrator.store import stage_runs
+
+    async def _stamp_ordered(pool, req, stage, sid):
+        order.append("stamp")
+        stamp_calls.append((req, stage, sid))
+        return 1
+
+    monkeypatch.setattr(stage_runs, "stamp_bkd_session_id", _stamp_ordered)
+
+    from orchestrator import engine
+
+    async def _step_ordered(*a, **kw):
+        order.append("step")
+        step_calls.append(("step", kw))
+        return {"action": "noop"}
+
+    monkeypatch.setattr(engine, "step", _step_ordered)
+
+    req = _make_request("session.completed", None)
+    await webhook.webhook(req)
+
+    assert stamp_calls == [("REQ-x", "analyze", "sess-analyze-uuid")], (
+        f"STR-S1: stamp_bkd_session_id must be called once with (REQ-x, "
+        f"'analyze', 'sess-analyze-uuid'), got {stamp_calls!r}"
+    )
+    assert order.index("stamp") < order.index("step"), (
+        f"STR-S1: stamp must run before engine.step (otherwise close_latest_stage_run "
+        f"would have already moved the row out of ended_at IS NULL), got order={order!r}"
+    )
+
+
+# ─── STR-S2: mechanical stage → no stamp ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_str_s2_mechanical_stage_does_not_stamp(monkeypatch):
+    """STR-S2: cur_state SPEC_LINT_RUNNING (机械 checker，不在 AGENT_STAGES) →
+    即使 webhook fetch 到 issue 也不 stamp。"""
+    from orchestrator import webhook
+    from orchestrator.state import Event, ReqState
+
+    stamp_calls, _ = _setup_passthrough(
+        monkeypatch,
+        cur_state=ReqState.SPEC_LINT_RUNNING,
+        derive_event_val=Event.SPEC_LINT_PASS,
+    )
+    # 即使 BKD 给了 sid，也不该 stamp 机械 stage（它没 BKD agent）
+    _mock_bkd_returning(
+        monkeypatch, webhook,
+        tags=["spec_lint", "REQ-x", "result:pass"],
+        external_session_id="should-be-ignored",
+    )
+
+    req = _make_request("session.completed", None)
+    await webhook.webhook(req)
+
+    assert stamp_calls == [], (
+        f"STR-S2: stamp must be skipped for non-agent stages (spec_lint/dev_cross_check/"
+        f"staging_test/pr_ci/accept_teardown), got {stamp_calls!r}"
+    )
+
+
+# ─── STR-S3: 没 externalSessionId → no stamp ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_str_s3_no_external_session_id_skips_stamp(monkeypatch):
+    """STR-S3: BKD issue 还没分到 externalSessionId（None）→ 不 stamp。
+    避免给 stage_run 写空字符串。"""
+    from orchestrator import webhook
+    from orchestrator.state import Event, ReqState
+
+    stamp_calls, _ = _setup_passthrough(
+        monkeypatch,
+        cur_state=ReqState.ANALYZING,
+        derive_event_val=Event.ANALYZE_DONE,
+    )
+    _mock_bkd_returning(
+        monkeypatch, webhook,
+        tags=["analyze", "REQ-x"],
+        external_session_id=None,
+    )
+
+    req = _make_request("session.completed", None)
+    await webhook.webhook(req)
+
+    assert stamp_calls == [], (
+        f"STR-S3: stamp must be skipped when BKD issue has no externalSessionId, "
+        f"got {stamp_calls!r}"
+    )
+
+
+# ─── STR-S4: session.failed also fetches and stamps ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_str_s4_session_failed_also_stamps(monkeypatch):
+    """STR-S4: session.failed 也 fetch issue + stamp，让崩掉的 stage_run 也能从
+    dashboard 跳到对应 BKD chat 排查 agent 行为。
+
+    REVIEW_RUNNING + SESSION_FAILED 是合法 transition（self-loop → ESCALATED via
+    escalate action），derive_event 给 verifier issue session.failed 返回
+    Event.SESSION_FAILED，让 webhook 进 stamp 分支。
+    """
+    from orchestrator import webhook
+    from orchestrator.state import Event, ReqState
+
+    stamp_calls, _ = _setup_passthrough(
+        monkeypatch,
+        cur_state=ReqState.REVIEW_RUNNING,
+        derive_event_val=Event.SESSION_FAILED,
+    )
+    _mock_bkd_returning(
+        monkeypatch, webhook,
+        tags=["verifier", "verify:staging_test", "REQ-x"],
+        external_session_id="sess-verifier-crashed",
+    )
+
+    req = _make_request("session.failed", None)
+    await webhook.webhook(req)
+
+    assert stamp_calls == [("REQ-x", "verifier", "sess-verifier-crashed")], (
+        f"STR-S4: session.failed must also fetch + stamp so crashed agent runs "
+        f"are still linked to BKD chat, got {stamp_calls!r}"
+    )

--- a/orchestrator/tests/test_contract_stage_runs_token_tracking_challenger.py
+++ b/orchestrator/tests/test_contract_stage_runs_token_tracking_challenger.py
@@ -1,0 +1,509 @@
+"""Challenger contract tests for REQ-stage-runs-token-tracking-1777220172.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-stage-runs-token-tracking-1777220172/specs/stage-runs-token-tracking/spec.md
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is truly wrong, escalate to spec_fixer to correct the spec, not the test.
+
+Scenarios covered:
+  STR-S1  webhook stamps BKD agent token before engine.step (session.completed, agent stage)
+  STR-S2  AGENT_STAGES excludes mechanical checkers — spec_lint etc. stay NULL
+  STR-S3  webhook with externalSessionId=null skips stamp (no DB write)
+  STR-S4  session.failed also stamps for crash diagnostics
+  STR-S5  stamp_bkd_session_id SQL targets ended_at IS NULL AND bkd_session_id IS NULL
+  STR-S6  stamp_bkd_session_id with empty token returns None with no SQL emitted
+  STR-S7  _to_issue extracts externalSessionId from BKD payload into Issue.external_session_id
+  STR-S8  _to_issue defaults external_session_id to None when field absent (no KeyError)
+
+Module contracts under test:
+  orchestrator.bkd._to_issue / Issue.external_session_id   (STR-S7, STR-S8)
+  orchestrator.store.stage_runs.stamp_bkd_session_id       (STR-S5, STR-S6)
+  orchestrator.engine.AGENT_STAGES                         (STR-S2 boundary)
+  orchestrator.webhook POST /bkd-events                    (STR-S1, STR-S3, STR-S4)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+# ─── Minimal FakePool (shared by SQL contract tests) ─────────────────────────
+
+
+class _FakePool:
+    """Minimal asyncpg pool stub: captures all SQL calls and returns preset values."""
+
+    def __init__(self, fetchrow_returns: tuple = ()):
+        self._returns = list(fetchrow_returns)
+        self._pos = 0
+        self.execute_calls: list[tuple[str, tuple]] = []
+        self.fetchrow_calls: list[tuple[str, tuple]] = []
+
+    async def fetchrow(self, sql: str, *args):
+        self.fetchrow_calls.append((sql, args))
+        if self._pos < len(self._returns):
+            val = self._returns[self._pos]
+            self._pos += 1
+            return val
+        return None
+
+    async def execute(self, sql: str, *args):
+        self.execute_calls.append((sql, args))
+
+    async def fetch(self, sql: str, *args):
+        return []
+
+    async def fetchval(self, sql: str, *args):
+        return None
+
+
+# ─── STR-S7: _to_issue extracts externalSessionId ────────────────────────────
+
+
+def test_str_s7_to_issue_extracts_external_session_id() -> None:
+    """
+    STR-S7: _to_issue with a payload containing externalSessionId MUST set
+    Issue.external_session_id to that UUID string.
+    """
+    from orchestrator.bkd import _to_issue
+
+    payload = {
+        "id": "issue-str-s7",
+        "projectId": "proj-test",
+        "title": "test s7",
+        "tags": ["REQ-stage-runs-token-tracking-1777220172"],
+        "statusId": "working",
+        "issueNumber": 1,
+        "sessionStatus": "completed",
+        "externalSessionId": "a742034b-6fb0-4047-be96-d5431dc1f252",
+    }
+    issue = _to_issue(payload)
+
+    assert issue.external_session_id == "a742034b-6fb0-4047-be96-d5431dc1f252", (
+        "STR-S7: Issue.external_session_id MUST equal the payload's externalSessionId; "
+        f"got {issue.external_session_id!r}"
+    )
+
+
+# ─── STR-S8: _to_issue defaults external_session_id to None ──────────────────
+
+
+def test_str_s8_to_issue_defaults_external_session_id_to_none() -> None:
+    """
+    STR-S8: _to_issue with payload that omits externalSessionId MUST set
+    Issue.external_session_id to None — no KeyError, not an empty string.
+    """
+    from orchestrator.bkd import _to_issue
+
+    payload = {
+        "id": "issue-str-s8",
+        "projectId": "proj-test",
+        "title": "test s8 no session",
+        "tags": [],
+        "statusId": "todo",
+        "issueNumber": 2,
+        "sessionStatus": None,
+        # externalSessionId key deliberately absent
+    }
+
+    try:
+        issue = _to_issue(payload)
+    except KeyError as exc:
+        pytest.fail(
+            "STR-S8: _to_issue MUST NOT raise KeyError when externalSessionId is absent; "
+            f"got KeyError({exc})"
+        )
+
+    assert issue.external_session_id is None, (
+        "STR-S8: Issue.external_session_id MUST default to None when field absent; "
+        f"got {issue.external_session_id!r}"
+    )
+
+
+# ─── STR-S5: stamp SQL targets ended_at IS NULL AND bkd_session_id IS NULL ───
+
+
+async def test_str_s5_stamp_sql_targets_open_and_null_token_row() -> None:
+    """
+    STR-S5: stamp_bkd_session_id SQL MUST contain 'ended_at IS NULL' AND
+    'bkd_session_id IS NULL' in its WHERE clause, ensuring that closed rows
+    and already-stamped rows are never mutated.
+
+    The helper uses an UPDATE...RETURNING query via pool.fetchrow, so we
+    inspect fetchrow_calls (not execute_calls) for the SQL contract.
+    """
+    from orchestrator.store.stage_runs import stamp_bkd_session_id
+
+    # Return a row with numeric id (asyncpg pg_bigint → int)
+    pool = _FakePool(fetchrow_returns=({"id": 42},))
+    row_id = await stamp_bkd_session_id(pool, "REQ-7", "analyze", "new-sess")
+
+    assert len(pool.fetchrow_calls) == 1, (
+        f"STR-S5: stamp_bkd_session_id MUST emit exactly 1 SQL call (UPDATE…RETURNING via fetchrow); "
+        f"got {len(pool.fetchrow_calls)}"
+    )
+    sql_lower = pool.fetchrow_calls[0][0].lower()
+
+    assert "ended_at is null" in sql_lower, (
+        "STR-S5: SQL MUST contain 'ended_at IS NULL'; "
+        f"actual SQL:\n{pool.fetchrow_calls[0][0]}"
+    )
+    assert "bkd_session_id is null" in sql_lower, (
+        "STR-S5: SQL MUST contain 'bkd_session_id IS NULL'; "
+        f"actual SQL:\n{pool.fetchrow_calls[0][0]}"
+    )
+
+
+# ─── STR-S6: empty token is a no-op ──────────────────────────────────────────
+
+
+async def test_str_s6_empty_token_is_noop() -> None:
+    """
+    STR-S6: stamp_bkd_session_id with an empty string token MUST:
+      - return None immediately
+      - emit NO SQL (no round-trip to DB)
+    """
+    from orchestrator.store.stage_runs import stamp_bkd_session_id
+
+    pool = _FakePool()
+    result = await stamp_bkd_session_id(pool, "REQ-1", "analyze", "")
+
+    assert result is None, (
+        f"STR-S6: stamp_bkd_session_id('') MUST return None; got {result!r}"
+    )
+    assert pool.execute_calls == [], (
+        f"STR-S6: stamp_bkd_session_id('') MUST emit NO SQL; "
+        f"got {len(pool.execute_calls)} execute call(s)"
+    )
+
+
+# ─── STR-S2: AGENT_STAGES boundary ───────────────────────────────────────────
+
+
+def test_agent_stages_contains_all_spec_required_stages() -> None:
+    """
+    Boundary for STR-S1/S2: engine.AGENT_STAGES MUST be a frozenset containing
+    all five agent stages: analyze, verifier, fixer, accept, archive.
+    """
+    from orchestrator.engine import AGENT_STAGES
+
+    required = {"analyze", "verifier", "fixer", "accept", "archive"}
+    assert isinstance(AGENT_STAGES, frozenset), (
+        f"AGENT_STAGES MUST be frozenset; got {type(AGENT_STAGES).__name__!r}"
+    )
+    assert required <= AGENT_STAGES, (
+        f"AGENT_STAGES MUST contain {required!r}; missing: {required - AGENT_STAGES!r}"
+    )
+
+
+def test_agent_stages_excludes_mechanical_checkers() -> None:
+    """
+    STR-S2: mechanical stage names MUST NOT appear in AGENT_STAGES.
+    spec_lint, dev_cross_check, staging_test, pr_ci, accept_teardown
+    have no BKD agent — their bkd_session_id column MUST stay NULL.
+    """
+    from orchestrator.engine import AGENT_STAGES
+
+    mechanical = {"spec_lint", "dev_cross_check", "staging_test", "pr_ci", "accept_teardown"}
+    overlap = mechanical & AGENT_STAGES
+    assert overlap == set(), (
+        f"AGENT_STAGES MUST NOT contain mechanical stages; "
+        f"found unexpected overlap: {overlap!r}"
+    )
+
+
+# ─── Webhook stamp-ordering tests (STR-S1, STR-S3, STR-S4) ──────────────────
+#
+# These tests POST to /bkd-events via FastAPI's ASGI transport, monkeypatching
+# all I/O (DB pool, BKD HTTP, engine.step) to control inputs and capture outputs.
+# The call_order list is the key artifact: it proves stamp precedes step (STR-S1).
+
+
+@dataclass
+class _FakeReqRow:
+    state: Any
+    context: dict = field(default_factory=dict)
+
+
+def _make_fake_issue(tags: list[str], external_session_id: str | None):
+    """Build a minimal orchestrator.bkd.Issue with all required fields."""
+    from orchestrator.bkd import Issue
+
+    return Issue(
+        id="bkd-issue-id",
+        project_id="proj-test",
+        issue_number=99,
+        title="test issue",
+        status_id="working",
+        tags=tags,
+        session_status="completed",
+        external_session_id=external_session_id,
+    )
+
+
+def _patch_webhook_deps(
+    monkeypatch,
+    *,
+    bkd_tags: list[str],
+    bkd_external_session_id: str | None,
+    req_state_value: Any,
+    derive_event_return: Any,
+    call_order: list[str],
+    stamp_calls: list[tuple],
+    step_calls: list[dict],
+) -> _FakePool:
+    """Monkeypatch all external I/O in the webhook module for a single test."""
+    from orchestrator import webhook
+    from orchestrator.state import Event
+
+    pool = _FakePool()
+
+    # Pool
+    monkeypatch.setattr(webhook.db, "get_pool", lambda: pool)
+
+    # Dedup: always "new" (first call), then mark_processed is no-op
+    monkeypatch.setattr(webhook.dedup, "check_and_record", AsyncMock(return_value="new"))
+    monkeypatch.setattr(webhook.dedup, "mark_processed", AsyncMock(return_value=None))
+
+    # Observability: no-op
+    monkeypatch.setattr(webhook.obs, "record_event", AsyncMock(return_value=None))
+
+    # _push_upstream_status: no-op (session.completed upstream push)
+    monkeypatch.setattr(webhook, "_push_upstream_status", AsyncMock(return_value=None))
+
+    # BKDClient: return controlled Issue with desired external_session_id
+    fake_issue = _make_fake_issue(bkd_tags, bkd_external_session_id)
+
+    class _FakeBKD:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def get_issue(self, _project_id, _issue_id):
+            return fake_issue
+
+        async def update_issue(self, **_kw):
+            pass
+
+        async def get_last_assistant_message(self, *_a):
+            return None
+
+    monkeypatch.setattr(webhook, "BKDClient", lambda *_a, **_kw: _FakeBKD())
+
+    # router_lib: controlled event derivation and req_id extraction
+    monkeypatch.setattr(
+        webhook.router_lib, "derive_event", lambda _event, _tags: derive_event_return
+    )
+    monkeypatch.setattr(
+        webhook.router_lib, "extract_req_id", lambda _tags, _num=None: "REQ-test-stamp-x"
+    )
+
+    # req_state: return controlled state row
+    fake_row = _FakeReqRow(state=req_state_value)
+    monkeypatch.setattr(webhook.req_state, "get", AsyncMock(return_value=fake_row))
+    monkeypatch.setattr(webhook.req_state, "update_context", AsyncMock(return_value=None))
+    monkeypatch.setattr(webhook.req_state, "insert_init", AsyncMock(return_value=None))
+
+    # verifier_decisions: no-op
+    monkeypatch.setattr(
+        webhook.verifier_decisions, "insert_decision", AsyncMock(return_value=None)
+    )
+
+    # stage_runs: track stamp calls AND call order
+    class _TrackingStageRuns:
+        async def stamp_bkd_session_id(self, pool_arg, req_id, stage, bkd_session_id):
+            call_order.append("stamp")
+            stamp_calls.append((req_id, stage, bkd_session_id))
+            return "tracked-row-id"
+
+        def __getattr__(self, name):
+            return AsyncMock(return_value=None)
+
+    monkeypatch.setattr(webhook, "stage_runs", _TrackingStageRuns())
+
+    # engine.step: track call order
+    async def _fake_step(*_a, **kw):
+        call_order.append("step")
+        step_calls.append(kw)
+        return {"action": "ok", "req_id": kw.get("req_id", "?")}
+
+    monkeypatch.setattr(webhook.engine, "step", _fake_step)
+
+    return pool
+
+
+# STR-S1: session.completed for agent stage → stamp BEFORE step ───────────────
+
+
+async def test_str_s1_stamp_called_before_engine_step(monkeypatch) -> None:
+    """
+    STR-S1: When webhook receives session.completed for ANALYZING (analyze stage):
+      - stamp_bkd_session_id MUST be called exactly once
+      - The call MUST precede engine.step
+    """
+    from httpx import ASGITransport, AsyncClient
+    from orchestrator.main import app
+    from orchestrator.state import Event, ReqState
+
+    call_order: list[str] = []
+    stamp_calls: list[tuple] = []
+    step_calls: list[dict] = []
+
+    _patch_webhook_deps(
+        monkeypatch,
+        bkd_tags=["REQ-stage-runs-token-tracking-1777220172", "analyze"],
+        bkd_external_session_id="sess-analyze-uuid",
+        req_state_value=ReqState.ANALYZING,
+        derive_event_return=Event.ANALYZE_DONE,
+        call_order=call_order,
+        stamp_calls=stamp_calls,
+        step_calls=step_calls,
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/bkd-events",
+            json={
+                "event": "session.completed",
+                "issueId": "analyze-bkd-issue-id",
+                "projectId": "proj-test",
+                "executionId": "exec-str-s1",
+            },
+            headers={"Authorization": "Bearer test-webhook-token"},
+        )
+
+    assert response.status_code == 200, (
+        f"STR-S1: webhook MUST return 200; got {response.status_code}: {response.text}"
+    )
+    assert len(stamp_calls) == 1, (
+        f"STR-S1: stamp_bkd_session_id MUST be called exactly once for agent stage; "
+        f"got {len(stamp_calls)} call(s): {stamp_calls}"
+    )
+    assert stamp_calls[0][2] == "sess-analyze-uuid", (
+        f"STR-S1: stamp MUST carry externalSessionId='sess-analyze-uuid'; "
+        f"got {stamp_calls[0][2]!r}"
+    )
+
+    assert "stamp" in call_order and "step" in call_order, (
+        f"STR-S1: both stamp and step MUST appear in call_order; got {call_order!r}"
+    )
+    stamp_idx = call_order.index("stamp")
+    step_idx = call_order.index("step")
+    assert stamp_idx < step_idx, (
+        f"STR-S1: stamp MUST precede engine.step; "
+        f"stamp at index {stamp_idx}, step at index {step_idx} in {call_order!r}"
+    )
+
+
+# STR-S3: null externalSessionId → stamp NOT called ───────────────────────────
+
+
+async def test_str_s3_null_external_session_id_skips_stamp(monkeypatch) -> None:
+    """
+    STR-S3: When webhook receives session.completed with externalSessionId=null:
+      - stamp_bkd_session_id MUST NOT be called
+      (no empty/NULL token should be written to the DB)
+    """
+    from httpx import ASGITransport, AsyncClient
+    from orchestrator.main import app
+    from orchestrator.state import Event, ReqState
+
+    call_order: list[str] = []
+    stamp_calls: list[tuple] = []
+    step_calls: list[dict] = []
+
+    _patch_webhook_deps(
+        monkeypatch,
+        bkd_tags=["REQ-stage-runs-token-tracking-1777220172", "analyze"],
+        bkd_external_session_id=None,  # null — BKD hasn't assigned a session UUID yet
+        req_state_value=ReqState.ANALYZING,
+        derive_event_return=Event.ANALYZE_DONE,
+        call_order=call_order,
+        stamp_calls=stamp_calls,
+        step_calls=step_calls,
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/bkd-events",
+            json={
+                "event": "session.completed",
+                "issueId": "analyze-issue-no-session-id",
+                "projectId": "proj-test",
+                "executionId": "exec-str-s3",
+            },
+            headers={"Authorization": "Bearer test-webhook-token"},
+        )
+
+    assert response.status_code == 200, (
+        f"STR-S3: webhook MUST return 200; got {response.status_code}: {response.text}"
+    )
+    assert len(stamp_calls) == 0, (
+        f"STR-S3: stamp_bkd_session_id MUST NOT be called when externalSessionId is null; "
+        f"got {len(stamp_calls)} call(s): {stamp_calls}"
+    )
+
+
+# STR-S4: session.failed also stamps ─────────────────────────────────────────
+
+
+async def test_str_s4_session_failed_also_stamps(monkeypatch) -> None:
+    """
+    STR-S4: When webhook receives session.failed for REVIEW_RUNNING (verifier stage):
+      - The webhook MUST fetch the BKD issue (extending to session.failed path)
+      - stamp_bkd_session_id MUST be called with the crashed session's externalSessionId
+    """
+    from httpx import ASGITransport, AsyncClient
+    from orchestrator.main import app
+    from orchestrator.state import Event, ReqState
+
+    call_order: list[str] = []
+    stamp_calls: list[tuple] = []
+    step_calls: list[dict] = []
+
+    _patch_webhook_deps(
+        monkeypatch,
+        bkd_tags=["REQ-stage-runs-token-tracking-1777220172", "verifier"],
+        bkd_external_session_id="sess-verifier-crashed",
+        req_state_value=ReqState.REVIEW_RUNNING,
+        derive_event_return=Event.SESSION_FAILED,
+        call_order=call_order,
+        stamp_calls=stamp_calls,
+        step_calls=step_calls,
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/bkd-events",
+            json={
+                "event": "session.failed",
+                "issueId": "verifier-bkd-issue-id",
+                "projectId": "proj-test",
+                "executionId": "exec-str-s4",
+            },
+            headers={"Authorization": "Bearer test-webhook-token"},
+        )
+
+    assert response.status_code == 200, (
+        f"STR-S4: webhook MUST return 200; got {response.status_code}: {response.text}"
+    )
+    assert len(stamp_calls) == 1, (
+        f"STR-S4: stamp_bkd_session_id MUST be called once for session.failed on agent stage; "
+        f"got {len(stamp_calls)} call(s): {stamp_calls}"
+    )
+    assert stamp_calls[0][2] == "sess-verifier-crashed", (
+        f"STR-S4: stamp MUST carry the crashed session's externalSessionId; "
+        f"got {stamp_calls[0][2]!r}"
+    )

--- a/orchestrator/tests/test_contract_stage_runs_token_tracking_challenger.py
+++ b/orchestrator/tests/test_contract_stage_runs_token_tracking_challenger.py
@@ -30,7 +30,6 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-
 # ─── Minimal FakePool (shared by SQL contract tests) ─────────────────────────
 
 
@@ -140,7 +139,7 @@ async def test_str_s5_stamp_sql_targets_open_and_null_token_row() -> None:
 
     # Return a row with numeric id (asyncpg pg_bigint → int)
     pool = _FakePool(fetchrow_returns=({"id": 42},))
-    row_id = await stamp_bkd_session_id(pool, "REQ-7", "analyze", "new-sess")
+    await stamp_bkd_session_id(pool, "REQ-7", "analyze", "new-sess")
 
     assert len(pool.fetchrow_calls) == 1, (
         f"STR-S5: stamp_bkd_session_id MUST emit exactly 1 SQL call (UPDATE…RETURNING via fetchrow); "
@@ -258,7 +257,6 @@ def _patch_webhook_deps(
 ) -> _FakePool:
     """Monkeypatch all external I/O in the webhook module for a single test."""
     from orchestrator import webhook
-    from orchestrator.state import Event
 
     pool = _FakePool()
 
@@ -348,6 +346,7 @@ async def test_str_s1_stamp_called_before_engine_step(monkeypatch) -> None:
       - The call MUST precede engine.step
     """
     from httpx import ASGITransport, AsyncClient
+
     from orchestrator.main import app
     from orchestrator.state import Event, ReqState
 
@@ -413,6 +412,7 @@ async def test_str_s3_null_external_session_id_skips_stamp(monkeypatch) -> None:
       (no empty/NULL token should be written to the DB)
     """
     from httpx import ASGITransport, AsyncClient
+
     from orchestrator.main import app
     from orchestrator.state import Event, ReqState
 
@@ -464,6 +464,7 @@ async def test_str_s4_session_failed_also_stamps(monkeypatch) -> None:
       - stamp_bkd_session_id MUST be called with the crashed session's externalSessionId
     """
     from httpx import ASGITransport, AsyncClient
+
     from orchestrator.main import app
     from orchestrator.state import Event, ReqState
 

--- a/orchestrator/tests/test_store_stage_runs.py
+++ b/orchestrator/tests/test_store_stage_runs.py
@@ -107,3 +107,64 @@ async def test_update_stage_run_allows_partial_update():
     assert args[3] is None   # fail_reason 不动
     assert args[4] == 100
     assert args[5] is None
+
+
+# ─── stamp_bkd_session_id（REQ-stage-runs-token-tracking）────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stamp_bkd_session_id_writes_token_to_latest_open_row():
+    """正常路径：UPDATE 命中最新 ended_at IS NULL 的 (req, stage) 行，写 token。"""
+    pool = CapturePool(ret={"id": 99})
+
+    row_id = await sr.stamp_bkd_session_id(
+        pool, "REQ-7", "analyze", "sess-abc-123",
+    )
+
+    assert row_id == 99
+    assert len(pool.fetchrow_calls) == 1
+    sql, args = pool.fetchrow_calls[0]
+    assert "UPDATE stage_runs" in sql
+    assert "bkd_session_id = $3" in sql
+    # WHERE 子句必须同时限 ended_at IS NULL + bkd_session_id IS NULL
+    # 才能避免覆盖已写的 token，避免抢已经 close 的旧行
+    assert "ended_at IS NULL" in sql
+    assert "bkd_session_id IS NULL" in sql
+    assert "RETURNING id" in sql
+    assert args == ("REQ-7", "analyze", "sess-abc-123")
+
+
+@pytest.mark.asyncio
+async def test_stamp_bkd_session_id_returns_none_when_no_open_row_matched():
+    """没找到目标行（subquery 返 0 行 → UPDATE 0 行 → RETURNING 空）→ None。"""
+    pool = CapturePool(ret=None)
+
+    row_id = await sr.stamp_bkd_session_id(
+        pool, "REQ-99", "verifier", "sess-xyz",
+    )
+
+    assert row_id is None
+    assert len(pool.fetchrow_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_stamp_bkd_session_id_skips_empty_token():
+    """token 是空串/None 不发 SQL；BKD session 还没起来时 externalSessionId 是 None，
+    没必要往 DB 打无意义 UPDATE。"""
+    pool = CapturePool(ret={"id": 1})
+
+    assert await sr.stamp_bkd_session_id(pool, "REQ-1", "analyze", "") is None
+    assert await sr.stamp_bkd_session_id(pool, "REQ-1", "analyze", None) is None  # type: ignore[arg-type]
+    assert pool.fetchrow_calls == []
+
+
+@pytest.mark.asyncio
+async def test_insert_stage_run_does_not_write_bkd_session_id_inline():
+    """insert 路径不带 bkd_session_id —— action handler 起 BKD issue 时
+    externalSessionId 通常还没分配，留 NULL 由后续 stamp 兜。"""
+    pool = CapturePool(ret={"id": 1})
+    await sr.insert_stage_run(pool, "REQ-1", "analyze", agent_type="analyze")
+
+    sql, _args = pool.fetchrow_calls[0]
+    # INSERT 列表不应带 bkd_session_id；migration 给该列默认 NULL
+    assert "bkd_session_id" not in sql


### PR DESCRIPTION
## Summary

Adds `bkd_session_id TEXT` to `stage_runs` so each agent-stage row carries the
Claude Code `externalSessionId` of the BKD agent that ran it. Closes the
"M14e dashboard → BKD chat" navigation gap that today is the dominant
friction in the prompt-tuning feedback loop:

- **Forward**: Metabase row → BKD UI link (project + session id is enough)
- **Reverse**: paste a BKD session id, find the REQ / stage / outcome it
  produced, without scrolling chat history first
- **Audit**: which exact agent run produced a given fixer-round / verifier
  decision

Mechanical stages (`spec_lint`, `dev_cross_check`, `staging_test`, `pr_ci`,
`accept_teardown`) stay NULL — no BKD session to record.

## Approach

- **Migration 0008** — `ALTER TABLE stage_runs ADD COLUMN bkd_session_id
  TEXT` plus a **partial index** `WHERE bkd_session_id IS NOT NULL` so
  reverse lookups are cheap without indexing the dominant NULL bucket.
- **`Issue` dataclass** — gains `external_session_id`, populated from the BKD
  payload's `externalSessionId` (shared by REST and MCP transports).
- **`stage_runs.stamp_bkd_session_id`** — new idempotent helper. UPDATEs the
  most-recent open `(req_id, stage)` row whose `ended_at IS NULL AND
  bkd_session_id IS NULL`. Won't overwrite an already-set token (defends
  against BKD webhook redelivery clobbering the original); won't touch
  closed rows; empty token is a no-op.
- **`engine.AGENT_STAGES`** — promoted `_STATE_TO_STAGE` → public
  `STATE_TO_STAGE` and added `frozenset({"analyze", "verifier", "fixer",
  "accept", "archive"})` so the webhook can decide whether stamping is
  meaningful for the current state.
- **Webhook plumbing** — extends the existing BKD fetch to also cover
  `session.failed` (so crashed agents stay diagnosable). Before
  `engine.step` runs, if the fetched issue has an `external_session_id`
  and `cur_stage in AGENT_STAGES`, calls
  `stamp_bkd_session_id(...)`. Best-effort: any exception is logged and
  swallowed — observability writes never block state-machine progress.
  Stamps **before** `engine.step` because `_record_stage_transitions`
  closes the open row (sets `ended_at`); after that the stamp helper would
  no longer find the row to update.

## Test plan

- [x] `make ci-lint` clean
- [x] `make ci-unit-test` — 936 passed (4 new tests in
      `test_store_stage_runs.py`, 3 in `test_bkd_rest.py`, 4 in new
      `test_contract_stage_runs_token_tracking.py` covering STR-S1..S4)
- [x] `make ci-integration-test` — no integration tests collected (exit 5 = pass)
- [x] `openspec validate REQ-stage-runs-token-tracking-1777220172 --strict` — clean
- [x] `scripts/check-scenario-refs.sh` — all 295 scenario refs found
- [ ] After merge: orchestrator rollout-restart applies migration 0008; verify
      via `psql \\d stage_runs` that the new column + index exist; trigger one
      analyze stage end-to-end and confirm `bkd_session_id` is populated on
      the closed row

🤖 Generated with [Claude Code](https://claude.com/claude-code)