### PR TITLE
feat(checker): analyze post-artifact-check [REQ-analyze-artifact-check-1777254586]

### DIFF
--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -20,13 +20,14 @@
   `staging-test-running` 三个 checker stage 内部从单仓变成 for-each-repo 遍历
   （任一仓红 → stage fail）。状态机层面无影响。
 
-## 2. ReqState 枚举（16 个）
+## 2. ReqState 枚举（17 个）
 
 | state | 含义 | 类型 |
 |---|---|---|
 | `init` | 还没 analyze（intent_analyze 之前） | start |
 | `intaking` | **INTAKING** intake-agent 在跑（多轮 BKD chat 澄清 + 写 finalized intent） | in-flight |
 | `analyzing` | analyze-agent 在跑（M17 起全责交付：spec + 业务码 + push + 开 PR 都在 analyze 一段里完成） | in-flight |
+| `analyze-artifact-checking` | **REQ-analyze-artifact-check-1777254586** 机械 post-artifact-check：遍历 `/workspace/source/*` 校 `openspec/changes/<REQ>/` 下 proposal.md / tasks.md / spec.md 存在 + 非空（防 agent 自报 pass 但无产物） | in-flight |
 | `spec-lint-running` | **M15** 客观检查：**for-each-repo** openspec validate + check-scenario-refs.sh（遍历 `/workspace/source/*`） | in-flight |
 | `challenger-running` | **M18** challenger-agent 跑：黑盒读 spec 写 contract test + push feat 分支（不看 dev 代码，避免 prompt 泄露实现） | in-flight |
 | `dev-cross-check-running` | **M15** 客观检查：**for-each-repo** `BASE_REV=$(git merge-base HEAD origin/<default_branch>) make ci-lint`（default_branch 先 resolve `origin/HEAD` 符号引用，再退 main/master/develop/dev；ttpos-ci 标准，仅 lint 变更文件） | in-flight |
@@ -41,7 +42,7 @@
 | **`done`** | REQ 完成 | **terminal** |
 | **`escalated`** | 熔断 / session-failed / 人工止损 | **terminal** |
 
-## 3. Event 枚举（27 个）
+## 3. Event 枚举（29 个）
 
 | event | 来源 | 触发什么 |
 |---|---|---|
@@ -49,7 +50,9 @@
 | **`intake.pass`** | intake-agent PATCH `result:pass` + finalized intent JSON 解析成功 | start_analyze_with_finalized_intent |
 | **`intake.fail`** | intake-agent PATCH `result:fail` / 或 finalized intent JSON 解析失败 | escalate |
 | `intent.analyze` | 人在 BKD 打 `intent:analyze` tag（跳过 intake 直接进 analyze） | start_analyze |
-| `analyze.done` | analyze-agent session.completed | create_spec_lint |
+| `analyze.done` | analyze-agent session.completed | create_analyze_artifact_check |
+| **`analyze-artifact-check.pass`** | **REQ-analyze-artifact-check-1777254586** 产物校验退码 0 | create_spec_lint |
+| **`analyze-artifact-check.fail`** | **REQ-analyze-artifact-check-1777254586** 产物校验退码非 0 / timeout | invoke_verifier_for_analyze_artifact_check_fail |
 | **`spec-lint.pass`** | **M15** spec-lint checker 退码 0 | start_challenger（M18：先起 challenger 写 contract test） |
 | **`spec-lint.fail`** | **M15** spec-lint checker 退码非 0 | invoke_verifier_for_spec_lint_fail |
 | **`challenger.pass`** | **M18** challenger-agent 写完 contract test 推 feat 分支 | create_dev_cross_check |
@@ -85,7 +88,9 @@ stateDiagram-v2
     intaking --> escalated: intake.fail
     intaking --> escalated: verify.escalate\n(start_analyze_with_finalized_intent 内部判 escalate)
     analyzing --> escalated: verify.escalate\n(start_analyze 内部判 escalate, 如 clone failed)
-    analyzing --> spec_lint_running: analyze.done
+    analyzing --> analyze_artifact_checking: analyze.done
+    analyze_artifact_checking --> spec_lint_running: analyze-artifact-check.pass
+    analyze_artifact_checking --> review_running: analyze-artifact-check.fail
     spec_lint_running --> challenger_running: spec-lint.pass
     spec_lint_running --> review_running: spec-lint.fail
 

--- a/openspec/changes/REQ-analyze-artifact-check-1777254586/design.md
+++ b/openspec/changes/REQ-analyze-artifact-check-1777254586/design.md
@@ -1,0 +1,107 @@
+# Design — analyze 阶段 post-artifact-check
+
+## 上下文
+
+`spec_lint` 只调 `openspec validate` + `check-scenario-refs.sh`，关注
+`specs/*/spec.md` 的格式。analyze prompt 里要求的另外两件产物——
+`proposal.md` / `tasks.md`——并没有任何机械检查，agent 完全可以挂
+`analyze` tag 把 issue 挪到 review 而**只生成空文件甚至完全不生成它们**，
+sisyphus 仍会照常推进到 spec_lint。
+
+REQ 的目标：在 analyze 完成 → spec_lint 之前夹一层最便宜的契约校验，
+让 "self-reported pass but no artifacts" 立即在主链原地红掉。
+
+## 决策
+
+### 1. 单独 state，不复用 spec_lint 的 empty-source guard
+
+候选 A（在 spec_lint 里加更多 guard）和候选 B（独立 checker）的对比：
+
+| 维度 | A 加 guard | B 新 checker（采纳） |
+|---|---|---|
+| 关注点分离 | 模糊：spec_lint 既校验 spec 格式又校验产物存在性 | 清晰：artifact_check 校产物存在；spec_lint 校格式 |
+| 可观测性 | artifact_checks 一行 stage=spec-lint，混在一起 | artifact_checks 单独一行 stage=analyze-artifact-check，仪表盘可独立看 |
+| verifier 决策 | spec_lint fail 触发同一个 verifier prompt | 单独 verifier prompt，bias toward escalate（agent 没干活很难是 spec 错） |
+| 改动表面 | 改 spec_lint._build_cmd | 加新 module + 新 transition |
+
+采纳 B。`spec_lint` 已存在的 empty-source guard 保留不动（防 silent-pass 的最后一道
+门），新 artifact_check 是更前置、更精确的检查。
+
+### 2. 检查范围 = 三件产物 + 复选框 + spec-home 友好
+
+analyze prompt 顶部 ✅ 清单包含：proposal.md、tasks.md、design.md（可选）、
+contract.spec.yaml、spec.md、业务代码、unit test、PR opened with sisyphus label。
+
+机械可校验的子集，**proposal/tasks 累积、spec.md 每仓必有**：
+
+| 产物 | 检查方式 | 为何这样 |
+|---|---|---|
+| `openspec/changes/<REQ>/proposal.md` | 累积存在 + 非空（任一 eligible 仓） | 跨仓 spec-home 模式下 producer 仓才有 proposal |
+| `openspec/changes/<REQ>/tasks.md` | 累积存在 + 非空 + ≥1 个 `- [ ]` / `- [x]` 复选框 | 同上累积 |
+| `openspec/changes/<REQ>/specs/*/spec.md` | 每个 eligible 仓至少 1 个非空文件 | spec.md 必须每仓都有（每仓自带 capability） |
+| 业务代码 / unit test | **不**机械校 | 不少 REQ 是 docs-only / spec-only，强制业务代码 diff 会误伤 |
+| PR 已开 + label sisyphus | **不**机械校 | 跨网络 + GitHub API 限速；交给 pr_ci_watch（它本来就要轮 GH） |
+| design.md | **不**机械校 | analyze prompt 写"如需"，可选 |
+| contract.spec.yaml | **不**机械校 | 跨仓 REQ 才用；强校会误伤单仓 REQ |
+
+### 3. 多仓遍历语义跟 spec_lint 对齐
+
+依旧 `for repo in /workspace/source/*/`，每仓尝试 fetch + checkout `feat/<REQ>`：
+- fetch 失败 → 仓 skip（不算 fail，agent 没改它）
+- 所有 eligible 仓 spec.md 通过且累积 has_proposal=1 + has_tasks=1 → exit 0
+- 任一 eligible 仓缺 spec.md / 累积 has_proposal=0 / has_tasks=0 → exit 1
+- 0 仓 eligible（所有仓都 skip）→ exit 1（拒绝 silent-pass，跟 spec_lint 同语义）
+
+### 4. 触发先后跟 verifier 决策路径
+
+```
+ANALYZING --(ANALYZE_DONE)--> ANALYZE_ARTIFACT_CHECKING
+  |- pass --(ANALYZE_ARTIFACT_CHECK_PASS)--> SPEC_LINT_RUNNING
+  |- fail --(ANALYZE_ARTIFACT_CHECK_FAIL)--> REVIEW_RUNNING
+                                              |- verify.pass --> ANALYZE_ARTIFACT_CHECKING --(PASS)--> SPEC_LINT_RUNNING
+                                              |- verify.fix --> FIXER_RUNNING (fixer=spec)
+                                              |- verify.escalate --> ESCALATED
+```
+
+`_verifier._PASS_ROUTING["analyze_artifact_check"]` 走
+`(ANALYZE_ARTIFACT_CHECKING, ANALYZE_ARTIFACT_CHECK_PASS)` —— `apply_verify_pass`
+会先 CAS REVIEW_RUNNING → ANALYZE_ARTIFACT_CHECKING 再 emit PASS 让原主链
+继续推到 SPEC_LINT_RUNNING。
+
+### 5. fixer 倾向：spec
+
+如果 verifier 判 fix（很少见，多数情况下是 escalate"agent 直接没干活"），
+fixer 应该是 `spec` 而不是 `dev` —— 缺的是 `openspec/changes/<REQ>/` 下的产物。
+verifier prompt 模板里写明这一点。
+
+### 6. 为啥不强制 PR / 业务代码 diff
+
+- PR 检查需要 GitHub REST 调用，有限速 + 网络抖动，不该塞进机械 checker（pr_ci_watch
+  本就要拉 PR check-runs，complete-time 检查 PR 存在更自然）
+- 业务代码 diff 对 docs/spec-only REQ 是误伤；analyze prompt 也没把它写成"必须"
+- 三件 openspec 产物的存在性已经能挡住 90%+ "self-reported pass but no artifacts"
+  场景；剩下的少数边缘情况（写了 spec 但没写代码）由 dev_cross_check / staging_test
+  通过 lint 0 文件 / test 0 case 检出
+
+### 7. infra-flake retry 复用
+
+复用 `_flake.run_with_flake_retry`：DNS / kubectl exec channel / git fetch 抖动
+也可能砸到本 checker。配置开关沿用 `settings.checker_infra_flake_retry_*`。
+
+## Trade-offs
+
+- **新加 1 个 stage** vs **塞进 spec_lint**：付出 1 个 state + 4 transition + 一份
+  prompt 的代价，换来观测口径独立 + 关注点分离。判断值得。
+- **不校业务代码** vs **校业务代码**：选不校，避免 docs-only REQ 误伤。极端"写
+  了 spec 没写代码"由下游 stage 兜。
+- **shell 实现** vs **Python**：shell 跟 spec_lint / dev_cross_check / staging_test
+  对齐，可以走同一套 kubectl exec + flake retry；改 Python 要新建一套机制，不值得。
+
+## Risks
+
+1. **path 假设**：`/workspace/source/<repo>/openspec/changes/<REQ>/` 的形状假设
+   sisyphus clone helper 已 stage（实际上 start_analyze 已经替 agent 做完）。
+   如果未来路径约定改了，本 checker 跟 spec_lint 同样需要更新——影响面对齐。
+2. **agent 写空文件骗过非空检查**：`-s` 检查仅校 size > 0。若 agent 真要骗，
+   写 1 字节也能过。但成本 vs 真正动手写一份合规 proposal 差不多——这是预期外
+   的恶意行为，由 verifier 主观判兜底，机械层不打这一仗。

