### PR TITLE
feat(prompts): canonical REQ status block at top of intent body (REQ-ux-status-block-1777257283)

### DIFF
--- a/openspec/changes/REQ-ux-status-block-1777257283/design.md
+++ b/openspec/changes/REQ-ux-status-block-1777257283/design.md
@@ -1,0 +1,168 @@
+# Design — BKD intent body status block
+
+## Constraints (from probing the running BKD REST)
+
+- BKD REST issue object only PATCHes `title` / `tags` / `statusId`. `description`
+  and `prompt` PATCH bodies are silently dropped (verified against
+  `localhost:3000/api/projects/.../issues/{id}` — server returns `success:true`
+  but the field stays unchanged).
+- No `/notes` / `/comments` / `/messages` write endpoints (all 404).
+- `follow_up_issue` POSTs a new prompt to the agent and re-triggers the session,
+  so it cannot be used to "post a passive status pane" — it would re-fire the
+  agent every transition.
+- The only durable, agent-visible text we control is the prompt body that
+  `start_intake` / `start_analyze` / `start_analyze_with_finalized_intent` follow-up
+  once at dispatch.
+
+→ The status block must live inside that prompt body. We add it once, at
+dispatch time, with whatever facts are in hand. We do *not* try to keep it
+"live"; the orchestrator does not re-PATCH the prompt later (BKD doesn't allow
+it anyway).
+
+## Where the block lives in the template
+
+```jinja2
+{% if status_block -%}
+{% include "_shared/status_block.md.j2" %}
+
+─────────
+
+{% endif -%}
+{% include "_shared/tools_whitelist.md.j2" %}
+... (rest unchanged)
+```
+
+The `{% if status_block %}` guard means callers that don't pass the kwarg
+(verifier prompts, bugfix prompt, challenger prompt — out of scope this REQ) get
+a no-op include and zero diff in their rendered output. Only `intake.md.j2` and
+`analyze.md.j2` get a populated block this REQ. Every other template in
+`prompts/` already has a `{% include %}` chain at the top, so this slot is a
+natural extension.
+
+The separator line `─────────` and the trailing horizontal rule `---` inside the
+partial are deliberate: they visually delimit the block from the constraint
+walls below it, both in the BKD UI rendering and in the agent's reading order.
+
+## Schema of the partial's context
+
+Single dict variable `status_block` with these keys:
+
+| Key | Type | Required | Renders as row |
+|---|---|---|---|
+| `req_id` | `str` | yes | `REQ` |
+| `stage` | `str` | yes | `Stage` |
+| `bkd_intent_issue_url` | `str \| None` | no | `BKD intent issue` |
+| `cloned_repos` | `list[str] \| None` | no | `Pre-cloned repos` |
+| `pr_links_inline` | `str \| None` | no | `Linked PRs` |
+
+`Branch` and `Runner Pod` rows are computed inline from `req_id` (they're 1:1
+deterministic — sisyphus convention is `feat/<req_id>` and `runner-<req_id|lower>`).
+
+`pr_links_inline` is **pre-rendered by Python** via the existing
+`links.format_pr_links_inline(pr_urls)` helper (returns a comma-separated string
+of `[repo#NN](url)` markdown). Pre-rendering keeps the Jinja2 template simple and
+avoids duplicating the `_PR_NUMBER_RE` regex logic.
+
+## The helper
+
+```python
+# orchestrator/src/orchestrator/prompts/status_block.py
+from __future__ import annotations
+
+from .. import links
+
+
+def build_status_block_ctx(
+    *,
+    req_id: str,
+    stage: str,
+    bkd_intent_issue_url: str | None = None,
+    cloned_repos: list[str] | None = None,
+    pr_urls: dict[str, str] | None = None,
+) -> dict:
+    """Assemble the dict consumed by ``_shared/status_block.md.j2``.
+
+    Falsy/empty values become None so the template's ``{% if %}`` guards
+    suppress the corresponding row cleanly.
+    """
+    return {
+        "req_id": req_id,
+        "stage": stage,
+        "bkd_intent_issue_url": (bkd_intent_issue_url or None),
+        "cloned_repos": (list(cloned_repos) if cloned_repos else None),
+        "pr_links_inline": (links.format_pr_links_inline(pr_urls) or None),
+    }
+```
+
+`format_pr_links_inline` already returns `""` on empty/None input (from
+`links.py`), and `or None` collapses that to `None` so the template skips the
+row.
+
+## Wiring into start_*.py
+
+Three callsites change:
+
+1. `start_intake.py` — adds `bkd_intent_issue_url` (currently not passed) +
+   `status_block=build_status_block_ctx(...)`. No `cloned_repos`, no `pr_urls`
+   at intake.
+2. `start_analyze.py` — adds `status_block=build_status_block_ctx(...)`,
+   reusing the already-passed `bkd_intent_issue_url`, `cloned_repos`, plus
+   `pr_urls=ctx.get("pr_urls")` if present (re-entry from later stages may have
+   discovered them).
+3. `start_analyze_with_finalized_intent.py` — same as `start_analyze`. It
+   currently does NOT pass `bkd_intent_issue_url`; this REQ adds it (it's a
+   one-line `links.bkd_issue_url(proj, issue.id)` call, parity with the direct
+   path).
+
+Existing `cloned_repos` / `bkd_intent_issue_url` / footer-block kwargs on
+`analyze.md.j2` are left untouched — no behavioural change for code paths that
+don't consume the new block.
+
+## Why not a Python pre-rendered string?
+
+We considered: `prompt = render(...) + "\n\n" + render_status_block(...)`. Two
+reasons against:
+
+1. The block belongs at the *top* of the prompt, not concatenated at the end.
+   Inserting a string into a pre-rendered template is fragile; using a Jinja2
+   `{% include %}` slot is the project's idiomatic pattern (already used for
+   `tools_whitelist.md.j2` etc.).
+2. Per-template control over the block's position survives future template
+   edits. If we later add a status block to `staging_test.md.j2` we just add the
+   `{% include %}` at the desired line, no Python concatenation glue.
+
+## Tests
+
+New file `orchestrator/tests/test_prompts_status_block.py`:
+
+- BISB-S1: render `_shared/status_block.md.j2` directly with all-fields-present
+  context → table contains 7 rows in the documented column order.
+- BISB-S2: render with only `req_id` + `stage` → table contains exactly the 4
+  always-on rows; no empty cells; no row for omitted optional fields.
+- BISB-S3: render `analyze.md.j2` with `status_block=...` and
+  `cloned_repos=[...]` → first non-blank section is `## REQ Status`, which
+  appears *before* `## 工具白名单`.
+- BISB-S4: render `intake.md.j2` with `status_block=...` (no cloned_repos) →
+  same as S3 but Pre-cloned repos row absent.
+- BISB-S5: `pr_links_inline` row formats `pr_urls` dict via
+  `links.format_pr_links_inline` (clickable per-repo markdown links, comma
+  separated).
+- BISB-S6: `build_status_block_ctx` collapses empty/None inputs to None so the
+  template's `{% if %}` row guards drop the row.
+- BISB-S7: rendering with `status_block=None` (omitted kwarg) is a no-op — the
+  rest of the template is byte-identical to pre-REQ behaviour. Covers
+  backwards-compat for any future caller that hasn't been wired yet.
+
+Existing tests stay unchanged. `test_prompts_sisyphus_label.py::_render_analyze`
+calls `render("analyze.md.j2", ...)` without `status_block` — it should keep
+working (no new required kwargs).
+
+## Out of scope
+
+- Re-PATCH-ing the status block when REQ state changes mid-flight. BKD doesn't
+  let us; even if it did, no callsite re-renders the intent issue prompt. The
+  block is dispatch-time only.
+- Posting to the BKD UI as a separate panel. No such surface exists.
+- Extending the block to staging-test / pr-ci-watch / accept / verifier /
+  challenger / fixer / done_archive prompts. Their issue is sisyphus-created
+  (not "intent"), so it's a different REQ if we want it.

