### PR TITLE
log: include explicit traceback + error_type in engine.action_failed

### DIFF
--- a/orchestrator/src/orchestrator/engine.py
+++ b/orchestrator/src/orchestrator/engine.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+import traceback
 from typing import Any
 
 import asyncpg
@@ -306,7 +307,11 @@ async def _dispatch_with_retry(
         result = await handler(body=body, req_id=req_id, tags=tags, ctx=ctx)
     except Exception as e:
         duration_ms = int((time.monotonic() - started) * 1000)
-        log.exception("engine.action_failed", action=action_name, error=str(e))
+        log.exception(
+            "engine.action_failed", action=action_name, error=str(e),
+            error_type=type(e).__name__,
+            traceback=traceback.format_exc(),
+        )
         await obs.record_event(
             "action.failed",
             req_id=req_id, issue_id=issue_id, tags=tags,


### PR DESCRIPTION
## Why

Today's K8s exec failures (\"Handshake status 200 OK\" pattern) escalated 6 dispatched dogfoods within 14ms of state transition, but the existing \`log.exception(\"engine.action_failed\", ...)\` only emitted the message — no actual traceback in the JSON log line, just a boolean \`exc_info: true\` field. Without the call stack, can't tell which K8s API call (ensure_runner / clone exec / pod create / disk probe) is throwing.

## Fix

Pass \`traceback=traceback.format_exc()\` and \`error_type=type(e).__name__\` explicitly so structlog renders them as fields in the JSON log. Now the next failure will show full Python stack.

## Test plan

- ruff clean
- No behavior change beyond log format