--- a/openspec/changes/REQ-analyze-artifact-check-1777254586/proposal.md
+++ b/openspec/changes/REQ-analyze-artifact-check-1777254586/proposal.md
@@ -1,0 +1,55 @@
+# REQ-analyze-artifact-check-1777254586 — analyze 阶段 post-artifact-check
+
+## Why
+
+analyze BKD agent 完成 session 后会被 router 派 `Event.ANALYZE_DONE`，
+`(ANALYZING, ANALYZE_DONE)` 直接转 `SPEC_LINT_RUNNING`。但 sisyphus 没机械验过
+agent 是否真的写出了顶层 ✅ 清单要求的产物：
+
+- 仅看 BKD session 状态和 `analyze` tag —— agent 可以"我做完了"声明，把 issue
+  挪到 review 就触发 ANALYZE_DONE。
+- `spec_lint` 是下一站，但它只跑 `openspec validate` + `check-scenario-refs.sh`，
+  逻辑只关心 `openspec/changes/<REQ>/specs/<capability>/spec.md`。
+  proposal.md / tasks.md 缺失或 0 字节，spec_lint 仍可能过。
+- 实证：`spec_lint._build_cmd` 已经针对"0 cloned repo / 0 eligible repo"加了
+  empty-source guard（REQ-checker-empty-source-1777113775），但那是兜底，不是
+  对 analyze 产物的契约级检查。
+
+只要 agent "自报 pass 但无产物"通过 sisyphus 的机械关，REQ 会一路推到 verifier
+甚至 fixer 才被发现，浪费 token + 拖慢 wall-clock。
+
+## What Changes
+
+新增**机械 post-artifact-check** stage，夹在 ANALYZING → SPEC_LINT_RUNNING 之间：
+
+- 加状态 `ReqState.ANALYZE_ARTIFACT_CHECKING`
+- 加事件 `Event.ANALYZE_ARTIFACT_CHECK_PASS` / `Event.ANALYZE_ARTIFACT_CHECK_FAIL`
+- 改 transition：
+  - `(ANALYZING, ANALYZE_DONE)` → `ANALYZE_ARTIFACT_CHECKING` + `create_analyze_artifact_check`（原来直接转 SPEC_LINT_RUNNING）
+  - `(ANALYZE_ARTIFACT_CHECKING, ANALYZE_ARTIFACT_CHECK_PASS)` → `SPEC_LINT_RUNNING` + `create_spec_lint`
+  - `(ANALYZE_ARTIFACT_CHECKING, ANALYZE_ARTIFACT_CHECK_FAIL)` → `REVIEW_RUNNING` + `invoke_verifier_for_analyze_artifact_check_fail`
+- 加 SESSION_FAILED self-loop 兜 ANALYZE_ARTIFACT_CHECKING
+- 新 checker `checkers/analyze_artifact_check.py` —— 在 runner pod 内遍历
+  `/workspace/source/*/`，对每个有 `feat/<REQ>` 远程分支的仓校验：
+  1. `openspec/changes/<REQ>/proposal.md` 存在且非空（累积，至少一仓有）
+  2. `openspec/changes/<REQ>/tasks.md` 存在且非空，**至少含一个 `- [ ]` 或 `- [x]` 复选框**（累积）
+  3. `openspec/changes/<REQ>/specs/*/spec.md` 至少有一个非空文件（每个 eligible 仓必须有）
+- 新 action `create_analyze_artifact_check` —— 调 checker、写 `artifact_checks`、
+  emit pass/fail（与 `create_spec_lint` 同形）
+- 复用 `artifact_checks` 表，stage 列写 `analyze-artifact-check`
+- verifier 接入：在 `_verifier.py` 注册 `analyze_artifact_check` 作为合法 stage、
+  加 `_PASS_ROUTING` 条目（pass → 回 ANALYZE_ARTIFACT_CHECKING + emit PASS）、
+  注册 `invoke_verifier_for_analyze_artifact_check_fail` action handler；新增
+  `prompts/verifier/analyze_artifact_check_{success,fail}.md.j2` 模板
+
+## Impact
+
+- **架构 checker 数从 4 加到 5**（原 spec_lint / dev_cross_check / staging_test /
+  pr_ci_watch）。接口形状对齐，`artifact_checks` 表 / 看板 SQL 不需结构变更
+- **状态机 transition 数 +5**（4 主链 + 1 SESSION_FAILED self-loop）
+- **fail 路径多走一轮 verifier**；快乐路径通过率不变（只多一次轻量 shell 检查
+  ~1s），代价微乎其微
+- 对 docs-only / spec-only REQ 不会误伤——只要 proposal.md / tasks.md / spec.md
+  非空就 pass，**不**强制要求实际业务代码 diff
+- 旧 REQ 在迁移上线时不受影响（artifact_checks schema 不变；checker 找不到
+  feat 分支会跳过，跟 spec_lint 一致）

--- a/openspec/changes/REQ-analyze-artifact-check-1777254586/specs/analyze-artifact-check/spec.md
+++ b/openspec/changes/REQ-analyze-artifact-check-1777254586/specs/analyze-artifact-check/spec.md
@@ -1,0 +1,119 @@
+# Spec — analyze post-artifact-check
+
+## ADDED Requirements
+
+### Requirement: analyze post-artifact-check stage gates ANALYZE_DONE → SPEC_LINT_RUNNING
+
+The orchestrator state machine SHALL insert a mechanical post-artifact-check stage
+between `ANALYZING` and `SPEC_LINT_RUNNING`. After the analyze BKD agent emits
+`ANALYZE_DONE`, the system MUST transition to a new state
+`ANALYZE_ARTIFACT_CHECKING` and dispatch the `create_analyze_artifact_check`
+action; only after that action emits `ANALYZE_ARTIFACT_CHECK_PASS` SHALL the
+state machine advance to `SPEC_LINT_RUNNING`. On
+`ANALYZE_ARTIFACT_CHECK_FAIL` the state SHALL move to `REVIEW_RUNNING` and the
+`invoke_verifier_for_analyze_artifact_check_fail` action SHALL be dispatched.
+
+#### Scenario: AAC-S1 happy path inserts the new stage between analyze and spec_lint
+- **GIVEN** the state machine module `orchestrator.state`
+- **WHEN** a static reader inspects the `TRANSITIONS` table
+- **THEN** the entry for `(ANALYZING, ANALYZE_DONE)` MUST point to
+  `next_state=ANALYZE_ARTIFACT_CHECKING` with `action="create_analyze_artifact_check"`,
+  AND a separate entry `(ANALYZE_ARTIFACT_CHECKING, ANALYZE_ARTIFACT_CHECK_PASS)`
+  MUST point to `next_state=SPEC_LINT_RUNNING` with `action="create_spec_lint"`.
+  The legacy direct transition `(ANALYZING, ANALYZE_DONE) → SPEC_LINT_RUNNING`
+  MUST no longer exist.
+
+#### Scenario: AAC-S2 fail routes through verifier with the dedicated handler
+- **GIVEN** the state machine module
+- **WHEN** the entry for `(ANALYZE_ARTIFACT_CHECKING, ANALYZE_ARTIFACT_CHECK_FAIL)`
+  is read
+- **THEN** it MUST have `next_state=REVIEW_RUNNING` with
+  `action="invoke_verifier_for_analyze_artifact_check_fail"`,
+  AND the action handler MUST be registered in `actions._verifier`,
+  AND `_STAGES` in `_verifier.py` MUST contain `"analyze_artifact_check"` so
+  `invoke_verifier(stage="analyze_artifact_check", trigger="fail")` is accepted.
+
+#### Scenario: AAC-S3 SESSION_FAILED self-loop covers the new state
+- **GIVEN** the state machine module
+- **WHEN** the SESSION_FAILED self-loop dictionary in `TRANSITIONS` is enumerated
+- **THEN** `ANALYZE_ARTIFACT_CHECKING` MUST be one of the states whose
+  `(state, SESSION_FAILED)` entry maps to `Transition(state, "escalate", ...)`,
+  matching the pattern used for the other `*_RUNNING` states.
+
+### Requirement: artifact-check shell verifies analyze deliverables in every involved repo
+
+`checkers.analyze_artifact_check._build_cmd(req_id)` SHALL produce a POSIX shell
+script that, when executed inside the runner pod, MUST:
+
+1. Refuse to silent-pass when `/workspace/source` is missing or contains zero
+   subdirectories (exit 1 with a `=== FAIL analyze-artifact-check: ... ===` marker
+   on stderr).
+2. Iterate every `/workspace/source/*/`, attempt
+   `git fetch origin feat/<REQ>` then `git checkout -B feat/<REQ> origin/feat/<REQ>`.
+   A repo whose fetch fails MUST be skipped (treated as not involved) and MUST NOT
+   contribute to the failure count, mirroring `spec_lint._build_cmd`.
+3. For every eligible repo (fetch succeeded **and** `openspec/changes/<REQ>/`
+   exists), require that
+   `openspec/changes/<REQ>/specs/<capability>/spec.md` contains at least one
+   non-empty file (recursive find with `-type f -size +0`). Missing or all-empty
+   `spec.md` MUST cause exit 1.
+4. Require that, **across all eligible repos taken together**, at least one
+   non-empty `openspec/changes/<REQ>/proposal.md` and at least one non-empty
+   `openspec/changes/<REQ>/tasks.md` MUST be present. The shell MUST tolerate
+   the spec-home pattern where consumer repos may carry only `spec.md`.
+5. Require that the surviving non-empty `tasks.md` contains at least one
+   Markdown checkbox matching `^[[:space:]]*-[[:space:]]*\[[ xX]\]` (passed to
+   `grep -E`), so an empty stub passes the size check but fails the content check.
+6. Refuse to silent-pass when zero repos are eligible after the fetch loop
+   (exit 1 with a marker), mirroring spec_lint's `ran=0` guard.
+7. Exit 0 only when every eligible repo passes (3) and the cumulative checks
+   (4) and (5) hold.
+
+#### Scenario: AAC-S4 build_cmd guards /workspace/source missing and empty
+- **GIVEN** `checkers.analyze_artifact_check._build_cmd("REQ-X")` returns string `cmd`
+- **WHEN** a static reader greps `cmd`
+- **THEN** `cmd` MUST contain `[ ! -d /workspace/source ]` AND
+  `FAIL analyze-artifact-check: /workspace/source missing` AND
+  `find /workspace/source -mindepth 1 -maxdepth 1 -type d` AND
+  `"$repo_count" -eq 0` AND `FAIL analyze-artifact-check: /workspace/source empty`,
+  matching the empty-source guard pattern from `spec_lint._build_cmd`.
+
+#### Scenario: AAC-S5 build_cmd checks proposal/tasks/spec/checkbox literals
+- **GIVEN** `checkers.analyze_artifact_check._build_cmd("REQ-X")` returns string `cmd`
+- **WHEN** a static reader greps `cmd`
+- **THEN** `cmd` MUST contain literal references to
+  `openspec/changes/REQ-X/proposal.md`, `openspec/changes/REQ-X/tasks.md`,
+  the substring `specs` joined with `spec.md` for the recursive spec.md probe,
+  AND a checkbox regex containing `\[[ xX]\]` (passed to `grep -E`),
+  AND `git fetch origin "feat/REQ-X"`.
+
+#### Scenario: AAC-S6 build_cmd refuses 0 eligible repos
+- **GIVEN** `checkers.analyze_artifact_check._build_cmd("REQ-X")` returns string `cmd`
+- **WHEN** a static reader greps `cmd`
+- **THEN** `cmd` MUST contain `ran=0` AND `ran=$((ran+1))` AND `"$ran" -eq 0`
+  AND a marker string like `0 source repos eligible` (mirroring spec_lint),
+  AND it MUST end with `[ $fail -eq 0 ]` so the final exit code reflects the
+  aggregated check status.
+
+### Requirement: artifact_checks row is written for every analyze_artifact_check run
+
+`actions.create_analyze_artifact_check` SHALL invoke
+`checkers.analyze_artifact_check.run_analyze_artifact_check`, write the resulting
+`CheckResult` to the `artifact_checks` table with `stage="analyze-artifact-check"`,
+and MUST emit `ANALYZE_ARTIFACT_CHECK_PASS` on success or
+`ANALYZE_ARTIFACT_CHECK_FAIL` on any non-zero exit / timeout / unhandled
+exception.
+
+#### Scenario: AAC-S7 pass writes artifact_checks then emits PASS event
+- **GIVEN** a fake K8s controller that returns `exit_code=0` for the runner exec
+- **WHEN** `create_analyze_artifact_check.create_analyze_artifact_check(...)` is awaited
+- **THEN** `artifact_checks.insert_check` MUST have been called once with
+  `stage="analyze-artifact-check"` and `result.passed=True`,
+  AND the action's return dict MUST contain `"emit": "analyze-artifact-check.pass"`.
+
+#### Scenario: AAC-S8 non-zero exit emits FAIL event with non-zero exit_code
+- **GIVEN** a fake K8s controller that returns `exit_code=1` with marker stderr
+- **WHEN** `create_analyze_artifact_check.create_analyze_artifact_check(...)` is awaited
+- **THEN** the action's return dict MUST contain
+  `"emit": "analyze-artifact-check.fail"`, `"passed": False`, and `"exit_code": 1`,
+  AND `artifact_checks.insert_check` MUST still have been called once.

