### PR TITLE
test(engine): adversarial mock tests for state machine (REQ-engine-adversarial-tests-v2-1777256408)

### DIFF
--- a/openspec/changes/REQ-engine-adversarial-tests-v2-1777256408/proposal.md
+++ b/openspec/changes/REQ-engine-adversarial-tests-v2-1777256408/proposal.md
@@ -1,0 +1,64 @@
+# REQ-engine-adversarial-tests-v2-1777256408: test(engine): adversarial mock tests for state machine
+
+## 问题
+
+`orchestrator/src/orchestrator/engine.py` 的 `engine.step` 是状态机推进器：
+查 transition → CAS → record stage_runs → dispatch action → 链式 emit。
+任一环节挂掉都直接影响所有 REQ 的状态推进。
+
+现有 `test_engine.py`（14 条）只覆盖了 happy-path emit chain + 几个常规 fail
+（cleanup 失败 / illegal transition / 简单 CAS race）。**真要把 engine.step 当裁判**，
+我们需要一组系统性的 adversarial 单元测试，专门挑奇形输入 / 反常返回值 / 死路径
+往里灌，看 engine 会不会：
+
+1. 把脏数据当 emit 链下去（如 handler 返回 `{"emit": "garbage"}` 时尝试推进）
+2. 在 chain 中段 row 消失时崩溃（`req_state.get` 返回 None）
+3. 把 None / list / int 当 emit dict 解构 (`result.get("emit")`)
+4. 在已是 terminal state 时多次触发 cleanup（self-loop 在 ESCALATED 上）
+5. 因 stage_runs DB 写挂导致主流程异常（违反 best-effort 契约）
+6. action 不在 REGISTRY 时触发崩溃而非返回 error
+7. 在 chained 路径里命中 illegal transition 时丢失 base_result
+
+## 方案
+
+新增 `orchestrator/tests/test_engine_adversarial.py`：12 条 adversarial 用例
+（EAT-S1..S12），全部用 in-process FakePool + stub action 隔离副作用，**不打 BKD
+不打 Postgres 不打 K8s**，复用已有 `test_engine.py` 的 `FakePool` + `stub_actions`
+fixture 模式（直接从 conftest / 跨 test 引用，不抄一份）。
+
+每个 case 一句话：
+
+| ID | 反常输入 | 期望 |
+|---|---|---|
+| EAT-S1 | handler 返回 `{"emit": "garbage-event"}` | 不抛错；engine 记 `engine.invalid_emit` log；返回 base_result，无 `chained` 字段 |
+| EAT-S2 | handler 返回 `None` | 不抛错；engine 把 result 当空 dict 处理；无 `chained` 字段 |
+| EAT-S3 | handler 返回 `[1,2,3]`（非 dict） | 同 S2：被规整成空 dict，无 `chained` |
+| EAT-S4 | chain 中段 `req_state.get` 返回 None（行被删 / 库重置） | engine 早返 base_result，不抛 AttributeError |
+| EAT-S5 | chained emit 推到一个该 state 没注册的 transition | 子 step 返回 skip+`no transition`；父 base_result 含 `chained.action == "skip"` |
+| EAT-S6 | action 名在 transition 表但不在 REGISTRY | 返回 `{"action":"error","reason":"action <X> not registered"}`，CAS 已经成功但不副作用 |
+| EAT-S7 | ESCALATED + VERIFY_ESCALATE（self-loop, action=None） | 返回 `no-op`，**不**再次触发 cleanup_runner（cur 已 terminal） |
+| EAT-S8 | stage_runs INSERT 抛异常 | engine.step 不抛；transition 仍成功 |
+| EAT-S9 | body 缺 issueId 属性（getattr 默认 None） | 不抛 AttributeError |
+| EAT-S10 | depth=12 边界（合法）+ depth=13（触红） | depth=12 走完最后一次 dispatch；depth=13 立刻返 recursion error |
+| EAT-S11 | SESSION_FAILED 在 terminal state（DONE） | 无 transition → skip，escalate action 不被调 |
+| EAT-S12 | DONE 终态对所有 Event 都返 skip | 全枚举遍历 Event：terminal DONE 不接任何事件 |
+
+S1-S6 验"垃圾输入不崩 engine"。
+S7-S9 验"边界 / 内部异常不传染主链"。
+S10-S12 验"终态语义"。
+
+测试**只触 engine.py**，不触 actions/checkers/k8s_runner —— 这是状态机层的契约
+测试，不应混入 stage 业务逻辑（否则跟 `test_engine_chain_*` / `test_actions_*`
+重叠）。
+
+## 不做
+
+- ❌ 不增加新 ReqState / Event：纯测试增量
+- ❌ 不改 `engine.py`：全部用现有 API + 伪输入；如果某条 case 挂了
+  说明 engine 真的有 bug，需要 follow-up REQ 修
+- ❌ 不写 integration test（M18 challenger 写）
+
+## 影响
+
+- `orchestrator/tests/test_engine_adversarial.py` 新增 1 个文件 ≈ 350 行
+- 不动 prod 代码。不动 schema。不影响 runtime