--- a/openspec/changes/REQ-ux-status-block-1777257283/proposal.md
+++ b/openspec/changes/REQ-ux-status-block-1777257283/proposal.md
@@ -1,0 +1,91 @@
+# Proposal — BKD intent body status block
+
+## Why
+
+When sisyphus dispatches `start_intake` / `start_analyze`, it follow-ups a multi-page
+prompt to the user-facing **BKD intent issue**. Today every status-relevant fact is
+*scattered* across that wall of text:
+
+| Fact | Where it surfaces (analyze.md.j2) |
+|---|---|
+| REQ id | line 15 (`REQ={{ req_id }}`) |
+| Pod name | line 79, 102, 222 |
+| Branch | line 152, 184 |
+| Cloned repos | line 95 (conditional inline sentence) |
+| BKD intent URL | line 259 (footer block, hard to find) |
+| Linked PRs | nowhere |
+
+Both **the agent** (who needs canonical REQ identity / branch / pod within the first
+screenful so it can re-derive context after compaction) and **the human in BKD UI**
+(who opens the issue to understand "what's running, where, what's linked") have to
+hunt. The intake template is even worse — it has zero visible link back to the
+intent issue, so a fan-out sub-agent reading the chat has no clickable anchor.
+
+## What
+
+Add a single canonical **`## REQ Status` markdown table** at the top of the BKD
+intent stage prompts (`intake.md.j2` + `analyze.md.j2`). It consolidates the
+identity / location / link facts the orchestrator already has in hand at dispatch
+time:
+
+```markdown
+## REQ Status
+
+| Field | Value |
+|---|---|
+| REQ | `REQ-foo` |
+| Stage | `analyze` |
+| Branch | `feat/REQ-foo` |
+| Runner Pod | `runner-req-foo` |
+| BKD intent issue | [open](https://bkd.example.com/projects/p/issues/iss-1) |
+| Pre-cloned repos | `phona/sisyphus` |
+| Linked PRs | [phona/sisyphus#123](https://github.com/phona/sisyphus/pull/123) |
+
+---
+```
+
+Rows whose value is unset (e.g., no PRs at intake time) are omitted; the four
+identity rows (REQ / Stage / Branch / Runner Pod) are always present because they
+are computable from `req_id` alone.
+
+The block is rendered by a new shared partial
+`orchestrator/src/orchestrator/prompts/_shared/status_block.md.j2`, fed by a
+helper `prompts.status_block.build_status_block_ctx(...)`. Both intake and analyze
+templates `{% include %}` the partial **above** `tools_whitelist.md.j2` so it is
+the first thing the agent reads.
+
+## What it is NOT
+
+- Not a new state, event, transition, or checker. The state machine is unchanged.
+- Not pushed to other stage prompts (staging_test / pr_ci_watch / accept /
+  challenger / done_archive / verifier / fixer). Those run in sisyphus-created
+  sub-issues, not on the user-facing **intent** issue. Title says "intent body" so
+  scope is intent only — extending to other stages is a separate REQ.
+- Not posted to the BKD issue UI as a separate "metadata panel". BKD REST has no
+  writable description / comments / notes endpoint (probed: `description` PATCH
+  silently no-ops; `prompt` PATCH silently no-ops; `/notes`, `/comments`,
+  `/messages` all 404). The only durable text surface is the prompt body that
+  sisyphus follow-ups, so that is where the block must live.
+- Does not remove the existing scattered references (`REQ={{ req_id }}` line 15,
+  pod name occurrences, footer cross-link block). Those stay — the status block
+  is additive context, not a refactor.
+
+## Risk / blast radius
+
+- Pure prompt-template addition. No behavioural change to checkers, state, BKD
+  REST, or runner. Worst case: agent ignores the new block and reads the old
+  scattered references like before.
+- Tests: prompt regression tests (`test_prompts_sisyphus_label.py`,
+  `test_prompts_repo_agnostic.py`) assert specific strings inside the rendered
+  output but not "must NOT contain X", so adding a block above them is safe.
+- Backwards compat for callers: render() continues to accept the same kwargs;
+  callers that omit `status_block=` get a falsy include (template no-op).
+
+## Acceptance
+
+- `## REQ Status` header is the first non-blank section of rendered analyze and
+  intake prompts.
+- Always-on rows (REQ / Stage / Branch / Runner Pod) appear with values
+  derived from `req_id`.
+- Optional rows omit cleanly when their input is empty / None.
+- `make ci-unit-test` passes.