--- a/openspec/changes/REQ-analyze-artifact-check-1777254586/tasks.md
+++ b/openspec/changes/REQ-analyze-artifact-check-1777254586/tasks.md
@@ -1,0 +1,44 @@
+# Tasks — REQ-analyze-artifact-check-1777254586
+
+> owner: analyze-agent or sub-agent of analyze
+> 所有 checkbox 完成时勾上，反映真实做了的事。
+
+## Stage: contract / spec
+
+- [x] author `proposal.md`（why / what / impact）
+- [x] author `design.md`（决策、trade-offs、risks）
+- [x] author `specs/analyze-artifact-check/spec.md`（delta + scenarios AAC-S1..S8）
+- [x] 复用 artifact_checks 表，无 schema 变更
+
+## Stage: implementation — orchestrator
+
+- [x] 加 `ReqState.ANALYZE_ARTIFACT_CHECKING`
+- [x] 加 `Event.ANALYZE_ARTIFACT_CHECK_PASS` / `Event.ANALYZE_ARTIFACT_CHECK_FAIL`
+- [x] 改 `(ANALYZING, ANALYZE_DONE)` transition：next_state 改为 `ANALYZE_ARTIFACT_CHECKING`，action 改为 `create_analyze_artifact_check`
+- [x] 加 `(ANALYZE_ARTIFACT_CHECKING, ANALYZE_ARTIFACT_CHECK_PASS)` → `SPEC_LINT_RUNNING` + `create_spec_lint`
+- [x] 加 `(ANALYZE_ARTIFACT_CHECKING, ANALYZE_ARTIFACT_CHECK_FAIL)` → `REVIEW_RUNNING` + `invoke_verifier_for_analyze_artifact_check_fail`
+- [x] 把 `ANALYZE_ARTIFACT_CHECKING` 加进 SESSION_FAILED self-loop 列表
+- [x] `engine.STATE_TO_STAGE`：`ANALYZE_ARTIFACT_CHECKING → "analyze_artifact_check"`
+- [x] `engine._EVENT_TO_OUTCOME`：PASS=pass / FAIL=fail
+- [x] `watchdog._STATE_ISSUE_KEY[ANALYZE_ARTIFACT_CHECKING] = None`
+- [x] 新文件 `checkers/analyze_artifact_check.py` —— mirror spec_lint：`_build_cmd(req_id)` + `run_analyze_artifact_check(req_id, *, timeout_sec=120)`，返回 `CheckResult`
+- [x] 新文件 `actions/create_analyze_artifact_check.py` —— mirror create_spec_lint：跑 checker，写 artifact_checks，emit pass/fail
+- [x] `actions/__init__.py` 注册 import
+- [x] `actions/_verifier.py`：
+  - [x] `_STAGES` 加 `analyze_artifact_check`
+  - [x] `_PASS_ROUTING["analyze_artifact_check"] = (ANALYZE_ARTIFACT_CHECKING, ANALYZE_ARTIFACT_CHECK_PASS)`
+  - [x] 新 handler `invoke_verifier_for_analyze_artifact_check_fail`
+- [x] 新模板 `prompts/verifier/analyze_artifact_check_fail.md.j2`
+- [x] 新模板 `prompts/verifier/analyze_artifact_check_success.md.j2`（fixer recheck 用）
+
+## Stage: tests
+
+- [x] `test_checkers_analyze_artifact_check.py`：build_cmd 形状 + pass/fail/timeout/empty-source guards + flake retry
+- [x] 扩 `test_actions_smoke.py` or 新文件：create_analyze_artifact_check pass/fail/timeout 三路
+- [x] `test_state_machine_analyze_artifact_check.py`：4 条新 transition + SESSION_FAILED self-loop
+- [x] `test_contract_analyze_artifact_check.py`：AAC-S1..S8 黑盒 scenarios
+
+## Stage: PR
+
+- [x] git push feat/REQ-analyze-artifact-check-1777254586
+- [x] gh pr create --label sisyphus

