### PR TITLE
chore(bkd): backfill review-stuck sub-issues to done (REQ-bkd-cleanup-historical-review-1777222384)

### DIFF
--- a/openspec/changes/REQ-bkd-cleanup-historical-review-1777222384/proposal.md
+++ b/openspec/changes/REQ-bkd-cleanup-historical-review-1777222384/proposal.md
@@ -1,0 +1,106 @@
+# REQ-bkd-cleanup-historical-review-1777222384: chore(bkd): backfill review-stuck sub-issues to done
+
+## Why
+
+BKD 看板的 "review" 列被历史 sub-issue 堆满。截至 2026-04-26，project `nnvxh8wj`
+有 46 条 `statusId='review'` 的 issue（用户的初步估算是 ~55，量级一致），全部是
+sub-agent 类型的 issue（不是 user 创的 intent issue）：
+
+- 40 条 `verifier` + `sessionStatus='completed'` —— webhook 在 VERIFY_ESCALATE 路径
+  上**故意**把 BKD status 推到 "review"（让用户能看到待 follow-up 的入口），但当
+  REQ 后续被 admin 推 done / pr-merged-override 短路终态后，原 verifier issue 的
+  BKD status 没有被反向收尾，永久留在 "review"
+- 3 条 `fixer` + `sessionStatus='failed'` / 2 条 `analyze` + `sessionStatus='failed'` /
+  1 条 `challenger` + `sessionStatus='failed'` —— webhook 的 `_push_upstream_status`
+  只在 `body.event == 'session.completed'` 才推（webhook.py:233），`session.failed`
+  不推；BKD agent 失败后 statusId 维持原值（多半是预先被 follow-up 之前的
+  `working` 一路保留，再被某个旧路径写成 review）
+
+这些 issue 全部 `sessionStatus in {completed, failed}`（无 `running`），其母 REQ 要么
+已经 DONE / ESCALATED 终态，要么早已被新一轮人工 / sub-agent 重新接管 —— 它们对
+当前活流没有任何作用，但污染：
+
+1. **BKD 看板 UI** —— "review" 列堆 40+ 历史 issue，用户找当前要 follow-up 的入口
+   要翻很久
+2. **观测面** —— `verifier_decisions` / `stage_runs` 表已记完工号志，BKD 那边的
+   "review" 状态对仪表盘没价值，反而误导 "看板上还有 N 个待审"
+3. **dedup / observability** —— 后台清理脚本扫 review 列时被噪音淹没
+
+需要一次性 backfill：把这 46 条（实际跑时取 live 列表，量级 40-55）安全地推到
+`statusId='done'`。
+
+## What Changes
+
+加一个 **一次性 maintenance CLI**：`orchestrator/src/orchestrator/maintenance/backfill_bkd_review_stuck.py`
+
+跑法：
+
+```bash
+cd orchestrator
+uv run python -m orchestrator.maintenance.backfill_bkd_review_stuck \
+  --project nnvxh8wj --bkd-base-url http://localhost:3000 [--apply]
+```
+
+不加 `--apply` 即 dry-run，stdout 列出每条候选 + decision_reason，不动任何状态。
+加 `--apply` 才真发 PATCH。
+
+### 决策契约
+
+对项目里每条 BKD issue 应用以下 filter（顺序短路）：
+
+```
+def is_safe_target(issue) -> tuple[bool, str]:
+    if issue.statusId != "review":     return (False, "not-review")
+    if issue.sessionStatus == "running":return (False, "session-running")
+    role = first_role_tag(issue.tags)  # verifier / fixer / analyze / challenger / accept-agent / done-archive
+    if role is None:                   return (False, "no-role-tag")  # 保护 user 创的 intent issue
+    if not has_req_tag(issue.tags):    return (False, "no-req-tag")   # 防误伤无 REQ 关联的孤儿
+    return (True, f"role={role};session={issue.sessionStatus}")
+```
+
+通过 filter 的逐条 PATCH `statusId='done'`，tags 不动（保留 REQ-* / 阶段 tag /
+verifier decision tag —— 让审计能回放 "这条 issue 历史上跑了什么"）。
+
+### 为什么不用 admin REST endpoint / 不入热路径
+
+- **不是状态机职责** —— sisyphus 的 `req_state` 已经是 source of truth，BKD UI 状态
+  只是显示用。这次 cleanup 不动 sisyphus 状态，只 PATCH BKD UI；admin endpoint
+  路径会让 caller 误以为这是 REQ 状态变更
+- **一次性，不需要常驻** —— 加 admin endpoint = 加路由 + 加 token 鉴权 + 加常驻代码
+  路径，跑一次扔了不划算。后续再有同类需求再写一次脚本，diff 比维护一坨"通用清理"
+  小
+- **不修 webhook hot-path** —— webhook.py:233 只推 completed 不推 failed 是 **有意
+  设计**：session.failed 在 sub-agent 类（fixer/analyze/challenger）上可能值得人
+  审视。改它要重新评估 router 行为，超出本 REQ 范围。本 REQ 只清历史 stuck
+
+## Tradeoffs
+
+- **为什么 dry-run 默认而不是 apply 默认** —— 不可逆操作（PATCH BKD status）。
+  默认 dry-run 让 caller 先看清楚再点。mirror `kubectl apply` 之于 `--dry-run=client`
+- **为什么不 backfill 直接走 sisyphus 内 BKDClient** —— BKDClient 配置依赖 settings
+  + DI（pool / observability hooks 等），跑一次性脚本不值得拉起完整 app context。
+  脚本 import `bkd_rest.BKDRestClient` 直接走 httpx，最小依赖
+- **为什么不写额外的 sisyphus state 反查** —— 候选 filter 已经够保守：role-tagged
+  + session 非 running。即便母 REQ 还活着，也不会有 sub-issue 在 sessionStatus !=
+  running 时被 sisyphus 重新路由（sisyphus 不依赖 BKD UI status，依赖 webhook 事件
+  + req_state row）。把 BKD UI status 推 "done" 不影响任何 sisyphus 决策
+- **为什么不删 BKD issue** —— 删了观测面取数源没了（verifier_decisions / stage_runs
+  跨表 join 还要回查 BKD 元信息）。"done" 是 BKD UI 里的 "归档" 列，正合适
+- **为什么不区分 verifier-completed-escalate vs verifier-completed-pass** —— 都已经
+  REQ 终态。verifier 的 follow-up 入口在它的 BKD issue 本身（user click "follow up"
+  按钮即可），跟 statusId 无关。维持 "review" 没有功能意义
+
+## Impact
+
+- 新增 `orchestrator/src/orchestrator/maintenance/__init__.py`（空）
+- 新增 `orchestrator/src/orchestrator/maintenance/backfill_bkd_review_stuck.py`
+  - `is_safe_target(issue) -> tuple[bool, str]` 纯函数（pytest 可白盒）
+  - `select_targets(issues: list[Issue]) -> list[Issue]` filter pipeline
+  - `async def run(project_id: str, bkd_base_url: str, apply: bool, ...)` 主流
+  - `main()` argparse + `asyncio.run`
+- 新增 `orchestrator/tests/test_backfill_bkd_review_stuck.py`
+  - BBR-S1..S6 unit scenarios（详见 spec.md）
+- 不动 `webhook.py` / `engine.py` / `actions/*.py` / `state.py` / migrations
+- 不动 BKD tag schema / state-machine.md / docs/architecture.md
+- 跑一次后产出：cleaned issue count + audit log（stdout JSON）—— 落 PR description
+  作为 evidence