--- a/openspec/changes/REQ-ux-status-block-1777257283/specs/bkd-intent-status-block/contract.spec.yaml
+++ b/openspec/changes/REQ-ux-status-block-1777257283/specs/bkd-intent-status-block/contract.spec.yaml
@@ -1,0 +1,104 @@
+# Contract — bkd-intent-status-block partial
+#
+# Renders a markdown "REQ Status" table at the top of BKD intent stage prompts.
+# Defines the dict the orchestrator passes to the partial, the rows the partial
+# emits, and the templates that {% include %} it.
+
+partial:
+  path: orchestrator/src/orchestrator/prompts/_shared/status_block.md.j2
+  context_variable: status_block
+
+context_schema:
+  required:
+    req_id:
+      type: string
+      example: "REQ-ux-status-block-1777257283"
+    stage:
+      type: string
+      example: "analyze"
+      allowed_values: ["intake", "analyze"]
+  optional:
+    bkd_intent_issue_url:
+      type: ["string", "null"]
+      empty_values: ["", null]
+      empty_behaviour: row_omitted
+      example: "https://bkd.example.com/projects/p/issues/iss-1"
+    cloned_repos:
+      type: ["array", "null"]
+      item_type: string
+      empty_values: [[], null]
+      empty_behaviour: row_omitted
+      example: ["phona/sisyphus", "ZonEaseTech/ttpos-server-go"]
+    pr_links_inline:
+      type: ["string", "null"]
+      empty_values: ["", null]
+      empty_behaviour: row_omitted
+      pre_rendered_by: "orchestrator.links.format_pr_links_inline"
+      example: "[phona/sisyphus#42](https://github.com/phona/sisyphus/pull/42)"
+
+builder:
+  module: orchestrator.prompts.status_block
+  function: build_status_block_ctx
+  signature:
+    keyword_only: true
+    parameters:
+      req_id: "str"
+      stage: "str"
+      bkd_intent_issue_url: "str | None"
+      cloned_repos: "list[str] | None"
+      pr_urls: "dict[str, str] | None"
+  behaviour:
+    empty_to_none: true
+    pr_urls_pre_rendered_via: "orchestrator.links.format_pr_links_inline"
+
+output:
+  format: github_flavored_markdown
+  heading: "## REQ Status"
+  table_columns: ["Field", "Value"]
+  row_order:
+    - field: REQ
+      always: true
+      value_template: "`{{ req_id }}`"
+    - field: Stage
+      always: true
+      value_template: "`{{ stage }}`"
+    - field: Branch
+      always: true
+      value_template: "`feat/{{ req_id }}`"
+      derivation: "feat/<req_id>"
+    - field: Runner Pod
+      always: true
+      value_template: "`runner-{{ req_id | lower }}`"
+      derivation: "runner-<req_id_lowercase>"
+    - field: BKD intent issue
+      always: false
+      value_template: "[open]({{ bkd_intent_issue_url }})"
+      condition: "bkd_intent_issue_url truthy"
+    - field: Pre-cloned repos
+      always: false
+      value_template: "{{ cloned_repos | join(\", \") }}"
+      condition: "cloned_repos truthy and non-empty"
+    - field: Linked PRs
+      always: false
+      value_template: "{{ pr_links_inline }}"
+      condition: "pr_links_inline truthy"
+  trailing_separator: "---"
+
+consumers:
+  - template: orchestrator/src/orchestrator/prompts/intake.md.j2
+    inclusion_position: above_tools_whitelist
+    callsite: orchestrator/src/orchestrator/actions/start_intake.py
+  - template: orchestrator/src/orchestrator/prompts/analyze.md.j2
+    inclusion_position: above_tools_whitelist
+    callsites:
+      - orchestrator/src/orchestrator/actions/start_analyze.py
+      - orchestrator/src/orchestrator/actions/start_analyze_with_finalized_intent.py
+
+backwards_compat:
+  unset_kwarg_behaviour: noop_render
+  reason: "{% if status_block %} guard in includer templates suppresses the partial when the caller has not been wired yet"
+
+out_of_scope:
+  - "re-rendering the block when REQ state changes (BKD has no PATCH-able prompt/description field — verified)"
+  - "extending the partial to staging_test / pr_ci_watch / accept / verifier / challenger / fixer / done_archive prompts (sub-issues, not 'intent')"
+  - "posting the block as a separate BKD UI panel (no such surface exists in BKD REST)"

--- a/openspec/changes/REQ-ux-status-block-1777257283/specs/bkd-intent-status-block/spec.md
+++ b/openspec/changes/REQ-ux-status-block-1777257283/specs/bkd-intent-status-block/spec.md
@@ -1,0 +1,107 @@
+# Spec — bkd-intent-status-block
+
+## ADDED Requirements
+
+### Requirement: BKD intent stage prompts SHALL begin with a canonical status block
+
+The orchestrator SHALL render a canonical markdown "REQ Status" section at the
+top of every BKD intent stage prompt (`intake.md.j2` and `analyze.md.j2`). The
+block MUST consolidate REQ identity, current stage, feat-branch name, runner
+pod name, BKD intent issue URL, pre-cloned repos, and any known linked PRs into
+a single markdown table whose four identity rows (REQ / Stage / Branch / Runner
+Pod) are always present. Optional rows MUST be omitted when their input is
+empty or missing — no empty cells, no placeholder text. The block MUST appear
+above the `tools_whitelist.md.j2` include so that it is the first non-blank
+section both the agent and human readers encounter.
+
+#### Scenario: BISB-S1 partial renders a 7-row table when every field is set
+
+- **GIVEN** the partial `_shared/status_block.md.j2` is rendered with
+  `status_block` containing `req_id="REQ-foo"`, `stage="analyze"`,
+  `bkd_intent_issue_url="https://bkd.example/projects/p/issues/iss-1"`,
+  `cloned_repos=["phona/sisyphus","ZonEaseTech/ttpos-server-go"]`, and
+  `pr_links_inline="[phona/sisyphus#123](https://github.com/phona/sisyphus/pull/123)"`
+- **WHEN** the partial is rendered to a string
+- **THEN** the output MUST start with the heading `## REQ Status`
+- **AND** the rendered markdown table MUST contain rows in this order: `REQ`
+  (value `` `REQ-foo` ``), `Stage` (value `` `analyze` ``), `Branch` (value
+  `` `feat/REQ-foo` ``), `Runner Pod` (value `` `runner-req-foo` ``), `BKD
+  intent issue` (clickable link to the URL), `Pre-cloned repos` (comma-joined
+  repo basenames), `Linked PRs` (the pre-rendered inline string)
+- **AND** the output MUST end with a trailing horizontal rule `---` so the
+  block is visually delimited from whatever follows
+
+#### Scenario: BISB-S2 partial omits optional rows when their input is unset
+
+- **GIVEN** `status_block={"req_id": "REQ-bar", "stage": "intake",
+  "bkd_intent_issue_url": None, "cloned_repos": None, "pr_links_inline": None}`
+- **WHEN** the partial is rendered
+- **THEN** the rendered table MUST contain exactly four data rows (REQ, Stage,
+  Branch, Runner Pod) and no others
+- **AND** the strings `BKD intent issue`, `Pre-cloned repos`, and `Linked PRs`
+  MUST NOT appear anywhere in the rendered output
+- **AND** the rendered output MUST NOT contain any empty markdown table cells
+  (`| |` or `|  |`)
+
+#### Scenario: BISB-S3 analyze prompt opens with the status block above tools_whitelist
+
+- **GIVEN** `analyze.md.j2` is rendered with `req_id="REQ-foo"`,
+  `cloned_repos=["phona/sisyphus"]`,
+  `bkd_intent_issue_url="https://bkd.example/projects/p/issues/iss-1"`, and
+  `status_block=build_status_block_ctx(req_id="REQ-foo", stage="analyze",
+  bkd_intent_issue_url=..., cloned_repos=...)`
+- **WHEN** the rendered prompt is searched
+- **THEN** the substring `## REQ Status` MUST appear in the output
+- **AND** the index of `## REQ Status` MUST be strictly less than the index of
+  `## 工具白名单` (the heading defined inside `tools_whitelist.md.j2`)
+- **AND** the rendered prompt MUST contain the row `Pre-cloned repos` with
+  value `phona/sisyphus`
+
+#### Scenario: BISB-S4 intake prompt opens with the status block and omits cloned_repos
+
+- **GIVEN** `intake.md.j2` is rendered with `req_id="REQ-foo"`,
+  `bkd_intent_issue_url="https://bkd.example/projects/p/issues/iss-1"`, and
+  `status_block=build_status_block_ctx(req_id="REQ-foo", stage="intake",
+  bkd_intent_issue_url=...)` (no `cloned_repos`, no `pr_urls`)
+- **WHEN** the rendered prompt is searched
+- **THEN** the substring `## REQ Status` MUST appear before `## 工具白名单`
+- **AND** the row `Pre-cloned repos` MUST NOT appear in the rendered intake
+  prompt (intake never pre-clones)
+- **AND** the row `Linked PRs` MUST NOT appear (no PRs at intake)
+- **AND** the row `BKD intent issue` MUST appear with the supplied URL
+
+#### Scenario: BISB-S5 linked PRs row formats pr_urls via format_pr_links_inline
+
+- **GIVEN** `build_status_block_ctx` is called with
+  `pr_urls={"phona/sisyphus": "https://github.com/phona/sisyphus/pull/42",
+  "ZonEaseTech/ttpos-server-go":
+  "https://github.com/ZonEaseTech/ttpos-server-go/pull/7"}`
+- **WHEN** the resulting context dict is rendered through the partial
+- **THEN** the `Linked PRs` row MUST contain
+  `[phona/sisyphus#42](https://github.com/phona/sisyphus/pull/42)`
+- **AND** it MUST contain
+  `[ZonEaseTech/ttpos-server-go#7](https://github.com/ZonEaseTech/ttpos-server-go/pull/7)`
+- **AND** the two link strings MUST be separated by a comma so the row stays
+  on a single markdown table cell
+
+#### Scenario: BISB-S6 helper collapses empty inputs to None for clean row drop
+
+- **GIVEN** `build_status_block_ctx(req_id="REQ-foo", stage="intake",
+  bkd_intent_issue_url="", cloned_repos=[], pr_urls={})` is invoked
+- **WHEN** its return value is inspected
+- **THEN** the returned dict MUST have `bkd_intent_issue_url=None`,
+  `cloned_repos=None`, and `pr_links_inline=None`
+- **AND** `req_id` and `stage` MUST be preserved verbatim
+- **AND** rendering through the partial MUST yield exactly the four
+  always-on rows (proves the empty→None collapse drops optional rows cleanly)
+
+#### Scenario: BISB-S7 omitted status_block kwarg is a no-op for backwards compat
+
+- **GIVEN** `analyze.md.j2` is rendered without a `status_block` kwarg (the
+  variable is therefore Jinja2-undefined / falsy) but with all other kwargs
+  identical to a control rendering that does pass `status_block=None`
+- **WHEN** both rendered outputs are compared after stripping leading/trailing
+  whitespace
+- **THEN** they MUST be byte-identical, proving the `{% if status_block %}`
+  guard makes the include a no-op when the caller hasn't been wired yet
+- **AND** neither output MUST contain the string `## REQ Status`