--- a/openspec/changes/REQ-engine-adversarial-tests-v2-1777256408/specs/engine-adversarial-tests/spec.md
+++ b/openspec/changes/REQ-engine-adversarial-tests-v2-1777256408/specs/engine-adversarial-tests/spec.md
@@ -1,0 +1,211 @@
+## ADDED Requirements
+
+### Requirement: Engine.step rejects invalid emit strings without crashing
+
+The state-machine engine (`orchestrator/src/orchestrator/engine.py::step`) SHALL
+treat an action handler's return value `{"emit": "<unknown-string>"}` — where
+`<unknown-string>` is not a member of the `Event` enum — as a no-op for the
+chained recursion path. The engine MUST NOT raise; it MUST log
+`engine.invalid_emit` and return the unchained `base_result` so the caller can
+proceed safely. This guard exists because handlers are external code (BKD agent
+prompts construct event names dynamically) and a typo in the emit name MUST NOT
+take down the orchestrator.
+
+#### Scenario: EAT-S1 unknown emit string is logged and dropped
+
+- **GIVEN** an action handler registered for `start_challenger` returns
+  `{"emit": "totally-not-an-event"}` from `engine.step` invoked at
+  `(SPEC_LINT_RUNNING, SPEC_LINT_PASS)`
+- **WHEN** the engine processes the emit chain
+- **THEN** `engine.step` MUST return without raising, the returned dict MUST
+  contain `action="start_challenger"` and `next_state="challenger-running"`,
+  and MUST NOT contain a `chained` key (the bogus emit was dropped)
+
+### Requirement: Engine.step normalizes non-dict handler returns
+
+`engine.step` MUST tolerate action handlers that return values other than
+`dict` (e.g. `None`, lists, primitives). When the handler return value is not a
+`dict`, the engine SHALL substitute an empty dict and skip the chained emit
+path. The handler return value of any shape MUST NOT raise an `AttributeError`
+or `TypeError` from `engine.step`. This requirement protects the engine from
+adversarial / sloppy handler implementations and from `await` chains that
+accidentally drop the return value.
+
+#### Scenario: EAT-S2 handler returning None is treated as empty dict
+
+- **GIVEN** an action handler registered for `start_challenger` returns `None`
+- **WHEN** `engine.step` runs at `(SPEC_LINT_RUNNING, SPEC_LINT_PASS)`
+- **THEN** the call MUST NOT raise, the result MUST contain
+  `action="start_challenger"` and `next_state="challenger-running"`, and the
+  `result` field of the returned dict MUST be `{}` (the empty-dict
+  substitution)
+
+#### Scenario: EAT-S3 handler returning a list is treated as empty dict
+
+- **GIVEN** an action handler registered for `start_challenger` returns
+  `[1, 2, 3]`
+- **WHEN** `engine.step` runs at `(SPEC_LINT_RUNNING, SPEC_LINT_PASS)`
+- **THEN** the call MUST NOT raise, and the returned dict MUST contain
+  `action="start_challenger"` with no `chained` key
+
+### Requirement: Engine.step survives row disappearance during emit chain
+
+`engine.step` MUST early-return the parent `base_result` without raising
+`AttributeError` when, after dispatching a chained action, the reloaded
+`req_state.get` returns `None` (row deleted, DB reset, or test-mode purge
+mid-chain). The chain MUST silently truncate at that point rather than
+crashing the webhook handler. This guard exists because action handlers can
+trigger DB compaction / admin cleanup as a side effect, and a missing row
+mid-recursion is a recoverable race, not a programmer error.
+
+#### Scenario: EAT-S4 row vanishes between dispatch and chained reload
+
+- **GIVEN** an action handler registered for `create_spec_lint` returns
+  `{"emit": "spec-lint.pass"}`, AND between the action's CAS-advance and the
+  chained `req_state.get` the row for that REQ is removed from the FakePool
+- **WHEN** `engine.step` runs at `(ANALYZE_ARTIFACT_CHECKING,
+  ANALYZE_ARTIFACT_CHECK_PASS)`
+- **THEN** the call MUST NOT raise, and the returned dict MUST contain
+  `action="create_spec_lint"` without a `chained` key
+
+### Requirement: Engine.step propagates illegal chained transitions as skip
+
+`engine.step` MUST return `{"action": "skip", "reason": "no transition
+<state>+<event>"}` when a handler emits an event that has no defined
+transition from the post-dispatch state. The parent call MUST attach this
+skip dict at `base_result["chained"]` rather than discarding it, so audit
+logs preserve the dropped event for debugging.
+
+#### Scenario: EAT-S5 chained emit hits illegal transition
+
+- **GIVEN** an action handler registered for `start_challenger` returns
+  `{"emit": "archive.done"}` (event has no transition from
+  `CHALLENGER_RUNNING`)
+- **WHEN** `engine.step` runs at `(SPEC_LINT_RUNNING, SPEC_LINT_PASS)` so the
+  CAS advances to `CHALLENGER_RUNNING` then chains
+- **THEN** the returned dict MUST contain `action="start_challenger"`,
+  `chained.action="skip"`, and `chained.reason` containing
+  `"no transition challenger-running+archive.done"`
+
+### Requirement: Engine.step reports unregistered action without crashing
+
+`engine.step` MUST return `{"action": "error", "reason": "action <name> not
+registered"}` without raising and without invoking the chain when the
+transition table names an `action` string that is not present in
+`actions.REGISTRY`. The CAS-advance to `next_state` has already been
+committed at this point and MUST NOT be rolled back — terminal audit recovery
+is the operator's job, not the engine's.
+
+#### Scenario: EAT-S6 transition action missing from registry returns error
+
+- **GIVEN** the `REGISTRY` has been cleared (no `start_challenger` registered)
+- **WHEN** `engine.step` runs at `(SPEC_LINT_RUNNING, SPEC_LINT_PASS)`
+- **THEN** the returned dict MUST contain `action="error"`, the `reason` field
+  MUST equal the literal string
+  `"action start_challenger not registered"`, and the FakePool's row MUST
+  have advanced to `state="challenger-running"` (CAS already committed)
+
+### Requirement: Engine.step does not re-trigger runner cleanup on terminal self-loop
+
+`engine.step` MUST trigger `cleanup_runner` exactly once when transitioning
+**into** a terminal state (`DONE` / `ESCALATED`) **from** a non-terminal
+state. Self-loop transitions where both `cur_state` and `next_state` are
+terminal (e.g. `(ESCALATED, VERIFY_ESCALATE) → ESCALATED`, fired by a user
+follow-up) MUST NOT schedule another cleanup task. This prevents cleanup
+races where a just-resumed runner pod is killed by an idempotent self-loop
+event.
+
+#### Scenario: EAT-S7 ESCALATED + VERIFY_ESCALATE does not re-trigger cleanup
+
+- **GIVEN** a row at state `ESCALATED` and a fake k8s controller injected
+- **WHEN** `engine.step` runs at `(ESCALATED, VERIFY_ESCALATE)`
+- **THEN** the returned dict MUST contain `action="no-op"`, the row state MUST
+  remain `ESCALATED`, and the fake controller's `cleanup_runner` mock MUST NOT
+  have been awaited
+
+### Requirement: Engine.step is best-effort on stage_runs failures
+
+`engine.step` MUST catch any database failure inside `_record_stage_transitions`
+(connection error, schema drift, INSERT raising) and MUST log at WARNING level
+(`engine.stage_runs.write_failed`) without propagating to the caller —
+state-machine progress depends on CAS, not observability writes.
+
+#### Scenario: EAT-S8 stage_runs insert raises but engine still advances
+
+- **GIVEN** a FakePool whose `INSERT INTO stage_runs` path raises
+  `RuntimeError("DB down")`
+- **WHEN** `engine.step` runs at `(SPEC_LINT_RUNNING, SPEC_LINT_PASS)`
+- **THEN** the call MUST NOT raise, the returned dict MUST contain
+  `action="start_challenger"`, and the row state MUST be `CHALLENGER_RUNNING`
+
+### Requirement: Engine.step tolerates body objects missing optional attributes
+
+`engine.step` MUST proceed with `issue_id=None` for observability records when
+the webhook body lacks an `issueId` attribute, and a missing attribute MUST
+NOT raise. The engine reads `body.issueId` via `getattr(body, "issueId",
+None)` to support tests and edge cases where the webhook body is synthetic
+(e.g. INTENT_ANALYZE injection from snapshot loop).
+
+#### Scenario: EAT-S9 body without issueId attribute does not raise
+
+- **GIVEN** a `body` object created with `type("B", (), {})()` (no attributes)
+- **WHEN** `engine.step` runs at `(SPEC_LINT_RUNNING, SPEC_LINT_PASS)`
+- **THEN** the call MUST NOT raise, and the returned dict MUST contain
+  `action="start_challenger"` and `next_state="challenger-running"`
+
+### Requirement: Engine.step recursion guard fires at depth 13
+
+`engine.step` MUST short-circuit and return `{"action": "error", "reason":
+"engine recursion >12"}` without dispatching the action when `depth > 12`.
+The engine accepts a `depth` parameter (default 0) and increments it on every
+chained recursion; calls at exactly `depth=12` MUST still execute normally —
+the boundary is strict greater-than.
+
+#### Scenario: EAT-S10a depth=12 still dispatches handler
+
+- **GIVEN** a registered handler `start_challenger`
+- **WHEN** `engine.step` is invoked with `depth=12` at
+  `(SPEC_LINT_RUNNING, SPEC_LINT_PASS)`
+- **THEN** the handler MUST be called once, and the returned dict MUST contain
+  `action="start_challenger"` with no recursion-error reason
+
+#### Scenario: EAT-S10b depth=13 triggers recursion guard
+
+- **GIVEN** a registered handler `start_challenger`
+- **WHEN** `engine.step` is invoked with `depth=13` at
+  `(SPEC_LINT_RUNNING, SPEC_LINT_PASS)`
+- **THEN** the handler MUST NOT be called, and the returned dict MUST equal
+  `{"action": "error", "reason": "engine recursion >12"}`
+
+### Requirement: Engine.step skips SESSION_FAILED on terminal states
+
+`engine.step` MUST return `{"action": "skip", "reason": "no transition
+<state>+session.failed"}` without invoking the `escalate` action when
+`SESSION_FAILED` arrives at a terminal state (`DONE` or `ESCALATED`). The
+transition table only registers `(SESSION_FAILED, *_RUNNING)` self-loops, so
+terminal states have no `SESSION_FAILED` transition. This prevents zombie
+session-failure events from re-escalating an already-archived REQ.
+
+#### Scenario: EAT-S11 SESSION_FAILED on DONE is skipped
+
+- **GIVEN** a row at state `DONE` and an `escalate` stub registered
+- **WHEN** `engine.step` runs at `(DONE, SESSION_FAILED)`
+- **THEN** the returned dict MUST contain `action="skip"` with reason
+  starting `"no transition done+"`, and the `escalate` stub MUST NOT have
+  been invoked
+
+### Requirement: DONE terminal accepts no events
+
+`engine.step(cur_state=DONE, ...)` MUST return `skip` for every member of the
+`Event` enum without dispatching any action or scheduling cleanup. The `DONE`
+state is a strict terminal state: every member of the `Event` enum MUST
+yield `decide(DONE, event) is None`. This guards against late webhooks (BKD
+`session.completed` arriving after archive) re-running work on an
+already-finished REQ.
+
+#### Scenario: EAT-S12 DONE skips every Event in the enum
+
+- **GIVEN** a row at state `DONE`
+- **WHEN** `engine.step` is invoked once for each member of `Event`
+- **THEN** every call MUST return `action="skip"`, none of the calls MUST
+  raise, and no action handler MUST be invoked across the full sweep