--- a/orchestrator/src/orchestrator/actions/__init__.py
+++ b/orchestrator/src/orchestrator/actions/__init__.py
@@ -71,6 +71,7 @@ def register(name: str, *, idempotent: bool = False):
 from . import (  # noqa: E402,F401
     _verifier,
     create_accept,
+    create_analyze_artifact_check,
     create_dev_cross_check,
     create_pr_ci_watch,
     create_spec_lint,

--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -41,7 +41,10 @@ log = structlog.get_logger(__name__)
 
 # 支持的 stage 名（对应 prompts/verifier/{stage}_{trigger}.md.j2）
 # 包括 agent stage（analyze）和 checker stage（spec_lint / dev_cross_check / staging_test / pr_ci）
-_STAGES = {"analyze", "spec_lint", "challenger", "dev_cross_check", "staging_test", "pr_ci", "accept"}
+_STAGES = {
+    "analyze", "analyze_artifact_check", "spec_lint", "challenger",
+    "dev_cross_check", "staging_test", "pr_ci", "accept",
+}
 
 # Trigger 类型
 Trigger = Literal["success", "fail"]
@@ -50,13 +53,15 @@ Trigger = Literal["success", "fail"]
 # 用于 apply_verify_pass 手工把 state 从 REVIEW_RUNNING 回推到对应 stage_running，
 # 随后链式 emit 该 stage 的 done/pass 事件走原 transition。
 _PASS_ROUTING: dict[str, tuple[ReqState, Event]] = {
-    "analyze":           (ReqState.ANALYZING,                Event.ANALYZE_DONE),
-    "spec_lint":         (ReqState.SPEC_LINT_RUNNING,        Event.SPEC_LINT_PASS),
-    "challenger":        (ReqState.CHALLENGER_RUNNING,       Event.CHALLENGER_PASS),
-    "dev_cross_check":   (ReqState.DEV_CROSS_CHECK_RUNNING,  Event.DEV_CROSS_CHECK_PASS),
-    "staging_test":      (ReqState.STAGING_TEST_RUNNING,     Event.STAGING_TEST_PASS),
-    "pr_ci":             (ReqState.PR_CI_RUNNING,            Event.PR_CI_PASS),
-    "accept":            (ReqState.ACCEPT_RUNNING,           Event.ACCEPT_PASS),
+    "analyze":                 (ReqState.ANALYZING,                Event.ANALYZE_DONE),
+    "analyze_artifact_check":  (ReqState.ANALYZE_ARTIFACT_CHECKING,
+                                Event.ANALYZE_ARTIFACT_CHECK_PASS),
+    "spec_lint":               (ReqState.SPEC_LINT_RUNNING,        Event.SPEC_LINT_PASS),
+    "challenger":              (ReqState.CHALLENGER_RUNNING,       Event.CHALLENGER_PASS),
+    "dev_cross_check":         (ReqState.DEV_CROSS_CHECK_RUNNING,  Event.DEV_CROSS_CHECK_PASS),
+    "staging_test":            (ReqState.STAGING_TEST_RUNNING,     Event.STAGING_TEST_PASS),
+    "pr_ci":                   (ReqState.PR_CI_RUNNING,            Event.PR_CI_PASS),
+    "accept":                  (ReqState.ACCEPT_RUNNING,           Event.ACCEPT_PASS),
 }
 
 # ─── invoke_verifier：起 BKD verifier issue ──────────────────────────────
@@ -426,6 +431,19 @@ async def invoke_verifier_for_dev_cross_check_fail(*, body, req_id, tags, ctx):
     """DEV_CROSS_CHECK_FAIL → 起 verifier-agent(stage=dev_cross_check, trigger=fail)。"""
     return await _invoke_verifier_fail(
         stage="dev_cross_check", body=body, req_id=req_id, ctx=ctx,
+    )
+
+
+@register("invoke_verifier_for_analyze_artifact_check_fail", idempotent=False)
+async def invoke_verifier_for_analyze_artifact_check_fail(*, body, req_id, tags, ctx):
+    """ANALYZE_ARTIFACT_CHECK_FAIL → 起 verifier-agent(stage=analyze_artifact_check, trigger=fail)。
+
+    REQ-analyze-artifact-check-1777254586：analyze 产物结构性校验失败。verifier
+    通常应判 escalate（agent 自报 pass 但产物缺失，是 LLM 抽风类失败），少数
+    情况是 agent 写了 spec 漏了 proposal/tasks → 可判 fix + fixer=spec。
+    """
+    return await _invoke_verifier_fail(
+        stage="analyze_artifact_check", body=body, req_id=req_id, ctx=ctx,
     )
 
 

--- a/orchestrator/src/orchestrator/actions/create_analyze_artifact_check.py
+++ b/orchestrator/src/orchestrator/actions/create_analyze_artifact_check.py
@@ -1,0 +1,86 @@
+"""create_analyze_artifact_check：analyze done → 跑机械产物结构校验
+（REQ-analyze-artifact-check-1777254586）。
+
+夹在 ANALYZING → SPEC_LINT_RUNNING 之间，机械校 analyze BKD agent 真的写出了
+proposal.md / tasks.md / spec.md，而非"自报 pass 实际无产物"。
+
+退出码语义跟 spec_lint 对齐：0 = 全过；非 0 / timeout / 异常 → emit fail。
+"""
+from __future__ import annotations
+
+import structlog
+
+from ..checkers import analyze_artifact_check as checker
+from ..checkers._types import CheckResult
+from ..state import Event
+from ..store import artifact_checks, db
+from . import register
+
+log = structlog.get_logger(__name__)
+
+_STAGE = "analyze-artifact-check"
+
+
+@register("create_analyze_artifact_check", idempotent=False)
+async def create_analyze_artifact_check(*, body, req_id, tags, ctx):
+    """下发 analyze 产物校验任务到 runner pod（proposal/tasks/spec.md 存在 + 非空）。"""
+    log.info("create_analyze_artifact_check.start", req_id=req_id)
+
+    pool = db.get_pool()
+
+    try:
+        result = await checker.run_analyze_artifact_check(req_id, timeout_sec=120)
+    except TimeoutError:
+        log.error("create_analyze_artifact_check.timeout", req_id=req_id)
+        # 超时也写一行 artifact_checks，让仪表盘看见（与 staging_test 同语义）
+        try:
+            await artifact_checks.insert_check(
+                pool, req_id, _STAGE,
+                CheckResult(
+                    passed=False, exit_code=-1,
+                    stdout_tail="", stderr_tail="timeout",
+                    duration_sec=0.0, cmd="(timeout)", reason="timeout",
+                ),
+            )
+        except Exception as e:
+            log.warning("create_analyze_artifact_check.timeout_insert_failed",
+                        req_id=req_id, error=str(e))
+        return {
+            "emit": Event.ANALYZE_ARTIFACT_CHECK_FAIL.value,
+            "passed": False,
+            "exit_code": -1,
+            "reason": "timeout",
+        }
+    except Exception as e:
+        log.exception("create_analyze_artifact_check.error", req_id=req_id, error=str(e))
+        return {
+            "emit": Event.ANALYZE_ARTIFACT_CHECK_FAIL.value,
+            "passed": False,
+            "exit_code": -1,
+            "reason": str(e)[:200],
+        }
+
+    await artifact_checks.insert_check(pool, req_id, _STAGE, result)
+
+    if result.passed:
+        log.info("create_analyze_artifact_check.done", req_id=req_id,
+                 passed=True, exit_code=result.exit_code,
+                 duration_sec=round(result.duration_sec, 1))
+        return {
+            "emit": Event.ANALYZE_ARTIFACT_CHECK_PASS.value,
+            "passed": True,
+            "exit_code": result.exit_code,
+            "cmd": result.cmd,
+            "duration_sec": result.duration_sec,
+        }
+
+    log.info("create_analyze_artifact_check.done", req_id=req_id,
+             passed=False, exit_code=result.exit_code,
+             duration_sec=round(result.duration_sec, 1))
+    return {
+        "emit": Event.ANALYZE_ARTIFACT_CHECK_FAIL.value,
+        "passed": False,
+        "exit_code": result.exit_code,
+        "cmd": result.cmd,
+        "duration_sec": result.duration_sec,
+    }

--- a/orchestrator/src/orchestrator/checkers/analyze_artifact_check.py
+++ b/orchestrator/src/orchestrator/checkers/analyze_artifact_check.py
@@ -1,0 +1,182 @@
+"""analyze 阶段 post-artifact-check（REQ-analyze-artifact-check-1777254586）。
+
+夹在 ANALYZING → SPEC_LINT_RUNNING 之间，机械校 analyze BKD agent 的产物：
+prevent agent self-reporting pass with no artifacts.
+
+校验规则（分两层）：
+- 仓级（每个 eligible 仓必须满足）：
+    * `openspec/changes/<REQ>/specs/*/spec.md` 至少一个非空文件
+- 累积（所有 eligible 仓加起来满足）：
+    * 至少一个非空 `openspec/changes/<REQ>/proposal.md`
+    * 至少一个非空 `openspec/changes/<REQ>/tasks.md`，并且其内容包含至少一个
+      Markdown checkbox（`- [ ]` / `- [x]` / `- [X]`）
+  这种"累积"语义是为了不误伤跨仓 spec-home REQ —— consumer 仓常只放 spec.md，
+  proposal / tasks 只在 spec home 仓里有一份。
+
+eligible = 该仓有远程 `feat/<REQ>` 分支、能本地 fetch + checkout，且仓里有
+`openspec/changes/<REQ>/` 目录。仓没改过本 REQ 则 fetch 失败 / 没 changes 目录
+→ 直接 skip（不算 fail），与 spec_lint 同语义。
+
+empty-source guards 与 spec_lint 对齐（防 silent-pass）：
+- /workspace/source 缺失 / 0 子目录 → 直接 exit 1
+- 0 仓 eligible（agent 一份产物都没 push）→ exit 1
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import structlog
+
+from .. import k8s_runner
+from ..config import settings
+from ._flake import run_with_flake_retry
+from ._types import CheckResult
+
+log = structlog.get_logger(__name__)
+
+_TAIL = 2048
+_STAGE = "analyze_artifact_check"
+
+
+def _build_cmd(req_id: str) -> str:
+    """生成 runner pod 内执行的 POSIX shell。
+
+    主循环每仓：
+    1. `git fetch origin feat/<REQ>` + `git checkout -B feat/<REQ> origin/feat/<REQ>`
+       —— 失败视为该仓 not involved（agent 没改它），跳过不算 fail
+    2. eligible 仓必须有 `openspec/changes/<REQ>/specs/<capability>/spec.md`
+       至少一个非空文件
+    3. eligible 仓如果有非空 proposal.md / 含 checkbox 的 tasks.md，记进
+       cumulative flag（has_proposal / has_tasks）
+    遍历完后：
+    - 任一 eligible 仓缺 spec.md → fail
+    - 累积 has_proposal / has_tasks 任一为 0 → fail
+    - 0 仓 eligible → exit 1（与 spec_lint 一致）
+    """
+    return (
+        "set -o pipefail; "
+        "if [ ! -d /workspace/source ]; then "
+        '  echo "=== FAIL analyze-artifact-check: /workspace/source missing — refusing to silent-pass ===" >&2; '
+        "  exit 1; "
+        "fi; "
+        "repo_count=$(find /workspace/source -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l); "
+        'if [ "$repo_count" -eq 0 ]; then '
+        '  echo "=== FAIL analyze-artifact-check: /workspace/source empty (0 cloned repos) — refusing to silent-pass ===" >&2; '
+        "  exit 1; "
+        "fi; "
+        "fail=0; "
+        "ran=0; "
+        "has_proposal=0; "
+        "has_tasks=0; "
+        "for repo in /workspace/source/*/; do "
+        '  name=$(basename "$repo"); '
+        f'  if ! (cd "$repo" && git fetch origin "feat/{req_id}" 2>/dev/null && git checkout -B "feat/{req_id}" "origin/feat/{req_id}" 2>/dev/null); then '
+        '    echo "[skip] $name: no feat branch / not involved"; '
+        "    continue; "
+        "  fi; "
+        f'  ch="$repo/openspec/changes/{req_id}"; '
+        '  if [ ! -d "$ch" ]; then '
+        f'    echo "[skip] $name: no openspec/changes/{req_id}/"; '
+        "    continue; "
+        "  fi; "
+        "  ran=$((ran+1)); "
+        '  echo "=== analyze-artifact-check: $name ==="; '
+        # spec.md per-repo（必须）
+        '  spec_count=$(find "$ch/specs" -name spec.md -type f -size +0 2>/dev/null | wc -l); '
+        '  if [ "$spec_count" -eq 0 ]; then '
+        f'    echo "=== FAIL: $name: openspec/changes/{req_id}/specs/<capability>/spec.md missing or all empty ===" >&2; '
+        "    fail=1; "
+        "  fi; "
+        # proposal.md 累积
+        '  if [ -s "$ch/proposal.md" ]; then has_proposal=1; fi; '
+        # tasks.md 累积 + checkbox 校验
+        '  if [ -s "$ch/tasks.md" ]; then '
+        '    if grep -E "^[[:space:]]*-[[:space:]]*\\[[ xX]\\]" "$ch/tasks.md" >/dev/null 2>&1; then '
+        "      has_tasks=1; "
+        "    fi; "
+        "  fi; "
+        "done; "
+        'if [ "$ran" -eq 0 ]; then '
+        f'  echo "=== FAIL analyze-artifact-check: 0 source repos eligible (no feat/{req_id} branch with openspec/changes/{req_id}/) — refusing to silent-pass ===" >&2; '
+        "  exit 1; "
+        "fi; "
+        'if [ "$has_proposal" -eq 0 ]; then '
+        f'  echo "=== FAIL analyze-artifact-check: no eligible repo has a non-empty openspec/changes/{req_id}/proposal.md ===" >&2; '
+        "  fail=1; "
+        "fi; "
+        'if [ "$has_tasks" -eq 0 ]; then '
+        f'  echo "=== FAIL analyze-artifact-check: no eligible repo has openspec/changes/{req_id}/tasks.md with at least one Markdown checkbox ===" >&2; '
+        "  fail=1; "
+        "fi; "
+        "[ $fail -eq 0 ]"
+    )
+
+
+async def run_analyze_artifact_check(
+    req_id: str,
+    *,
+    timeout_sec: int = 120,
+) -> CheckResult:
+    """kubectl exec runner -- <for-each-repo proposal/tasks/spec.md 校验>。
+
+    复用 _flake.run_with_flake_retry：DNS / kubectl exec channel / git fetch 抖动
+    自动重跑（与 spec_lint 同 flake retry 配置）。
+    """
+    rc = k8s_runner.get_controller()
+    cmd = _build_cmd(req_id)
+    log.info(
+        "checker.analyze_artifact_check.start",
+        req_id=req_id, timeout=timeout_sec,
+    )
+    started = time.monotonic()
+
+    max_retries = (
+        settings.checker_infra_flake_retry_max
+        if settings.checker_infra_flake_retry_enabled
+        else 0
+    )
+
+    async def _run_once():
+        return await asyncio.wait_for(
+            rc.exec_in_runner(req_id, cmd, timeout_sec=timeout_sec),
+            timeout=timeout_sec + 10,
+        )
+
+    try:
+        exec_result, attempts, flake_reason = await run_with_flake_retry(
+            coro_factory=_run_once,
+            stage=_STAGE,
+            req_id=req_id,
+            max_retries=max_retries,
+            backoff_sec=settings.checker_infra_flake_retry_backoff_sec,
+        )
+    except TimeoutError:
+        log.error(
+            "checker.analyze_artifact_check.timeout", req_id=req_id,
+        )
+        return CheckResult(
+            passed=False, exit_code=-1,
+            stdout_tail="", stderr_tail=f"analyze artifact check 超时 {timeout_sec}s",
+            duration_sec=time.monotonic() - started, cmd=cmd,
+            reason="timeout",
+        )
+
+    passed = exec_result.exit_code == 0
+    log.info(
+        "checker.analyze_artifact_check.done",
+        req_id=req_id,
+        passed=passed, exit_code=exec_result.exit_code,
+        duration_sec=round(exec_result.duration_sec, 2),
+        attempts=attempts, flake_reason=flake_reason,
+    )
+    return CheckResult(
+        passed=passed,
+        exit_code=exec_result.exit_code,
+        stdout_tail=exec_result.stdout[-_TAIL:],
+        stderr_tail=exec_result.stderr[-_TAIL:],
+        duration_sec=exec_result.duration_sec,
+        cmd=cmd,
+        reason=flake_reason,
+        attempts=attempts,
+    )

--- a/orchestrator/src/orchestrator/engine.py
+++ b/orchestrator/src/orchestrator/engine.py
@@ -31,6 +31,7 @@ _TERMINAL_STATES = {ReqState.DONE, ReqState.ESCALATED}
 # M14e/M15：state → stage 名（用于 stage_runs 表）。
 STATE_TO_STAGE: dict[ReqState, str] = {
     ReqState.ANALYZING:              "analyze",
+    ReqState.ANALYZE_ARTIFACT_CHECKING: "analyze_artifact_check",
     ReqState.SPEC_LINT_RUNNING:      "spec_lint",
     ReqState.DEV_CROSS_CHECK_RUNNING: "dev_cross_check",
     ReqState.STAGING_TEST_RUNNING:   "staging_test",
@@ -49,7 +50,9 @@ AGENT_STAGES: frozenset[str] = frozenset({
 
 # event → stage_runs.outcome 标签。escalate / session.failed 全归 fail。
 _EVENT_TO_OUTCOME: dict[Event, str] = {
-    Event.ANALYZE_DONE:         "pass",
+    Event.ANALYZE_DONE:                "pass",
+    Event.ANALYZE_ARTIFACT_CHECK_PASS: "pass",
+    Event.ANALYZE_ARTIFACT_CHECK_FAIL: "fail",
     Event.SPEC_LINT_PASS:       "pass",
     Event.SPEC_LINT_FAIL:       "fail",
     Event.DEV_CROSS_CHECK_PASS: "pass",

--- a/orchestrator/src/orchestrator/prompts/verifier/analyze_artifact_check_fail.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/analyze_artifact_check_fail.md.j2
@@ -1,0 +1,56 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（analyze_artifact_check / fail）
+
+sisyphus 的机械 **post-artifact-check** 红了。它在 ANALYZING → SPEC_LINT_RUNNING
+之间 mechanically 校 analyze BKD agent 真的写出了 ✅ 清单产物：
+
+- 每个 eligible 仓必须有 `openspec/changes/{{ req_id }}/specs/<capability>/spec.md`（至少一个非空）
+- 累积（所有 eligible 仓加起来）至少一个非空 `proposal.md`
+- 累积至少一个非空 `tasks.md` 且含 ≥1 个 `- [ ]` / `- [x]` 复选框
+- 至少 1 仓 eligible（fetch 成功且有 `openspec/changes/{{ req_id }}/`）
+
+任一缺失 → 红。
+
+你要判：是**analyze agent 实际没干活**（自报 pass 但没写产物 / 写了空文件），
+还是**sisyphus 机械层 bug**（路径 / clone / fetch 抽风）。
+
+{% if stderr_tail %}
+### 失败栈尾
+```
+{{ stderr_tail }}
+```
+{% endif %}
+
+### 关注点
+
+- `0 source repos eligible` / `0 cloned repos` → analyze agent 根本没 push `feat/{{ req_id }}` 分支
+  ↑ 高概率 LLM 抽风（agent 自报 pass 但 git push 没真跑）→ `escalate`
+- `specs/<capability>/spec.md missing or all empty` → spec 没写或写了空 → `fix` + `fixer=spec`
+  + `scope=openspec/changes/{{ req_id }}/`
+- `no eligible repo has a non-empty proposal.md` → 写了 spec 漏了 proposal → `fix` + `fixer=spec`
+- `no eligible repo has openspec/changes/{{ req_id }}/tasks.md with at least one Markdown checkbox`
+  → tasks.md 缺失 / 0 字节 / 没有任何 `- [ ]` 项 → `fix` + `fixer=spec`
+- 多类同时缺（spec + proposal + tasks 都没） → 通常是 agent 完全没动手，建议 `escalate`
+  让人重起 analyze（fixer 不擅长从 0 写 analyze 全套产物）
+- sisyphus runner / kubectl exec / `/workspace/source` 空 → `escalate`
+
+### NOT 该做
+
+- 不亲自跑机械检查（sisyphus 已经跑过；stderr_tail 就是结果）
+- 不改业务代码（这一关只看 openspec/ 下产物）
+- 不开新 BKD analyze 子 agent（M15 起 sisyphus 不再起 spec / dev 子 agent；fixer
+  应该走 spec fixer 路径）
+
+### 典型决策
+
+- `fix` + `fixer=spec` + `scope=openspec/changes/{{ req_id }}/`：spec / proposal /
+  tasks 中**部分**缺失，spec fixer 能补完
+- `escalate`：agent 一份产物都没写（0 eligible repos / 同时多类全空），
+  或 sisyphus 机械层抽风
+- `pass`：极少见——只有当你确认机械层判错（比如 stderr_tail 里 `[skip]` 信息明确告诉你
+  agent 用的是非约定路径，但产物实际存在）才走这条；否则不要 pass
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/prompts/verifier/analyze_artifact_check_success.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/analyze_artifact_check_success.md.j2
@@ -1,0 +1,42 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（analyze_artifact_check / success）
+
+sisyphus 的机械 **post-artifact-check** 全绿。机械层确认：
+
+- 至少一个 eligible 仓（有 `feat/{{ req_id }}` 远程分支 + `openspec/changes/{{ req_id }}/`）
+- 每个 eligible 仓都有 `specs/<capability>/spec.md` 非空
+- 累积有 `proposal.md` 非空
+- 累积有 `tasks.md` 非空且含 ≥1 个 `- [ ]` / `- [x]` 复选框
+
+⚠️ 这一关**只校产物存在 + 非空**——不校 spec **内容**对不对（那是 spec_lint /
+challenger 的活）。所以"绿"只是说 agent 真动手了，不是说产物质量好。
+
+你（多数情况下被 fixer recheck 触发）要判：spec / proposal / tasks **内容是否可信**。
+
+### 关注点
+
+- proposal.md 是否说清 why / what / impact，还是 placeholder？
+- tasks.md 复选框是否反映真实工作（不是占位 `- [ ] todo` 一行）？
+- spec.md 能不能让一个不熟悉本 REQ 的 challenger 黑盒读懂？（具体 endpoint /
+  scenario 命名 / 输入输出）
+- 有没有跨仓 REQ 漏写其中一个仓的 spec.md？
+
+### NOT 该做
+
+- 不再机械校产物存在（已校）
+- 不开新 analyze 子 agent
+- 跑 `openspec validate` 不是你的活——下一站 spec_lint 会跑
+
+### 典型决策
+
+- `pass`：产物结构 + 内容质量都过得去，让 spec_lint 接着校 spec 格式
+- `fix` + `fixer=spec` + `scope=openspec/changes/{{ req_id }}/`：内容稀薄 / 占位
+  / 跨仓漏写 → spec fixer 补
+- `escalate`：内容看起来 agent 完全没理解需求，需要重起 analyze（fixer 救不回来）
+
+─────────
+
+{% if history %}{% include 'verifier/_audit.md.j2' %}{% endif %}
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/state.py
+++ b/orchestrator/src/orchestrator/state.py
@@ -26,6 +26,7 @@ class ReqState(StrEnum):
     INIT = "init"                               # 还没 analyze / 待初始化
     INTAKING = "intaking"                       # intake-agent 在跑（多轮 BKD chat 澄清 + 写 finalized intent）
     ANALYZING = "analyzing"                     # analyze-agent 在跑
+    ANALYZE_ARTIFACT_CHECKING = "analyze-artifact-checking"  # 机械校 analyze 产物（proposal/tasks/spec.md 存在 + 非空）
     SPEC_LINT_RUNNING = "spec-lint-running"     # openspec validate 检查（sisyphus 下发 runner 任务）
     CHALLENGER_RUNNING = "challenger-running"   # M18：challenger-agent 读 spec 写 contract test（黑盒，不看 dev 代码）
     DEV_CROSS_CHECK_RUNNING = "dev-cross-check-running"  # 开发交叉验证（sisyphus 下发 runner 任务）
@@ -48,6 +49,8 @@ class Event(StrEnum):
     INTAKE_FAIL = "intake.fail"                     # intake-agent 异常 / 用户放弃
     INTENT_ANALYZE = "intent.analyze"               # 人在 BKD 打 intent:analyze tag（旧入口，现支持 init:STATE）
     ANALYZE_DONE = "analyze.done"                   # analyze-agent 完成
+    ANALYZE_ARTIFACT_CHECK_PASS = "analyze-artifact-check.pass"   # 机械校 analyze 产物（proposal/tasks/spec.md）通过
+    ANALYZE_ARTIFACT_CHECK_FAIL = "analyze-artifact-check.fail"   # 机械校 analyze 产物失败 → verifier
     SPEC_LINT_PASS = "spec-lint.pass"               # openspec validate 通过
     SPEC_LINT_FAIL = "spec-lint.fail"               # openspec validate 失败 → verifier
     CHALLENGER_PASS = "challenger.pass"             # M18：challenger 写完 contract test 推 feat 分支
@@ -114,8 +117,19 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
         Transition(ReqState.ESCALATED, "escalate",
                    "start_analyze_with_finalized_intent 内部判 escalate"),
 
+    # REQ-analyze-artifact-check-1777254586：analyze done 后先机械校 proposal/tasks/spec.md
+    # 是否真存在 + 非空，再放进 spec_lint。防 agent 自报 pass 但产物全空。
     (ReqState.ANALYZING, Event.ANALYZE_DONE):
-        Transition(ReqState.SPEC_LINT_RUNNING, "create_spec_lint", "下发 openspec validate 任务"),
+        Transition(ReqState.ANALYZE_ARTIFACT_CHECKING, "create_analyze_artifact_check",
+                   "下发 analyze 产物结构性检查（proposal.md / tasks.md / spec.md 存在 + 非空）"),
+
+    (ReqState.ANALYZE_ARTIFACT_CHECKING, Event.ANALYZE_ARTIFACT_CHECK_PASS):
+        Transition(ReqState.SPEC_LINT_RUNNING, "create_spec_lint",
+                   "analyze 产物齐 → 下发 openspec validate 任务"),
+
+    (ReqState.ANALYZE_ARTIFACT_CHECKING, Event.ANALYZE_ARTIFACT_CHECK_FAIL):
+        Transition(ReqState.REVIEW_RUNNING, "invoke_verifier_for_analyze_artifact_check_fail",
+                   "analyze 产物不全 → verifier"),
 
     (ReqState.SPEC_LINT_RUNNING, Event.SPEC_LINT_PASS):
         Transition(ReqState.CHALLENGER_RUNNING, "start_challenger",
@@ -233,7 +247,9 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
     **{
         (st, Event.SESSION_FAILED): Transition(st, "escalate", "session crash → auto-resume or escalate")
         for st in [
-            ReqState.INTAKING, ReqState.ANALYZING, ReqState.SPEC_LINT_RUNNING, ReqState.CHALLENGER_RUNNING,
+            ReqState.INTAKING, ReqState.ANALYZING,
+            ReqState.ANALYZE_ARTIFACT_CHECKING,
+            ReqState.SPEC_LINT_RUNNING, ReqState.CHALLENGER_RUNNING,
             ReqState.DEV_CROSS_CHECK_RUNNING,
             ReqState.STAGING_TEST_RUNNING, ReqState.PR_CI_RUNNING,
             ReqState.ACCEPT_RUNNING, ReqState.ACCEPT_TEARING_DOWN,

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -50,6 +50,7 @@ _INTAKE_NO_RESULT_REASON: str = "intake-no-result-tag"
 _STATE_ISSUE_KEY: dict[ReqState, str | None] = {
     ReqState.INTAKING: "intent_issue_id",        # intake-agent 复用 intent issue
     ReqState.ANALYZING: "intent_issue_id",
+    ReqState.ANALYZE_ARTIFACT_CHECKING: None,    # 客观 checker，由 orchestrator 下发不绑 issue
     ReqState.SPEC_LINT_RUNNING: None,            # M15: 客观 checker，由 orchestrator 下发不绑 issue
     ReqState.DEV_CROSS_CHECK_RUNNING: None,      # M15: 客观 checker，由 orchestrator 下发不绑 issue
     ReqState.STAGING_TEST_RUNNING: "staging_test_issue_id",

--- a/orchestrator/tests/test_actions_create_analyze_artifact_check.py
+++ b/orchestrator/tests/test_actions_create_analyze_artifact_check.py
@@ -1,0 +1,154 @@
+"""actions/create_analyze_artifact_check.py 单测：mock checker + artifact_checks
+(REQ-analyze-artifact-check-1777254586)。
+
+跟 test_actions_smoke.py 里 create_staging_test 同结构。
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def patch_db(monkeypatch, target_module: str):
+    pool_writes: list = []
+
+    class P:
+        async def execute(self, sql, *args):
+            pool_writes.append((sql.strip()[:40], args))
+
+        async def fetchrow(self, sql, *args):
+            return None
+
+    monkeypatch.setattr(f"orchestrator.actions.{target_module}.db.get_pool", lambda: P())
+    return pool_writes
+
+
+def make_body(issue_id="src-1", project_id="p", event="session.completed", title="T"):
+    return type("B", (), {
+        "issueId": issue_id, "projectId": project_id,
+        "event": event, "title": title, "tags": [], "issueNumber": None,
+    })()
+
+
+@pytest.mark.asyncio
+async def test_pass_emits_pass_and_writes_artifact(monkeypatch):
+    from orchestrator.actions import create_analyze_artifact_check as mod
+    from orchestrator.checkers._types import CheckResult
+
+    fake_result = CheckResult(
+        passed=True, exit_code=0,
+        stdout_tail="ok\n", stderr_tail="",
+        duration_sec=1.2,
+        cmd="set -o pipefail; ...",
+    )
+
+    async def fake_run(req_id, *, timeout_sec=120):
+        return fake_result
+
+    monkeypatch.setattr(mod.checker, "run_analyze_artifact_check", fake_run)
+
+    insert_calls: list = []
+
+    async def fake_insert(pool, req_id, stage, result):
+        insert_calls.append((req_id, stage, result))
+
+    monkeypatch.setattr(mod.artifact_checks, "insert_check", fake_insert)
+    patch_db(monkeypatch, "create_analyze_artifact_check")
+
+    out = await mod.create_analyze_artifact_check(
+        body=make_body(), req_id="REQ-9", tags=[], ctx={},
+    )
+    assert out["emit"] == "analyze-artifact-check.pass"
+    assert out["passed"] is True
+    assert out["exit_code"] == 0
+    assert len(insert_calls) == 1
+    assert insert_calls[0] == ("REQ-9", "analyze-artifact-check", fake_result)
+
+
+@pytest.mark.asyncio
+async def test_fail_emits_fail_with_exit_code(monkeypatch):
+    from orchestrator.actions import create_analyze_artifact_check as mod
+    from orchestrator.checkers._types import CheckResult
+
+    fake_result = CheckResult(
+        passed=False, exit_code=1,
+        stdout_tail="", stderr_tail="=== FAIL analyze-artifact-check: tasks.md ...\n",
+        duration_sec=0.7,
+        cmd="set -o pipefail; ...",
+    )
+
+    async def fake_run(req_id, *, timeout_sec=120):
+        return fake_result
+
+    monkeypatch.setattr(mod.checker, "run_analyze_artifact_check", fake_run)
+
+    insert_calls: list = []
+
+    async def fake_insert(pool, req_id, stage, result):
+        insert_calls.append((req_id, stage, result))
+
+    monkeypatch.setattr(mod.artifact_checks, "insert_check", fake_insert)
+    patch_db(monkeypatch, "create_analyze_artifact_check")
+
+    out = await mod.create_analyze_artifact_check(
+        body=make_body(), req_id="REQ-9", tags=[], ctx={},
+    )
+    assert out["emit"] == "analyze-artifact-check.fail"
+    assert out["passed"] is False
+    assert out["exit_code"] == 1
+    assert len(insert_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_timeout_emits_fail_and_inserts_timeout_row(monkeypatch):
+    from orchestrator.actions import create_analyze_artifact_check as mod
+
+    async def fake_run(req_id, *, timeout_sec=120):
+        raise TimeoutError()
+
+    monkeypatch.setattr(mod.checker, "run_analyze_artifact_check", fake_run)
+
+    insert_calls: list = []
+
+    async def fake_insert(pool, req_id, stage, result):
+        insert_calls.append((req_id, stage, result))
+
+    monkeypatch.setattr(mod.artifact_checks, "insert_check", fake_insert)
+    patch_db(monkeypatch, "create_analyze_artifact_check")
+
+    out = await mod.create_analyze_artifact_check(
+        body=make_body(), req_id="REQ-9", tags=[], ctx={},
+    )
+    assert out["emit"] == "analyze-artifact-check.fail"
+    assert out["passed"] is False
+    assert out["reason"] == "timeout"
+    assert out["exit_code"] == -1
+    assert len(insert_calls) == 1
+    assert insert_calls[0][1] == "analyze-artifact-check"
+    assert insert_calls[0][2].reason == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_unhandled_exception_emits_fail(monkeypatch):
+    from orchestrator.actions import create_analyze_artifact_check as mod
+
+    async def fake_run(req_id, *, timeout_sec=120):
+        raise RuntimeError("kubectl exec channel busted")
+
+    monkeypatch.setattr(mod.checker, "run_analyze_artifact_check", fake_run)
+
+    insert_calls: list = []
+
+    async def fake_insert(pool, req_id, stage, result):
+        insert_calls.append((req_id, stage, result))
+
+    monkeypatch.setattr(mod.artifact_checks, "insert_check", fake_insert)
+    patch_db(monkeypatch, "create_analyze_artifact_check")
+
+    out = await mod.create_analyze_artifact_check(
+        body=make_body(), req_id="REQ-9", tags=[], ctx={},
+    )
+    assert out["emit"] == "analyze-artifact-check.fail"
+    assert out["passed"] is False
+    assert "kubectl" in out["reason"]
+    # 异常分支不写 artifact_checks（与 spec_lint 同语义）
+    assert insert_calls == []

--- a/orchestrator/tests/test_checkers_analyze_artifact_check.py
+++ b/orchestrator/tests/test_checkers_analyze_artifact_check.py
@@ -1,0 +1,228 @@
+"""checkers/analyze_artifact_check.py 单测：mock RunnerController，验 CheckResult
+字段 + empty-source guard / 0-eligible guard / proposal/tasks/spec literals
+（REQ-analyze-artifact-check-1777254586）。
+
+跟 test_checkers_spec_lint.py 同结构。
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from orchestrator.checkers._types import CheckResult
+from orchestrator.checkers.analyze_artifact_check import (
+    _build_cmd,
+    run_analyze_artifact_check,
+)
+from orchestrator.k8s_runner import ExecResult
+
+
+def make_fake_controller(exit_code: int, stdout: str = "", stderr: str = "", duration: float = 1.0):
+    class FakeRC:
+        async def exec_in_runner(self, req_id, command, **kw):
+            FakeRC.last_cmd = command
+            return ExecResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration_sec=duration)
+    FakeRC.last_cmd = ""
+    return FakeRC
+
+
+@pytest.mark.asyncio
+async def test_run_pass(monkeypatch):
+    FakeRC = make_fake_controller(exit_code=0, stdout="ok\n", stderr="", duration=2.0)
+    monkeypatch.setattr(
+        "orchestrator.checkers.analyze_artifact_check.k8s_runner.get_controller",
+        lambda: FakeRC(),
+    )
+    result = await run_analyze_artifact_check("REQ-1")
+
+    assert isinstance(result, CheckResult)
+    assert result.passed is True
+    assert result.exit_code == 0
+    assert result.stdout_tail == "ok\n"
+    assert "/workspace/source/*/" in result.cmd
+    assert "openspec/changes/REQ-1" in result.cmd
+    assert FakeRC.last_cmd == result.cmd
+
+
+@pytest.mark.asyncio
+async def test_run_fail(monkeypatch):
+    FakeRC = make_fake_controller(
+        exit_code=1, stdout="",
+        stderr="=== FAIL: repo-a: ... missing or all empty ===\n",
+        duration=3.1,
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.analyze_artifact_check.k8s_runner.get_controller",
+        lambda: FakeRC(),
+    )
+    result = await run_analyze_artifact_check("REQ-2")
+
+    assert result.passed is False
+    assert result.exit_code == 1
+    assert "FAIL" in result.stderr_tail
+
+
+@pytest.mark.asyncio
+async def test_run_timeout(monkeypatch):
+    class SlowRC:
+        async def exec_in_runner(self, req_id, command, **kw):
+            await asyncio.sleep(9999)
+            return ExecResult(exit_code=0, stdout="", stderr="", duration_sec=0)
+
+    monkeypatch.setattr(
+        "orchestrator.checkers.analyze_artifact_check.k8s_runner.get_controller",
+        lambda: SlowRC(),
+    )
+
+    async def fast_wait_for(coro, timeout):
+        task = asyncio.ensure_future(coro)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            raise TimeoutError() from None
+
+    monkeypatch.setattr(
+        "orchestrator.checkers.analyze_artifact_check.asyncio.wait_for",
+        fast_wait_for,
+    )
+
+    result = await run_analyze_artifact_check("REQ-3", timeout_sec=1)
+    assert result.passed is False
+    assert result.exit_code == -1
+    assert "超时" in result.stderr_tail
+
+
+def test_build_cmd_workspace_source_existence_guard():
+    cmd = _build_cmd("REQ-X")
+    assert "[ ! -d /workspace/source ]" in cmd
+    assert "FAIL analyze-artifact-check: /workspace/source missing" in cmd
+
+
+def test_build_cmd_repo_count_zero_guard():
+    cmd = _build_cmd("REQ-X")
+    assert "find /workspace/source -mindepth 1 -maxdepth 1 -type d" in cmd
+    assert '"$repo_count" -eq 0' in cmd
+    assert "FAIL analyze-artifact-check: /workspace/source empty" in cmd
+
+
+def test_build_cmd_zero_eligible_guard():
+    cmd = _build_cmd("REQ-X")
+    assert "ran=0" in cmd
+    assert "ran=$((ran+1))" in cmd
+    assert '"$ran" -eq 0' in cmd
+    assert "0 source repos eligible" in cmd
+
+
+def test_build_cmd_references_proposal_tasks_spec():
+    cmd = _build_cmd("REQ-X")
+    assert "openspec/changes/REQ-X/proposal.md" in cmd
+    assert "openspec/changes/REQ-X/tasks.md" in cmd
+    assert '"$ch/specs"' in cmd and "spec.md" in cmd
+
+
+def test_build_cmd_has_checkbox_regex():
+    cmd = _build_cmd("REQ-X")
+    assert r"\[[ xX]\]" in cmd
+    assert "grep -E" in cmd
+
+
+def test_build_cmd_uses_feat_branch():
+    cmd = _build_cmd("REQ-X")
+    assert 'git fetch origin "feat/REQ-X"' in cmd
+    assert 'git checkout -B "feat/REQ-X" "origin/feat/REQ-X"' in cmd
+
+
+def test_build_cmd_aggregate_proposal_tasks_flags():
+    cmd = _build_cmd("REQ-X")
+    assert "has_proposal=0" in cmd
+    assert "has_tasks=0" in cmd
+    assert "has_proposal=1" in cmd
+    assert "has_tasks=1" in cmd
+    assert '"$has_proposal" -eq 0' in cmd
+    assert '"$has_tasks" -eq 0' in cmd
+
+
+def test_build_cmd_ends_with_aggregate_exit():
+    cmd = _build_cmd("REQ-X")
+    assert cmd.rstrip().endswith("[ $fail -eq 0 ]")
+
+
+def _make_seq_controller(*results: ExecResult):
+    seq = list(results)
+
+    class FakeRC:
+        calls = 0
+
+        async def exec_in_runner(self, req_id, command, **kw):
+            FakeRC.calls += 1
+            return seq.pop(0)
+
+    return FakeRC
+
+
+@pytest.mark.asyncio
+async def test_recovers_from_dns_flake(monkeypatch):
+    monkeypatch.setattr(
+        "orchestrator.checkers.analyze_artifact_check.settings.checker_infra_flake_retry_enabled",
+        True,
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.analyze_artifact_check.settings.checker_infra_flake_retry_max",
+        1,
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.analyze_artifact_check.settings.checker_infra_flake_retry_backoff_sec",
+        0,
+    )
+    FakeRC = _make_seq_controller(
+        ExecResult(
+            exit_code=128, stdout="",
+            stderr="fatal: Could not resolve host github.com", duration_sec=1.0,
+        ),
+        ExecResult(exit_code=0, stdout="ok\n", stderr="", duration_sec=2.5),
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.analyze_artifact_check.k8s_runner.get_controller",
+        lambda: FakeRC(),
+    )
+    result = await run_analyze_artifact_check("REQ-X")
+    assert result.passed is True
+    assert result.attempts == 2
+    assert result.reason is not None
+    assert "flake-retry-recovered" in result.reason
+    assert FakeRC.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_real_artifact_failure(monkeypatch):
+    monkeypatch.setattr(
+        "orchestrator.checkers.analyze_artifact_check.settings.checker_infra_flake_retry_enabled",
+        True,
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.analyze_artifact_check.settings.checker_infra_flake_retry_max",
+        2,
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.analyze_artifact_check.settings.checker_infra_flake_retry_backoff_sec",
+        0,
+    )
+    FakeRC = _make_seq_controller(
+        ExecResult(
+            exit_code=1,
+            stdout="",
+            stderr="=== FAIL analyze-artifact-check: no eligible repo has openspec/changes/REQ-X/tasks.md with at least one Markdown checkbox ===\n",
+            duration_sec=0.5,
+        ),
+    )
+    monkeypatch.setattr(
+        "orchestrator.checkers.analyze_artifact_check.k8s_runner.get_controller",
+        lambda: FakeRC(),
+    )
+    result = await run_analyze_artifact_check("REQ-X")
+    assert result.passed is False
+    assert result.attempts == 1
+    assert result.reason is None
+    assert FakeRC.calls == 1

--- a/orchestrator/tests/test_contract_analyze_artifact_check.py
+++ b/orchestrator/tests/test_contract_analyze_artifact_check.py
@@ -1,11 +1,14 @@
-"""Contract tests for REQ-analyze-artifact-check-1777254586.
+"""Challenger contract tests for REQ-analyze-artifact-check-1777254586.
 
 Black-box contracts derived exclusively from:
   openspec/changes/REQ-analyze-artifact-check-1777254586/specs/analyze-artifact-check/spec.md
 
+Written by: challenger-agent (M18 — independent of dev implementation)
+
 Scenarios covered:
   AAC-S1  ANALYZING/ANALYZE_DONE → ANALYZE_ARTIFACT_CHECKING + create_analyze_artifact_check
           AND ANALYZE_ARTIFACT_CHECKING/PASS → SPEC_LINT_RUNNING + create_spec_lint
+          AND create_analyze_artifact_check is callable via actions REGISTRY
   AAC-S2  ANALYZE_ARTIFACT_CHECKING/FAIL → REVIEW_RUNNING + invoke_verifier_for_analyze_artifact_check_fail
           + verifier _STAGES contains "analyze_artifact_check"
   AAC-S3  ANALYZE_ARTIFACT_CHECKING in SESSION_FAILED self-loop
@@ -58,6 +61,15 @@ def test_aac_s1_analyze_done_routes_to_artifact_check_then_spec_lint() -> None:
     assert t2.action == "create_spec_lint", (
         "AAC-S1: ANALYZE_ARTIFACT_CHECK_PASS action MUST be 'create_spec_lint'. "
         f"Got {t2.action!r}"
+    )
+
+    # The orchestrator dispatches actions by name via REGISTRY; if
+    # create_analyze_artifact_check is not registered, the state machine
+    # would fail at runtime even though the transition is defined.
+    from orchestrator.actions import REGISTRY
+    assert "create_analyze_artifact_check" in REGISTRY, (
+        "AAC-S1: 'create_analyze_artifact_check' MUST be registered in actions.REGISTRY "
+        "so the orchestrator can dispatch it when ANALYZE_DONE fires"
     )
 
 

--- a/orchestrator/tests/test_contract_analyze_artifact_check.py
+++ b/orchestrator/tests/test_contract_analyze_artifact_check.py
@@ -22,8 +22,7 @@ from __future__ import annotations
 
 import pytest
 
-from orchestrator.state import Event, ReqState, TRANSITIONS, decide
-
+from orchestrator.state import TRANSITIONS, Event, ReqState, decide
 
 # ─── AAC-S1 ──────────────────────────────────────────────────────────────
 

--- a/orchestrator/tests/test_contract_analyze_artifact_check.py
+++ b/orchestrator/tests/test_contract_analyze_artifact_check.py
@@ -1,0 +1,311 @@
+"""Contract tests for REQ-analyze-artifact-check-1777254586.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-analyze-artifact-check-1777254586/specs/analyze-artifact-check/spec.md
+
+Scenarios covered:
+  AAC-S1  ANALYZING/ANALYZE_DONE → ANALYZE_ARTIFACT_CHECKING + create_analyze_artifact_check
+          AND ANALYZE_ARTIFACT_CHECKING/PASS → SPEC_LINT_RUNNING + create_spec_lint
+  AAC-S2  ANALYZE_ARTIFACT_CHECKING/FAIL → REVIEW_RUNNING + invoke_verifier_for_analyze_artifact_check_fail
+          + verifier _STAGES contains "analyze_artifact_check"
+  AAC-S3  ANALYZE_ARTIFACT_CHECKING in SESSION_FAILED self-loop
+  AAC-S4  build_cmd has /workspace/source missing/empty guards
+  AAC-S5  build_cmd checks proposal/tasks/spec/checkbox literals + feat branch
+  AAC-S6  build_cmd refuses 0 eligible repos + ends with `[ $fail -eq 0 ]`
+  AAC-S7  create_analyze_artifact_check pass writes artifact_checks + emits PASS
+  AAC-S8  create_analyze_artifact_check non-zero exit emits FAIL + still writes artifact_checks
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is truly wrong, escalate to spec_fixer to correct the spec.
+"""
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.state import Event, ReqState, TRANSITIONS, decide
+
+
+# ─── AAC-S1 ──────────────────────────────────────────────────────────────
+
+
+def test_aac_s1_analyze_done_routes_to_artifact_check_then_spec_lint() -> None:
+    """AAC-S1: (ANALYZING, ANALYZE_DONE) MUST route through ANALYZE_ARTIFACT_CHECKING
+    instead of jumping straight to SPEC_LINT_RUNNING; the artifact check pass MUST
+    then route to SPEC_LINT_RUNNING with create_spec_lint.
+    """
+    t1 = decide(ReqState.ANALYZING, Event.ANALYZE_DONE)
+    assert t1 is not None, (
+        "AAC-S1: (ANALYZING, ANALYZE_DONE) MUST be a registered transition"
+    )
+    assert t1.next_state is ReqState.ANALYZE_ARTIFACT_CHECKING, (
+        "AAC-S1: ANALYZE_DONE MUST move into ANALYZE_ARTIFACT_CHECKING, not "
+        "directly into SPEC_LINT_RUNNING. Got next_state="
+        f"{t1.next_state.value!r}"
+    )
+    assert t1.action == "create_analyze_artifact_check", (
+        "AAC-S1: ANALYZE_DONE transition action MUST be 'create_analyze_artifact_check'. "
+        f"Got {t1.action!r}"
+    )
+
+    t2 = decide(ReqState.ANALYZE_ARTIFACT_CHECKING, Event.ANALYZE_ARTIFACT_CHECK_PASS)
+    assert t2 is not None, (
+        "AAC-S1: (ANALYZE_ARTIFACT_CHECKING, ANALYZE_ARTIFACT_CHECK_PASS) MUST be "
+        "a registered transition"
+    )
+    assert t2.next_state is ReqState.SPEC_LINT_RUNNING, (
+        "AAC-S1: ANALYZE_ARTIFACT_CHECK_PASS MUST move to SPEC_LINT_RUNNING. "
+        f"Got {t2.next_state.value!r}"
+    )
+    assert t2.action == "create_spec_lint", (
+        "AAC-S1: ANALYZE_ARTIFACT_CHECK_PASS action MUST be 'create_spec_lint'. "
+        f"Got {t2.action!r}"
+    )
+
+
+# ─── AAC-S2 ──────────────────────────────────────────────────────────────
+
+
+def test_aac_s2_fail_routes_to_verifier_with_dedicated_handler() -> None:
+    """AAC-S2: (ANALYZE_ARTIFACT_CHECKING, FAIL) → REVIEW_RUNNING +
+    invoke_verifier_for_analyze_artifact_check_fail; the action is registered;
+    _STAGES contains the new stage so invoke_verifier accepts it.
+    """
+    t = decide(ReqState.ANALYZE_ARTIFACT_CHECKING, Event.ANALYZE_ARTIFACT_CHECK_FAIL)
+    assert t is not None, "AAC-S2: FAIL transition MUST be registered"
+    assert t.next_state is ReqState.REVIEW_RUNNING, (
+        f"AAC-S2: FAIL MUST go to REVIEW_RUNNING. Got {t.next_state.value!r}"
+    )
+    assert t.action == "invoke_verifier_for_analyze_artifact_check_fail", (
+        f"AAC-S2: FAIL action MUST be the dedicated verifier handler. Got {t.action!r}"
+    )
+
+    from orchestrator.actions import REGISTRY
+    assert "invoke_verifier_for_analyze_artifact_check_fail" in REGISTRY, (
+        "AAC-S2: invoke_verifier_for_analyze_artifact_check_fail MUST be registered "
+        "in the actions REGISTRY"
+    )
+
+    from orchestrator.actions._verifier import _STAGES
+    assert "analyze_artifact_check" in _STAGES, (
+        "AAC-S2: '_verifier._STAGES' MUST contain 'analyze_artifact_check' so "
+        "invoke_verifier(stage='analyze_artifact_check', trigger='fail') is accepted"
+    )
+
+
+# ─── AAC-S3 ──────────────────────────────────────────────────────────────
+
+
+def test_aac_s3_session_failed_self_loop_covers_new_state() -> None:
+    """AAC-S3: ANALYZE_ARTIFACT_CHECKING MUST appear in the SESSION_FAILED self-loop
+    so a runner-side crash during the artifact check is funneled through escalate
+    rather than silently bouncing.
+    """
+    t = TRANSITIONS.get((ReqState.ANALYZE_ARTIFACT_CHECKING, Event.SESSION_FAILED))
+    assert t is not None, (
+        "AAC-S3: (ANALYZE_ARTIFACT_CHECKING, SESSION_FAILED) MUST be in TRANSITIONS"
+    )
+    assert t.next_state is ReqState.ANALYZE_ARTIFACT_CHECKING, (
+        "AAC-S3: SESSION_FAILED self-loop MUST keep state on "
+        "ANALYZE_ARTIFACT_CHECKING (action 'escalate' decides whether to truly "
+        f"escalate). Got {t.next_state.value!r}"
+    )
+    assert t.action == "escalate", (
+        f"AAC-S3: SESSION_FAILED self-loop action MUST be 'escalate'. Got {t.action!r}"
+    )
+
+
+# ─── AAC-S4 ──────────────────────────────────────────────────────────────
+
+
+def _get_build_cmd(req_id: str = "REQ-X") -> str:
+    """Black-box: call _build_cmd as the spec calls out."""
+    from orchestrator.checkers import analyze_artifact_check as c
+    return c._build_cmd(req_id)
+
+
+def test_aac_s4_build_cmd_guards_workspace_source_missing_and_empty() -> None:
+    """AAC-S4: empty-source guard mirrors spec_lint."""
+    cmd = _get_build_cmd()
+    assert "[ ! -d /workspace/source ]" in cmd, (
+        "AAC-S4: cmd MUST guard /workspace/source missing"
+    )
+    assert "FAIL analyze-artifact-check: /workspace/source missing" in cmd, (
+        "AAC-S4: cmd MUST emit a FAIL marker when /workspace/source is missing"
+    )
+    assert "find /workspace/source -mindepth 1 -maxdepth 1 -type d" in cmd, (
+        "AAC-S4: cmd MUST count repos under /workspace/source via find"
+    )
+    assert '"$repo_count" -eq 0' in cmd, (
+        "AAC-S4: cmd MUST exit when repo_count == 0"
+    )
+    assert "FAIL analyze-artifact-check: /workspace/source empty" in cmd, (
+        "AAC-S4: cmd MUST emit a FAIL marker on empty /workspace/source"
+    )
+
+
+# ─── AAC-S5 ──────────────────────────────────────────────────────────────
+
+
+def test_aac_s5_build_cmd_checks_proposal_tasks_spec_checkbox_feat_branch() -> None:
+    """AAC-S5: cmd references proposal.md / tasks.md / spec.md / checkbox regex /
+    feat branch fetch literals.
+    """
+    cmd = _get_build_cmd("REQ-X")
+    assert "openspec/changes/REQ-X/proposal.md" in cmd, (
+        "AAC-S5: cmd MUST reference openspec/changes/REQ-X/proposal.md"
+    )
+    assert "openspec/changes/REQ-X/tasks.md" in cmd, (
+        "AAC-S5: cmd MUST reference openspec/changes/REQ-X/tasks.md"
+    )
+    # spec.md is searched recursively under specs/
+    assert '"$ch/specs"' in cmd and "spec.md" in cmd, (
+        "AAC-S5: cmd MUST recursively probe specs/<capability>/spec.md inside the "
+        "openspec/changes/<REQ>/ directory"
+    )
+    # Markdown checkbox char class fed to grep -E
+    assert r"\[[ xX]\]" in cmd, (
+        "AAC-S5: cmd MUST include a Markdown checkbox regex with class [ xX]"
+    )
+    assert "grep -E" in cmd, (
+        "AAC-S5: cmd MUST use 'grep -E' for the checkbox check"
+    )
+    assert 'git fetch origin "feat/REQ-X"' in cmd, (
+        "AAC-S5: cmd MUST fetch origin feat/REQ-X to obtain the analyze branch"
+    )
+
+
+# ─── AAC-S6 ──────────────────────────────────────────────────────────────
+
+
+def test_aac_s6_build_cmd_refuses_zero_eligible_repos_and_aggregates_failure() -> None:
+    """AAC-S6: ran=0 guard + final aggregated `[ $fail -eq 0 ]`."""
+    cmd = _get_build_cmd()
+    assert "ran=0" in cmd, "AAC-S6: cmd MUST initialise ran counter to 0"
+    assert "ran=$((ran+1))" in cmd, (
+        "AAC-S6: cmd MUST increment ran for each eligible repo"
+    )
+    assert '"$ran" -eq 0' in cmd, (
+        "AAC-S6: cmd MUST guard ran==0 so 0-eligible-repos is a failure"
+    )
+    assert "0 source repos eligible" in cmd, (
+        "AAC-S6: cmd MUST emit '0 source repos eligible' marker (mirrors spec_lint)"
+    )
+    assert cmd.rstrip().endswith("[ $fail -eq 0 ]"), (
+        "AAC-S6: cmd MUST end with '[ $fail -eq 0 ]' so the final exit reflects "
+        "the aggregated check status"
+    )
+
+
+# ─── AAC-S7 ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aac_s7_action_pass_writes_artifact_then_emits_pass(monkeypatch) -> None:
+    """AAC-S7: pass result MUST insert into artifact_checks with stage
+    'analyze-artifact-check' AND return dict containing emit=PASS event.
+    """
+    from orchestrator.actions import create_analyze_artifact_check as mod
+    from orchestrator.checkers._types import CheckResult
+
+    fake_result = CheckResult(
+        passed=True, exit_code=0,
+        stdout_tail="ok\n", stderr_tail="",
+        duration_sec=1.5, cmd="<<cmd>>",
+    )
+
+    async def fake_run(req_id, *, timeout_sec=120):
+        return fake_result
+
+    monkeypatch.setattr(mod.checker, "run_analyze_artifact_check", fake_run)
+
+    insert_calls: list = []
+
+    async def fake_insert(pool, req_id, stage, result):
+        insert_calls.append((req_id, stage, result))
+
+    monkeypatch.setattr(mod.artifact_checks, "insert_check", fake_insert)
+
+    class FakePool:
+        async def execute(self, sql, *args):
+            return None
+
+        async def fetchrow(self, sql, *args):
+            return None
+
+    monkeypatch.setattr(mod.db, "get_pool", lambda: FakePool())
+
+    body = type("B", (), {
+        "issueId": "x", "projectId": "p", "event": "session.completed",
+        "title": "T", "tags": [], "issueNumber": None,
+    })()
+    out = await mod.create_analyze_artifact_check(
+        body=body, req_id="REQ-7", tags=[], ctx={},
+    )
+    assert out["emit"] == "analyze-artifact-check.pass", (
+        "AAC-S7: emit MUST be analyze-artifact-check.pass on success"
+    )
+    assert len(insert_calls) == 1, (
+        "AAC-S7: artifact_checks.insert_check MUST be called exactly once on success"
+    )
+    assert insert_calls[0][1] == "analyze-artifact-check", (
+        f"AAC-S7: artifact_checks stage MUST be 'analyze-artifact-check'. "
+        f"Got {insert_calls[0][1]!r}"
+    )
+    assert insert_calls[0][2].passed is True
+
+
+# ─── AAC-S8 ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aac_s8_action_nonzero_emits_fail_with_exit_code(monkeypatch) -> None:
+    """AAC-S8: non-zero exit MUST emit FAIL with the same exit_code AND still
+    write a row to artifact_checks for observability.
+    """
+    from orchestrator.actions import create_analyze_artifact_check as mod
+    from orchestrator.checkers._types import CheckResult
+
+    fake_result = CheckResult(
+        passed=False, exit_code=1,
+        stdout_tail="",
+        stderr_tail="=== FAIL analyze-artifact-check: ... ===\n",
+        duration_sec=0.5, cmd="<<cmd>>",
+    )
+
+    async def fake_run(req_id, *, timeout_sec=120):
+        return fake_result
+
+    monkeypatch.setattr(mod.checker, "run_analyze_artifact_check", fake_run)
+
+    insert_calls: list = []
+
+    async def fake_insert(pool, req_id, stage, result):
+        insert_calls.append((req_id, stage, result))
+
+    monkeypatch.setattr(mod.artifact_checks, "insert_check", fake_insert)
+
+    class FakePool:
+        async def execute(self, sql, *args):
+            return None
+
+        async def fetchrow(self, sql, *args):
+            return None
+
+    monkeypatch.setattr(mod.db, "get_pool", lambda: FakePool())
+
+    body = type("B", (), {
+        "issueId": "x", "projectId": "p", "event": "session.completed",
+        "title": "T", "tags": [], "issueNumber": None,
+    })()
+    out = await mod.create_analyze_artifact_check(
+        body=body, req_id="REQ-8", tags=[], ctx={},
+    )
+    assert out["emit"] == "analyze-artifact-check.fail", (
+        "AAC-S8: emit MUST be analyze-artifact-check.fail on non-zero exit"
+    )
+    assert out["passed"] is False
+    assert out["exit_code"] == 1
+    assert len(insert_calls) == 1, (
+        "AAC-S8: artifact_checks.insert_check MUST still be called once on FAIL"
+    )
+    assert insert_calls[0][1] == "analyze-artifact-check"

--- a/orchestrator/tests/test_state.py
+++ b/orchestrator/tests/test_state.py
@@ -16,7 +16,10 @@ EXPECTED = [
     # 内部 emit verify.escalate 路径（clone_involved_repos 失败等）
     (ReqState.ANALYZING,            Event.VERIFY_ESCALATE,     ReqState.ESCALATED,           "escalate"),
     (ReqState.INTAKING,             Event.VERIFY_ESCALATE,     ReqState.ESCALATED,           "escalate"),
-    (ReqState.ANALYZING,            Event.ANALYZE_DONE,        ReqState.SPEC_LINT_RUNNING,   "create_spec_lint"),
+    # REQ-analyze-artifact-check-1777254586：analyze done 走 artifact check 再到 spec_lint
+    (ReqState.ANALYZING,            Event.ANALYZE_DONE,                 ReqState.ANALYZE_ARTIFACT_CHECKING, "create_analyze_artifact_check"),
+    (ReqState.ANALYZE_ARTIFACT_CHECKING, Event.ANALYZE_ARTIFACT_CHECK_PASS, ReqState.SPEC_LINT_RUNNING, "create_spec_lint"),
+    (ReqState.ANALYZE_ARTIFACT_CHECKING, Event.ANALYZE_ARTIFACT_CHECK_FAIL, ReqState.REVIEW_RUNNING,    "invoke_verifier_for_analyze_artifact_check_fail"),
     (ReqState.SPEC_LINT_RUNNING,    Event.SPEC_LINT_PASS,      ReqState.CHALLENGER_RUNNING,  "start_challenger"),
     (ReqState.SPEC_LINT_RUNNING,    Event.SPEC_LINT_FAIL,      ReqState.REVIEW_RUNNING,      "invoke_verifier_for_spec_lint_fail"),
     # M18: challenger between spec_lint and dev_cross_check
@@ -62,7 +65,9 @@ def test_session_failed_routes_to_escalate_action_all_running_states():
     所以这里只验 action 名 + transition 存在，不再要求 next_state == ESCALATED。
     """
     running = [
-        ReqState.INTAKING, ReqState.ANALYZING, ReqState.SPEC_LINT_RUNNING, ReqState.DEV_CROSS_CHECK_RUNNING,
+        ReqState.INTAKING, ReqState.ANALYZING,
+        ReqState.ANALYZE_ARTIFACT_CHECKING,
+        ReqState.SPEC_LINT_RUNNING, ReqState.DEV_CROSS_CHECK_RUNNING,
         ReqState.STAGING_TEST_RUNNING, ReqState.PR_CI_RUNNING,
         ReqState.ACCEPT_RUNNING, ReqState.ACCEPT_TEARING_DOWN,
         # M14b：verifier / fixer running state 也必须 escalate


### PR DESCRIPTION
## Summary

Insert a mechanical post-artifact-check between `ANALYZING` and `SPEC_LINT_RUNNING` so an analyze BKD agent that **self-reports pass but ships no artifacts** is caught immediately on the main chain instead of leaking through to spec_lint / dev_cross_check / verifier.

- New state \`ReqState.ANALYZE_ARTIFACT_CHECKING\` + 2 events \`ANALYZE_ARTIFACT_CHECK_PASS\`/\`_FAIL\`. analyze.done now routes through the new check; pass → spec_lint, fail → verifier with a dedicated prompt that biases toward \`escalate\` (LLM抽风 0 产物) or \`fix+fixer=spec\` (部分缺失).
- New checker \`checkers/analyze_artifact_check.py\` mirrors the spec_lint pattern: per-eligible-repo \`specs/<capability>/spec.md\` non-empty + cumulative non-empty \`proposal.md\` and \`tasks.md\` with ≥1 Markdown checkbox; reuses \`_flake.run_with_flake_retry\` and the existing empty-source guards. spec-home cross-repo REQ stays supported because proposal/tasks are checked cumulatively.
- Reuses the existing \`artifact_checks\` table (stage=\`analyze-artifact-check\`); no schema migration.
- Verifier glue: \`_STAGES\` + \`_PASS_ROUTING\` + \`invoke_verifier_for_analyze_artifact_check_fail\` action; new \`prompts/verifier/analyze_artifact_check_{fail,success}.md.j2\`. \`watchdog._STATE_ISSUE_KEY\` registers the new mechanical state with \`None\`.
- docs/state-machine.md ReqState count 16→17, Event count 27→29, mermaid diagram updated.

## Test plan
- [x] \`make ci-lint\` (BASE_REV scoped to this branch) → All checks passed
- [x] \`make ci-unit-test\` → 1256 passed, 2 deselected, 0 failed
- [x] \`scripts/check-scenario-refs.sh\` → all 403 scenario refs resolved
- [x] \`openspec validate REQ-analyze-artifact-check-1777254586\` → valid
- [x] AAC-S1..S8 contract tests cover state-machine wiring + build_cmd literals + action emit (\`tests/test_contract_analyze_artifact_check.py\`)
- [x] Unit tests for checker (\`test_checkers_analyze_artifact_check.py\`, 12) + action (\`test_actions_create_analyze_artifact_check.py\`, 4) + state-machine drift (\`test_state.py\` + \`test_contract_docs_drift_audit.py\`)
- [ ] Live REQ on dev: trigger an analyze that pushes feat branch with empty proposal.md → confirm \`analyze-artifact-check.fail\` row in \`artifact_checks\` + verifier issue created with \`verify:analyze_artifact_check\`/\`trigger:fail\` tags

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-analyze-artifact-check-1777254586\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)