--- a/openspec/changes/REQ-ux-status-block-1777257283/tasks.md
+++ b/openspec/changes/REQ-ux-status-block-1777257283/tasks.md
@@ -1,0 +1,33 @@
+# Tasks — REQ-ux-status-block-1777257283
+
+## Stage: contract / spec
+- [x] author `specs/bkd-intent-status-block/spec.md` (BISB-S1..S7 scenarios)
+- [x] author `specs/bkd-intent-status-block/contract.spec.yaml` (partial schema)
+- [x] author `proposal.md` + `design.md`
+
+## Stage: implementation
+- [x] add `orchestrator/src/orchestrator/prompts/_shared/status_block.md.j2`
+      (markdown table, four always-on rows + three optional rows)
+- [x] add `orchestrator/src/orchestrator/prompts/status_block.py` exposing
+      `build_status_block_ctx(req_id, stage, ...)`
+- [x] include status block at the top of `intake.md.j2` (above tools_whitelist)
+- [x] include status block at the top of `analyze.md.j2` (above tools_whitelist)
+- [x] `start_intake.py`: pass `bkd_intent_issue_url` + `status_block` into render
+- [x] `start_analyze.py`: pass `status_block` into render (re-uses existing
+      `bkd_intent_issue_url` + `cloned_repos`, adds `pr_urls` from ctx)
+- [x] `start_analyze_with_finalized_intent.py`: pass `bkd_intent_issue_url` +
+      `status_block` into render (parity with direct path)
+
+## Stage: tests
+- [x] add `orchestrator/tests/test_prompts_status_block.py` covering BISB-S1..S7
+- [x] verify existing `test_prompts_sisyphus_label.py` and
+      `test_prompts_repo_agnostic.py` still pass (no `status_block` kwarg
+      required — guarded by `{% if status_block %}`)
+
+## Stage: PR
+- [x] `cd /workspace/source/sisyphus && BASE_REV=$(git merge-base HEAD origin/main) make ci-lint`
+      (only changed files lint-clean — Makefile ci contract)
+- [x] `make ci-unit-test` passes (integration tests excluded — Postgres-required tests skip)
+- [x] `git push origin feat/REQ-ux-status-block-1777257283`
+- [x] `gh label create sisyphus --force` then `gh pr create --label sisyphus`
+      with body containing the `<!-- sisyphus:cross-link -->` footer block

--- a/orchestrator/src/orchestrator/actions/start_analyze.py
+++ b/orchestrator/src/orchestrator/actions/start_analyze.py
@@ -30,6 +30,7 @@ from ..bkd import BKDClient
 from ..config import settings
 from ..intent_tags import filter_propagatable_intent_tags
 from ..prompts import render
+from ..prompts.status_block import build_status_block_ctx
 from ..state import Event
 from ..store import db, req_state
 from . import register, short_title
@@ -85,6 +86,7 @@ async def start_analyze(*, body, req_id, tags, ctx):
     # so they survive the rename PATCH and stay visible to downstream agents /
     # dashboards / fallback layers.
     forwarded = filter_propagatable_intent_tags(tags)
+    bkd_intent_issue_url = links.bkd_issue_url(proj, issue_id) or ""
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         await bkd.update_issue(
             project_id=proj,
@@ -102,7 +104,19 @@ async def start_analyze(*, body, req_id, tags, ctx):
             cloned_repos=cloned_repos,
             # REQ-pr-issue-traceability-1777218612: lets analyze.md.j2 render
             # the PR-body cross-link footer with a clickable BKD link.
-            bkd_intent_issue_url=links.bkd_issue_url(proj, issue_id) or "",
+            bkd_intent_issue_url=bkd_intent_issue_url,
+            # REQ-ux-status-block-1777257283: canonical at-a-glance REQ status
+            # block at the top of the analyze prompt. ctx.pr_urls is populated
+            # by later stages (pr_ci_watch.discover_pr_urls); on first analyze
+            # it is absent so format_pr_links_inline returns "" and the row
+            # is omitted by the partial.
+            status_block=build_status_block_ctx(
+                req_id=req_id,
+                stage="analyze",
+                bkd_intent_issue_url=bkd_intent_issue_url,
+                cloned_repos=cloned_repos,
+                pr_urls=(ctx or {}).get("pr_urls"),
+            ),
         )
         await bkd.follow_up_issue(project_id=proj, issue_id=issue_id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue_id, status_id="working")

--- a/orchestrator/src/orchestrator/actions/start_analyze_with_finalized_intent.py
+++ b/orchestrator/src/orchestrator/actions/start_analyze_with_finalized_intent.py
@@ -20,11 +20,12 @@ from __future__ import annotations
 
 import structlog
 
-from .. import k8s_runner
+from .. import k8s_runner, links
 from ..bkd import BKDClient
 from ..config import settings
 from ..intent_tags import filter_propagatable_intent_tags
 from ..prompts import render
+from ..prompts.status_block import build_status_block_ctx
 from ..state import Event
 from ..store import db, req_state
 from . import register, short_title
@@ -81,6 +82,11 @@ async def start_analyze_with_finalized_intent(*, body, req_id, tags, ctx):
             use_worktree=True,
             model=settings.agent_model,
         )