--- a/openspec/changes/REQ-engine-adversarial-tests-v2-1777256408/tasks.md
+++ b/openspec/changes/REQ-engine-adversarial-tests-v2-1777256408/tasks.md
@@ -1,0 +1,32 @@
+# Tasks for REQ-engine-adversarial-tests-v2-1777256408
+
+## Stage: contract / spec
+
+- [x] author `proposal.md` —— 描述 12 条 adversarial scenario 范围 + 不做清单
+- [x] author `specs/engine-adversarial-tests/spec.md` ADDED delta：
+      列出 EAT-S1..EAT-S12 全部 GIVEN/WHEN/THEN
+
+## Stage: implementation
+
+- [x] 新增 `orchestrator/tests/test_engine_adversarial.py`：
+  - 复用 `test_engine.py` 已有的 `FakePool` + `FakeReq` + `stub_actions` 设计
+    （直接 import 它们的私有定义，避免抄一份让两边漂移）
+  - 12 条 case 一一对应 EAT-S1..S12 scenario
+  - 所有 case 用 `pytest.mark.asyncio`，不依赖真 DB / BKD / K8s
+- [x] EAT-S1：emit garbage → invalid_emit log，无 chained
+- [x] EAT-S2：handler 返 None → 视作空 dict
+- [x] EAT-S3：handler 返 list → 视作空 dict
+- [x] EAT-S4：chain 中段 row 消失（FakePool 删 row）→ 安全早返
+- [x] EAT-S5：chained emit 推到无 transition 的 state → skip
+- [x] EAT-S6：action 不在 REGISTRY → action 'X' not registered
+- [x] EAT-S7：terminal self-loop（ESCALATED + VERIFY_ESCALATE）不再 cleanup
+- [x] EAT-S8：stage_runs INSERT 抛异常 → 主流程不挂
+- [x] EAT-S9：body 缺 issueId → 不抛
+- [x] EAT-S10：recursion 边界（depth=12 vs depth=13）
+- [x] EAT-S11：SESSION_FAILED 在 DONE → skip（terminal 不接 SESSION_FAILED）
+- [x] EAT-S12：DONE 终态对所有 Event → skip（穷举）
+
+## Stage: PR
+
+- [x] git push feat/REQ-engine-adversarial-tests-v2-1777256408
+- [x] gh pr create --label sisyphus（PR body 写动机 + 测试方案）

