### PR TITLE
audit: ttpos biz PR landability — server-go#217 + arch-lab#10 [REQ-ttpos-biz-pr-landability-1777247423]

### DIFF
--- a/openspec/changes/REQ-ttpos-biz-pr-landability-1777247423/audit-report.md
+++ b/openspec/changes/REQ-ttpos-biz-pr-landability-1777247423/audit-report.md
@@ -1,0 +1,355 @@
+# Audit Report — landability of `ttpos-server-go#217` + `ttpos-arch-lab#10`
+
+> Read-only audit. PASS / BLOCKED / RISK per scenario in
+> `specs/pr-landability-audit/spec.md`. No business-repo changes filed
+> here; fixes deferred to follow-up REQs.
+
+Audit timestamp: **2026-04-26 23:50 UTC** (sisyphus runner pod
+`runner-req-ttpos-biz-pr-landability-1777247423`).
+
+## 0. PR-at-a-glance
+
+| | `ttpos-server-go#217` | `ttpos-arch-lab#10` |
+|---|---|---|
+| Title | `feat(ci): accept-env-up/down via helm chart [REQ-server-go-accept-env-helm-1777200858]` | `feat(accept-lab): helm chart for ttpos-server-go lab` |
+| REQ tag | `REQ-server-go-accept-env-helm-1777200858` | `REQ-arch-lab-helm-chart-1777200858` |
+| Author | `phona` | `phona` |
+| Head | `feat/REQ-server-go-accept-env-helm-1777200858` | `feat/REQ-arch-lab-helm-chart-1777200858` |
+| Base | `release` | `main` |
+| Repo default branch | `release` ✓ | `main` ✓ |
+| Diff | `+935 / -2`, 22 files, 2 commits | `+2831 / -0`, 35 files, 41 commits ahead of `main` (3 from this REQ + 38 from in-flight `seed-json` etc. that haven't reached `main`) |
+| `mergeStateStatus` (GH) | `UNSTABLE` | `CLEAN` |
+| `mergeable` (GH) | `MERGEABLE` | `MERGEABLE` |
+| Status checks | 3 failing + 6 skipped (all reject-before-start) | **0 checks** (repo has no `.github/workflows/`) |
+| Predecessor PR | `#214` (Makefile-via-arch-lab approach) — **CLOSED unmerged** 2026-04-26 11:45 UTC | `#9` (cookbook skeleton) — **CLOSED unmerged** 2026-04-26 11:51 UTC |
+| `sisyphus` GitHub label | not visible on PR | not visible on PR |
+
+## 1. Per-PR findings — `ZonEaseTech/ttpos-server-go#217`
+
+### LAND-S1 — branch tracks REQ tag · **PASS**
+
+`feat/REQ-server-go-accept-env-helm-1777200858` matches
+`feat/<REQ-id>` exactly. REQ tag in title `[REQ-...]`.
+
+### LAND-S2 — base aligns with repo default · **PASS**
+
+`base = release`. `gh repo view ZonEaseTech/ttpos-server-go` confirms
+`defaultBranchRef = release` (the repo's release-track convention; not
+`main`).
+
+### LAND-S3 — PR has actionable CI signal · **BLOCKED**
+
+The 3 "failing" checks (`Check Skip`, `claude-review`, `dispatch`) are
+**all platform-rejected, not code-failed**. Annotation on each:
+
+```
+The job was not started because recent account payments have failed or
+your spending limit needs to be increased. Please check the
+'Billing & plans' section in your settings
+```
+
+The 6 downstream jobs (`Lint`, `Main Unit Tests`, `BMP Unit Tests`,
+`Main Integration Tests`, `BMP Integration Tests`, `SonarQube
+Analysis`) all show `SKIPPED` because they were gated on
+`Check Skip`'s rollup.
+
+**Net result: zero real CI signal on this PR.** The author's PR body
+test plan asserts `openspec validate --strict`, `helm lint`,
+`helm template`, `go vet`, `go test -run TestSGOH` all pass in the
+sisyphus runner pod, but none of those are visible on
+`statusCheckRollup` — they only count as "ran in the runner pod, took
+the author's word for it."
+
+**Blocker class: organisation-level GitHub Actions billing.** No code
+fix on this PR will move it. Owner: `ZonEaseTech` org admin.
+
+### LAND-S4 — Makefile contract targets present · **PASS**
+
+Branch HEAD ships `ttpos-scripts/accept-env.mk` (included from
+`Makefile`) defining `.PHONY: accept-env-up accept-env-down`. Existing
+`ttpos-scripts/lint-ci-test.mk` (touched +9/-2) keeps `ci-lint`,
+`ci-unit-test`, `ci-integration-test` intact (per
+`REQ-audit-business-repo-makefile-1777125538` baseline).
+
+### LAND-S5 — openspec change is structurally valid · **PASS** (asserted)
+
+Branch ships `openspec/{config.yaml, project.md, AGENTS.md, specs/.gitkeep}`
+(this is the repo's openspec init — was not present before) and
+`openspec/changes/REQ-server-go-accept-env-helm-1777200858/` with
+`proposal.md`, `design.md`, `tasks.md`, plus
+`specs/accept-env-helm/{contract.spec.yaml, spec.md}` covering 4
+scenarios `SGOH-S1..S4`. Author asserts
+`openspec validate --strict REQ-server-go-accept-env-helm-1777200858`
+passes (openspec 1.3.1 in runner pod).
+
+> Audit did not re-run `openspec validate` against the PR branch
+> because that is `sisyphus spec_lint`'s job — flagged here as
+> "trust-but-verify; spec_lint will independently confirm."
+
+### LAND-S6 — no semantic conflict with sibling / predecessor PRs · **RISK**
+
+- **Predecessor `#214` (REQ-server-go-accept-env-makefile-1777195860)
+  closed unmerged.** PR #217 properly retires it. ✓
+- **Sibling `ttpos-arch-lab#10` ships a competing `accept-env-up`
+  implementation** (`charts/accept-lab` in arch-lab repo, with MySQL +
+  lab service). PR #217's own body is explicit on the architectural
+  choice: "*A self-contained helm chart shipped inside this repo
+  removes that coupling. The producer repo now owns both halves of the
+  contract... no `$(MAKE) -C` indirection*."
+- **Resolver-flip `REQ-flip-integration-resolver-source-1777195860`**
+  has shipped (changes dir present in `phona/sisyphus`):
+  `_integration_resolver._decide` now picks the **single source repo**
+  carrying `accept-env-up:` over any explicit
+  `/workspace/integration/<basename>` (per scenarios SDA-S4 / SDA-S10).
+  After PR #217 lands and `ttpos-server-go` enters `involved_repos`,
+  the source-first resolver will pick its `accept-env-up` directly —
+  the arch-lab chart will only matter to non-sisyphus consumers (humans
+  running `make accept-env-up` from arch-lab manually).
+
+PR #217 itself is **landable on this axis** — the conflict points at
+PR #10's relevance, not PR #217's.
+
+### Verdict on `#217`
+
+**LAND when GHA billing on `ZonEaseTech` is restored, modulo human +
+sisyphus mechanical re-check.** No code change required on the PR.
+
+| Check | Status |
+|---|---|
+| LAND-S1 branch tracks REQ tag | PASS |
+| LAND-S2 base = repo default | PASS |
+| LAND-S3 PR has CI signal | **BLOCKED — GHA billing** |
+| LAND-S4 Makefile contract | PASS |
+| LAND-S5 openspec validity | PASS (asserted) |
+| LAND-S6 no semantic conflict | RISK (orphans `#10`, see §3) |
+
+## 2. Per-PR findings — `ZonEaseTech/ttpos-arch-lab#10`
+
+### LAND-S1 — branch tracks REQ tag · **PASS**
+
+`feat/REQ-arch-lab-helm-chart-1777200858`. REQ tag in title implicit
+via the body `REQ:` line; not in title-string. Minor — lint-pass.
+
+### LAND-S2 — base aligns with repo default · **PASS**
+
+`base = main`, `defaultBranchRef = main`.
+
+### LAND-S3 — PR has actionable CI signal · **BLOCKED**
+
+`statusCheckRollup` is **empty**. `gh api
+repos/ZonEaseTech/ttpos-arch-lab/contents/.github/workflows` returns
+HTTP 404 on **both** the PR branch and `main` — the repo has no
+`.github/` directory at all. No workflow ran on this PR; nothing
+gates merge other than `mergeStateStatus = CLEAN` (which only means
+"no merge conflicts").
+
+The author's test plan asserts `helm lint`,
+`helm template` (4 variants), `openspec validate --strict`,
+`check-scenario-refs.sh`, and `make accept-env-up` skeleton mode all
+pass — again, none of these are visible to GitHub. Pure
+runner-pod-runs-on-trust.
+
+**Blocker class: missing GHA workflows in repo.** Distinct from
+`#217`'s billing blocker — this is "no CI configured at all." Owner:
+the arch-lab repo maintainer (or a follow-up REQ that ports the
+sisyphus contract targets into a workflow).
+
+### LAND-S4 — Makefile contract targets present · **PASS**
+
+Verified by reading `Makefile` on
+`origin/feat/REQ-arch-lab-helm-chart-1777200858`:
+
+```make
+.PHONY: ci-lint ci-unit-test ci-integration-test accept-env-up accept-env-down
+
+ci-lint:                 # shellcheck + helm lint charts/accept-lab (skip if missing)
+ci-unit-test:            # helm template charts/accept-lab × 2 profiles
+ci-integration-test:     # bash tests/integration/accept_lab_contract_test.sh
+accept-env-up:           # bash accept-env/env-up.sh
+accept-env-down:         # bash accept-env/env-down.sh
+```
+
+All five sisyphus contract targets present and consistent with
+`docs/integration-contracts.md` §2. Tools-missing-tolerated style
+(`command -v helm >/dev/null && ...`) matches
+`REQ-audit-business-repo-makefile-1777125538` recommendations.
+
+### LAND-S5 — openspec change is structurally valid · **PASS** (asserted)
+
+Ships
+`openspec/changes/REQ-arch-lab-helm-chart-1777200858/{design.md,
+proposal.md, tasks.md, specs/accept-lab/{contract.spec.yaml, spec.md}}`
+plus `openspec/AGENTS.md`. Author asserts 12 ADDED Requirements with
+19 scenario defs `ARLAB-S1..S12`,
+`openspec validate --strict` and `check-scenario-refs.sh` both pass.
+
+> Same caveat as LAND-S5 on `#217` — sisyphus `spec_lint` will
+> independently confirm.
+
+### LAND-S6 — no semantic conflict with sibling / predecessor PRs · **RISK**
+
+Two coupled risks:
+
+1. **Predecessor PR #9 (REQ-arch-lab-accept-env-cookbook-1777195098)
+   was closed unmerged 2026-04-26 11:51 UTC** — but PR #10's branch
+   was opened on top of `#9`'s branch and still carries those 3 PR-#9
+   commits in its diff. PR #10's body acknowledges this:
+   "*When PR #9 merges first, GitHub will rebase this PR down to just
+   the helm chart additions.*" That premise is now violated — `#9`
+   never merged.
+
+   Concrete impact: `git log origin/main..origin/feat/...` shows 41
+   commits ahead, of which only 3 are this REQ's work; the other 38
+   are pre-existing in-flight branches (`feat/seed-json`,
+   `fix/qr-h5-payment-redirect`, etc.) that haven't landed on `main`
+   yet. GitHub still reports `mergeStateStatus = CLEAN`, so the PR
+   *will* merge as a fat commit if accepted — but it'll bring along
+   PR-#9's skeleton commit + the seed-json work as collateral.
+
+   **Recommendation: rebase on `origin/main` so the PR diff matches
+   only this REQ's work** (drop the inherited-from-#9 skeleton commit
+   `d7d2108` if it should be subsumed, or land it as a separate PR
+   first). Today, "what does `#10` actually merge?" is non-obvious from
+   reading the PR.
+
+2. **Sibling `ttpos-server-go#217` chooses the source-first
+   `deploy/accept-env/` strategy and explicitly rejects the arch-lab
+   coupling.** Combined with the resolver flip
+   (`REQ-flip-integration-resolver-source-1777195860`), this means the
+   arch-lab `charts/accept-lab` chart will **not be invoked by the
+   sisyphus accept stage** for any REQ where `ttpos-server-go` is the
+   source — the resolver picks `ttpos-server-go`'s in-repo chart and
+   never reaches arch-lab.
+
+   PR #10's body frames the chart as "*sisyphus accept stages have
+   been promising via the accept-env-up/down contract*" — that primary
+   consumer is now gone. The chart can still serve **manual / human
+   `make accept-env-up`** in arch-lab and as a richer
+   server-go + MySQL acceptance lab for separate use cases — but this
+   intent is not stated in the PR.
+
+   **Recommendation: PR #10's author needs to make an explicit call**:
+   either reframe the PR's "why" (manual lab tool, not sisyphus
+   plumbing) or close it as superseded by `#217`. As written, future
+   readers will think the chart is what sisyphus calls when it isn't.
+
+### Verdict on `#10`
+
+**RISK on landing as-is.** Two distinct blockers (no CI in repo +
+broken stacking premise) plus a strategic question (does the chart
+have a real consumer post-resolver-flip). Mergeable per GitHub
+mechanics, but landing without addressing the §3 coupling discussion
+ships a chart whose stated purpose no longer holds.
+
+| Check | Status |
+|---|---|
+| LAND-S1 branch tracks REQ tag | PASS |
+| LAND-S2 base = repo default | PASS |
+| LAND-S3 PR has CI signal | **BLOCKED — repo has no `.github/workflows/`** |
+| LAND-S4 Makefile contract | PASS |
+| LAND-S5 openspec validity | PASS (asserted) |
+| LAND-S6 no semantic conflict | **RISK — broken stacking + post-flip orphan** (see §3) |
+
+## 3. Cross-PR coupling discussion
+
+The two REQs share timestamp suffix `1777200858` — they were created
+as a coordinated pair the same minute. Reading their proposals
+side-by-side:
+
+| | `ttpos-server-go#217` | `ttpos-arch-lab#10` |
+|---|---|---|
+| Where does `accept-env-up` live? | inside `ttpos-server-go/Makefile` | inside `ttpos-arch-lab/Makefile` |
+| Where does the helm chart live? | `ttpos-server-go/deploy/accept-env/` (1 pod + 1 svc, no DB) | `ttpos-arch-lab/charts/accept-lab/` (server + MySQL + lab svc) |
+| `helm upgrade --install` target | `$(SISYPHUS_NAMESPACE)` w/ contract `--set` flags | `$NAMESPACE` w/ marker ConfigMap + GHCR pull secret |
+| Lab shape | minimal — server-go binary on a port | richer — server-go + ephemeral MySQL backing |
+| Coupling to the other repo | **none** (self-contained) | none (chart is self-contained inside arch-lab) |
+
+After the resolver flip, sisyphus' accept stage will pick whichever
+source repo carries `accept-env-up:` (or fall back to integration
+only if no source has it). This means:
+
+- **If only `#217` lands:** sisyphus accept stage runs the
+  server-go-internal chart (no MySQL). Works for any REQ whose
+  acceptance scenarios don't need a DB.
+- **If only `#10` lands:** arch-lab will be picked up only if
+  `ttpos-arch-lab` is added to `involved_repos` and is the sole source
+  with `accept-env-up:`. (As of the audit, `default_involved_repos =
+  [phona/sisyphus]`; arch-lab is not in any default.)
+- **If both land:** when both repos appear in `involved_repos` for a
+  REQ that touches both, the resolver hits scenario SDA-S7 ("multiple
+  sources with `accept-env-up:` and no integration → returns None")
+  and accept stage **cannot resolve**. SDA-S10 only breaks the tie if
+  there's an explicit `/workspace/integration/<basename>` clone, which
+  `sisyphus-clone-repos.sh` never produces.
+
+**That last row is the latent landing-order bug.** Landing both PRs
+without disambiguating leaves any future REQ that touches *both*
+ttpos-server-go and ttpos-arch-lab with an unresolvable accept stage.
+
+## 4. Recommendations
+
+### For `ttpos-server-go#217`
+
+1. **Block on GHA billing.** Org admin restores spending limits /
+   payment method. No code change. Once unblocked, retrigger
+   `Check Skip` workflow on the PR (pushing an empty commit or
+   re-requesting the check); confirm `claude-review` and `dispatch`
+   complete, downstream tests run.
+2. **Optional: explicitly note in the PR body that PR `#214` is
+   superseded.** The body says it does, but adding `Closes #214` (PR
+   #214 is already closed-unmerged, so this is documentation only)
+   removes ambiguity for future readers.
+3. **No spec / chart / test changes recommended.** The PR is
+   structurally clean.
+
+### For `ttpos-arch-lab#10`
+
+1. **Decide intent first.** Either:
+   - **(A) Close the PR** as superseded by `#217` (the architectural
+     direction explicitly chosen on the server-go side), and file a
+     follow-up REQ if a richer-with-MySQL lab is genuinely wanted as
+     a parallel artefact for human use.
+   - **(B) Reframe the PR** to "manual / multi-stack acceptance lab"
+     scope, drop language about sisyphus accept stages, and document
+     when one would invoke `make accept-env-up` from arch-lab manually
+     vs let sisyphus call server-go's.
+2. **If keeping the PR (option B), rebase on `origin/main`.** Currently
+   the diff carries 38 unrelated commits from in-flight branches
+   (`feat/seed-json`, `fix/qr-h5-payment-redirect`) that haven't
+   reached `main`. `git rebase --onto origin/main d7d2108^
+   feat/REQ-arch-lab-helm-chart-1777200858` (or interactive equivalent)
+   to drop the predecessor-PR-#9 skeleton commit and the inherited
+   work. Force-push the cleaned branch.
+3. **Open a follow-up REQ to add minimal CI to the arch-lab repo:**
+   port the sisyphus contract checks (`make ci-lint`,
+   `make ci-unit-test`) into a `.github/workflows/ci.yml` so future
+   PRs don't depend on author-asserted runner-pod runs alone. The
+   sisyphus repo's own `.github/workflows/` is a near-drop-in template.
+4. **Independent of (1)-(3): if both `#217` and `#10` are intended to
+   coexist long-term, file a separate REQ in `phona/sisyphus` to
+   handle SDA-S7** (multiple sources with `accept-env-up:` and no
+   integration). Either deterministic ordering rules, or an explicit
+   `accept_env_repo` field on the REQ, would prevent the latent
+   resolver deadlock.
+
+### For sisyphus repo (this audit)
+
+1. Land this audit report + the `pr-landability-audit` checklist spec.
+2. Future PR-pair landability questions: re-run the six LAND-Sx
+   scenarios mechanically against the new pair.
+
+## 5. Items intentionally not audited
+
+- **Per-line code review** (correctness of helm templates, shell
+  scripts, Go code). Out of scope — that's claude-review +
+  human-review territory, not landability.
+- **Whether the helm charts actually deploy a working stack on K3s.**
+  That's accept-stage's job once the PRs land + sisyphus runs
+  `make accept-env-up` for a real REQ. Audit only checks that the
+  Makefile + chart files exist and pass static lint.
+- **Spec-vs-code drift inside each PR's openspec change.** Authors
+  assert validity; sisyphus `spec_lint` will independently re-run
+  `openspec validate --strict` and `check-scenario-refs.sh` once the
+  PRs go through the pipeline.
+- **Performance / cost of the two lab shapes.** Architectural choice
+  question; not landability.

--- a/openspec/changes/REQ-ttpos-biz-pr-landability-1777247423/proposal.md
+++ b/openspec/changes/REQ-ttpos-biz-pr-landability-1777247423/proposal.md
@@ -1,0 +1,80 @@
+# REQ-ttpos-biz-pr-landability-1777247423: audit(read-only) — landability of `ttpos-server-go#217` + `ttpos-arch-lab#10`
+
+## Why
+
+Two coordinated REQs landed feat branches against the ttpos biz repos in
+parallel late on 2026-04-26:
+
+- `ttpos-server-go#217` — `feat(ci): accept-env-up/down via helm chart
+  [REQ-server-go-accept-env-helm-1777200858]` (base `release`)
+- `ttpos-arch-lab#10` — `feat(accept-lab): helm chart for ttpos-server-go lab
+  [REQ-arch-lab-helm-chart-1777200858]` (base `main`)
+
+Both PRs implement halves of the sisyphus accept-env contract
+(`accept-env-up` / `accept-env-down` + JSON endpoint line on stdout — see
+`docs/integration-contracts.md` §3) and both are sitting "open + ready" by
+their authors' test plans. Before sisyphus' done-archive stage merges them,
+we need an external read of:
+
+- whether each PR is actually mergeable from a CI / reviewer-signal stance
+  (independent of what the PR body claims), and
+- whether the two PRs interact with each other and with the recently-flipped
+  source-first accept-env resolver
+  (`REQ-flip-integration-resolver-source-1777195860`) in a way that makes
+  one of them dead-on-arrival or in conflict.
+
+This REQ is a **read-only audit**. It does not modify the two ttpos biz
+repos and does not ship behavior changes to sisyphus. The only deliverables
+are an audit report + a reusable PR-landability checklist sunk back into
+sisyphus' specs so the next "are these two PRs ready to merge?" question
+can be answered by running the same six checks.
+
+## What Changes
+
+- New capability `pr-landability-audit` with 6 ADDED Requirements
+  (LAND-S1..LAND-S6) covering branch naming, base alignment, CI signal,
+  Makefile contract, openspec validity, and cross-PR conflict — the
+  checklist any future PR-pair audit can follow.
+- New audit deliverable
+  `openspec/changes/REQ-ttpos-biz-pr-landability-1777247423/audit-report.md`
+  applying that checklist to `ttpos-server-go#217` and `ttpos-arch-lab#10`,
+  with PASS / BLOCKED / RISK per scenario and a recommendation per PR.
+- No changes to `ZonEaseTech/ttpos-server-go` or `ZonEaseTech/ttpos-arch-lab`
+  (both PRs stay open as-is — fixes belong in follow-up REQs filed against
+  those repos).
+- No behavioral changes to sisyphus orchestrator code.
+
+## Task nature
+
+**Read-only audit.** Findings and recommendations only. Concrete fixes for
+the blockers identified in `audit-report.md` (e.g. resolving the GitHub
+Actions billing rejection that's failing all checks on `#217`, or the
+"zero `.github/workflows/`" gap on `ttpos-arch-lab`, or the architectural
+overlap between the two `accept-env` chart implementations) are deferred
+to independent follow-up REQs.
+
+## Why a checklist, not a one-shot doc
+
+The pair `(server-go-accept-env-helm, arch-lab-helm-chart)` is the second
+time sisyphus has shipped two coordinated PRs whose `accept-env-up`
+implementations partially overlap (the first being PR #214 ↔ PR #9, both
+now closed-unmerged). The answer "can these two PRs land together?" keeps
+recurring; pinning the criteria as a reusable spec means the next pair
+audit doesn't have to re-derive them.
+
+## Out of scope
+
+- **Resolving the GHA billing-rejection blocker on `ZonEaseTech` org.**
+  That's an org-level admin task, not a REQ-level deliverable. The audit
+  flags it; a human or a follow-up REQ owns the fix.
+- **Closing or rebasing the two PRs themselves.** This audit produces
+  recommendations; the actual close / rebase / re-push decisions are made
+  by whoever owns each repo.
+- **Bringing CI online in `ttpos-arch-lab`.** The repo currently has zero
+  `.github/workflows/` and PR #10 inherits that gap. A separate REQ should
+  port the sisyphus contract checks (`make ci-lint` etc.) into a workflow.
+- **Choosing the "winning" `accept-env` implementation.** PR #217's
+  self-contained `deploy/accept-env/` chart and PR #10's external
+  `charts/accept-lab` represent two architectural strategies; the audit
+  surfaces the conflict and the resolver-flip impact, but the
+  pick-one-and-deprecate-the-other call needs a human or a design REQ.

--- a/openspec/changes/REQ-ttpos-biz-pr-landability-1777247423/specs/pr-landability-audit/spec.md
+++ b/openspec/changes/REQ-ttpos-biz-pr-landability-1777247423/specs/pr-landability-audit/spec.md
@@ -1,0 +1,132 @@
+# PR Landability Audit Checklist
+
+## ADDED Requirements
+
+### Requirement: PR head branch tracks its REQ tag
+
+The audit SHALL verify that every audited PR's head branch name matches
+the pattern `feat/<REQ-id>` and that the same `<REQ-id>` appears either
+in the PR title or in a `REQ:` line in the PR body. The audit MUST mark
+LAND-S1 as PASS when both conditions hold and as RISK when either is
+missing or mismatched.
+
+#### Scenario: LAND-S1 — branch name and REQ tag align
+- **GIVEN** an audited PR with head ref `feat/REQ-foo-1234`
+- **AND** PR title or body containing the literal string `REQ-foo-1234`
+- **WHEN** the audit applies the LAND-S1 check
+- **THEN** the result for that PR's LAND-S1 cell SHALL be `PASS`
+
+### Requirement: PR base branch is the repo's actual default
+
+The audit SHALL fetch the target repo's default branch via
+`gh repo view <owner>/<repo> --json defaultBranchRef` and compare it
+to the audited PR's `baseRefName`. The audit MUST mark LAND-S2 as PASS
+when they match exactly and as RISK when the PR is targeting a
+non-default branch (e.g. `develop`, a release-train branch, or a stale
+fork) without an explicit justification in the PR body.
+
+#### Scenario: LAND-S2 — base equals defaultBranchRef
+- **GIVEN** a repo whose `defaultBranchRef.name` is `release`
+- **AND** an audited PR with `baseRefName = release`
+- **WHEN** the audit applies the LAND-S2 check
+- **THEN** the result for that PR's LAND-S2 cell SHALL be `PASS`
+
+### Requirement: PR has actionable CI signal
+
+The audit SHALL fetch `statusCheckRollup` for every audited PR and
+inspect every entry whose `conclusion` is `failure`. For each failing
+check the audit MUST also fetch `check-runs/<id>/annotations` and
+classify the failure as one of `code-failed` (the workflow ran and a
+real assertion failed), `platform-rejected` (the workflow never started
+because of GHA billing, quota, permissions, or other org-level
+infrastructure), or `infra-flake` (the workflow started but exited on
+a non-deterministic infrastructure issue). The audit MUST mark LAND-S3
+as BLOCKED when any failure is `platform-rejected` or when the rollup
+is empty because the repo has no `.github/workflows/`, and as RISK
+when the only failures are `infra-flake`. The audit SHALL never count
+author-asserted "ran in the runner pod, passed" claims as CI signal —
+those belong to LAND-S5.
+
+#### Scenario: LAND-S3 — billing-rejected check counts as BLOCKED
+- **GIVEN** an audited PR whose `statusCheckRollup` contains a check with `conclusion = failure`
+- **AND** that check's annotation message starts with "The job was not started because recent account payments have failed"
+- **WHEN** the audit applies the LAND-S3 check
+- **THEN** the result for that PR's LAND-S3 cell SHALL be `BLOCKED — GHA billing`
+- **AND** the audit recommendation MUST attribute the fix to an org-admin action, not to the PR author
+
+#### Scenario: LAND-S3 — repo with zero workflows counts as BLOCKED
+- **GIVEN** an audited PR whose `statusCheckRollup` is `[]`
+- **AND** `gh api repos/<owner>/<repo>/contents/.github/workflows` returns HTTP 404 on the PR's head ref
+- **WHEN** the audit applies the LAND-S3 check
+- **THEN** the result for that PR's LAND-S3 cell SHALL be `BLOCKED — repo has no .github/workflows/`
+- **AND** the audit recommendation MUST propose a follow-up REQ to port the sisyphus contract checks into a workflow
+
+### Requirement: PR's Makefile honors the sisyphus contract targets
+
+The audit SHALL grep the PR's branch `Makefile` (and any included
+fragments like `ttpos-scripts/*.mk`) for `^ci-lint:`, `^ci-unit-test:`,
+and `^ci-integration-test:`. For source repos that the sisyphus
+accept stage will route to (i.e. those that ship `accept-env-up:`),
+the audit MUST additionally verify `^accept-env-up:` and
+`^accept-env-down:` are defined. The audit MUST mark LAND-S4 as PASS
+only when every required target is present; missing targets fail with
+the exact target name surfaced in the report.
+
+#### Scenario: LAND-S4 — all five contract targets present
+- **GIVEN** an audited PR's branch Makefile + included fragments contain all of `ci-lint`, `ci-unit-test`, `ci-integration-test`, `accept-env-up`, `accept-env-down` as `.PHONY` recipes
+- **WHEN** the audit applies the LAND-S4 check
+- **THEN** the result for that PR's LAND-S4 cell SHALL be `PASS`
+
+### Requirement: PR's openspec change is structurally valid
+
+The audit SHALL confirm that the PR ships
+`openspec/changes/<REQ-id>/proposal.md` plus at least one
+`openspec/changes/<REQ-id>/specs/<capability>/spec.md` written in
+delta format (`## ADDED Requirements` / `## MODIFIED Requirements` /
+`## REMOVED Requirements` / `## RENAMED Requirements`) and that every
+`### Requirement:` heading is followed by prose containing `SHALL` or
+`MUST`. The audit MAY defer the actual `openspec validate --strict`
+run to sisyphus `spec_lint` and mark LAND-S5 as PASS-asserted when the
+file structure looks correct on inspection. The audit MUST mark
+LAND-S5 as RISK when any required file is missing or the spec.md
+lacks a delta heading.
+
+#### Scenario: LAND-S5 — delta-format spec with SHALL prose passes assertion
+- **GIVEN** an audited PR's branch contains `openspec/changes/<REQ-id>/specs/<capability>/spec.md`
+- **AND** that file starts with `## ADDED Requirements`
+- **AND** every `### Requirement:` heading is followed (after blank lines, before the first `####`) by prose containing the literal token `SHALL` or `MUST`
+- **WHEN** the audit applies the LAND-S5 check
+- **THEN** the result for that PR's LAND-S5 cell SHALL be `PASS (asserted)`
+- **AND** the audit report MUST flag that sisyphus `spec_lint` will independently confirm via `openspec validate --strict`
+
+### Requirement: PR has no semantic conflict with predecessor or sibling PRs
+
+The audit SHALL identify, for each audited PR, (a) any predecessor PR
+referenced in the body and check whether it is closed-unmerged or
+merged, (b) any sibling PR that ships an overlapping implementation of
+the same contract surface, and (c) any in-flight sisyphus capability
+change (e.g. resolver flips, contract renames) that affects whether
+the PR's deliverable will actually be invoked downstream. The audit
+MUST mark LAND-S6 as PASS only when no overlap or stale-stacking
+condition is present. RISK is recorded when (a) a predecessor PR is
+closed-unmerged but the audited PR's diff still includes commits
+inherited from the predecessor's branch, (b) a sibling PR ships a
+competing implementation without an explicit pick-one decision, or
+(c) a sisyphus resolver / contract change between PR open time and
+audit time has changed which implementation will actually be invoked.
+
+#### Scenario: LAND-S6 — broken stacking on a closed-unmerged predecessor
+- **GIVEN** an audited PR whose body declares "Pairs with PR #N (skeleton); when PR #N merges first, GitHub will rebase this PR down"
+- **AND** PR #N has `state = CLOSED` and `mergedAt = null`
+- **AND** `git log <repo-default>..<PR-head>` shows commits authored on PR #N's branch still present in the audited PR's diff
+- **WHEN** the audit applies the LAND-S6 check
+- **THEN** the result for that PR's LAND-S6 cell SHALL be `RISK`
+- **AND** the audit recommendation MUST propose either rebasing on the repo default to drop the inherited commits, or closing the audited PR as superseded
+
+#### Scenario: LAND-S6 — sibling PR competes for the same contract surface
+- **GIVEN** an audited PR pair `(A, B)` whose REQ-id timestamps match (same coordinated change)
+- **AND** both PRs ship a `make accept-env-up` target backed by helm charts in their respective repos
+- **AND** sisyphus' `_integration_resolver._decide` (post `REQ-flip-integration-resolver-source-1777195860`) prefers source repos and returns None when multiple sources have `accept-env-up:` and no integration tie-breaker
+- **WHEN** the audit applies the LAND-S6 check to both PRs
+- **THEN** both PRs' LAND-S6 cells SHALL be `RISK`
+- **AND** the audit recommendation MUST surface the latent SDA-S7 deadlock and propose either deprecating one implementation or filing a sisyphus follow-up to introduce an explicit tie-breaker

--- a/openspec/changes/REQ-ttpos-biz-pr-landability-1777247423/tasks.md
+++ b/openspec/changes/REQ-ttpos-biz-pr-landability-1777247423/tasks.md
@@ -1,0 +1,32 @@
+# Tasks — REQ-ttpos-biz-pr-landability-1777247423
+
+## Stage: investigate
+
+- [x] Pull `ttpos-server-go#217` metadata, files, statusCheckRollup, annotations
+- [x] Pull `ttpos-arch-lab#10` metadata, files, statusCheckRollup, branch contents
+- [x] Resolve why each failing check on `#217` fails (annotation-level, not log-level)
+- [x] Confirm `ttpos-arch-lab` repo has no `.github/workflows/` (root cause for `#10` having zero checks)
+- [x] Cross-check predecessor PR fates: `ttpos-server-go#214` and `ttpos-arch-lab#9` (both CLOSED unmerged)
+- [x] Confirm sisyphus resolver flip (`REQ-flip-integration-resolver-source-1777195860`) source-first semantics from sibling spec + `_integration_resolver` tests
+- [x] Read `Makefile` on both feat branches to verify sisyphus contract targets present
+- [x] Walk PR #10's `git log origin/main..HEAD` to surface the broken-stacking-on-#9 problem (41 commits ahead, only 3 from this REQ)
+
+## Stage: spec / audit deliverable
+
+- [x] Author `proposal.md` (this REQ's why + scope, read-only stance)
+- [x] Author `specs/pr-landability-audit/spec.md` with 6 ADDED Requirements (LAND-S1..LAND-S6) — reusable PR-pair landability checklist
+- [x] Author `audit-report.md` applying LAND-S1..LAND-S6 to each PR with PASS / BLOCKED / RISK
+- [x] Cross-PR coupling §3 — landing-order resolver-deadlock (SDA-S7) discussion
+- [x] Recommendations §4 — concrete next actions per PR + a sisyphus follow-up
+
+## Stage: PR
+
+- [x] Push `feat/REQ-ttpos-biz-pr-landability-1777247423` to `phona/sisyphus`
+- [x] `gh label create sisyphus --force` + `gh pr create --label sisyphus`
+- [x] PR body links to the two audited PRs + the audit-report.md path
+- [x] Confirm openspec validate --strict on the change (let sisyphus spec_lint re-confirm independently)
+
+## Stage: BKD
+
+- [x] Update BKD issue tags: keep `analyze` + `REQ-ttpos-biz-pr-landability-1777247423`
+- [x] Move BKD issue to `review` status

--- a/orchestrator/tests/test_contract_pr_landability_audit.py
+++ b/orchestrator/tests/test_contract_pr_landability_audit.py
@@ -1,0 +1,464 @@
+"""Contract tests for pr-landability-audit (REQ-ttpos-biz-pr-landability-1777247423).
+
+Black-box challenger — derives from:
+  openspec/changes/REQ-ttpos-biz-pr-landability-1777247423/specs/pr-landability-audit/spec.md
+
+Scenarios covered:
+  LAND-S1  branch name + REQ tag align → PASS when both match
+  LAND-S2  base == defaultBranchRef → PASS when they match
+  LAND-S3a billing-rejected check → BLOCKED — GHA billing
+  LAND-S3b repo with zero workflows → BLOCKED — repo has no .github/workflows/
+  LAND-S4  all five Makefile contract targets present → PASS
+  LAND-S5  delta-format spec with SHALL prose → PASS (asserted)
+  LAND-S6a broken stacking on closed-unmerged predecessor → RISK
+  LAND-S6b sibling PR competes for same contract surface → RISK
+
+Testing strategy:
+  The REQ deliverables are spec.md + audit-report.md (no Python implementation).
+  Tests assert structural and content properties of those artefacts as required
+  by the spec scenarios. Mirrors the pattern in test_contract_observability_dashboard.py.
+
+Dev MUST NOT modify these tests to make them pass — fix the deliverables instead.
+If a test is wrong, escalate to spec_fixer to correct the spec.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+REQ = "REQ-ttpos-biz-pr-landability-1777247423"
+_CHANGES = REPO_ROOT / "openspec" / "changes" / REQ
+SPEC_MD = _CHANGES / "specs" / "pr-landability-audit" / "spec.md"
+AUDIT_REPORT = _CHANGES / "audit-report.md"
+PROPOSAL_MD = _CHANGES / "proposal.md"
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"Required deliverable not found: {path}"
+    assert path.stat().st_size > 0, f"Required deliverable is empty: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+# ── Spec structural invariants ─────────────────────────────────────────────────
+
+
+def test_proposal_md_exists():
+    """proposal.md MUST exist for the REQ."""
+    _read(PROPOSAL_MD)
+
+
+def test_spec_md_exists_and_is_delta_format():
+    """spec.md MUST exist under specs/pr-landability-audit/ and use openspec delta format."""
+    content = _read(SPEC_MD)
+    assert "## ADDED Requirements" in content, (
+        "spec.md MUST start with '## ADDED Requirements' (openspec delta format); "
+        "openspec validate --strict will reject any spec.md missing a delta heading"
+    )
+
+
+def test_spec_md_all_six_scenario_headings_defined():
+    """spec.md MUST define all six LAND-S1..S6 scenarios using the exact heading prefix
+    '#### Scenario: LAND-Sn' as required by check-scenario-refs.sh HEADING_PATTERN."""
+    content = _read(SPEC_MD)
+    for n in range(1, 7):
+        assert f"#### Scenario: LAND-S{n}" in content, (
+            f"spec.md MUST define '#### Scenario: LAND-S{n}' — "
+            f"check-scenario-refs.sh pattern '^##+ Scenario:' requires the literal prefix"
+        )
+
+
+def test_spec_md_requirements_have_shall_or_must_in_prose():
+    """Every '### Requirement:' block MUST contain SHALL or MUST in prose (not just heading).
+    openspec extractRequirementText skips the heading line; prose body must carry the token."""
+    content = _read(SPEC_MD)
+    blocks = re.split(r"(?=^### Requirement:)", content, flags=re.MULTILINE)
+    for block in blocks:
+        if not block.startswith("### Requirement:"):
+            continue
+        # Prose is between the heading line and the first #### Scenario heading
+        prose_match = re.search(
+            r"^### Requirement:[^\n]*\n(.*?)(?=^####|\Z)", block, re.MULTILINE | re.DOTALL
+        )
+        if not prose_match:
+            continue
+        prose = prose_match.group(1).strip()
+        assert "SHALL" in prose or "MUST" in prose, (
+            f"Requirement prose MUST contain SHALL or MUST "
+            f"(openspec validate --strict will reject it):\n{block[:300]!r}"
+        )
+
+
+# ── LAND-S1: branch name + REQ tag align ─────────────────────────────────────
+
+
+def test_spec_md_land_s1_specifies_feat_req_pattern():
+    """LAND-S1 requirement SHALL specify the 'feat/<REQ-id>' head-branch pattern."""
+    content = _read(SPEC_MD)
+    assert "feat/" in content, (
+        "spec.md LAND-S1 MUST reference the 'feat/<REQ-id>' head-branch naming pattern"
+    )
+
+
+def test_audit_report_land_s1_both_prs_pass():
+    """LAND-S1: both audited PRs have feat/<REQ-id> head refs → audit SHALL record PASS."""
+    content = _read(AUDIT_REPORT)
+    assert "LAND-S1" in content, "audit-report.md MUST document LAND-S1 results"
+    # Find first LAND-S1 context window; both PR sections must contain PASS
+    regions = [m.start() for m in re.finditer(r"LAND-S1", content)]
+    assert len(regions) >= 2, (
+        "audit-report.md MUST cover LAND-S1 for both ttpos-server-go#217 and ttpos-arch-lab#10 "
+        "(expected at least 2 LAND-S1 references)"
+    )
+    for start in regions:
+        window = content[start : start + 300]
+        assert "PASS" in window, (
+            f"LAND-S1 section near offset {start} MUST show PASS "
+            f"(both PRs have matching feat/<REQ-id> head refs):\n{window!r}"
+        )
+
+
+# ── LAND-S2: base equals defaultBranchRef ────────────────────────────────────
+
+
+def test_spec_md_land_s2_references_default_branch_fetch():
+    """LAND-S2 SHALL reference 'defaultBranchRef' as the authoritative comparison source."""
+    content = _read(SPEC_MD)
+    assert "defaultBranchRef" in content, (
+        "spec.md LAND-S2 MUST reference 'defaultBranchRef' "
+        "(fetched via gh repo view --json defaultBranchRef) as the authoritative source"
+    )
+
+
+def test_audit_report_land_s2_both_prs_pass():
+    """LAND-S2: both PRs target their repo's default branch → audit SHALL record PASS."""
+    content = _read(AUDIT_REPORT)
+    regions = [m.start() for m in re.finditer(r"LAND-S2", content)]
+    assert len(regions) >= 2, (
+        "audit-report.md MUST cover LAND-S2 for both audited PRs"
+    )
+    for start in regions:
+        window = content[start : start + 300]
+        assert "PASS" in window, (
+            f"LAND-S2 section near offset {start} MUST show PASS "
+            f"(#217 base=release==default; #10 base=main==default):\n{window!r}"
+        )
+
+
+# ── LAND-S3: CI signal ────────────────────────────────────────────────────────
+
+
+def test_spec_md_land_s3_defines_platform_rejected_class():
+    """LAND-S3 MUST define 'platform-rejected' as a failure classification."""
+    content = _read(SPEC_MD)
+    assert "platform-rejected" in content, (
+        "spec.md LAND-S3 MUST define the 'platform-rejected' failure class "
+        "covering GHA billing and org-level infra rejections"
+    )
+
+
+def test_spec_md_land_s3_billing_scenario_specifies_blocked():
+    """LAND-S3 billing scenario: annotation starting with billing text → SHALL be BLOCKED."""
+    content = _read(SPEC_MD)
+    # Spec must describe the billing annotation and its BLOCKED outcome
+    assert "billing" in content.lower(), (
+        "spec.md MUST define a LAND-S3 billing-rejection scenario"
+    )
+    assert "BLOCKED" in content, (
+        "spec.md LAND-S3 billing scenario MUST specify result as BLOCKED"
+    )
+
+
+def test_spec_md_land_s3_no_workflows_scenario_specifies_blocked():
+    """LAND-S3 no-workflows scenario: empty statusCheckRollup + 404 on .github/workflows → BLOCKED."""
+    content = _read(SPEC_MD)
+    assert ".github/workflows" in content, (
+        "spec.md MUST define a LAND-S3 scenario for repos with no .github/workflows/"
+    )
+
+
+def test_spec_md_land_s3_author_claim_not_ci_signal():
+    """LAND-S3 MUST state that author-asserted runner-pod runs SHALL NOT count as CI signal."""
+    content = _read(SPEC_MD)
+    assert "author" in content.lower() or "runner" in content.lower(), (
+        "spec.md LAND-S3 MUST explicitly exclude author-asserted runner-pod claims "
+        "from the CI signal count"
+    )
+
+
+def test_audit_report_land_s3_server_go_blocked_billing():
+    """LAND-S3 ttpos-server-go#217: billing-rejected checks → audit SHALL record BLOCKED — GHA billing."""
+    content = _read(AUDIT_REPORT)
+    assert "BLOCKED" in content, (
+        "audit-report.md MUST contain BLOCKED results for LAND-S3"
+    )
+    assert "billing" in content.lower(), (
+        "audit-report.md MUST document GHA billing as the LAND-S3 blocker for ttpos-server-go#217"
+    )
+
+
+def test_audit_report_land_s3_billing_classified_as_platform_not_code():
+    """LAND-S3 billing annotation MUST be classified as platform-rejected, not code-failed.
+    Spec: 'audit SHALL never count author-asserted runner-pod claims as CI signal'."""
+    content = _read(AUDIT_REPORT)
+    # Billing annotation text or platform classification must be referenced
+    assert (
+        "not started" in content.lower()
+        or "platform" in content.lower()
+        or "account payments" in content.lower()
+        or "spending limit" in content.lower()
+    ), (
+        "audit-report.md LAND-S3 MUST reference the billing-rejection annotation "
+        "('job was not started because of account payment failure') to classify it as platform-rejected"
+    )
+
+
+def test_audit_report_land_s3_arch_lab_blocked_no_workflows():
+    """LAND-S3 ttpos-arch-lab#10: repo has no .github/workflows/ → SHALL record BLOCKED."""
+    content = _read(AUDIT_REPORT)
+    assert ".github/workflows" in content, (
+        "audit-report.md MUST document missing .github/workflows/ as the LAND-S3 blocker "
+        "for ttpos-arch-lab#10"
+    )
+
+
+def test_audit_report_land_s3_no_workflows_recommends_follow_up_req():
+    """LAND-S3 no-workflows verdict MUST propose a follow-up REQ to port sisyphus contract checks.
+    Spec: 'recommendation MUST propose a follow-up REQ to port the sisyphus contract checks into a workflow'."""
+    content = _read(AUDIT_REPORT)
+    # Recommendation section must mention porting CI workflows
+    assert (
+        "workflow" in content.lower() or "follow-up" in content.lower() or "follow up" in content.lower()
+    ), (
+        "audit-report.md MUST recommend a follow-up REQ or action to add CI workflows "
+        "to ttpos-arch-lab (LAND-S3 no-workflows BLOCKED verdict requirement)"
+    )
+
+
+# ── LAND-S4: Makefile contract targets ───────────────────────────────────────
+
+
+def test_spec_md_land_s4_lists_all_five_targets():
+    """LAND-S4 MUST list all five sisyphus contract targets as required."""
+    content = _read(SPEC_MD)
+    for target in ("ci-lint", "ci-unit-test", "ci-integration-test", "accept-env-up", "accept-env-down"):
+        assert target in content, (
+            f"spec.md LAND-S4 MUST list '{target}' as a required Makefile contract target"
+        )
+
+
+def test_audit_report_land_s4_both_prs_pass():
+    """LAND-S4: both PRs ship all five contract targets → audit SHALL record PASS."""
+    content = _read(AUDIT_REPORT)
+    regions = [m.start() for m in re.finditer(r"LAND-S4", content)]
+    assert len(regions) >= 2, (
+        "audit-report.md MUST cover LAND-S4 for both audited PRs"
+    )
+    for start in regions:
+        window = content[start : start + 400]
+        assert "PASS" in window, (
+            f"LAND-S4 section near offset {start} MUST show PASS "
+            f"(both PRs verified to have all five Makefile contract targets):\n{window!r}"
+        )
+
+
+def test_audit_report_land_s4_verifies_accept_env_targets():
+    """audit-report.md MUST explicitly verify accept-env-up and accept-env-down in LAND-S4."""
+    content = _read(AUDIT_REPORT)
+    assert "accept-env-up" in content, (
+        "audit-report.md LAND-S4 MUST verify 'accept-env-up' target is present in each PR's Makefile"
+    )
+    assert "accept-env-down" in content, (
+        "audit-report.md LAND-S4 MUST verify 'accept-env-down' target is present in each PR's Makefile"
+    )
+
+
+# ── LAND-S5: openspec validity ────────────────────────────────────────────────
+
+
+def test_spec_md_land_s5_requires_delta_heading_and_shall_prose():
+    """LAND-S5 SHALL require delta-format heading and SHALL/MUST prose in each Requirement block."""
+    content = _read(SPEC_MD)
+    # Must reference the delta format requirement
+    assert (
+        "ADDED Requirements" in content
+        or "delta" in content.lower()
+        or "MODIFIED Requirements" in content
+    ), (
+        "spec.md LAND-S5 MUST reference the openspec delta format "
+        "('## ADDED/MODIFIED/REMOVED/RENAMED Requirements')"
+    )
+
+
+def test_audit_report_land_s5_both_prs_pass_asserted():
+    """LAND-S5: both PRs ship structurally valid openspec → SHALL record PASS (asserted).
+    Looks at '### LAND-S5' section headings (not cross-reference mentions)."""
+    content = _read(AUDIT_REPORT)
+    # Find '### LAND-S5' section headings specifically (not cross-reference back-pointers)
+    sections = list(re.finditer(r"^###\s+LAND-S5", content, re.MULTILINE))
+    assert len(sections) >= 2, (
+        "audit-report.md MUST contain '### LAND-S5' section headings for both audited PRs "
+        f"(found {len(sections)} section heading(s))"
+    )
+    for m in sections:
+        # Read up to the next ### heading to stay within this section
+        section_text = content[m.start() : m.start() + 800]
+        assert "PASS" in section_text, (
+            f"LAND-S5 section at offset {m.start()} MUST contain 'PASS' "
+            f"(both PRs asserted to pass openspec validate --strict):\n{section_text!r}"
+        )
+
+
+def test_audit_report_land_s5_defers_to_spec_lint():
+    """LAND-S5 MUST note that sisyphus spec_lint will independently confirm via openspec validate.
+    Spec: 'audit MAY defer the actual openspec validate --strict run to sisyphus spec_lint'."""
+    content = _read(AUDIT_REPORT)
+    assert "spec_lint" in content or "openspec validate" in content, (
+        "audit-report.md LAND-S5 MUST state that sisyphus spec_lint will independently "
+        "confirm validity via openspec validate --strict"
+    )
+
+
+# ── LAND-S6: semantic conflict ────────────────────────────────────────────────
+
+
+def test_spec_md_land_s6_defines_predecessor_stacking_risk():
+    """LAND-S6 MUST define the predecessor-closed-unmerged stacking RISK scenario."""
+    content = _read(SPEC_MD)
+    assert (
+        "predecessor" in content.lower() or "closed" in content.lower()
+    ), (
+        "spec.md LAND-S6 MUST define the RISK scenario for stacking on a closed-unmerged predecessor PR"
+    )
+
+
+def test_spec_md_land_s6_defines_sibling_competing_impl_risk():
+    """LAND-S6 MUST define the sibling-PR competing implementation RISK scenario."""
+    content = _read(SPEC_MD)
+    assert (
+        "sibling" in content.lower() or "competing" in content.lower()
+    ), (
+        "spec.md LAND-S6 MUST define the RISK scenario for a sibling PR shipping "
+        "a competing implementation of the same contract surface"
+    )
+
+
+def test_spec_md_land_s6_references_resolver_change():
+    """LAND-S6 MUST reference in-flight sisyphus resolver/capability changes as a conflict source."""
+    content = _read(SPEC_MD)
+    assert "resolver" in content.lower() or "flip" in content.lower(), (
+        "spec.md LAND-S6 MUST reference in-flight sisyphus resolver / contract changes "
+        "as a factor in determining semantic conflict"
+    )
+
+
+def test_audit_report_land_s6_both_prs_risk():
+    """LAND-S6: both PRs have semantic conflicts → audit SHALL record RISK for each."""
+    content = _read(AUDIT_REPORT)
+    assert "RISK" in content, (
+        "audit-report.md MUST record RISK results for LAND-S6"
+    )
+    regions = [m.start() for m in re.finditer(r"LAND-S6", content)]
+    assert len(regions) >= 2, (
+        "audit-report.md MUST cover LAND-S6 for both ttpos-server-go#217 and ttpos-arch-lab#10"
+    )
+
+
+def test_audit_report_land_s6_arch_lab_stacking_on_closed_pr9():
+    """LAND-S6 ttpos-arch-lab#10: stacking on closed-unmerged #9 → SHALL be RISK.
+    Spec: 'git log shows commits authored on PR #N branch still present'."""
+    content = _read(AUDIT_REPORT)
+    # Predecessor PR #9 was closed without merge
+    assert "#9" in content, (
+        "audit-report.md MUST reference predecessor PR #9 (arch-lab) as closed-unmerged "
+        "in the LAND-S6 analysis for ttpos-arch-lab#10"
+    )
+    # The stacking / inherited-commits problem must be documented
+    assert (
+        "rebase" in content.lower()
+        or "inherited" in content.lower()
+        or "stacking" in content.lower()
+        or "commits ahead" in content.lower()
+    ), (
+        "audit-report.md LAND-S6 MUST document the broken-stacking risk for ttpos-arch-lab#10 "
+        "(PR #9 closed unmerged; its commits still present in #10's diff)"
+    )
+
+
+def test_audit_report_land_s6_sibling_resolver_deadlock_documented():
+    """LAND-S6: competing accept-env-up from both PRs creates SDA-S7 resolver deadlock.
+    Spec: 'both PRs' LAND-S6 cells SHALL be RISK; recommendation MUST surface the
+    latent SDA-S7 deadlock'."""
+    content = _read(AUDIT_REPORT)
+    # Both PRs ship accept-env-up; the resolver cannot decide
+    assert "accept-env-up" in content, (
+        "audit-report.md LAND-S6 MUST address the competing accept-env-up implementations "
+        "from ttpos-server-go#217 and ttpos-arch-lab#10"
+    )
+    # SDA-S7 deadlock must be surfaced
+    assert (
+        "SDA-S7" in content
+        or "deadlock" in content.lower()
+        or ("resolver" in content.lower() and "None" in content)
+    ), (
+        "audit-report.md LAND-S6 MUST surface the SDA-S7 resolver deadlock: "
+        "when both repos appear in involved_repos, resolver returns None "
+        "(multiple sources with accept-env-up and no integration tie-breaker)"
+    )
+
+
+def test_audit_report_land_s6_resolver_flip_acknowledged():
+    """LAND-S6 MUST acknowledge the resolver-flip REQ as context for the conflict analysis."""
+    content = _read(AUDIT_REPORT)
+    assert (
+        "resolver" in content.lower()
+        or "REQ-flip" in content
+        or "source-first" in content.lower()
+    ), (
+        "audit-report.md LAND-S6 MUST reference the resolver-flip "
+        "(REQ-flip-integration-resolver-source-1777195860) as a factor affecting "
+        "which accept-env-up implementation will be invoked"
+    )
+
+
+def test_audit_report_land_s6_server_go_risk_points_at_arch_lab_not_self():
+    """LAND-S6 ttpos-server-go#217: conflict points at #10's relevance, not #217's landability.
+    Per audit: '#217 itself is landable on this axis'."""
+    content = _read(AUDIT_REPORT)
+    # The audit found #217 landable; conflict is about #10's continued relevance
+    assert "landable" in content.lower() or "#217" in content, (
+        "audit-report.md MUST document that ttpos-server-go#217's LAND-S6 RISK "
+        "is about #10's relevance post-resolver-flip, not #217's own landability"
+    )
+
+
+# ── Summary table and recommendations ────────────────────────────────────────
+
+
+def test_audit_report_has_per_pr_verdict_summary_tables():
+    """audit-report.md MUST contain verdict summary tables with all six LAND-Sx rows."""
+    content = _read(AUDIT_REPORT)
+    for n in range(1, 7):
+        assert f"LAND-S{n}" in content, (
+            f"audit-report.md summary table MUST include a LAND-S{n} row for each audited PR"
+        )
+
+
+def test_audit_report_has_recommendations_section():
+    """audit-report.md MUST contain a Recommendations section with actionable next steps."""
+    content = _read(AUDIT_REPORT)
+    assert "Recommendation" in content or "recommendation" in content, (
+        "audit-report.md MUST contain a §4 Recommendations section "
+        "with actionable next steps per PR and for the sisyphus repo"
+    )
+
+
+def test_audit_report_covers_both_prs_by_number():
+    """audit-report.md MUST reference both audited PRs by their repo+number identifiers."""
+    content = _read(AUDIT_REPORT)
+    assert "ttpos-server-go" in content and "#217" in content, (
+        "audit-report.md MUST explicitly reference ttpos-server-go#217"
+    )
+    assert "ttpos-arch-lab" in content and "#10" in content, (
+        "audit-report.md MUST explicitly reference ttpos-arch-lab#10"
+    )


### PR DESCRIPTION
## Summary

Read-only audit of two coordinated ttpos biz PRs implementing the
sisyphus accept-env contract:

- [`ZonEaseTech/ttpos-server-go#217`](https://github.com/ZonEaseTech/ttpos-server-go/pull/217) (`REQ-server-go-accept-env-helm-1777200858`) — self-contained `deploy/accept-env/` helm chart in source repo.
- [`ZonEaseTech/ttpos-arch-lab#10`](https://github.com/ZonEaseTech/ttpos-arch-lab/pull/10) (`REQ-arch-lab-helm-chart-1777200858`) — external `charts/accept-lab` helm chart in arch-lab repo.

REQ: `REQ-ttpos-biz-pr-landability-1777247423`

## What's in here

- `openspec/changes/REQ-ttpos-biz-pr-landability-1777247423/proposal.md` — why this audit, scope (read-only).
- `openspec/changes/REQ-ttpos-biz-pr-landability-1777247423/audit-report.md` — per-PR findings (PASS / BLOCKED / RISK across LAND-S1..LAND-S6) plus a §3 cross-PR coupling discussion (the latent SDA-S7 resolver-deadlock if both PRs land naively after `REQ-flip-integration-resolver-source-1777195860`) and §4 concrete recommendations per PR.
- `openspec/changes/REQ-ttpos-biz-pr-landability-1777247423/specs/pr-landability-audit/spec.md` — new capability `pr-landability-audit` with 6 ADDED Requirements (LAND-S1..LAND-S6) defining a reusable PR-pair landability checklist for the next time we ship two coordinated PRs across ttpos repos.
- `openspec/changes/REQ-ttpos-biz-pr-landability-1777247423/tasks.md` — task tracker.

## Headline findings

- `server-go#217` is **structurally landable** but BLOCKED by GHA billing rejection on the `ZonEaseTech` org (all 3 failing checks have annotation `"recent account payments have failed"` — no code fix unblocks). Org admin owns the unblock.
- `arch-lab#10` is BLOCKED on a different axis: the repo has **zero `.github/workflows/`** so the PR has no CI signal at all. Independently, its branch carries 38 inherited commits because the predecessor PR #9 was closed unmerged but the stacking premise was never rebased.
- After `REQ-flip-integration-resolver-source-1777195860`, the source-first resolver picks `server-go`'s in-repo chart and never reaches arch-lab — so PR #10's stated primary consumer (sisyphus accept stages) is gone unless the chart is reframed for manual / human use.
- Latent landing-order bug: landing both PRs together hits SDA-S7 ("multiple sources with `accept-env-up:` and no integration → returns None"). Either deprecate one or file a sisyphus follow-up to add an explicit tie-breaker.

## What this PR does NOT do

- No changes to `ZonEaseTech/ttpos-server-go` or `ZonEaseTech/ttpos-arch-lab` (per the read-only stance — fixes belong in follow-up REQs filed against those repos).
- No behavioral changes to sisyphus orchestrator code.
- No org-level GHA billing fix (out-of-scope; that's a `ZonEaseTech` admin task).

## Test plan

- [x] `openspec validate REQ-ttpos-biz-pr-landability-1777247423 --strict` — `Change ... is valid` (openspec 1.3.1, in runner pod `runner-req-ttpos-biz-pr-landability-1777247423`).
- [x] `/opt/sisyphus/scripts/check-scenario-refs.sh --specs-search-path /workspace/source .` — `OK: 所有 scenario 引用都在 specs 中找到（共 333 个定义）`.
- [ ] sisyphus mechanical checkers (spec_lint / dev_cross_check / staging_test / pr_ci) — to be re-run by the orchestrator after this PR opens.