+        # REQ-ux-status-block-1777257283: parity with start_analyze direct path —
+        # the cross-link footer block (analyze.md.j2 §B.7) and the new status
+        # block both want the BKD intent issue URL, so resolve it once after
+        # create_issue gives us the new issue id.
+        bkd_intent_issue_url = links.bkd_issue_url(proj, issue.id) or ""
         prompt = render(
             "analyze.md.j2",
             req_id=req_id,
@@ -90,6 +96,14 @@ async def start_analyze_with_finalized_intent(*, body, req_id, tags, ctx):
             issue_id=issue.id,
             intake_summary=finalized,
             cloned_repos=cloned_repos,
+            bkd_intent_issue_url=bkd_intent_issue_url,
+            status_block=build_status_block_ctx(
+                req_id=req_id,
+                stage="analyze",
+                bkd_intent_issue_url=bkd_intent_issue_url,
+                cloned_repos=cloned_repos,
+                pr_urls=(ctx or {}).get("pr_urls"),
+            ),
         )
         await bkd.follow_up_issue(project_id=proj, issue_id=issue.id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue.id, status_id="working")

--- a/orchestrator/src/orchestrator/actions/start_intake.py
+++ b/orchestrator/src/orchestrator/actions/start_intake.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 
 import structlog
 
-from .. import k8s_runner
+from .. import k8s_runner, links
 from ..admission import check_admission
 from ..bkd import BKDClient
 from ..config import settings
 from ..intent_tags import filter_propagatable_intent_tags
 from ..prompts import render
+from ..prompts.status_block import build_status_block_ctx
 from ..state import Event
 from ..store import db, req_state
 from . import register, short_title
@@ -57,6 +58,7 @@ async def start_intake(*, body, req_id, tags, ctx):
     # so they survive the rename PATCH and stay visible to downstream agents /
     # dashboards / fallback layers.
     forwarded = filter_propagatable_intent_tags(tags)
+    bkd_intent_issue_url = links.bkd_issue_url(proj, issue_id) or ""
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         await bkd.update_issue(
             project_id=proj,
@@ -71,6 +73,12 @@ async def start_intake(*, body, req_id, tags, ctx):
             project_id=proj,
             project_alias=proj,
             issue_id=issue_id,
+            bkd_intent_issue_url=bkd_intent_issue_url,
+            status_block=build_status_block_ctx(
+                req_id=req_id,
+                stage="intake",
+                bkd_intent_issue_url=bkd_intent_issue_url,
+            ),
         )
         await bkd.follow_up_issue(project_id=proj, issue_id=issue_id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue_id, status_id="working")

--- a/orchestrator/src/orchestrator/prompts/_shared/status_block.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/status_block.md.j2
@@ -1,0 +1,19 @@
+## REQ Status
+
+| Field | Value |
+|---|---|
+| REQ | `{{ status_block.req_id }}` |
+| Stage | `{{ status_block.stage }}` |
+| Branch | `feat/{{ status_block.req_id }}` |
+| Runner Pod | `runner-{{ status_block.req_id | lower }}` |
+{% if status_block.bkd_intent_issue_url %}
+| BKD intent issue | [open]({{ status_block.bkd_intent_issue_url }}) |
+{% endif %}
+{% if status_block.cloned_repos %}
+| Pre-cloned repos | {{ status_block.cloned_repos | join(", ") }} |
+{% endif %}
+{% if status_block.pr_links_inline %}
+| Linked PRs | {{ status_block.pr_links_inline }} |
+{% endif %}
+
+---

--- a/orchestrator/src/orchestrator/prompts/analyze.md.j2
+++ b/orchestrator/src/orchestrator/prompts/analyze.md.j2
@@ -1,3 +1,9 @@
+{% if status_block -%}
+{% include "_shared/status_block.md.j2" %}
+
+─────────
+
+{% endif -%}
 {% include "_shared/tools_whitelist.md.j2" %}
 
 ─────────

--- a/orchestrator/src/orchestrator/prompts/intake.md.j2
+++ b/orchestrator/src/orchestrator/prompts/intake.md.j2
@@ -1,3 +1,9 @@
+{% if status_block -%}
+{% include "_shared/status_block.md.j2" %}
+
+─────────
+
+{% endif -%}
 {% include "_shared/tools_whitelist.md.j2" %}
 
 ─────────

--- a/orchestrator/src/orchestrator/prompts/status_block.py
+++ b/orchestrator/src/orchestrator/prompts/status_block.py
@@ -1,0 +1,30 @@
+"""Builder for the ``status_block`` context dict (REQ-ux-status-block-1777257283).
+
+Shared by ``start_intake`` / ``start_analyze`` /
+``start_analyze_with_finalized_intent``: each callsite hands over whatever
+identity / location facts it has at dispatch time, the helper normalises
+empty values to ``None`` so the partial's row guards drop optional rows
+cleanly, and ``pr_urls`` is pre-rendered through ``links.format_pr_links_inline``
+so the Jinja2 template only emits a flat string.
+"""
+from __future__ import annotations
+
+from .. import links
+
+
+def build_status_block_ctx(
+    *,
+    req_id: str,
+    stage: str,
+    bkd_intent_issue_url: str | None = None,
+    cloned_repos: list[str] | None = None,
+    pr_urls: dict[str, str] | None = None,
+) -> dict:
+    """Assemble the dict consumed by ``_shared/status_block.md.j2``."""
+    return {
+        "req_id": req_id,
+        "stage": stage,
+        "bkd_intent_issue_url": (bkd_intent_issue_url or None),
+        "cloned_repos": (list(cloned_repos) if cloned_repos else None),
+        "pr_links_inline": (links.format_pr_links_inline(pr_urls) or None),
+    }