--- a/orchestrator/tests/test_contract_engine_adversarial_challenger.py
+++ b/orchestrator/tests/test_contract_engine_adversarial_challenger.py
@@ -1,0 +1,552 @@
+"""Challenger contract tests for REQ-engine-adversarial-tests-v2-1777256408.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-engine-adversarial-tests-v2-1777256408/specs/engine-adversarial-tests/spec.md
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is truly wrong, escalate to spec_fixer to correct the spec, not the test.
+
+Scenarios covered:
+  EAT-S1   handler returns unknown emit string → logged+dropped, no chained key
+  EAT-S2   handler returns None → treated as empty dict, result["result"]=={}
+  EAT-S3   handler returns list → treated as empty dict, no chained key
+  EAT-S4   req_state.get returns None mid-chain → early return base_result, no chained
+  EAT-S5   chained emit hits illegal transition → base_result["chained"].action=="skip"
+  EAT-S6   action missing from REGISTRY → returns error dict, CAS committed to next_state
+  EAT-S7   ESCALATED+VERIFY_ESCALATE self-loop → no-op, cleanup_runner not triggered
+  EAT-S8   stage_runs raises → engine still advances (best-effort write)
+  EAT-S9   body without issueId attribute → no AttributeError, normal result
+  EAT-S10a depth=12 → handler still dispatched normally
+  EAT-S10b depth=13 → recursion guard fires immediately, handler not called
+  EAT-S11  SESSION_FAILED on DONE → skip, escalate not invoked
+  EAT-S12  DONE terminal skips every Event enum member
+
+Module contract under test: orchestrator.engine.step
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+# ─── Shared helpers ───────────────────────────────────────────────────────────
+
+
+class _Body:
+    issueId = "bkd-eat-test"
+    projectId = "proj-eat"
+
+
+class _NoAttrBody:
+    """Body with no attributes at all (EAT-S9)."""
+
+
+class _FakeRow:
+    def __init__(self, state, context=None):
+        self.state = state
+        self.context = context or {}
+
+
+_POOL = object()  # sentinel; all DB calls are patched away
+_REQ_ID = "REQ-engine-adversarial-tests-v2-1777256408"
+_PROJECT = "proj-eat"
+_TAGS: list[str] = [_REQ_ID]
+
+
+def _patch_io(
+    monkeypatch,
+    *,
+    get_side_effects=None,
+    cas_return: bool = True,
+    stage_raises: Exception | None = None,
+) -> tuple[AsyncMock, AsyncMock]:
+    """Patch all engine external I/O. Returns (cas_mock, get_mock)."""
+    from orchestrator import engine
+
+    cas = AsyncMock(return_value=cas_return)
+    monkeypatch.setattr(engine.req_state, "cas_transition", cas)
+
+    get = (
+        AsyncMock(side_effect=list(get_side_effects))
+        if get_side_effects is not None
+        else AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(engine.req_state, "get", get)
+
+    if stage_raises is not None:
+        monkeypatch.setattr(
+            engine.stage_runs,
+            "close_latest_stage_run",
+            AsyncMock(side_effect=stage_raises),
+        )
+        monkeypatch.setattr(
+            engine.stage_runs,
+            "insert_stage_run",
+            AsyncMock(side_effect=stage_raises),
+        )
+    else:
+        monkeypatch.setattr(engine.stage_runs, "close_latest_stage_run", AsyncMock())
+        monkeypatch.setattr(engine.stage_runs, "insert_stage_run", AsyncMock())
+
+    monkeypatch.setattr(engine.obs, "record_event", AsyncMock())
+    return cas, get
+
+
+@pytest.fixture(autouse=True)
+def _restore_registry():
+    """Snapshot and restore REGISTRY around each test to prevent pollution."""
+    from orchestrator.actions import REGISTRY
+
+    snapshot = dict(REGISTRY)
+    yield
+    REGISTRY.clear()
+    REGISTRY.update(snapshot)
+
+
+async def _step(**overrides):
+    """Helper: call engine.step with sensible defaults, overrideable per test."""
+    from orchestrator.engine import step
+    from orchestrator.state import Event, ReqState
+
+    defaults: dict = dict(
+        pool=_POOL,
+        body=_Body(),
+        req_id=_REQ_ID,
+        project_id=_PROJECT,
+        tags=_TAGS,
+        cur_state=ReqState.SPEC_LINT_RUNNING,
+        ctx={},
+        event=Event.SPEC_LINT_PASS,
+        depth=0,
+    )
+    defaults.update(overrides)
+    return await step(**defaults)
+
+
+# ─── EAT-S1: unknown emit string is logged and dropped ───────────────────────
+
+
+async def test_eat_s1_unknown_emit_string_dropped(monkeypatch) -> None:
+    """
+    EAT-S1: handler returning {"emit": "totally-not-an-event"} MUST NOT raise;
+    engine MUST log engine.invalid_emit and return base_result without chained key.
+    """
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import ReqState
+
+    _patch_io(monkeypatch)
+
+    async def _handler(**_kw):
+        return {"emit": "totally-not-an-event"}
+
+    REGISTRY["start_challenger"] = _handler
+
+    result = await _step()
+
+    assert result.get("action") == "start_challenger", (
+        f"EAT-S1: action MUST be 'start_challenger'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.CHALLENGER_RUNNING.value, (
+        f"EAT-S1: next_state MUST be 'challenger-running'; got {result!r}"
+    )
+    assert "chained" not in result, (
+        f"EAT-S1: bogus emit MUST be dropped — no 'chained' key; got {result!r}"
+    )
+
+
+# ─── EAT-S2: handler returning None treated as empty dict ────────────────────
+
+
+async def test_eat_s2_none_result_normalised_to_empty_dict(monkeypatch) -> None:
+    """
+    EAT-S2: handler returns None → no raise; result["result"] MUST equal {}.
+    """
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import ReqState
+
+    _patch_io(monkeypatch)
+
+    async def _handler(**_kw):
+        return None
+
+    REGISTRY["start_challenger"] = _handler
+
+    result = await _step()
+
+    assert result.get("action") == "start_challenger", (
+        f"EAT-S2: action MUST be 'start_challenger'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.CHALLENGER_RUNNING.value, (
+        f"EAT-S2: next_state MUST be 'challenger-running'; got {result!r}"
+    )
+    assert result.get("result") == {}, (
+        f"EAT-S2: None return MUST be normalised to empty dict; "
+        f"got result['result']={result.get('result')!r}"
+    )
+
+
+# ─── EAT-S3: handler returning list treated as empty dict ────────────────────
+
+
+async def test_eat_s3_list_result_treated_as_empty_dict(monkeypatch) -> None:
+    """
+    EAT-S3: handler returns [1,2,3] → no raise; no chained key (treated as empty dict).
+    """
+    from orchestrator.actions import REGISTRY
+
+    _patch_io(monkeypatch)
+
+    async def _handler(**_kw):
+        return [1, 2, 3]
+
+    REGISTRY["start_challenger"] = _handler
+
+    result = await _step()
+
+    assert result.get("action") == "start_challenger", (
+        f"EAT-S3: action MUST be 'start_challenger'; got {result!r}"
+    )
+    assert "chained" not in result, (
+        f"EAT-S3: list return MUST be treated as empty dict → no chained; got {result!r}"
+    )
+
+
+# ─── EAT-S4: row vanishes between dispatch and chained reload ────────────────
+
+
+async def test_eat_s4_row_vanishes_mid_chain(monkeypatch) -> None:
+    """
+    EAT-S4: handler emits valid event but req_state.get returns None (row deleted)
+    → engine MUST early-return base_result without chained key, no AttributeError.
+    """
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    _patch_io(monkeypatch, get_side_effects=[None])
+
+    async def _handler(**_kw):
+        return {"emit": Event.SPEC_LINT_PASS.value}
+
+    REGISTRY["create_spec_lint"] = _handler
+
+    result = await _step(
+        cur_state=ReqState.ANALYZE_ARTIFACT_CHECKING,
+        event=Event.ANALYZE_ARTIFACT_CHECK_PASS,
+    )
+
+    assert result.get("action") == "create_spec_lint", (
+        f"EAT-S4: action MUST be 'create_spec_lint'; got {result!r}"
+    )
+    assert "chained" not in result, (
+        f"EAT-S4: row vanished → chain MUST truncate, no 'chained' key; got {result!r}"
+    )
+
+
+# ─── EAT-S5: chained emit hits illegal transition ────────────────────────────
+
+
+async def test_eat_s5_chained_emit_illegal_transition(monkeypatch) -> None:
+    """
+    EAT-S5: handler returns {"emit": "archive.done"} → after CAS to CHALLENGER_RUNNING,
+    chained step hits no-transition and returns skip attached at base_result["chained"].
+    """
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    _patch_io(monkeypatch, get_side_effects=[_FakeRow(ReqState.CHALLENGER_RUNNING)])
+
+    async def _handler(**_kw):
+        return {"emit": Event.ARCHIVE_DONE.value}
+
+    REGISTRY["start_challenger"] = _handler
+
+    result = await _step()
+
+    assert result.get("action") == "start_challenger", (
+        f"EAT-S5: parent action MUST be 'start_challenger'; got {result!r}"
+    )
+    chained = result.get("chained")
+    assert chained is not None, (
+        f"EAT-S5: 'chained' key MUST be present when chained step ran; got {result!r}"
+    )
+    assert chained.get("action") == "skip", (
+        f"EAT-S5: chained.action MUST be 'skip'; got chained={chained!r}"
+    )
+    reason = chained.get("reason") or ""
+    assert "no transition challenger-running+archive.done" in reason, (
+        f"EAT-S5: reason MUST contain 'no transition challenger-running+archive.done'; "
+        f"got {reason!r}"
+    )
+
+
+# ─── EAT-S6: transition action missing from REGISTRY ─────────────────────────
+
+
+async def test_eat_s6_action_not_in_registry_returns_error(monkeypatch) -> None:
+    """
+    EAT-S6: REGISTRY missing start_challenger → returns error dict;
+    CAS MUST have been committed to CHALLENGER_RUNNING before the registry check.
+    """
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import ReqState
+
+    cas, _ = _patch_io(monkeypatch)
+    REGISTRY.pop("start_challenger", None)
+
+    result = await _step()
+
+    assert result.get("action") == "error", (
+        f"EAT-S6: MUST return action='error'; got {result!r}"
+    )
+    assert result.get("reason") == "action start_challenger not registered", (
+        f"EAT-S6: reason MUST equal 'action start_challenger not registered'; "
+        f"got {result.get('reason')!r}"
+    )
+    assert cas.called, (
+        "EAT-S6: cas_transition MUST have been called (CAS committed before registry check)"
+    )
+    # 4th positional arg (index 3) is next_state
+    next_state_arg = cas.call_args.args[3]
+    assert next_state_arg == ReqState.CHALLENGER_RUNNING, (
+        f"EAT-S6: CAS MUST advance to CHALLENGER_RUNNING; got {next_state_arg!r}"
+    )
+
+
+# ─── EAT-S7: ESCALATED self-loop does not re-trigger cleanup ─────────────────
+
+
+async def test_eat_s7_escalated_self_loop_no_cleanup(monkeypatch) -> None:
+    """
+    EAT-S7: (ESCALATED, VERIFY_ESCALATE) → action=None → no-op;
+    cleanup_runner MUST NOT be triggered (cur_state already terminal).
+    """
+    from orchestrator import engine
+    from orchestrator.state import Event, ReqState
+
+    _patch_io(monkeypatch)
+
+    cleanup_calls: list[tuple] = []
+
+    class _FakeController:
+        async def cleanup_runner(self, req_id, *, retain_pvc=False):
+            cleanup_calls.append((req_id, retain_pvc))
+
+    monkeypatch.setattr(engine.k8s_runner, "get_controller", lambda: _FakeController())
+
+    result = await _step(
+        cur_state=ReqState.ESCALATED,
+        event=Event.VERIFY_ESCALATE,
+    )
+
+    assert result.get("action") == "no-op", (
+        f"EAT-S7: (ESCALATED, VERIFY_ESCALATE) MUST return action='no-op'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.ESCALATED.value, (
+        f"EAT-S7: next_state MUST remain 'escalated'; got {result!r}"
+    )
+    # Yield to let any fire-and-forget tasks settle
+    await asyncio.sleep(0)
+    assert cleanup_calls == [], (
+        f"EAT-S7: cleanup_runner MUST NOT be called on terminal self-loop; "
+        f"got {len(cleanup_calls)} call(s): {cleanup_calls}"
+    )
+
+
+# ─── EAT-S8: stage_runs raises, engine still advances ────────────────────────
+
+
+async def test_eat_s8_stage_runs_failure_does_not_propagate(monkeypatch) -> None:
+    """
+    EAT-S8: stage_runs INSERT raises RuntimeError → engine.step MUST NOT raise;
+    transition MUST still be committed (best-effort observability).
+    """
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import ReqState
+
+    _patch_io(monkeypatch, stage_raises=RuntimeError("DB down"))
+
+    async def _handler(**_kw):
+        return {}
+
+    REGISTRY["start_challenger"] = _handler
+
+    result = await _step()
+
+    assert result.get("action") == "start_challenger", (
+        f"EAT-S8: MUST return action='start_challenger' despite stage_runs failure; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.CHALLENGER_RUNNING.value, (
+        f"EAT-S8: transition MUST be committed; next_state MUST be 'challenger-running'; got {result!r}"
+    )
+
+
+# ─── EAT-S9: body without issueId does not raise ─────────────────────────────
+
+
+async def test_eat_s9_body_without_issue_id_no_raise(monkeypatch) -> None:
+    """
+    EAT-S9: body with no issueId attribute → engine.step MUST NOT raise AttributeError;
+    result MUST contain action='start_challenger'.
+    """
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import ReqState
+
+    _patch_io(monkeypatch)
+
+    async def _handler(**_kw):
+        return {}
+
+    REGISTRY["start_challenger"] = _handler
+
+    result = await _step(body=_NoAttrBody())
+
+    assert result.get("action") == "start_challenger", (
+        f"EAT-S9: MUST return action='start_challenger'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.CHALLENGER_RUNNING.value, (
+        f"EAT-S9: MUST return next_state='challenger-running'; got {result!r}"
+    )
+
+
+# ─── EAT-S10a: depth=12 still dispatches handler ────────────────────────────
+
+
+async def test_eat_s10a_depth_12_dispatches_handler(monkeypatch) -> None:
+    """
+    EAT-S10a: depth=12 is the last valid depth; handler MUST be called exactly once.
+    """
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import ReqState
+
+    _patch_io(monkeypatch)
+    calls: list[int] = []
+
+    async def _handler(**_kw):
+        calls.append(1)
+        return {}
+
+    REGISTRY["start_challenger"] = _handler
+
+    result = await _step(depth=12)
+
+    assert len(calls) == 1, (
+        f"EAT-S10a: handler MUST be called exactly once at depth=12; "
+        f"got {len(calls)} call(s)"
+    )
+    assert result.get("action") == "start_challenger", (
+        f"EAT-S10a: MUST return action='start_challenger'; got {result!r}"
+    )
+
+
+# ─── EAT-S10b: depth=13 triggers recursion guard ────────────────────────────
+
+
+async def test_eat_s10b_depth_13_recursion_guard_fires() -> None:
+    """
+    EAT-S10b: depth=13 → engine MUST return recursion error dict without calling handler.
+    """
+    from orchestrator.actions import REGISTRY
+
+    calls: list[int] = []
+
+    async def _handler(**_kw):
+        calls.append(1)
+        return {}
+
+    REGISTRY["start_challenger"] = _handler
+
+    result = await _step(depth=13)
+
+    assert calls == [], (
+        f"EAT-S10b: handler MUST NOT be called at depth=13; got {len(calls)} call(s)"
+    )
+    assert result == {"action": "error", "reason": "engine recursion >12"}, (
+        f"EAT-S10b: MUST return exact recursion error dict; got {result!r}"
+    )
+
+
+# ─── EAT-S11: SESSION_FAILED on DONE is skipped ──────────────────────────────
+
+
+async def test_eat_s11_session_failed_on_done_skipped() -> None:
+    """
+    EAT-S11: (DONE, SESSION_FAILED) → action='skip'; escalate MUST NOT be invoked.
+    """
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    escalate_calls: list[int] = []
+
+    async def _fake_escalate(**_kw):
+        escalate_calls.append(1)
+        return {}
+
+    REGISTRY["escalate"] = _fake_escalate
+
+    result = await _step(
+        cur_state=ReqState.DONE,
+        event=Event.SESSION_FAILED,
+    )
+
+    assert result.get("action") == "skip", (
+        f"EAT-S11: MUST return action='skip'; got {result!r}"
+    )
+    reason = (result.get("reason") or "").lower()
+    assert reason.startswith("no transition done+"), (
+        f"EAT-S11: reason MUST start with 'no transition done+'; got {result.get('reason')!r}"
+    )
+    assert escalate_calls == [], (
+        f"EAT-S11: escalate MUST NOT be invoked on terminal DONE; "
+        f"got {len(escalate_calls)} call(s)"
+    )
+
+
+# ─── EAT-S12: DONE terminal skips every Event ────────────────────────────────
+
+
+async def test_eat_s12_done_skips_every_event() -> None:
+    """
+    EAT-S12: engine.step(DONE, event) MUST return action='skip' for every Event member;
+    no handler MUST be invoked; no call MUST raise.
+    """
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    handler_calls: list[str] = []
+
+    async def _any_handler(**_kw):
+        handler_calls.append("called")
+        return {}
+
+    for name in list(REGISTRY.keys()):
+        REGISTRY[name] = _any_handler
+    for name in [
+        "start_intake", "start_analyze", "start_challenger", "escalate",
+        "create_spec_lint", "create_staging_test", "create_pr_ci_watch",
+        "create_accept", "done_archive",
+        "invoke_verifier_for_analyze_artifact_check_fail",
+    ]:
+        REGISTRY[name] = _any_handler
+
+    failures: list[str] = []
+    for event in Event:
+        try:
+            result = await _step(cur_state=ReqState.DONE, event=event)
+        except Exception as exc:
+            failures.append(f"{event.value}: raised {exc!r}")
+            continue
+        if result.get("action") != "skip":
+            failures.append(
+                f"{event.value}: action={result.get('action')!r} (want 'skip')"
+            )
+
+    if failures:
+        pytest.fail(
+            "EAT-S12: DONE MUST skip every Event:\n" + "\n".join(failures)
+        )
+
+    assert handler_calls == [], (
+        f"EAT-S12: no handler MUST be invoked for DONE terminal state; "
+        f"got {len(handler_calls)} call(s)"
+    )

--- a/orchestrator/tests/test_contract_engine_adversarial_challenger.py
+++ b/orchestrator/tests/test_contract_engine_adversarial_challenger.py
@@ -417,7 +417,6 @@ async def test_eat_s10a_depth_12_dispatches_handler(monkeypatch) -> None:
     EAT-S10a: depth=12 is the last valid depth; handler MUST be called exactly once.
     """
     from orchestrator.actions import REGISTRY