--- a/openspec/changes/REQ-bkd-cleanup-historical-review-1777222384/specs/bkd-status-backfill/contract.spec.yaml
+++ b/openspec/changes/REQ-bkd-cleanup-historical-review-1777222384/specs/bkd-status-backfill/contract.spec.yaml
@@ -1,0 +1,75 @@
+spec: bkd-status-backfill
+version: 1
+description: >-
+  One-shot maintenance CLI that PATCHes BKD sub-agent issues stuck at
+  statusId='review' to statusId='done'. Targets only role-tagged issues
+  (verifier / fixer / analyze / challenger / accept-agent / done-archive)
+  whose sessionStatus != 'running' AND that carry a REQ-* tag. Intent
+  issues (no role tag) and live sessions are protected.
+
+inputs:
+  - name: project_id
+    type: string
+    description: BKD project alias (e.g. nnvxh8wj)
+  - name: bkd_base_url
+    type: string
+    description: BKD REST base URL (e.g. http://localhost:3000)
+  - name: apply
+    type: bool
+    description: |
+      false (default) → dry-run, list candidates only.
+      true            → actually PATCH each candidate to statusId='done'.
+  - name: limit
+    type: int
+    description: BKD issues list page size; default 2000 (one shot, no pagination loop)
+
+side_effects_on_apply:
+  - bkd_patch:
+      method: PATCH
+      path: /api/projects/{project_id}/issues/{issue_id}
+      body: {"statusId": "done"}
+      tags_unchanged: true   # we never write tags; preserves audit trail
+  - stdout_audit_json:
+      shape:
+        - issue_id
+        - req_id
+        - role
+        - sessionStatus
+        - action          # "patched" | "skipped"
+        - reason          # decision_reason string
+
+side_effects_on_dry_run:
+  - no_bkd_writes: true
+  - stdout_audit_json: same shape, action always "skipped"
+
+decision_logic:
+  for_each_issue:
+    - if issue.statusId != "review": skip ("not-review")
+    - elif issue.sessionStatus == "running": skip ("session-running")
+    - elif first_role_tag(issue.tags) is None: skip ("no-role-tag")
+        # role tag set: verifier / fixer / analyze / challenger / accept-agent / done-archive
+    - elif extract_req_tag(issue.tags) is None: skip ("no-req-tag")
+    - else: target (PATCH to done)
+
+failure_modes:
+  - bkd_list_5xx: helper raises; main() exits non-zero (no partial PATCH attempts)
+  - bkd_patch_5xx_for_one_issue: log warning + continue with next issue (best-effort);
+                                  exit code 0 if at least one PATCH succeeded, non-zero
+                                  only if all PATCH calls failed
+  - dry_run: no exit-code change, returns 0 even if no candidates
+
+idempotency:
+  - PATCHing statusId='done' on an already-done issue is a no-op at BKD level
+    (BKD allows it). Re-running with --apply is safe.
+  - Run twice without --apply: deterministic same candidate list.
+
+audit:
+  - stdout MUST be machine-readable JSON lines (one entry per issue), so the
+    operator can pipe to jq / save as evidence in PR description
+  - log lines (stderr) are human-readable, do NOT pollute stdout JSON stream
+
+scope_constraints:
+  - DOES NOT modify sisyphus state machine, req_state rows, history, or context
+  - DOES NOT touch session.failed webhook handling (orthogonal hot-path concern)
+  - DOES NOT remove BKD tags (REQ-* / role / decision tags remain for audit)
+  - DOES NOT delete BKD issues (only PATCHes statusId)

--- a/openspec/changes/REQ-bkd-cleanup-historical-review-1777222384/specs/bkd-status-backfill/spec.md
+++ b/openspec/changes/REQ-bkd-cleanup-historical-review-1777222384/specs/bkd-status-backfill/spec.md
@@ -1,0 +1,88 @@
+# bkd-status-backfill
+
+## ADDED Requirements
+
+### Requirement: maintenance CLI MUST select only role-tagged review-stuck sub-issues
+
+The `orchestrator.maintenance.backfill_bkd_review_stuck` CLI SHALL list every
+BKD issue in the target project and select for backfill **only** those issues
+whose `statusId == "review"` AND whose `sessionStatus` is not `"running"` AND
+whose tag set contains exactly one of the recognised role tags
+(`verifier`, `fixer`, `analyze`, `challenger`, `accept-agent`, `done-archive`)
+AND whose tag set contains at least one tag matching the `REQ-*` prefix. Any
+issue missing a role tag MUST NOT be patched — this protects user-created
+intent issues from being silently archived. Any issue without a `REQ-*` tag
+MUST NOT be patched — this protects orphan BKD entries unrelated to the
+sisyphus workflow.
+
+#### Scenario: BBR-S1 verifier issue at review with completed session is selected
+
+- **GIVEN** a BKD issue with `statusId="review"`,
+  `tags=["verifier","REQ-foo-1234","verify:staging_test","decision:escalate"]`,
+  and `sessionStatus="completed"`
+- **WHEN** `select_targets([issue])` is invoked
+- **THEN** the issue MUST appear in the returned target list
+- **AND** the decision_reason MUST start with `role=verifier;session=completed`
+
+#### Scenario: BBR-S2 intent issue without role tag is rejected
+
+- **GIVEN** a BKD issue with `statusId="review"`,
+  `tags=["REQ-foo-1234"]` only (no role tag), and any sessionStatus
+- **WHEN** `select_targets([issue])` is invoked
+- **THEN** the issue MUST NOT appear in the returned target list
+- **AND** the per-issue decision_reason MUST equal `"no-role-tag"`
+
+#### Scenario: BBR-S3 running session is rejected even with role tag
+
+- **GIVEN** a BKD issue with `statusId="review"`, `tags=["fixer","REQ-foo-1234"]`,
+  and `sessionStatus="running"`
+- **WHEN** `select_targets([issue])` is invoked
+- **THEN** the issue MUST NOT appear in the returned target list
+- **AND** the per-issue decision_reason MUST equal `"session-running"`
+
+### Requirement: dry-run mode MUST emit decisions without any BKD write
+
+When invoked **without** the `--apply` flag, the CLI SHALL list every candidate
+and print one machine-readable JSON object per issue to stdout, but MUST NOT
+issue any HTTP PATCH against the BKD REST API. The CLI MUST exit 0 even if
+the candidate list is empty. Operators rely on this to preview before
+committing.
+
+#### Scenario: BBR-S4 dry-run prints candidates and makes zero PATCH calls
+
+- **GIVEN** a BKD list response containing 2 candidate issues meeting BBR-S1
+- **WHEN** `run(project_id="p", apply=False, ...)` is invoked
+- **THEN** `httpx.AsyncClient.patch` MUST NOT be called
+- **AND** stdout MUST contain exactly 2 JSON lines, each with `action="skipped"`
+  and a non-empty `reason` field
+
+### Requirement: --apply mode MUST PATCH each target to statusId='done' best-effort
+
+When invoked with `--apply`, the CLI SHALL iterate the target list and call
+`PATCH /api/projects/{project_id}/issues/{issue_id}` with body
+`{"statusId": "done"}` for each. Tags MUST NOT be sent in the PATCH body
+(BKD treats tags as full-replace, omitting the field preserves them). If a
+single PATCH raises an HTTP error, the CLI MUST log a warning to stderr and
+continue with the next target. The CLI exits 0 if at least one PATCH
+succeeded; exits non-zero only if every PATCH attempt failed.
+
+#### Scenario: BBR-S5 apply patches each candidate with statusId-only body
+
+- **GIVEN** 3 candidate issues meeting BBR-S1
+- **WHEN** `run(project_id="p", apply=True, ...)` is invoked and BKD returns
+  HTTP 200 for each PATCH
+- **THEN** `httpx.AsyncClient.patch` MUST be called exactly 3 times
+- **AND** each call MUST target `/api/projects/p/issues/<issue_id>`
+- **AND** each call body MUST be exactly `{"statusId": "done"}` — no `tags` key
+- **AND** stdout MUST contain 3 JSON lines with `action="patched"`
+
+#### Scenario: BBR-S6 partial PATCH failures continue and exit zero
+
+- **GIVEN** 3 candidate issues; the second PATCH returns HTTP 503 while the
+  first and third return 200
+- **WHEN** `run(project_id="p", apply=True, ...)` is invoked
+- **THEN** the run MUST attempt 3 PATCH calls (loop does not abort on the 503)
+- **AND** the first and third stdout entries MUST report `action="patched"`
+- **AND** the second stdout entry MUST report `action="failed"` with a non-empty
+  `reason` mentioning the HTTP error
+- **AND** the CLI exit code MUST be 0 (≥1 success)

--- a/openspec/changes/REQ-bkd-cleanup-historical-review-1777222384/tasks.md
+++ b/openspec/changes/REQ-bkd-cleanup-historical-review-1777222384/tasks.md
@@ -1,0 +1,24 @@
+# tasks: REQ-bkd-cleanup-historical-review-1777222384
+
+## Stage: spec
+- [x] 写 proposal.md（动机 / 方案 / 取舍 / 影响面）
+- [x] 写 specs/bkd-status-backfill/contract.spec.yaml（black-box 契约）
+- [x] 写 specs/bkd-status-backfill/spec.md（ADDED Requirements + Scenarios BBR-S1..S6）
+
+## Stage: implementation
+- [x] orchestrator/src/orchestrator/maintenance/__init__.py 占位 package
+- [x] orchestrator/src/orchestrator/maintenance/backfill_bkd_review_stuck.py 主体（is_safe_target / select_targets / run / main）
+- [x] 走 httpx 直连 BKD REST（不依赖 settings / DI），最小依赖
+
+## Stage: tests
+- [x] orchestrator/tests/test_backfill_bkd_review_stuck.py 新文件，覆盖 BBR-S1..S6
+- [x] 跑 `make ci-unit-test`（新 test 全过 + 不破坏现有套件）
+- [x] 跑 `make ci-lint`（ruff 全过）
+
+## Stage: backfill 实跑
+- [x] `--dry-run` 列出 candidates 落 PR description（46 条，分布 40 verifier / 3 fixer / 2 analyze / 1 challenger）
+- [ ] `--apply` 实跑（**等 user 显式授权后跑**，本次 sandbox 拦了 mass-write；script 已就绪，跑法在 PR description）
+
+## Stage: PR
+- [x] git push origin feat/REQ-bkd-cleanup-historical-review-1777222384
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/maintenance/__init__.py
+++ b/orchestrator/src/orchestrator/maintenance/__init__.py
@@ -1,0 +1,5 @@
+"""一次性运维 CLI 集合（不在 sisyphus 主进程的热路径上）。
+
+每个模块独立可跑：`python -m orchestrator.maintenance.<name>`，依赖最小，
+不拉 settings / db pool / engine。失败 / 不再用了直接删，没人会引。
+"""

--- a/orchestrator/src/orchestrator/maintenance/backfill_bkd_review_stuck.py
+++ b/orchestrator/src/orchestrator/maintenance/backfill_bkd_review_stuck.py
@@ -1,0 +1,241 @@
+"""一次性 backfill：把卡在 BKD `statusId='review'` 的 sub-agent issue 推到 'done'。
+
+REQ: REQ-bkd-cleanup-historical-review-1777222384
+Spec: openspec/changes/REQ-bkd-cleanup-historical-review-1777222384/specs/bkd-status-backfill/
+
+跑法（dry-run 默认）：
+
+    cd orchestrator
+    uv run python -m orchestrator.maintenance.backfill_bkd_review_stuck \\
+        --project nnvxh8wj --bkd-base-url http://localhost:3000
+
+加 --apply 才真发 PATCH。
+
+stdout 是 machine-readable JSON lines（每条候选一行），stderr 是人读 log。
+operator 可 `2>/dev/null | jq -s .` 收 audit。
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any
+
+import httpx
+
+# 业务能识别的 sub-agent role tag（intake 不在此列：intake 跑在 user 创的 intent
+# issue 上，那条 issue 的 statusId 反映用户意图，不该被本脚本动）
+_ROLE_TAGS = frozenset(
+    {"verifier", "fixer", "analyze", "challenger", "accept-agent", "done-archive"}
+)
+
+
+def _first_role_tag(tags: list[str]) -> str | None:
+    """返回 issue 上第一个 _ROLE_TAGS 命中；都没命中返 None。"""
+    for t in tags or []:
+        if t in _ROLE_TAGS:
+            return t
+    return None
+
+
+def _has_req_tag(tags: list[str]) -> bool:
+    return any((t or "").startswith("REQ-") for t in tags or [])
+
+
+def _extract_req_tag(tags: list[str]) -> str | None:
+    for t in tags or []:
+        if (t or "").startswith("REQ-"):
+            return t
+    return None
+
+
+def is_safe_target(issue: dict[str, Any]) -> tuple[bool, str]:
+    """单条 issue 决策：能不能 PATCH 到 done。
+
+    返回 (selected, decision_reason)。selected=False 时 reason 说明被跳的原因；
+    selected=True 时 reason 写 role/session 用作 audit。
+    """
+    if issue.get("statusId") != "review":
+        return False, "not-review"
+    if issue.get("sessionStatus") == "running":
+        return False, "session-running"
+    role = _first_role_tag(issue.get("tags") or [])
+    if role is None:
+        return False, "no-role-tag"
+    if not _has_req_tag(issue.get("tags") or []):
+        return False, "no-req-tag"
+    return True, f"role={role};session={issue.get('sessionStatus') or '-'}"
+
+
+def select_targets(
+    issues: list[dict[str, Any]],
+) -> list[tuple[dict[str, Any], str]]:
+    """对全 issue 列表过滤；返回 [(issue, reason)] 仅含 selected=True 的项。"""
+    out: list[tuple[dict[str, Any], str]] = []
+    for it in issues:
+        ok, reason = is_safe_target(it)
+        if ok:
+            out.append((it, reason))
+    return out
+
+
+def _audit_line(
+    *,
+    issue: dict[str, Any],
+    action: str,
+    reason: str,
+) -> dict[str, Any]:
+    """单条 stdout JSON line 的 shape（spec contract.spec.yaml 落定）。"""
+    tags = issue.get("tags") or []
+    return {
+        "issue_id": issue.get("id"),
+        "req_id": _extract_req_tag(tags),
+        "role": _first_role_tag(tags),
+        "sessionStatus": issue.get("sessionStatus"),
+        "action": action,
+        "reason": reason,
+    }
+
+
+async def _list_issues(
+    client: httpx.AsyncClient,
+    base_url: str,
+    project_id: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """调 BKD `GET /api/projects/{pid}/issues?limit=N`；返 list of dict。"""
+    url = f"{base_url.rstrip('/')}/api/projects/{project_id}/issues"
+    r = await client.get(url, params={"limit": limit})
+    r.raise_for_status()
+    payload = r.json()
+    # BKD envelope: {success, data: [...]} or {success, data: {items: [...]}}
+    data = payload.get("data") if isinstance(payload, dict) else payload
+    if isinstance(data, dict) and "items" in data:
+        data = data["items"]
+    if not isinstance(data, list):
+        raise RuntimeError(f"unexpected list-issues response shape: {type(data).__name__}")
+    return data
+
+
+async def _patch_status_done(
+    client: httpx.AsyncClient,
+    base_url: str,
+    project_id: str,
+    issue_id: str,
+) -> None:
+    """PATCH 单条 issue statusId='done'；body **不**带 tags（避免 BKD replace 语义抹历史 tag）。"""
+    url = f"{base_url.rstrip('/')}/api/projects/{project_id}/issues/{issue_id}"
+    r = await client.patch(url, json={"statusId": "done"})
+    r.raise_for_status()
+
+
+async def run(
+    *,
+    project_id: str,
+    bkd_base_url: str,
+    apply: bool,
+    limit: int = 2000,
+    out=sys.stdout,
+    err=sys.stderr,
+) -> int:
+    """主流程；返 exit code（0=成功，非 0=全失败）。
+
+    out / err 可注入用于测试。logging 走 stderr（人读），audit 走 stdout（JSON-lines）。
+    """
+    print(
+        f"[backfill] project={project_id} base_url={bkd_base_url} "
+        f"apply={apply} limit={limit}",
+        file=err,
+    )
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            issues = await _list_issues(client, bkd_base_url, project_id, limit)
+        except (httpx.HTTPError, RuntimeError, ValueError) as e:
+            print(f"[backfill] list-issues failed: {e}", file=err)
+            return 2
+
+        targets = select_targets(issues)
+        print(
+            f"[backfill] scanned={len(issues)} candidates={len(targets)}",
+            file=err,
+        )
+
+        if not apply:
+            for it, reason in targets:
+                line = _audit_line(issue=it, action="skipped", reason=reason)
+                print(json.dumps(line, ensure_ascii=False), file=out)
+            return 0
+
+        ok = 0
+        fail = 0
+        for it, reason in targets:
+            issue_id = it.get("id")
+            try:
+                await _patch_status_done(
+                    client, bkd_base_url, project_id, issue_id,
+                )
+            except (httpx.HTTPError, ValueError) as e:
+                fail += 1
+                line = _audit_line(
+                    issue=it,
+                    action="failed",
+                    reason=f"http-error: {e}",
+                )
+                print(json.dumps(line, ensure_ascii=False), file=out)
+                print(
+                    f"[backfill] PATCH {issue_id} failed: {e}",
+                    file=err,
+                )
+                continue
+            ok += 1
+            line = _audit_line(issue=it, action="patched", reason=reason)
+            print(json.dumps(line, ensure_ascii=False), file=out)
+
+        print(f"[backfill] done patched={ok} failed={fail}", file=err)
+        # exit 0 iff at least one success（spec 合约：partial failure 不阻塞 caller）
+        if ok == 0 and fail > 0:
+            return 1
+        return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="backfill_bkd_review_stuck",
+        description="One-shot backfill: PATCH BKD review-stuck sub-issues to statusId=done.",
+    )
+    p.add_argument(
+        "--project",
+        required=True,
+        help="BKD project alias (e.g. nnvxh8wj)",
+    )
+    p.add_argument(
+        "--bkd-base-url",
+        default="http://localhost:3000",
+        help="BKD REST base URL",
+    )
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually PATCH (default: dry-run)",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=2000,
+        help="BKD list-issues page size (default 2000, single-shot)",
+    )
+    args = p.parse_args(argv)
+
+    return asyncio.run(
+        run(
+            project_id=args.project,
+            bkd_base_url=args.bkd_base_url,
+            apply=args.apply,
+            limit=args.limit,
+        )
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/orchestrator/tests/test_backfill_bkd_review_stuck.py
+++ b/orchestrator/tests/test_backfill_bkd_review_stuck.py
@@ -1,0 +1,326 @@
+"""单测：orchestrator.maintenance.backfill_bkd_review_stuck
+
+覆盖 spec.md 的 BBR-S1..S6（决策 + dry-run + apply + partial failure）。
+"""
+from __future__ import annotations
+
+import io
+import json
+
+import httpx
+import pytest
+
+from orchestrator.maintenance.backfill_bkd_review_stuck import (
+    is_safe_target,
+    run,
+    select_targets,
+)
+
+
+def _issue(
+    *,
+    id: str = "i1",
+    status: str = "review",
+    tags: list[str] | None = None,
+    session: str = "completed",
+) -> dict:
+    return {
+        "id": id,
+        "statusId": status,
+        "tags": tags if tags is not None else [],
+        "sessionStatus": session,
+    }
+
+
+# ─── BBR-S1 ─────────────────────────────────────────────────────────────────
+
+
+def test_bbr_s1_verifier_review_completed_is_selected():
+    issue = _issue(
+        tags=[
+            "verifier",
+            "REQ-foo-1234",
+            "verify:staging_test",
+            "decision:escalate",
+        ],
+        session="completed",
+    )
+    ok, reason = is_safe_target(issue)
+    assert ok is True
+    assert reason.startswith("role=verifier;session=completed")
+
+    selected = select_targets([issue])
+    assert len(selected) == 1
+    assert selected[0][0]["id"] == "i1"
+
+
+# ─── BBR-S2 ─────────────────────────────────────────────────────────────────
+
+
+def test_bbr_s2_intent_issue_without_role_tag_rejected():
+    issue = _issue(tags=["REQ-foo-1234"], session="completed")
+    ok, reason = is_safe_target(issue)
+    assert ok is False
+    assert reason == "no-role-tag"
+
+
+# ─── BBR-S3 ─────────────────────────────────────────────────────────────────
+
+
+def test_bbr_s3_running_session_rejected():
+    issue = _issue(
+        tags=["fixer", "REQ-foo-1234"],
+        session="running",
+    )
+    ok, reason = is_safe_target(issue)
+    assert ok is False
+    assert reason == "session-running"
+
+
+# ─── BBR-S2 兄弟：no-req-tag ────────────────────────────────────────────────
+
+
+def test_no_req_tag_rejected():
+    """role 有但 REQ-* tag 没 → 跳（防误伤孤儿 issue）。"""
+    issue = _issue(tags=["verifier"], session="completed")
+    ok, reason = is_safe_target(issue)
+    assert ok is False
+    assert reason == "no-req-tag"
+
+
+def test_status_not_review_rejected():
+    issue = _issue(
+        status="working",
+        tags=["verifier", "REQ-x-1"],
+        session="completed",
+    )
+    ok, reason = is_safe_target(issue)
+    assert ok is False
+    assert reason == "not-review"
+
+
+# ─── 通用 fixture：模拟 BKD list 返回 + capture PATCH 调用 ────────────────────
+
+
+class _FakeTransport(httpx.AsyncBaseTransport):
+    """模拟 BKD HTTP server。注入 list 结果 + 每条 PATCH 的预设 status code。"""
+
+    def __init__(
+        self,
+        *,
+        list_issues: list[dict],
+        patch_outcomes: dict[str, int] | None = None,
+    ):
+        self.list_issues = list_issues
+        # patch_outcomes: {issue_id -> status_code}; 默认全 200
+        self.patch_outcomes = patch_outcomes or {}
+        self.patch_calls: list[tuple[str, dict]] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        method = request.method
+        if method == "GET" and path.endswith("/issues"):
+            envelope = {"success": True, "data": self.list_issues}
+            return httpx.Response(200, text=json.dumps(envelope))
+        if method == "PATCH" and "/issues/" in path:
+            issue_id = path.rsplit("/", 1)[-1]
+            body = json.loads(request.content.decode())
+            self.patch_calls.append((issue_id, body))
+            sc = self.patch_outcomes.get(issue_id, 200)
+            envelope = (
+                {"success": True, "data": {"id": issue_id, "statusId": "done"}}
+                if sc < 400
+                else {"success": False, "error": f"HTTP {sc}"}
+            )
+            return httpx.Response(sc, text=json.dumps(envelope))
+        return httpx.Response(
+            404,
+            text=json.dumps({"success": False, "error": f"unexpected {method} {path}"}),
+        )
+
+
+async def _run_with_transport(
+    *,
+    transport: _FakeTransport,
+    apply: bool,
+    monkeypatch,
+) -> tuple[int, str, str]:
+    """跑 run()，把 httpx.AsyncClient 换成走 transport 的 client。返 (exit, stdout, stderr)。"""
+    out = io.StringIO()
+    err = io.StringIO()
+
+    real_client = httpx.AsyncClient
+
+    def _factory(*a, **kw):
+        kw.pop("timeout", None)
+        return real_client(transport=transport)
+
+    monkeypatch.setattr(
+        "orchestrator.maintenance.backfill_bkd_review_stuck.httpx.AsyncClient",
+        _factory,
+    )
+
+    rc = await run(
+        project_id="p",
+        bkd_base_url="http://test",
+        apply=apply,
+        out=out,
+        err=err,
+    )
+    return rc, out.getvalue(), err.getvalue()
+
+
+# ─── BBR-S4 dry-run ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bbr_s4_dry_run_zero_patches(monkeypatch):
+    issues = [
+        _issue(id="a", tags=["verifier", "REQ-x-1"], session="completed"),
+        _issue(id="b", tags=["fixer", "REQ-y-2"], session="failed"),
+    ]
+    t = _FakeTransport(list_issues=issues)
+
+    rc, stdout, _ = await _run_with_transport(
+        transport=t, apply=False, monkeypatch=monkeypatch,
+    )
+    assert rc == 0
+    assert t.patch_calls == []  # 关键：没发任何 PATCH
+
+    lines = [json.loads(line) for line in stdout.strip().splitlines()]
+    assert len(lines) == 2
+    for line in lines:
+        assert line["action"] == "skipped"
+        assert line["reason"]  # 非空
+
+
+# ─── BBR-S5 apply 主路径 ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bbr_s5_apply_patches_each_with_statusid_only(monkeypatch):
+    issues = [
+        _issue(id="a", tags=["verifier", "REQ-x-1"], session="completed"),
+        _issue(id="b", tags=["fixer", "REQ-y-2"], session="failed"),
+        _issue(id="c", tags=["analyze", "REQ-z-3"], session="failed"),
+    ]
+    t = _FakeTransport(list_issues=issues)
+
+    rc, stdout, _ = await _run_with_transport(
+        transport=t, apply=True, monkeypatch=monkeypatch,
+    )
+    assert rc == 0
+    # 三条都被 PATCH 一次
+    assert {iid for iid, _ in t.patch_calls} == {"a", "b", "c"}
+    assert len(t.patch_calls) == 3
+    # body 必须只有 statusId，没有 tags
+    for _, body in t.patch_calls:
+        assert body == {"statusId": "done"}
+        assert "tags" not in body
+
+    lines = [json.loads(line) for line in stdout.strip().splitlines()]
+    assert all(line["action"] == "patched" for line in lines)
+    assert len(lines) == 3
+
+
+# ─── BBR-S6 partial failure ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bbr_s6_partial_failure_continues_exit_zero(monkeypatch):
+    issues = [
+        _issue(id="a", tags=["verifier", "REQ-x-1"], session="completed"),
+        _issue(id="b", tags=["fixer", "REQ-y-2"], session="failed"),  # 故障
+        _issue(id="c", tags=["analyze", "REQ-z-3"], session="failed"),
+    ]
+    t = _FakeTransport(
+        list_issues=issues,
+        patch_outcomes={"b": 503},  # 第二条 503
+    )
+
+    rc, stdout, _ = await _run_with_transport(
+        transport=t, apply=True, monkeypatch=monkeypatch,
+    )
+    # ≥1 成功 → exit 0
+    assert rc == 0
+    # 三次 PATCH 都被尝试（loop 不中断）
+    assert {iid for iid, _ in t.patch_calls} == {"a", "b", "c"}
+
+    lines = [json.loads(line) for line in stdout.strip().splitlines()]
+    by_id = {line["issue_id"]: line for line in lines}
+    assert by_id["a"]["action"] == "patched"
+    assert by_id["c"]["action"] == "patched"
+    assert by_id["b"]["action"] == "failed"
+    assert by_id["b"]["reason"]
+
+
+@pytest.mark.asyncio
+async def test_all_failures_exits_nonzero(monkeypatch):
+    """全部 PATCH 都失败 → exit 1（caller 能感知）"""
+    issues = [
+        _issue(id="a", tags=["verifier", "REQ-x-1"], session="completed"),
+        _issue(id="b", tags=["fixer", "REQ-y-2"], session="failed"),
+    ]
+    t = _FakeTransport(
+        list_issues=issues,
+        patch_outcomes={"a": 503, "b": 503},
+    )
+    rc, _, _ = await _run_with_transport(
+        transport=t, apply=True, monkeypatch=monkeypatch,
+    )
+    assert rc == 1
+
+
+@pytest.mark.asyncio
+async def test_intent_and_running_filtered_in_full_pipeline(monkeypatch):
+    """跨 filter：list 里同时有 intent / running / 合法候选；仅合法候选被 PATCH。"""
+    issues = [
+        _issue(id="intent", tags=["REQ-x-1"], session="completed"),  # no role
+        _issue(id="live",
+               tags=["analyze", "REQ-x-1"], session="running"),  # session running
+        _issue(id="ok",
+               tags=["verifier", "REQ-x-1"], session="completed"),  # 候选
+        _issue(id="orphan", tags=["verifier"], session="completed"),  # no REQ
+        _issue(id="working",
+               status="working", tags=["fixer", "REQ-x-1"],
+               session="completed"),  # 不是 review
+    ]
+    t = _FakeTransport(list_issues=issues)
+    rc, _, _ = await _run_with_transport(
+        transport=t, apply=True, monkeypatch=monkeypatch,
+    )
+    assert rc == 0
+    # 只有 "ok" 被 PATCH
+    assert [iid for iid, _ in t.patch_calls] == ["ok"]
+
+
+@pytest.mark.asyncio
+async def test_list_failure_exits_two(monkeypatch):
+    """list-issues 失败 → exit 2，0 个 PATCH 尝试。"""
+
+    class _Failing(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                503, text=json.dumps({"success": False, "error": "down"}),
+            )
+
+    real_client = httpx.AsyncClient
+
+    def _factory(*a, **kw):
+        kw.pop("timeout", None)
+        return real_client(transport=_Failing())
+
+    monkeypatch.setattr(
+        "orchestrator.maintenance.backfill_bkd_review_stuck.httpx.AsyncClient",
+        _factory,
+    )
+    out, err = io.StringIO(), io.StringIO()
+    rc = await run(
+        project_id="p",
+        bkd_base_url="http://test",
+        apply=True,
+        out=out,
+        err=err,
+    )
+    assert rc == 2
+    assert out.getvalue() == ""  # 没有 audit line 输出

--- a/orchestrator/tests/test_contract_bkd_status_backfill_challenger.py
+++ b/orchestrator/tests/test_contract_bkd_status_backfill_challenger.py
@@ -1,0 +1,315 @@
+"""Challenger contract tests for REQ-bkd-cleanup-historical-review-1777222384.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-bkd-cleanup-historical-review-1777222384/specs/bkd-status-backfill/spec.md
+
+Run the CLI as a subprocess against a local embedded HTTP server (no internal
+imports, no monkeypatching) — testing only externally observable behaviour.
+
+Scenarios:
+  BBR-S1  verifier review+completed → selected, stdout action="skipped" with role=verifier reason
+  BBR-S2  intent issue (no role tag) → rejected, NOT in stdout
+  BBR-S3  running session + role tag → rejected, NOT in stdout
+  BBR-S4  dry-run: 0 HTTP PATCHes, exactly 2 JSON lines action="skipped", exit 0
+  BBR-S5  apply: 3 PATCHes with {"statusId":"done"} body only, 3 "patched" lines, exit 0
+  BBR-S6  partial PATCH failure (503): loop continues, "failed" entry, ≥1 success → exit 0
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is truly wrong, escalate to spec_fixer to correct the spec.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from urllib.parse import urlparse
+
+
+# ─── Embedded mock BKD HTTP server ───────────────────────────────────────────
+
+
+class _BKDHandler(BaseHTTPRequestHandler):
+    """Minimal mock: GET /…/issues returns list; PATCH /…/issues/<id> records call."""
+
+    def log_message(self, *_: Any) -> None:
+        pass  # suppress access-log noise on stderr
+
+    def _send_json(self, code: int, body: Any) -> None:
+        payload = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self) -> None:
+        if urlparse(self.path).path.endswith("/issues"):
+            self._send_json(200, {"success": True, "data": self.server.list_issues})  # type: ignore[attr-defined]
+        else:
+            self._send_json(404, {"success": False, "error": "not found"})
+
+    def do_PATCH(self) -> None:
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length)) if length else {}
+        issue_id = urlparse(self.path).path.rsplit("/", 1)[-1]
+        self.server.patch_calls.append((issue_id, body))  # type: ignore[attr-defined]
+        sc = self.server.patch_outcomes.get(issue_id, 200)  # type: ignore[attr-defined]
+        if sc >= 400:
+            self._send_json(sc, {"success": False, "error": f"HTTP {sc}"})
+        else:
+            self._send_json(200, {"success": True, "data": {"id": issue_id, "statusId": "done"}})
+
+
+@contextmanager
+def _mock_bkd(
+    list_issues: list[dict],
+    patch_outcomes: dict[str, int] | None = None,
+):
+    """Spin up a mock BKD HTTP server; yield (server, base_url); shut down on exit."""
+    server = HTTPServer(("127.0.0.1", 0), _BKDHandler)
+    server.list_issues = list_issues  # type: ignore[attr-defined]
+    server.patch_outcomes = patch_outcomes or {}  # type: ignore[attr-defined]
+    server.patch_calls: list[tuple[str, dict]] = []  # type: ignore[attr-defined]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    host, port = server.server_address
+    try:
+        yield server, f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+
+
+def _run_cli(
+    base_url: str,
+    *,
+    apply: bool = False,
+) -> tuple[int, list[dict], str]:
+    """Run CLI as subprocess; return (exit_code, parsed_stdout_json_lines, stderr)."""
+    cmd = [
+        sys.executable, "-m",
+        "orchestrator.maintenance.backfill_bkd_review_stuck",
+        "--project", "p",
+        "--bkd-base-url", base_url,
+    ]
+    if apply:
+        cmd.append("--apply")
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=20)
+    lines: list[dict] = []
+    for raw in result.stdout.strip().splitlines():
+        raw = raw.strip()
+        if raw:
+            lines.append(json.loads(raw))
+    return result.returncode, lines, result.stderr
+
+
+def _issue(
+    *,
+    id: str = "i1",
+    status: str = "review",
+    tags: list[str] | None = None,
+    session: str = "completed",
+) -> dict:
+    return {
+        "id": id,
+        "statusId": status,
+        "tags": tags if tags is not None else [],
+        "sessionStatus": session,
+    }
+
+
+# ─── BBR-S1 ──────────────────────────────────────────────────────────────────
+
+
+def test_bbr_s1_verifier_review_completed_selected() -> None:
+    """BBR-S1: verifier issue at review with completed session MUST be selected.
+
+    In dry-run, the issue appears in stdout with action='skipped' and
+    reason starting with 'role=verifier;session=completed'.
+    """
+    issue = _issue(
+        id="v1",
+        tags=["verifier", "REQ-foo-1234", "verify:staging_test", "decision:escalate"],
+        session="completed",
+    )
+    with _mock_bkd([issue]) as (_, url):
+        rc, lines, _ = _run_cli(url, apply=False)
+
+    assert rc == 0
+    assert len(lines) == 1, f"BBR-S1: expected 1 JSON line; got {len(lines)}"
+    entry = lines[0]
+    assert entry.get("action") == "skipped", (
+        f"BBR-S1: dry-run candidate MUST have action='skipped'; got {entry!r}"
+    )
+    reason = entry.get("reason", "")
+    assert reason.startswith("role=verifier;session=completed"), (
+        f"BBR-S1: reason MUST start with 'role=verifier;session=completed'; got {reason!r}"
+    )
+
+
+# ─── BBR-S2 ──────────────────────────────────────────────────────────────────
+
+
+def test_bbr_s2_intent_issue_without_role_tag_rejected() -> None:
+    """BBR-S2: issue with no role tag MUST NOT appear in stdout output.
+
+    The CLI protects user-created intent issues from being silently archived.
+    """
+    intent = _issue(id="intent1", tags=["REQ-foo-1234"], session="completed")
+    with _mock_bkd([intent]) as (server, url):
+        rc, lines, _ = _run_cli(url, apply=False)
+        patch_calls = list(server.patch_calls)
+
+    assert rc == 0
+    assert patch_calls == [], "BBR-S2: no PATCHes for rejected issue"
+    issue_ids_in_output = [ln["issue_id"] for ln in lines if "issue_id" in ln]
+    assert "intent1" not in issue_ids_in_output, (
+        "BBR-S2: intent issue without role tag MUST NOT appear in stdout"
+    )
+
+
+# ─── BBR-S3 ──────────────────────────────────────────────────────────────────
+
+
+def test_bbr_s3_running_session_rejected_even_with_role_tag() -> None:
+    """BBR-S3: sessionStatus='running' MUST prevent selection even when role tag present.
+
+    Live sessions MUST NOT be patched to 'done'.
+    """
+    live = _issue(id="live1", tags=["fixer", "REQ-foo-1234"], session="running")
+    with _mock_bkd([live]) as (server, url):
+        rc, lines, _ = _run_cli(url, apply=False)
+        patch_calls = list(server.patch_calls)
+
+    assert rc == 0
+    assert patch_calls == [], "BBR-S3: no PATCHes for running session"
+    issue_ids_in_output = [ln["issue_id"] for ln in lines if "issue_id" in ln]
+    assert "live1" not in issue_ids_in_output, (
+        "BBR-S3: running session issue MUST NOT appear in stdout"
+    )
+
+
+# ─── BBR-S4 ──────────────────────────────────────────────────────────────────
+
+
+def test_bbr_s4_dry_run_zero_patches_two_skipped_lines() -> None:
+    """BBR-S4: without --apply, CLI MUST make zero HTTP PATCHes.
+
+    stdout MUST contain exactly 2 JSON lines, each with action='skipped' and
+    a non-empty reason. Exit code MUST be 0.
+    """
+    issues = [
+        _issue(id="a", tags=["verifier", "REQ-x-1"], session="completed"),
+        _issue(id="b", tags=["fixer", "REQ-y-2"], session="failed"),
+    ]
+    with _mock_bkd(issues) as (server, url):
+        rc, lines, _ = _run_cli(url, apply=False)
+        patch_calls = list(server.patch_calls)
+
+    assert rc == 0
+    assert patch_calls == [], (
+        f"BBR-S4: dry-run MUST make zero HTTP PATCH calls; got {patch_calls!r}"
+    )
+    assert len(lines) == 2, (
+        f"BBR-S4: dry-run MUST emit exactly 2 JSON lines for 2 candidates; got {len(lines)}"
+    )
+    for line in lines:
+        assert line.get("action") == "skipped", (
+            f"BBR-S4: every dry-run line MUST have action='skipped'; got {line!r}"
+        )
+        assert line.get("reason"), (
+            f"BBR-S4: reason MUST be non-empty; got {line!r}"
+        )
+
+
+# ─── BBR-S5 ──────────────────────────────────────────────────────────────────
+
+
+def test_bbr_s5_apply_patches_each_candidate_with_statusid_only_body() -> None:
+    """BBR-S5: --apply MUST PATCH each candidate exactly once with {"statusId":"done"}.
+
+    Contract:
+    - exactly 3 HTTP PATCH calls, one per candidate
+    - each call body is {"statusId": "done"} — tags key MUST be absent
+    - stdout has 3 lines with action="patched"
+    - exit 0
+    """
+    issues = [
+        _issue(id="a", tags=["verifier", "REQ-x-1"], session="completed"),
+        _issue(id="b", tags=["fixer", "REQ-y-2"], session="failed"),
+        _issue(id="c", tags=["analyze", "REQ-z-3"], session="failed"),
+    ]
+    with _mock_bkd(issues) as (server, url):
+        rc, lines, _ = _run_cli(url, apply=True)
+        patch_calls = list(server.patch_calls)
+
+    assert rc == 0
+    assert len(patch_calls) == 3, (
+        f"BBR-S5: MUST make exactly 3 PATCH calls; got {len(patch_calls)}"
+    )
+    patched_ids = {iid for iid, _ in patch_calls}
+    assert patched_ids == {"a", "b", "c"}, (
+        f"BBR-S5: MUST patch all 3 candidate IDs; got {patched_ids!r}"
+    )
+    for iid, body in patch_calls:
+        assert body == {"statusId": "done"}, (
+            f"BBR-S5: PATCH body for {iid!r} MUST be exactly "
+            f'{{"statusId": "done"}}; got {body!r}'
+        )
+        assert "tags" not in body, (
+            f"BBR-S5: PATCH body MUST NOT include 'tags' key "
+            f"(full-replace semantics would wipe audit tags); got {body!r}"
+        )
+    assert len(lines) == 3, (
+        f"BBR-S5: stdout MUST have 3 JSON lines; got {len(lines)}"
+    )
+    for line in lines:
+        assert line.get("action") == "patched", (
+            f"BBR-S5: apply entries MUST have action='patched'; got {line!r}"
+        )
+
+
+# ─── BBR-S6 ──────────────────────────────────────────────────────────────────
+
+
+def test_bbr_s6_partial_patch_failure_continues_and_exits_zero() -> None:
+    """BBR-S6: a single PATCH returning 503 MUST NOT abort the loop; exit 0 if ≥1 success.
+
+    Contract:
+    - 3 PATCH attempts regardless of mid-loop failure
+    - first + third stdout entries have action="patched"
+    - second entry has action="failed" with non-empty reason
+    - exit code 0 (at least one succeeded)
+    """
+    issues = [
+        _issue(id="a", tags=["verifier", "REQ-x-1"], session="completed"),
+        _issue(id="b", tags=["fixer", "REQ-y-2"], session="failed"),   # will 503
+        _issue(id="c", tags=["analyze", "REQ-z-3"], session="failed"),
+    ]
+    with _mock_bkd(issues, patch_outcomes={"b": 503}) as (server, url):
+        rc, lines, _ = _run_cli(url, apply=True)
+        patch_calls = list(server.patch_calls)
+
+    assert rc == 0, (
+        f"BBR-S6: exit code MUST be 0 when ≥1 PATCH succeeded; got {rc}"
+    )
+    assert len(patch_calls) == 3, (
+        f"BBR-S6: MUST attempt all 3 PATCHes even after mid-loop 503; got {len(patch_calls)}"
+    )
+    by_id = {line["issue_id"]: line for line in lines}
+    assert by_id.get("a", {}).get("action") == "patched", (
+        f"BBR-S6: first issue MUST be patched; got {by_id.get('a')!r}"
+    )
+    assert by_id.get("c", {}).get("action") == "patched", (
+        f"BBR-S6: third issue MUST be patched; got {by_id.get('c')!r}"
+    )
+    b_entry = by_id.get("b", {})
+    assert b_entry.get("action") == "failed", (
+        f"BBR-S6: second issue (503) MUST report action='failed'; got {b_entry!r}"
+    )
+    assert b_entry.get("reason"), (
+        f"BBR-S6: failed entry MUST have non-empty reason (mention HTTP error); got {b_entry!r}"
+    )