--- a/orchestrator/tests/test_contract_bkd_intent_status_block_challenger.py
+++ b/orchestrator/tests/test_contract_bkd_intent_status_block_challenger.py
@@ -15,8 +15,6 @@ Scenarios covered:
 """
 from __future__ import annotations
 
-import pytest
-
 from orchestrator.prompts import render
 from orchestrator.prompts.status_block import build_status_block_ctx
 

--- a/orchestrator/tests/test_contract_bkd_intent_status_block_challenger.py
+++ b/orchestrator/tests/test_contract_bkd_intent_status_block_challenger.py
@@ -1,0 +1,263 @@
+"""Challenger contract tests for REQ-ux-status-block-1777257283.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-ux-status-block-1777257283/specs/bkd-intent-status-block/spec.md
+  openspec/changes/REQ-ux-status-block-1777257283/specs/bkd-intent-status-block/contract.spec.yaml
+
+Scenarios covered:
+  BISB-S1  partial renders 7-row table when every field is set
+  BISB-S2  partial omits optional rows when inputs are unset
+  BISB-S3  analyze prompt opens with status block above tools_whitelist
+  BISB-S4  intake prompt opens with status block and omits cloned_repos
+  BISB-S5  linked PRs row formats pr_urls via format_pr_links_inline
+  BISB-S6  helper collapses empty inputs to None for clean row drop
+  BISB-S7  omitted status_block kwarg is a no-op for backwards compat
+"""
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.prompts import render
+from orchestrator.prompts.status_block import build_status_block_ctx
+
+
+def _render_partial(status_block) -> str:
+    return render("_shared/status_block.md.j2", status_block=status_block)
+
+
+def _render_analyze(**extra) -> str:
+    return render(
+        "analyze.md.j2",
+        req_id="REQ-foo",
+        project_id="proj-1",
+        project_alias="proj-1",
+        issue_id="iss-1",
+        cloned_repos=["<owner>/repo-a"],
+        aissh_server_id="srv-1",
+        **extra,
+    )
+
+
+def _render_intake(**extra) -> str:
+    return render(
+        "intake.md.j2",
+        project_alias="proj-1",
+        project_id="proj-1",
+        issue_id="iss-1",
+        intent_issue_id="iss-1",
+        aissh_server_id="srv-1",
+        **extra,
+    )
+
+
+# ---------------------------------------------------------------------------
+# BISB-S1  partial renders 7-row table when every field is set
+# ---------------------------------------------------------------------------
+
+def test_bisb_s1_partial_renders_7row_table_all_fields_set() -> None:
+    ctx = build_status_block_ctx(
+        req_id="REQ-foo",
+        stage="analyze",
+        bkd_intent_issue_url="https://bkd.example/projects/p/issues/iss-1",
+        cloned_repos=["phona/sisyphus", "ZonEaseTech/ttpos-server-go"],
+        pr_urls={"phona/sisyphus": "https://github.com/phona/sisyphus/pull/123"},
+    )
+    out = _render_partial(ctx)
+
+    assert out.strip().startswith("## REQ Status"), (
+        "BISB-S1: partial output must start with '## REQ Status'"
+    )
+    for field in ("REQ", "Stage", "Branch", "Runner Pod",
+                  "BKD intent issue", "Pre-cloned repos", "Linked PRs"):
+        assert field in out, f"BISB-S1: expected row '{field}' missing from partial output"
+
+    assert "`REQ-foo`" in out, "BISB-S1: REQ row must contain `REQ-foo`"
+    assert "`analyze`" in out, "BISB-S1: Stage row must contain `analyze`"
+    assert "`feat/REQ-foo`" in out, "BISB-S1: Branch row must contain `feat/REQ-foo`"
+    assert "`runner-req-foo`" in out, "BISB-S1: Runner Pod row must contain `runner-req-foo`"
+    assert "https://bkd.example/projects/p/issues/iss-1" in out, (
+        "BISB-S1: BKD intent issue row must contain the URL"
+    )
+    assert out.rstrip().endswith("---"), (
+        "BISB-S1: partial output must end with trailing horizontal rule '---'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# BISB-S2  partial omits optional rows when inputs are unset
+# ---------------------------------------------------------------------------
+
+def test_bisb_s2_partial_omits_optional_rows_when_unset() -> None:
+    ctx = build_status_block_ctx(
+        req_id="REQ-bar",
+        stage="intake",
+        bkd_intent_issue_url=None,
+        cloned_repos=None,
+        pr_urls=None,
+    )
+    out = _render_partial(ctx)
+
+    for field in ("REQ", "Stage", "Branch", "Runner Pod"):
+        assert field in out, f"BISB-S2: always-on row '{field}' must be present"
+
+    for field in ("BKD intent issue", "Pre-cloned repos", "Linked PRs"):
+        assert field not in out, (
+            f"BISB-S2: optional row '{field}' must not appear when input is None"
+        )
+
+    assert "| |" not in out and "|  |" not in out, (
+        "BISB-S2: output must not contain empty markdown table cells"
+    )
+
+
+# ---------------------------------------------------------------------------
+# BISB-S3  analyze prompt opens with status block above tools_whitelist
+# ---------------------------------------------------------------------------
+
+def test_bisb_s3_analyze_prompt_status_block_above_tools_whitelist() -> None:
+    sb = build_status_block_ctx(
+        req_id="REQ-foo",
+        stage="analyze",
+        bkd_intent_issue_url="https://bkd.example/projects/p/issues/iss-1",
+        cloned_repos=["phona/sisyphus"],
+    )
+    out = _render_analyze(status_block=sb)
+
+    assert "## REQ Status" in out, (
+        "BISB-S3: analyze prompt must contain '## REQ Status'"
+    )
+    idx_status = out.index("## REQ Status")
+    assert "## 工具白名单" in out, (
+        "BISB-S3: analyze prompt must contain '## 工具白名单'"
+    )
+    idx_whitelist = out.index("## 工具白名单")
+    assert idx_status < idx_whitelist, (
+        "BISB-S3: '## REQ Status' must appear before '## 工具白名单' in analyze prompt"
+    )
+    assert "Pre-cloned repos" in out, (
+        "BISB-S3: analyze prompt must contain 'Pre-cloned repos' row with value"
+    )
+
+
+# ---------------------------------------------------------------------------
+# BISB-S4  intake prompt opens with status block and omits cloned_repos
+# ---------------------------------------------------------------------------
+
+def test_bisb_s4_intake_prompt_status_block_omits_cloned_repos() -> None:
+    sb = build_status_block_ctx(
+        req_id="REQ-foo",
+        stage="intake",
+        bkd_intent_issue_url="https://bkd.example/projects/p/issues/iss-1",
+    )
+    out = _render_intake(status_block=sb)
+
+    assert "## REQ Status" in out, (
+        "BISB-S4: intake prompt must contain '## REQ Status'"
+    )
+    assert "## 工具白名单" in out, (
+        "BISB-S4: intake prompt must contain '## 工具白名单'"
+    )
+    idx_status = out.index("## REQ Status")
+    idx_whitelist = out.index("## 工具白名单")
+    assert idx_status < idx_whitelist, (
+        "BISB-S4: '## REQ Status' must appear before '## 工具白名单' in intake prompt"
+    )
+    assert "Pre-cloned repos" not in out, (
+        "BISB-S4: intake prompt must not contain 'Pre-cloned repos' (intake never pre-clones)"
+    )
+    assert "Linked PRs" not in out, (
+        "BISB-S4: intake prompt must not contain 'Linked PRs' (no PRs at intake)"
+    )
+    assert "BKD intent issue" in out, (
+        "BISB-S4: intake prompt must contain 'BKD intent issue' row"
+    )
+    assert "https://bkd.example/projects/p/issues/iss-1" in out, (
+        "BISB-S4: BKD intent issue row must contain the supplied URL"
+    )
+
+
+# ---------------------------------------------------------------------------
+# BISB-S5  linked PRs row formats pr_urls via format_pr_links_inline
+# ---------------------------------------------------------------------------
+
+def test_bisb_s5_pr_urls_formatted_as_inline_links() -> None:
+    ctx = build_status_block_ctx(
+        req_id="REQ-foo",
+        stage="analyze",
+        pr_urls={
+            "phona/sisyphus": "https://github.com/phona/sisyphus/pull/42",
+            "ZonEaseTech/ttpos-server-go": "https://github.com/ZonEaseTech/ttpos-server-go/pull/7",
+        },
+    )
+    out = _render_partial(ctx)
+
+    assert "[phona/sisyphus#42](https://github.com/phona/sisyphus/pull/42)" in out, (
+        "BISB-S5: Linked PRs row must contain formatted link for phona/sisyphus#42"
+    )
+    assert (
+        "[ZonEaseTech/ttpos-server-go#7](https://github.com/ZonEaseTech/ttpos-server-go/pull/7)"
+        in out
+    ), "BISB-S5: Linked PRs row must contain formatted link for ttpos-server-go#7"
+
+    linked_prs_line = next(
+        (line for line in out.splitlines() if "Linked PRs" in line), None
+    )
+    assert linked_prs_line is not None, "BISB-S5: Linked PRs row must exist in output"
+    assert "," in linked_prs_line, (
+        "BISB-S5: two PR links in the Linked PRs row must be comma-separated"
+    )
+
+
+# ---------------------------------------------------------------------------
+# BISB-S6  helper collapses empty inputs to None for clean row drop
+# ---------------------------------------------------------------------------
+
+def test_bisb_s6_helper_collapses_empty_inputs_to_none() -> None:
+    ctx = build_status_block_ctx(
+        req_id="REQ-foo",
+        stage="intake",
+        bkd_intent_issue_url="",
+        cloned_repos=[],
+        pr_urls={},
+    )
+
+    def _get(obj, key):
+        return obj[key] if isinstance(obj, dict) else getattr(obj, key)
+
+    assert _get(ctx, "bkd_intent_issue_url") is None, (
+        "BISB-S6: empty string bkd_intent_issue_url must collapse to None"
+    )
+    assert _get(ctx, "cloned_repos") is None, (
+        "BISB-S6: empty list cloned_repos must collapse to None"
+    )
+    assert _get(ctx, "pr_links_inline") is None, (
+        "BISB-S6: empty dict pr_urls must collapse to None pr_links_inline"
+    )
+
+    req_id_val = _get(ctx, "req_id")
+    stage_val = _get(ctx, "stage")
+    assert req_id_val == "REQ-foo", "BISB-S6: req_id must be preserved verbatim"
+    assert stage_val == "intake", "BISB-S6: stage must be preserved verbatim"
+
+    out = _render_partial(ctx)
+    for field in ("BKD intent issue", "Pre-cloned repos", "Linked PRs"):
+        assert field not in out, (
+            f"BISB-S6: optional row '{field}' must not appear after empty→None collapse"
+        )
+
+
+# ---------------------------------------------------------------------------
+# BISB-S7  omitted status_block kwarg is a no-op for backwards compat
+# ---------------------------------------------------------------------------
+
+def test_bisb_s7_omitted_status_block_is_noop() -> None:
+    out_with_none = _render_analyze(status_block=None)
+    out_without = _render_analyze()
+
+    assert out_with_none.strip() == out_without.strip(), (
+        "BISB-S7: rendering with status_block=None and without status_block kwarg "
+        "must produce byte-identical output (after strip)"
+    )
+    assert "## REQ Status" not in out_without, (
+        "BISB-S7: when status_block is not passed, '## REQ Status' must not appear"
+    )

--- a/orchestrator/tests/test_prompts_status_block.py
+++ b/orchestrator/tests/test_prompts_status_block.py
@@ -1,0 +1,210 @@
+"""REQ-ux-status-block-1777257283: BKD intent body status block tests.
+
+Covers spec scenarios BISB-S1..S7 in
+``openspec/changes/REQ-ux-status-block-1777257283/specs/bkd-intent-status-block/spec.md``.
+The partial under test renders a markdown ``## REQ Status`` table that gets
+included at the top of ``intake.md.j2`` and ``analyze.md.j2``.
+"""
+from __future__ import annotations
+
+from orchestrator.prompts import render
+from orchestrator.prompts.status_block import build_status_block_ctx
+
+
+def _render_partial(status_block: dict | None) -> str:
+    return render("_shared/status_block.md.j2", status_block=status_block)
+
+
+def _data_row_field_names(rendered: str) -> list[str]:
+    """Pick out the ``Field`` column of each data row in the rendered table."""
+    rows: list[str] = []
+    for line in rendered.splitlines():
+        if not line.startswith("| "):
+            continue
+        if line.startswith("| Field"):
+            continue  # header row
+        if line.startswith("|---"):
+            continue  # markdown separator
+        rows.append(line)
+    return [r.split(" | ", 1)[0].lstrip("| ") for r in rows]
+
+
+# ── BISB-S1 ────────────────────────────────────────────────────────────────
+
+
+def test_bisb_s1_partial_renders_seven_rows_when_every_field_set() -> None:
+    """BISB-S1: full table, 7 data rows in documented order."""
+    sb = {
+        "req_id": "REQ-foo",
+        "stage": "analyze",
+        "bkd_intent_issue_url": "https://bkd.example/projects/p/issues/iss-1",
+        "cloned_repos": ["phona/sisyphus", "ZonEaseTech/ttpos-server-go"],
+        "pr_links_inline":
+            "[phona/sisyphus#123](https://github.com/phona/sisyphus/pull/123)",
+    }
+    out = _render_partial(sb)
+    assert out.lstrip().startswith("## REQ Status"), out[:200]
+    assert _data_row_field_names(out) == [
+        "REQ", "Stage", "Branch", "Runner Pod",
+        "BKD intent issue", "Pre-cloned repos", "Linked PRs",
+    ]
+    assert "`REQ-foo`" in out
+    assert "`analyze`" in out
+    assert "`feat/REQ-foo`" in out
+    assert "`runner-req-foo`" in out
+    assert "[open](https://bkd.example/projects/p/issues/iss-1)" in out
+    assert "phona/sisyphus, ZonEaseTech/ttpos-server-go" in out
+    assert ("[phona/sisyphus#123]"
+            "(https://github.com/phona/sisyphus/pull/123)") in out
+    assert out.rstrip().endswith("---"), out[-100:]
+
+
+# ── BISB-S2 ────────────────────────────────────────────────────────────────
+
+
+def test_bisb_s2_partial_omits_optional_rows_when_unset() -> None:
+    """BISB-S2: only req_id + stage → 4 always-on rows, no optional row strings."""
+    sb = {
+        "req_id": "REQ-bar",
+        "stage": "intake",
+        "bkd_intent_issue_url": None,
+        "cloned_repos": None,
+        "pr_links_inline": None,
+    }
+    out = _render_partial(sb)
+    assert _data_row_field_names(out) == ["REQ", "Stage", "Branch", "Runner Pod"]
+    assert "BKD intent issue" not in out
+    assert "Pre-cloned repos" not in out
+    assert "Linked PRs" not in out
+    # No empty markdown table cells.
+    assert "| |" not in out
+    assert "|  |" not in out
+
+
+# ── BISB-S3 ────────────────────────────────────────────────────────────────
+
+
+def test_bisb_s3_analyze_prompt_status_block_above_tools_whitelist() -> None:
+    """BISB-S3: rendered analyze prompt has ## REQ Status before ## 工具白名单."""
+    sb = build_status_block_ctx(
+        req_id="REQ-foo",
+        stage="analyze",
+        bkd_intent_issue_url="https://bkd.example/projects/p/issues/iss-1",
+        cloned_repos=["phona/sisyphus"],
+    )
+    out = render(
+        "analyze.md.j2",
+        req_id="REQ-foo",
+        project_id="proj-1",
+        project_alias="proj-1",
+        issue_id="iss-1",
+        cloned_repos=["phona/sisyphus"],
+        bkd_intent_issue_url="https://bkd.example/projects/p/issues/iss-1",
+        aissh_server_id="srv-1",
+        status_block=sb,
+    )
+    idx_status = out.find("## REQ Status")
+    idx_tools = out.find("## 工具白名单")
+    assert idx_status >= 0, "## REQ Status missing from rendered analyze prompt"
+    assert idx_tools > idx_status, (idx_status, idx_tools)
+    assert "Pre-cloned repos" in out
+    assert "phona/sisyphus" in out
+
+
+# ── BISB-S4 ────────────────────────────────────────────────────────────────
+
+
+def test_bisb_s4_intake_prompt_status_block_omits_cloned_repos_and_prs() -> None:
+    """BISB-S4: intake → status block has BKD intent URL but no cloned_repos/PRs."""
+    sb = build_status_block_ctx(
+        req_id="REQ-foo",
+        stage="intake",
+        bkd_intent_issue_url="https://bkd.example/projects/p/issues/iss-1",
+    )
+    out = render(
+        "intake.md.j2",
+        req_id="REQ-foo",
+        project_id="proj-1",
+        project_alias="proj-1",
+        issue_id="iss-1",
+        aissh_server_id="srv-1",
+        bkd_intent_issue_url="https://bkd.example/projects/p/issues/iss-1",
+        status_block=sb,
+    )
+    idx_status = out.find("## REQ Status")
+    idx_tools = out.find("## 工具白名单")
+    assert idx_status >= 0, "## REQ Status missing from rendered intake prompt"
+    assert idx_tools > idx_status, (idx_status, idx_tools)
+    # Pre-cloned repos / Linked PRs strings only live in the partial; their
+    # absence proves those rows were omitted from the intake render.
+    assert "Pre-cloned repos" not in out
+    assert "Linked PRs" not in out
+    assert "BKD intent issue" in out
+    assert "https://bkd.example/projects/p/issues/iss-1" in out
+
+
+# ── BISB-S5 ────────────────────────────────────────────────────────────────
+
+
+def test_bisb_s5_pr_urls_renders_clickable_inline_links() -> None:
+    """BISB-S5: pr_urls dict → clickable per-repo markdown links, comma-joined."""
+    sb = build_status_block_ctx(
+        req_id="REQ-foo",
+        stage="analyze",
+        pr_urls={
+            "phona/sisyphus": "https://github.com/phona/sisyphus/pull/42",
+            "ZonEaseTech/ttpos-server-go":
+                "https://github.com/ZonEaseTech/ttpos-server-go/pull/7",
+        },
+    )
+    out = _render_partial(sb)
+    pr_rows = [line for line in out.splitlines() if "Linked PRs" in line]
+    assert len(pr_rows) == 1, pr_rows
+    pr_row = pr_rows[0]
+    assert ("[phona/sisyphus#42]"
+            "(https://github.com/phona/sisyphus/pull/42)") in pr_row
+    assert ("[ZonEaseTech/ttpos-server-go#7]"
+            "(https://github.com/ZonEaseTech/ttpos-server-go/pull/7)") in pr_row
+    assert ", " in pr_row  # the two links share one cell
+
+
+# ── BISB-S6 ────────────────────────────────────────────────────────────────
+
+
+def test_bisb_s6_helper_collapses_empty_inputs_to_none() -> None:
+    """BISB-S6: empty/blank optional inputs → None so the partial drops the row."""
+    sb = build_status_block_ctx(
+        req_id="REQ-foo",
+        stage="intake",
+        bkd_intent_issue_url="",
+        cloned_repos=[],
+        pr_urls={},
+    )
+    assert sb["bkd_intent_issue_url"] is None
+    assert sb["cloned_repos"] is None
+    assert sb["pr_links_inline"] is None
+    assert sb["req_id"] == "REQ-foo"
+    assert sb["stage"] == "intake"
+    out = _render_partial(sb)
+    assert _data_row_field_names(out) == ["REQ", "Stage", "Branch", "Runner Pod"]
+
+
+# ── BISB-S7 ────────────────────────────────────────────────────────────────
+
+
+def test_bisb_s7_omitted_status_block_kwarg_is_noop_for_backwards_compat() -> None:
+    """BISB-S7: status_block omitted vs status_block=None → byte-identical output."""
+    base = {
+        "req_id": "REQ-foo",
+        "project_id": "proj-1",
+        "project_alias": "proj-1",
+        "issue_id": "iss-1",
+        "cloned_repos": ["phona/sisyphus"],
+        "aissh_server_id": "srv-1",
+        "bkd_intent_issue_url": "https://bkd.example/projects/p/issues/iss-1",
+    }
+    out_omitted = render("analyze.md.j2", **base)
+    out_none = render("analyze.md.j2", status_block=None, **base)
+    assert out_omitted.strip() == out_none.strip()
+    assert "## REQ Status" not in out_omitted
+    assert "## REQ Status" not in out_none