-    from orchestrator.state import ReqState
 
     _patch_io(monkeypatch)
     calls: list[int] = []

--- a/orchestrator/tests/test_engine_adversarial.py
+++ b/orchestrator/tests/test_engine_adversarial.py
@@ -1,0 +1,397 @@
+"""Adversarial mock tests for engine.step (REQ-engine-adversarial-tests-v2-1777256408).
+
+Goal: feed engine.step奇形输入 / 反常 handler 返回 / 死路径，确认它不崩 / 不污染状态。
+全部用 in-process FakePool + stub action，**不打 BKD / Postgres / K8s**。
+
+EAT-S1..S12 一一对应 spec scenario，见
+`openspec/changes/REQ-engine-adversarial-tests-v2-1777256408/specs/engine-adversarial-tests/spec.md`。
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# 复用 test_engine.py 里的 FakePool / FakeReq —— 它们就是 engine adversarial 测的
+# 标准 stub。抄一份会跟 test_engine 漂移。pytest rootdir-based collection 把
+# tests/ 下的模块拍平到 sys.path，绝对 import 即可。
+from test_engine import FakePool, FakeReq, _drain_tasks  # type: ignore[import-not-found]
+
+from orchestrator import engine, k8s_runner
+from orchestrator.actions import ACTION_META, REGISTRY
+from orchestrator.state import Event, ReqState
+
+
+# ─── 共享 stub_actions fixture（独立于 test_engine 的同名 fixture，作用域局部） ──
+@pytest.fixture
+def stub_actions():
+    """clear REGISTRY / ACTION_META，测后还原。"""
+    saved_reg = dict(REGISTRY)
+    saved_meta = dict(ACTION_META)
+    REGISTRY.clear()
+    ACTION_META.clear()
+    yield REGISTRY
+    REGISTRY.clear()
+    ACTION_META.clear()
+    REGISTRY.update(saved_reg)
+    ACTION_META.update(saved_meta)
+
+
+def _body(**attrs):
+    """构造一个 minimal body 对象。"""
+    return type("B", (), attrs)()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# EAT-S1：handler 返 emit garbage
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_eat_s1_unknown_emit_string_dropped(stub_actions, caplog):
+    """Spec EAT-S1: handler emit 不在 Event 枚举的字符串 → 不抛 + 不 chain。"""
+    async def start_challenger(*, body, req_id, tags, ctx):
+        return {"emit": "totally-not-an-event"}
+
+    stub_actions["start_challenger"] = start_challenger
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.SPEC_LINT_RUNNING.value)})
+    body = _body(issueId="x", projectId="p", event="check.passed")
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.SPEC_LINT_RUNNING, ctx={}, event=Event.SPEC_LINT_PASS,
+    )
+
+    assert result["action"] == "start_challenger"
+    assert result["next_state"] == ReqState.CHALLENGER_RUNNING.value
+    assert "chained" not in result, "无效 emit 不应触发 chain"
+
+
+# ───────────────────────────────────────────────────────────────────────
+# EAT-S2 / S3：handler 返非 dict
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_eat_s2_handler_returns_none(stub_actions):
+    """Spec EAT-S2: handler 返 None → 视作空 dict。"""
+    async def start_challenger(*, body, req_id, tags, ctx):
+        return None
+
+    stub_actions["start_challenger"] = start_challenger
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.SPEC_LINT_RUNNING.value)})
+    result = await engine.step(
+        pool, body=_body(issueId="x", projectId="p", event="check.passed"),
+        req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.SPEC_LINT_RUNNING, ctx={}, event=Event.SPEC_LINT_PASS,
+    )
+    assert result["action"] == "start_challenger"
+    assert result["next_state"] == ReqState.CHALLENGER_RUNNING.value
+    assert result["result"] == {}, "None 应被规整成 empty dict"
+    assert "chained" not in result
+
+
+@pytest.mark.asyncio
+async def test_eat_s3_handler_returns_list(stub_actions):
+    """Spec EAT-S3: handler 返 list → 视作空 dict（不挂在 result.get）。"""
+    async def start_challenger(*, body, req_id, tags, ctx):
+        return [1, 2, 3]
+
+    stub_actions["start_challenger"] = start_challenger
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.SPEC_LINT_RUNNING.value)})
+    result = await engine.step(
+        pool, body=_body(issueId="x", projectId="p", event="check.passed"),
+        req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.SPEC_LINT_RUNNING, ctx={}, event=Event.SPEC_LINT_PASS,
+    )
+    assert result["action"] == "start_challenger"
+    assert "chained" not in result
+
+
+# ───────────────────────────────────────────────────────────────────────
+# EAT-S4：chain 中段 row 消失
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_eat_s4_row_vanishes_mid_chain(stub_actions):
+    """Spec EAT-S4: req_state.get 在 chain 中段返 None → 安全早返，不抛 AttributeError。"""
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ANALYZE_ARTIFACT_CHECKING.value)})
+
+    async def create_spec_lint(*, body, req_id, tags, ctx):
+        # 模拟 row 在 dispatch 后被删（管理员清理 / DB reset / 测试夹具）
+        pool.rows.pop(req_id, None)
+        return {"emit": Event.SPEC_LINT_PASS.value}
+
+    stub_actions["create_spec_lint"] = create_spec_lint
+
+    result = await engine.step(
+        pool, body=_body(issueId="x", projectId="p", event="check.passed"),
+        req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.ANALYZE_ARTIFACT_CHECKING, ctx={},
+        event=Event.ANALYZE_ARTIFACT_CHECK_PASS,
+    )
+    assert result["action"] == "create_spec_lint"
+    assert "chained" not in result, "row 没了，chain 应早返而不是再 step"
+
+
+# ───────────────────────────────────────────────────────────────────────
+# EAT-S5：chained emit 命中 illegal transition
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_eat_s5_chained_illegal_transition(stub_actions):
+    """Spec EAT-S5: handler emit 一个该 state 没注册的 event → chain 子 step 返 skip。"""
+    async def start_challenger(*, body, req_id, tags, ctx):
+        # CHALLENGER_RUNNING + ARCHIVE_DONE 没有 transition
+        return {"emit": Event.ARCHIVE_DONE.value}
+
+    stub_actions["start_challenger"] = start_challenger
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.SPEC_LINT_RUNNING.value)})
+    result = await engine.step(
+        pool, body=_body(issueId="x", projectId="p", event="check.passed"),
+        req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.SPEC_LINT_RUNNING, ctx={}, event=Event.SPEC_LINT_PASS,
+    )
+    assert result["action"] == "start_challenger"
+    assert "chained" in result
+    assert result["chained"]["action"] == "skip"
+    assert "no transition challenger-running+archive.done" in result["chained"]["reason"]
+
+
+# ───────────────────────────────────────────────────────────────────────
+# EAT-S6：action 不在 REGISTRY
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_eat_s6_unregistered_action_returns_error(stub_actions):
+    """Spec EAT-S6: transition.action 名在表里但 REGISTRY 没注册 → return error，不抛。"""
+    # stub_actions 已经清空了 REGISTRY；不再注册 start_challenger
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.SPEC_LINT_RUNNING.value)})
+    result = await engine.step(
+        pool, body=_body(issueId="x", projectId="p", event="check.passed"),
+        req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.SPEC_LINT_RUNNING, ctx={}, event=Event.SPEC_LINT_PASS,
+    )
+    assert result["action"] == "error"
+    assert result["reason"] == "action start_challenger not registered"
+    # CAS 已经成功 —— 行已推到 challenger-running（engine 不回滚）
+    assert pool.rows["REQ-1"].state == ReqState.CHALLENGER_RUNNING.value
+
+
+# ───────────────────────────────────────────────────────────────────────
+# EAT-S7：terminal self-loop 不再 cleanup
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_runner_controller():
+    fake = MagicMock()
+    fake.cleanup_runner = AsyncMock(return_value=None)
+    k8s_runner.set_controller(fake)
+    yield fake
+    k8s_runner.set_controller(None)
+
+
+@pytest.mark.asyncio
+async def test_eat_s7_terminal_self_loop_no_cleanup(stub_actions, mock_runner_controller):
+    """Spec EAT-S7: ESCALATED + VERIFY_ESCALATE 是 self-loop, action=None；不应再次 cleanup。"""
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ESCALATED.value)})
+    body = _body(issueId="x", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.ESCALATED, ctx={}, event=Event.VERIFY_ESCALATE,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "no-op"
+    assert result["next_state"] == ReqState.ESCALATED.value
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+    # 关键：cur 已 terminal → engine 跳过 cleanup
+    mock_runner_controller.cleanup_runner.assert_not_awaited()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# EAT-S8：stage_runs INSERT 抛异常
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_eat_s8_stage_runs_insert_failure_does_not_break_engine(stub_actions):
+    """Spec EAT-S8: stage_runs DB 写挂 → engine 仍推进 + 不抛。"""
+    async def start_challenger(*, body, req_id, tags, ctx):
+        return {"ok": True}
+
+    stub_actions["start_challenger"] = start_challenger
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.SPEC_LINT_RUNNING.value)})
+
+    # monkey-patch fetchrow：INSERT INTO stage_runs 抛错
+    orig_fetchrow = pool.fetchrow
+
+    async def evil_fetchrow(sql, *args):
+        if sql.strip().startswith("INSERT INTO stage_runs"):
+            raise RuntimeError("DB down (simulated)")
+        return await orig_fetchrow(sql, *args)
+
+    pool.fetchrow = evil_fetchrow  # type: ignore[method-assign]
+
+    result = await engine.step(
+        pool, body=_body(issueId="x", projectId="p", event="check.passed"),
+        req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.SPEC_LINT_RUNNING, ctx={}, event=Event.SPEC_LINT_PASS,
+    )
+    assert result["action"] == "start_challenger"
+    assert pool.rows["REQ-1"].state == ReqState.CHALLENGER_RUNNING.value
+
+
+# ───────────────────────────────────────────────────────────────────────
+# EAT-S9：body 缺 issueId 属性
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_eat_s9_body_without_issue_id(stub_actions):
+    """Spec EAT-S9: body 没 issueId 属性 → 用 getattr 默认 None，不抛。"""
+    async def start_challenger(*, body, req_id, tags, ctx):
+        return {"ok": True}
+
+    stub_actions["start_challenger"] = start_challenger
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.SPEC_LINT_RUNNING.value)})
+    body = _body()  # 完全空对象
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.SPEC_LINT_RUNNING, ctx={}, event=Event.SPEC_LINT_PASS,
+    )
+    assert result["action"] == "start_challenger"
+    assert result["next_state"] == ReqState.CHALLENGER_RUNNING.value
+
+
+# ───────────────────────────────────────────────────────────────────────
+# EAT-S10a/b：recursion guard 边界
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_eat_s10a_depth_12_still_dispatches(stub_actions):
+    """Spec EAT-S10a: depth=12 是合法边界，handler 仍执行。"""
+    called = {"n": 0}
+
+    async def start_challenger(*, body, req_id, tags, ctx):
+        called["n"] += 1
+        return {"ok": True}
+
+    stub_actions["start_challenger"] = start_challenger
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.SPEC_LINT_RUNNING.value)})
+    result = await engine.step(
+        pool, body=_body(issueId="x", projectId="p"),
+        req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.SPEC_LINT_RUNNING, ctx={}, event=Event.SPEC_LINT_PASS,
+        depth=12,
+    )
+    assert called["n"] == 1
+    assert result["action"] == "start_challenger"
+
+
+@pytest.mark.asyncio
+async def test_eat_s10b_depth_13_recursion_guard(stub_actions):
+    """Spec EAT-S10b: depth=13 触发 recursion guard，handler 不被调。"""
+    called = {"n": 0}
+
+    async def start_challenger(*, body, req_id, tags, ctx):
+        called["n"] += 1
+        return {"ok": True}
+
+    stub_actions["start_challenger"] = start_challenger
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.SPEC_LINT_RUNNING.value)})
+    result = await engine.step(
+        pool, body=_body(issueId="x", projectId="p"),
+        req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.SPEC_LINT_RUNNING, ctx={}, event=Event.SPEC_LINT_PASS,
+        depth=13,
+    )
+    assert called["n"] == 0, "depth>12 不应再 dispatch"
+    assert result == {"action": "error", "reason": "engine recursion >12"}
+
+
+# ───────────────────────────────────────────────────────────────────────
+# EAT-S11：SESSION_FAILED 在 terminal state DONE → skip
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_eat_s11_session_failed_on_done_skips(stub_actions):
+    """Spec EAT-S11: terminal DONE 没 SESSION_FAILED transition → skip。"""
+    escalate_called = {"n": 0}
+
+    async def escalate(*, body, req_id, tags, ctx):
+        escalate_called["n"] += 1
+        return {"ok": True}
+
+    stub_actions["escalate"] = escalate
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.DONE.value)})
+    result = await engine.step(
+        pool, body=_body(issueId="x", projectId="p"),
+        req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.DONE, ctx={}, event=Event.SESSION_FAILED,
+    )
+    assert result["action"] == "skip"
+    assert result["reason"].startswith("no transition done+")
+    assert escalate_called["n"] == 0
+    # 状态不动
+    assert pool.rows["REQ-1"].state == ReqState.DONE.value
+
+
+# ───────────────────────────────────────────────────────────────────────
+# EAT-S12：DONE 终态对所有 Event 都 skip
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_eat_s12_done_skips_every_event(stub_actions):
+    """Spec EAT-S12: 穷举 Event 枚举，DONE 状态下每个都 skip 不抛。"""
+    handler_calls = {"n": 0}
+
+    async def any_action(*, body, req_id, tags, ctx):
+        handler_calls["n"] += 1
+        return {"ok": True}
+
+    # 把每个可能的 action 都注册成 any_action（如果有 transition 漏到 DONE）
+    for name in [
+        "start_intake", "start_analyze", "start_analyze_with_finalized_intent",
+        "create_analyze_artifact_check", "create_spec_lint", "start_challenger",
+        "create_dev_cross_check", "create_staging_test", "create_pr_ci_watch",
+        "create_accept", "teardown_accept_env", "done_archive", "escalate",
+        "apply_verify_pass", "start_fixer", "invoke_verifier_after_fix",
+        "invoke_verifier_for_analyze_artifact_check_fail",
+        "invoke_verifier_for_spec_lint_fail",
+        "invoke_verifier_for_challenger_fail",
+        "invoke_verifier_for_dev_cross_check_fail",
+        "invoke_verifier_for_staging_test_fail",
+        "invoke_verifier_for_pr_ci_fail",
+        "invoke_verifier_for_accept_fail",
+    ]:
+        stub_actions[name] = any_action
+
+    for ev in Event:
+        pool = FakePool({"REQ-1": FakeReq(state=ReqState.DONE.value)})
+        result = await engine.step(
+            pool, body=_body(issueId="x", projectId="p"),
+            req_id="REQ-1", project_id="p", tags=[],
+            cur_state=ReqState.DONE, ctx={}, event=ev,
+        )
+        assert result["action"] == "skip", f"{ev.value} should skip on DONE"
+        assert pool.rows["REQ-1"].state == ReqState.DONE.value
+
+    assert handler_calls["n"] == 0, "DONE 下不应有任何 handler 被调"


### PR DESCRIPTION
## Summary

12 adversarial mock tests (EAT-S1..S12) for `orchestrator/src/orchestrator/engine.py::step`,
feeding malformed inputs to confirm the state-machine engine never crashes, never silently
corrupts state, and never re-triggers runner cleanup on terminal self-loops. All in-process
`FakePool` + stub action — no BKD / Postgres / K8s.

### What's covered

- **EAT-S1**: handler returns `{"emit": "garbage"}` → invalid_emit log, no chain
- **EAT-S2/S3**: handler returns `None` / `list` → treated as empty dict, no crash
- **EAT-S4**: row vanishes mid-emit-chain (`req_state.get` returns None) → safe early-return
- **EAT-S5**: chained emit hits illegal transition → propagates as `chained.action="skip"`
- **EAT-S6**: action name in transition table but missing from REGISTRY → returns error, CAS retained
- **EAT-S7**: `(ESCALATED, VERIFY_ESCALATE)` self-loop → no second `cleanup_runner` call
- **EAT-S8**: `INSERT INTO stage_runs` raises → engine.step still advances state
- **EAT-S9**: body without `issueId` attribute → no `AttributeError`
- **EAT-S10a/b**: recursion guard boundary (depth=12 dispatches; depth=13 errors)
- **EAT-S11**: `SESSION_FAILED` on `DONE` → skip, escalate not invoked
- **EAT-S12**: every `Event` enum member on `DONE` → all skip, no handler called

### Why now

`engine.step` is the single arbiter of every REQ's state advance. Existing
`test_engine.py` (14 cases) covers happy-path + a few normal failures, but
provides no system test of "what if external code feeds the engine garbage?"
— which is the realistic risk surface (BKD agent prompts construct emit
names dynamically, DB can blip, k8s cleanup can race). These 12 cases pin
down the contract: malformed input degrades to skip / error / no-op, never
to crash or silent corruption.

## Test plan

- [x] `make ci-lint` (BASE_REV=origin/main) → All checks passed
- [x] `make ci-unit-test` → 1269 passed, 2 deselected
- [x] `pytest tests/test_engine_adversarial.py -v` → 13 passed (EAT-S10 splits into 10a + 10b)
- [x] `openspec validate REQ-engine-adversarial-tests-v2-1777256408` → valid
- [x] `check-scenario-refs.sh` → OK 415 scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)