--- a/orchestrator/tests/test_contract_bkd_status_backfill_challenger.py
+++ b/orchestrator/tests/test_contract_bkd_status_backfill_challenger.py
@@ -28,7 +28,6 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
 from urllib.parse import urlparse
 
-
 # ─── Embedded mock BKD HTTP server ───────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- One-shot maintenance CLI `python -m orchestrator.maintenance.backfill_bkd_review_stuck` that PATCHes BKD sub-agent issues stuck at `statusId='review'` to `statusId='done'`. Default is dry-run; `--apply` flips to write mode.
- Decision filter is conservative: only role-tagged issues (`verifier`/`fixer`/`analyze`/`challenger`/`accept-agent`/`done-archive`) with `sessionStatus != 'running'` AND a `REQ-*` tag are touched. Intent issues (no role tag) are protected.
- Patches only `{\"statusId\": \"done\"}` — tags are not sent (BKD replaces tag arrays on PATCH; omitting preserves audit trail of REQ-* / role / `decision:*` tags).
- Spec: \`openspec/changes/REQ-bkd-cleanup-historical-review-1777222384/\`, BBR-S1..S6 scenarios.

## Why

BKD project \`nnvxh8wj\` 看板 review 列被 46 条历史 sub-agent issue 堆满，全部是已经
session 终态的 verifier / fixer / analyze / challenger，母 REQ 大都已 DONE / archived。
原因：

1. \`webhook.py:233\` 只在 \`session.completed\` 推 statusId，\`session.failed\` 不推 →
   fixer/analyze/challenger 失败的 issue 永远停在 review。
2. verifier-escalate 路径**故意**把 statusId 推到 review，让 user 能 follow-up；
   但当 REQ 后续被 admin/complete 或 pr-merged-override 终态后，原 verifier issue
   没人反向收。

清理走一次性 CLI，不改 webhook hot-path（session.failed 是否该 auto-done 是另一个
设计议题，超出本 REQ 范围）。

## Dry-run output (current state)

\`\`\`
[backfill] project=nnvxh8wj base_url=http://localhost:3000 apply=False limit=2000
[backfill] scanned=260 candidates=46
\`\`\`

候选分布（角色 × sessionStatus）：

| role       | sessionStatus | count |
|------------|---------------|------:|
| verifier   | completed     |  40 |
| fixer      | failed        |   3 |
| analyze    | failed        |   2 |
| challenger | failed        |   1 |
| **total**  |               |  **46** |

候选 issue 全列表（dry-run 输出）保存在 PR diff 之外的 evidence；每条 JSON-line 形如：

\`\`\`json
{\"issue_id\":\"7tqwa6jv\",\"req_id\":\"REQ-archive-state-cleanup-1777195098\",\"role\":\"verifier\",\"sessionStatus\":\"completed\",\"action\":\"skipped\",\"reason\":\"role=verifier;session=completed\"}
\`\`\`

## How to run --apply (post-merge or with operator approval)

本次 sandbox 拦了 \`--apply\` 调用（mass-write to shared system 需 user 显式授权）。
script 已 ready，跑法：

\`\`\`bash
cd orchestrator
uv run python -m orchestrator.maintenance.backfill_bkd_review_stuck \\
  --project nnvxh8wj \\
  --bkd-base-url http://localhost:3000 \\
  --apply 2>&1 1>backfill-audit.jsonl
\`\`\`

收完 \`backfill-audit.jsonl\` 后 \`jq -s 'group_by(.action) | map({action: .[0].action, count: length})' backfill-audit.jsonl\` 看分布；预期 patched=46 / failed=0。

## Test plan

- [x] \`make ci-unit-test\` — 905 / 905 passed (含本 PR 新加 11 条 BBR-S1..S6)
- [x] \`make ci-lint\` — ruff All checks passed
- [x] \`openspec validate REQ-bkd-cleanup-historical-review-1777222384\` — Change is valid
- [x] \`./scripts/check-scenario-refs.sh --specs-search-path . .\` — OK 283 scenarios
- [x] dry-run vs live BKD localhost:3000 — 46 candidates, 0 false positives, 0 intent / running issues touched
- [ ] **operator follow-up**: run with \`--apply\` after PR merge

## Out of scope

- 不改 \`webhook.py\` 的 session.failed 行为（hot-path orthogonal concern）
- 不动 sisyphus state machine / req_state rows / history / context
- 不删 BKD issue（仅 PATCH statusId）
- 不写 admin REST endpoint（一次性脚本不值得加常驻路径）

🤖 Generated with [Claude Code](https://claude.com/claude-code)