### PR DESCRIPTION
## Summary

Adds a shared `_shared/status_block.md.j2` partial rendering a markdown `## REQ Status` table at the top of the BKD intent stage prompts (`intake.md.j2` + `analyze.md.j2`). Consolidates scattered REQ identity / pod / branch / cloned-repos / intent-URL / linked-PR facts into one at-a-glance section that both the agent and humans see when the issue is opened in BKD UI.

- 4 always-on rows (REQ / Stage / Branch / Runner Pod) computed from `req_id`; 3 optional rows (BKD intent issue, Pre-cloned repos, Linked PRs) omitted cleanly when their input is empty/None.
- Includer templates wrap the include in `{% if status_block %}` so callers that haven't been wired yet (verifier / fixer / challenger / etc., out of scope) keep byte-identical output (BISB-S7 covers).
- `start_analyze_with_finalized_intent` gains parity with the direct analyze path by also forwarding `bkd_intent_issue_url`, so the existing PR-body cross-link footer block works through the intake → analyze flow too.

## Why

Today the intake/analyze prompt has REQ id / pod name / branch / cloned repos / intent URL scattered across 10+ lines spanning the whole template. Both agents (after compaction needs the canonical id within a screenful) and humans (BKD UI shows the prompt as the issue starter) have to hunt. BKD REST has no writable description / comments / notes endpoint (probed: PATCH `description` / `prompt` silently no-op, `/notes` `/comments` `/messages` all 404), so the prompt body is the only durable text surface — the block lives there.

## Test plan

- [x] `BASE_REV=$(git merge-base HEAD origin/main) make ci-lint` — clean, 5 files in scope.
- [x] `make ci-unit-test` — 1263 passed (including new \`test_prompts_status_block.py::test_bisb_s1..s7\`).
- [x] `openspec validate REQ-ux-status-block-1777257283` — change valid.
- [x] `check-scenario-refs.sh` — 410 scenarios, all references resolve.
- [x] Manually rendered both templates with / without the kwarg to verify backwards-compat (BISB-S7).

## Spec

`openspec/changes/REQ-ux-status-block-1777257283/specs/bkd-intent-status-block/spec.md` — BISB-S1..S7.

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-ux-status-block-1777257283\`
**BKD intent issue**: [BKD intent issue](https://bkd.5ok.co/projects/nnvxh8wj/issues/df5kw32f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)