### PR TITLE
test(engine): mock tests for 7 accept-phase transitions (REQ-test-accept-phase-1777267654)

### DIFF
--- a/openspec/changes/REQ-test-accept-phase-1777267654/proposal.md
+++ b/openspec/changes/REQ-test-accept-phase-1777267654/proposal.md
@@ -1,0 +1,79 @@
+# REQ-test-accept-phase-1777267654: test(engine): mock tests for the 7 accept-phase transitions
+
+## 问题
+
+`orchestrator/src/orchestrator/state.py` 的状态机定义里，accept 阶段（`ACCEPT_RUNNING` +
+`ACCEPT_TEARING_DOWN` 两个 state 出发的 7 条 transition）是 happy-path 链路从 PR-CI
+绿到 ARCHIVING 的最后一公里：
+
+```
+PR_CI_RUNNING ──pr-ci.pass──▶ ACCEPT_RUNNING
+                                  │
+                                  ├─accept-env-up.fail─▶ ESCALATED
+                                  ├─accept.pass───────▶ ACCEPT_TEARING_DOWN ──teardown-done.pass─▶ ARCHIVING
+                                  ├─accept.fail───────▶ ACCEPT_TEARING_DOWN ──teardown-done.fail─▶ REVIEW_RUNNING
+                                  └─session.failed────▶ ACCEPT_RUNNING (self-loop)
+                                                       ACCEPT_TEARING_DOWN
+                                                          └─session.failed─▶ ACCEPT_TEARING_DOWN (self-loop)
+```
+
+具体 7 条 transition（state.py L175-L191、L247-L259）：
+
+| # | (cur_state, event) | next_state | action |
+|---|---|---|---|
+| 1 | (ACCEPT_RUNNING, ACCEPT_PASS) | ACCEPT_TEARING_DOWN | teardown_accept_env |
+| 2 | (ACCEPT_RUNNING, ACCEPT_FAIL) | ACCEPT_TEARING_DOWN | teardown_accept_env |
+| 3 | (ACCEPT_RUNNING, ACCEPT_ENV_UP_FAIL) | ESCALATED | escalate |
+| 4 | (ACCEPT_TEARING_DOWN, TEARDOWN_DONE_PASS) | ARCHIVING | done_archive |
+| 5 | (ACCEPT_TEARING_DOWN, TEARDOWN_DONE_FAIL) | REVIEW_RUNNING | invoke_verifier_for_accept_fail |
+| 6 | (ACCEPT_RUNNING, SESSION_FAILED) | ACCEPT_RUNNING (self-loop) | escalate |
+| 7 | (ACCEPT_TEARING_DOWN, SESSION_FAILED) | ACCEPT_TEARING_DOWN (self-loop) | escalate |
+
+现有 `orchestrator/tests/test_engine.py` + `test_engine_adversarial.py` 集中验
+spec_lint / challenger / staging-test / DONE / ESCALATED 等点，**accept 这 7 条
+transition 一条单测都没有**。后果：
+
+- 改 `teardown_accept_env` action 名 / 改 emit 顺序 → CI 不会红
+- `(ACCEPT_RUNNING, ACCEPT_ENV_UP_FAIL) → ESCALATED` 这条 terminal 边漏了 cleanup_runner
+  断言，回归只能靠生产打脸
+- `(ACCEPT_TEARING_DOWN, SESSION_FAILED)` self-loop 是 sisyphus
+  唯一兜底 BKD session crash 的转移点，没单测保护就是定时炸弹
+
+## 方案
+
+新增 `orchestrator/tests/test_engine_accept_phase.py`：7 条 mock 用例
+（APT-S1..APT-S7），逐条验上面 7 条 transition 的：
+
+1. `engine.step` 收到事件后 CAS 成功推到目标 state
+2. 转移表声明的 action handler 被调用一次
+3. terminal 边（ESCALATED）触发 `cleanup_runner(retain_pvc=True)`，self-loop / 非
+   terminal 边不触发
+4. handler 主动 emit 下一事件（teardown_accept_env 真实代码会 emit
+   `teardown-done.pass` / `teardown-done.fail`）→ 链式 step 推到下一目标 state
+
+复用 `test_engine.py` 已有的 `FakePool` + `FakeReq` + `_drain_tasks` + `stub_actions`
+fixture 模式，**不打 BKD 不打 Postgres 不打 K8s**。每条 case 一句话：
+
+| ID | 输入 transition | 期望 |
+|---|---|---|
+| APT-S1 | (ACCEPT_RUNNING, ACCEPT_PASS) + handler emits `teardown-done.pass` | 状态推到 ACCEPT_TEARING_DOWN，链式再推到 ARCHIVING；done_archive 被调；非 terminal 不 cleanup |
+| APT-S2 | (ACCEPT_RUNNING, ACCEPT_FAIL) + handler emits `teardown-done.fail` | 状态推到 ACCEPT_TEARING_DOWN，链式推到 REVIEW_RUNNING；invoke_verifier_for_accept_fail 被调 |
+| APT-S3 | (ACCEPT_RUNNING, ACCEPT_ENV_UP_FAIL) | 状态推到 ESCALATED；escalate 被调；cleanup_runner(retain_pvc=True) 触发一次 |
+| APT-S4 | (ACCEPT_TEARING_DOWN, TEARDOWN_DONE_PASS) | 状态推到 ARCHIVING；done_archive 被调；不触发 cleanup（ARCHIVING 不是 terminal） |
+| APT-S5 | (ACCEPT_TEARING_DOWN, TEARDOWN_DONE_FAIL) | 状态推到 REVIEW_RUNNING；invoke_verifier_for_accept_fail 被调；不触发 cleanup |
+| APT-S6 | (ACCEPT_RUNNING, SESSION_FAILED) self-loop | 状态保持 ACCEPT_RUNNING；escalate 被调；非 terminal 不 cleanup |
+| APT-S7 | (ACCEPT_TEARING_DOWN, SESSION_FAILED) self-loop | 状态保持 ACCEPT_TEARING_DOWN；escalate 被调；非 terminal 不 cleanup |
+
+## 不做
+
+- ❌ 不动 `engine.py` / `state.py` —— 全部用现有 API + fake stub；如果 case 挂
+  说明状态机或 engine 真的有 bug，需要 follow-up REQ 修
+- ❌ 不增加新 ReqState / Event：纯测试增量
+- ❌ 不写 integration test（M18 challenger 自己读 spec 黑盒写 contract test）
+- ❌ 不验真 `teardown_accept_env` 的 helm uninstall 行为（那是 actions/ 的 unit
+  test 范围，不是 engine 状态机层的契约）
+
+## 影响
+
+- `orchestrator/tests/test_engine_accept_phase.py` 新增 1 个文件 ≈ 280 行
+- 不动 prod 代码。不动 schema。不影响 runtime

--- a/openspec/changes/REQ-test-accept-phase-1777267654/specs/accept-phase-tests/spec.md
+++ b/openspec/changes/REQ-test-accept-phase-1777267654/specs/accept-phase-tests/spec.md
@@ -1,0 +1,150 @@
+## ADDED Requirements
+
+### Requirement: Engine.step routes ACCEPT_RUNNING + ACCEPT_PASS to teardown then archive
+
+The state-machine engine (`orchestrator/src/orchestrator/engine.py::step`) SHALL
+advance a row from `ACCEPT_RUNNING` to `ACCEPT_TEARING_DOWN` when the
+`accept.pass` event arrives, and MUST dispatch the `teardown_accept_env`
+action exactly once. When the action's return value carries
+`{"emit": "teardown-done.pass"}` the engine MUST chain into
+`(ACCEPT_TEARING_DOWN, TEARDOWN_DONE_PASS) → ARCHIVING`, dispatching
+`done_archive` once. Neither transition leg crosses a terminal state, so the
+engine MUST NOT schedule `cleanup_runner` along this happy-path.
+
+#### Scenario: APT-S1 accept pass advances through teardown to archiving
+
+- **GIVEN** a FakePool row at state `ACCEPT_RUNNING`, an injected fake
+  `k8s_runner` controller, and stub actions where `teardown_accept_env`
+  returns `{"emit": "teardown-done.pass"}` and `done_archive` returns
+  `{"ok": True}`
+- **WHEN** `engine.step` runs at `(ACCEPT_RUNNING, ACCEPT_PASS)`
+- **THEN** the call MUST NOT raise; the returned dict MUST contain
+  `action="teardown_accept_env"` and a `chained` dict whose `action` is
+  `"done_archive"` and whose `next_state` equals `"archiving"`; the row
+  state MUST be `ARCHIVING`; both stubs MUST have been invoked exactly once;
+  the fake controller's `cleanup_runner` mock MUST NOT have been awaited
+
+### Requirement: Engine.step routes ACCEPT_RUNNING + ACCEPT_FAIL through teardown to verifier
+
+The engine SHALL advance a row from `ACCEPT_RUNNING` to
+`ACCEPT_TEARING_DOWN` when the `accept.fail` event arrives, and MUST
+dispatch the same `teardown_accept_env` action — `accept.pass` and
+`accept.fail` share the teardown step because env-down is mandatory before
+the verifier sees the failure. When the action emits `teardown-done.fail`
+the engine MUST chain into `(ACCEPT_TEARING_DOWN, TEARDOWN_DONE_FAIL) →
+REVIEW_RUNNING`, dispatching `invoke_verifier_for_accept_fail` once. The
+chain MUST NOT trigger `cleanup_runner` because `REVIEW_RUNNING` is not a
+terminal state.
+
+#### Scenario: APT-S2 accept fail advances through teardown to verifier
+
+- **GIVEN** a FakePool row at state `ACCEPT_RUNNING`, an injected fake
+  `k8s_runner` controller, and stub actions where `teardown_accept_env`
+  returns `{"emit": "teardown-done.fail"}` and
+  `invoke_verifier_for_accept_fail` returns `{"ok": True}`
+- **WHEN** `engine.step` runs at `(ACCEPT_RUNNING, ACCEPT_FAIL)`
+- **THEN** the call MUST NOT raise; the returned dict MUST contain
+  `action="teardown_accept_env"` and a `chained` dict whose `action` is
+  `"invoke_verifier_for_accept_fail"` and whose `next_state` equals
+  `"review-running"`; the row state MUST be `REVIEW_RUNNING`; both stubs
+  MUST have been invoked exactly once; `cleanup_runner` MUST NOT have been
+  awaited
+
+### Requirement: Engine.step escalates ACCEPT_ENV_UP_FAIL with cleanup retain_pvc
+
+The engine SHALL transition `(ACCEPT_RUNNING, ACCEPT_ENV_UP_FAIL) → ESCALATED`
+and MUST dispatch the `escalate` action. Because the destination is a
+terminal state and the source is non-terminal, the engine MUST schedule
+`cleanup_runner(req_id, retain_pvc=True)` exactly once via
+`asyncio.create_task` —  PVC retention is mandatory on `ESCALATED` so a
+human can debug the failed lab.
+
+#### Scenario: APT-S3 accept env-up fail escalates and triggers cleanup
+
+- **GIVEN** a FakePool row at state `ACCEPT_RUNNING`, an injected fake
+  `k8s_runner` controller, and a stub `escalate` action returning
+  `{"escalated": True}`
+- **WHEN** `engine.step` runs at `(ACCEPT_RUNNING, ACCEPT_ENV_UP_FAIL)` and
+  background tasks are drained
+- **THEN** the call MUST NOT raise; the returned dict MUST contain
+  `action="escalate"` and `next_state="escalated"`; the row state MUST be
+  `ESCALATED`; the stub `escalate` MUST have been invoked exactly once; the
+  fake controller's `cleanup_runner` mock MUST have been awaited exactly
+  once with `("REQ-1", retain_pvc=True)`
+
+### Requirement: Engine.step routes ACCEPT_TEARING_DOWN + TEARDOWN_DONE_PASS to archiving
+
+The engine SHALL transition `(ACCEPT_TEARING_DOWN, TEARDOWN_DONE_PASS) →
+ARCHIVING` and MUST dispatch `done_archive` exactly once. When invoked
+without a chained emit, the engine MUST NOT schedule `cleanup_runner`
+because `ARCHIVING` is not a terminal state — cleanup happens on the next
+hop into `DONE`, not here.
+
+#### Scenario: APT-S4 teardown-done.pass advances to archiving
+
+- **GIVEN** a FakePool row at state `ACCEPT_TEARING_DOWN`, an injected fake
+  `k8s_runner` controller, and a stub `done_archive` returning
+  `{"ok": True}`
+- **WHEN** `engine.step` runs at `(ACCEPT_TEARING_DOWN, TEARDOWN_DONE_PASS)`
+  and background tasks are drained
+- **THEN** the call MUST NOT raise; the returned dict MUST contain
+  `action="done_archive"` and `next_state="archiving"`; the row state MUST
+  be `ARCHIVING`; the stub MUST have been invoked exactly once;
+  `cleanup_runner` MUST NOT have been awaited
+
+### Requirement: Engine.step routes ACCEPT_TEARING_DOWN + TEARDOWN_DONE_FAIL to verifier
+
+The engine SHALL transition `(ACCEPT_TEARING_DOWN, TEARDOWN_DONE_FAIL) →
+REVIEW_RUNNING` and MUST dispatch `invoke_verifier_for_accept_fail` exactly
+once. The transition MUST NOT trigger `cleanup_runner` because
+`REVIEW_RUNNING` is not a terminal state.
+
+#### Scenario: APT-S5 teardown-done.fail routes to verifier
+
+- **GIVEN** a FakePool row at state `ACCEPT_TEARING_DOWN`, an injected fake
+  `k8s_runner` controller, and a stub `invoke_verifier_for_accept_fail`
+  returning `{"ok": True}`
+- **WHEN** `engine.step` runs at `(ACCEPT_TEARING_DOWN, TEARDOWN_DONE_FAIL)`
+  and background tasks are drained
+- **THEN** the call MUST NOT raise; the returned dict MUST contain
+  `action="invoke_verifier_for_accept_fail"` and
+  `next_state="review-running"`; the row state MUST be `REVIEW_RUNNING`;
+  the stub MUST have been invoked exactly once; `cleanup_runner` MUST NOT
+  have been awaited
+
+### Requirement: Engine.step routes ACCEPT_RUNNING + SESSION_FAILED as self-loop
+
+The engine SHALL treat `(ACCEPT_RUNNING, SESSION_FAILED)` as a self-loop
+whose `next_state` equals `cur_state`. The transition MUST dispatch the
+`escalate` action exactly once — the action itself decides between
+auto-resume and real escalate based on `ctx.auto_retry_count`. Because both
+endpoints are non-terminal, the engine MUST NOT schedule `cleanup_runner`.
+
+#### Scenario: APT-S6 session.failed at accept-running keeps state and dispatches escalate
+
+- **GIVEN** a FakePool row at state `ACCEPT_RUNNING`, an injected fake
+  `k8s_runner` controller, and a stub `escalate` returning `{"ok": True}`
+- **WHEN** `engine.step` runs at `(ACCEPT_RUNNING, SESSION_FAILED)` and
+  background tasks are drained
+- **THEN** the call MUST NOT raise; the returned dict MUST contain
+  `action="escalate"` and `next_state="accept-running"`; the row state
+  MUST remain `ACCEPT_RUNNING`; the stub MUST have been invoked exactly
+  once; `cleanup_runner` MUST NOT have been awaited
+
+### Requirement: Engine.step routes ACCEPT_TEARING_DOWN + SESSION_FAILED as self-loop
+
+The engine SHALL treat `(ACCEPT_TEARING_DOWN, SESSION_FAILED)` as a
+self-loop. The transition MUST dispatch the `escalate` action exactly once
+and MUST keep the row state at `ACCEPT_TEARING_DOWN`. Because both
+endpoints are non-terminal the engine MUST NOT schedule `cleanup_runner`.
+
+#### Scenario: APT-S7 session.failed at accept-tearing-down keeps state and dispatches escalate
+
+- **GIVEN** a FakePool row at state `ACCEPT_TEARING_DOWN`, an injected fake
+  `k8s_runner` controller, and a stub `escalate` returning `{"ok": True}`
+- **WHEN** `engine.step` runs at `(ACCEPT_TEARING_DOWN, SESSION_FAILED)`
+  and background tasks are drained
+- **THEN** the call MUST NOT raise; the returned dict MUST contain
+  `action="escalate"` and `next_state="accept-tearing-down"`; the row
+  state MUST remain `ACCEPT_TEARING_DOWN`; the stub MUST have been invoked
+  exactly once; `cleanup_runner` MUST NOT have been awaited

--- a/openspec/changes/REQ-test-accept-phase-1777267654/tasks.md
+++ b/openspec/changes/REQ-test-accept-phase-1777267654/tasks.md
@@ -1,0 +1,28 @@
+# Tasks for REQ-test-accept-phase-1777267654
+
+## Stage: contract / spec
+
+- [x] author `proposal.md` —— 描述 7 条 accept-phase transition + 不做清单
+- [x] author `specs/accept-phase-tests/spec.md` ADDED delta：
+      列出 APT-S1..APT-S7 全部 GIVEN/WHEN/THEN
+
+## Stage: implementation
+
+- [x] 新增 `orchestrator/tests/test_engine_accept_phase.py`：
+  - 复用 `test_engine.py` 已有的 `FakePool` / `FakeReq` / `_drain_tasks`
+    （直接 import 它们的私有定义，避免抄一份让两边漂移；与
+    `test_engine_adversarial.py` 同一套接入方式）
+  - 7 条 case 一一对应 APT-S1..APT-S7 scenario
+  - 所有 case 用 `pytest.mark.asyncio`，不依赖真 DB / BKD / K8s
+- [x] APT-S1：(ACCEPT_RUNNING, ACCEPT_PASS) + 链式 emit teardown-done.pass → ARCHIVING
+- [x] APT-S2：(ACCEPT_RUNNING, ACCEPT_FAIL) + 链式 emit teardown-done.fail → REVIEW_RUNNING
+- [x] APT-S3：(ACCEPT_RUNNING, ACCEPT_ENV_UP_FAIL) → ESCALATED + cleanup_runner(retain_pvc=True)
+- [x] APT-S4：(ACCEPT_TEARING_DOWN, TEARDOWN_DONE_PASS) → ARCHIVING（无 cleanup）
+- [x] APT-S5：(ACCEPT_TEARING_DOWN, TEARDOWN_DONE_FAIL) → REVIEW_RUNNING（无 cleanup）
+- [x] APT-S6：(ACCEPT_RUNNING, SESSION_FAILED) self-loop（无 cleanup）
+- [x] APT-S7：(ACCEPT_TEARING_DOWN, SESSION_FAILED) self-loop（无 cleanup）
+
+## Stage: PR
+
+- [x] git push feat/REQ-test-accept-phase-1777267654
+- [x] gh pr create --label sisyphus（PR body 写动机 + 测试方案）

--- a/orchestrator/tests/test_contract_accept_phase_challenger.py
+++ b/orchestrator/tests/test_contract_accept_phase_challenger.py
@@ -1,0 +1,488 @@
+"""Challenger contract tests for REQ-test-accept-phase-1777267654.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-test-accept-phase-1777267654/specs/accept-phase-tests/spec.md
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is truly wrong, escalate to spec_fixer to correct the spec, not the test.
+
+Scenarios covered:
+  APT-S1  (ACCEPT_RUNNING, ACCEPT_PASS) → teardown → ARCHIVING; done_archive called; no cleanup
+  APT-S2  (ACCEPT_RUNNING, ACCEPT_FAIL) → teardown → REVIEW_RUNNING; verifier called; no cleanup
+  APT-S3  (ACCEPT_RUNNING, ACCEPT_ENV_UP_FAIL) → ESCALATED; escalate called; cleanup_runner retain_pvc=True once
+  APT-S4  (ACCEPT_TEARING_DOWN, TEARDOWN_DONE_PASS) → ARCHIVING; done_archive called; no cleanup
+  APT-S5  (ACCEPT_TEARING_DOWN, TEARDOWN_DONE_FAIL) → REVIEW_RUNNING; verifier called; no cleanup
+  APT-S6  (ACCEPT_RUNNING, SESSION_FAILED) → self-loop ACCEPT_RUNNING; escalate called; no cleanup
+  APT-S7  (ACCEPT_TEARING_DOWN, SESSION_FAILED) → self-loop ACCEPT_TEARING_DOWN; escalate called; no cleanup
+
+Module contract under test: orchestrator.engine.step
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+# ─── Shared helpers ───────────────────────────────────────────────────────────
+
+_REQ_ID = "REQ-test-accept-phase-1777267654"
+_PROJECT = "proj-apt"
+_TAGS: list[str] = [_REQ_ID]
+_POOL = object()  # sentinel; all DB calls are patched away
+
+
+class _Body:
+    issueId = "bkd-apt-test"
+    projectId = _PROJECT
+
+
+def _patch_io(monkeypatch) -> tuple[AsyncMock, AsyncMock]:
+    """Patch all engine external I/O. Returns (cas_mock, get_mock)."""
+    from orchestrator import engine
+
+    cas = AsyncMock(return_value=True)
+    monkeypatch.setattr(engine.req_state, "cas_transition", cas)
+    monkeypatch.setattr(engine.req_state, "get", AsyncMock(return_value=None))
+    monkeypatch.setattr(engine.stage_runs, "close_latest_stage_run", AsyncMock())
+    monkeypatch.setattr(engine.stage_runs, "insert_stage_run", AsyncMock())
+    monkeypatch.setattr(engine.obs, "record_event", AsyncMock())
+    return cas
+
+
+class _FakeController:
+    """Fake k8s_runner controller that records cleanup_runner calls."""
+
+    def __init__(self):
+        self.cleanup_calls: list[tuple] = []
+
+    async def cleanup_runner(self, req_id, *, retain_pvc=False):
+        self.cleanup_calls.append((req_id, retain_pvc))
+
+
+@pytest.fixture(autouse=True)
+def _restore_registry():
+    """Snapshot and restore REGISTRY around each test to prevent pollution."""
+    from orchestrator.actions import REGISTRY
+
+    snapshot = dict(REGISTRY)
+    yield
+    REGISTRY.clear()
+    REGISTRY.update(snapshot)
+
+
+async def _step(**overrides):
+    """Call engine.step with accept-phase defaults, overrideable per test."""
+    from orchestrator.engine import step
+    from orchestrator.state import Event, ReqState
+
+    defaults: dict = dict(
+        pool=_POOL,
+        body=_Body(),
+        req_id=_REQ_ID,
+        project_id=_PROJECT,
+        tags=_TAGS,
+        cur_state=ReqState.ACCEPT_RUNNING,
+        ctx={},
+        event=Event.ACCEPT_PASS,
+        depth=0,
+    )
+    defaults.update(overrides)
+    return await step(**defaults)
+
+
+# ─── APT-S1: accept.pass → teardown → archiving ──────────────────────────────
+
+
+async def test_apt_s1_accept_pass_chains_through_teardown_to_archiving(
+    monkeypatch,
+) -> None:
+    """
+    APT-S1: (ACCEPT_RUNNING, ACCEPT_PASS) + teardown_accept_env emits teardown-done.pass
+    MUST chain into (ACCEPT_TEARING_DOWN, TEARDOWN_DONE_PASS) → ARCHIVING;
+    done_archive MUST be called exactly once; cleanup_runner MUST NOT be awaited.
+    """
+    from orchestrator import engine
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    _patch_io(monkeypatch)
+
+    teardown_calls: list[int] = []
+    archive_calls: list[int] = []
+    controller = _FakeController()
+    monkeypatch.setattr(engine.k8s_runner, "get_controller", lambda: controller)
+
+    # CAS must succeed for the chained transition too
+    monkeypatch.setattr(engine.req_state, "cas_transition", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        engine.req_state,
+        "get",
+        AsyncMock(return_value=type("Row", (), {"state": ReqState.ACCEPT_TEARING_DOWN.value, "context": {}})()),
+    )
+
+    async def _teardown(**_kw):
+        teardown_calls.append(1)
+        return {"emit": "teardown-done.pass"}
+
+    async def _archive(**_kw):
+        archive_calls.append(1)
+        return {"ok": True}
+
+    REGISTRY["teardown_accept_env"] = _teardown
+    REGISTRY["done_archive"] = _archive
+
+    result = await _step(
+        cur_state=ReqState.ACCEPT_RUNNING,
+        event=Event.ACCEPT_PASS,
+    )
+
+    # Drain any fire-and-forget tasks
+    await asyncio.sleep(0)
+
+    assert result.get("action") == "teardown_accept_env", (
+        f"APT-S1: base action MUST be 'teardown_accept_env'; got {result!r}"
+    )
+    chained = result.get("chained")
+    assert chained is not None, (
+        f"APT-S1: result MUST contain 'chained' key for emitted teardown-done.pass; got {result!r}"
+    )
+    assert chained.get("action") == "done_archive", (
+        f"APT-S1: chained action MUST be 'done_archive'; got {chained!r}"
+    )
+    assert chained.get("next_state") == ReqState.ARCHIVING.value, (
+        f"APT-S1: chained next_state MUST be 'archiving'; got {chained!r}"
+    )
+    assert teardown_calls == [1], (
+        f"APT-S1: teardown_accept_env MUST be called exactly once; got {len(teardown_calls)} call(s)"
+    )
+    assert archive_calls == [1], (
+        f"APT-S1: done_archive MUST be called exactly once; got {len(archive_calls)} call(s)"
+    )
+    assert controller.cleanup_calls == [], (
+        f"APT-S1: cleanup_runner MUST NOT be awaited on non-terminal path; "
+        f"got {controller.cleanup_calls}"
+    )
+
+
+# ─── APT-S2: accept.fail → teardown → verifier ───────────────────────────────
+
+
+async def test_apt_s2_accept_fail_chains_through_teardown_to_verifier(
+    monkeypatch,
+) -> None:
+    """
+    APT-S2: (ACCEPT_RUNNING, ACCEPT_FAIL) + teardown_accept_env emits teardown-done.fail
+    MUST chain into (ACCEPT_TEARING_DOWN, TEARDOWN_DONE_FAIL) → REVIEW_RUNNING;
+    invoke_verifier_for_accept_fail MUST be called exactly once; cleanup_runner MUST NOT be awaited.
+    """
+    from orchestrator import engine
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    _patch_io(monkeypatch)
+
+    teardown_calls: list[int] = []
+    verifier_calls: list[int] = []
+    controller = _FakeController()
+    monkeypatch.setattr(engine.k8s_runner, "get_controller", lambda: controller)
+
+    monkeypatch.setattr(engine.req_state, "cas_transition", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        engine.req_state,
+        "get",
+        AsyncMock(return_value=type("Row", (), {"state": ReqState.ACCEPT_TEARING_DOWN.value, "context": {}})()),
+    )
+
+    async def _teardown(**_kw):
+        teardown_calls.append(1)
+        return {"emit": "teardown-done.fail"}
+
+    async def _verifier(**_kw):
+        verifier_calls.append(1)
+        return {"ok": True}
+
+    REGISTRY["teardown_accept_env"] = _teardown
+    REGISTRY["invoke_verifier_for_accept_fail"] = _verifier
+
+    result = await _step(
+        cur_state=ReqState.ACCEPT_RUNNING,
+        event=Event.ACCEPT_FAIL,
+    )
+
+    await asyncio.sleep(0)
+
+    assert result.get("action") == "teardown_accept_env", (
+        f"APT-S2: base action MUST be 'teardown_accept_env'; got {result!r}"
+    )
+    chained = result.get("chained")
+    assert chained is not None, (
+        f"APT-S2: result MUST contain 'chained' key for emitted teardown-done.fail; got {result!r}"
+    )
+    assert chained.get("action") == "invoke_verifier_for_accept_fail", (
+        f"APT-S2: chained action MUST be 'invoke_verifier_for_accept_fail'; got {chained!r}"
+    )
+    assert chained.get("next_state") == ReqState.REVIEW_RUNNING.value, (
+        f"APT-S2: chained next_state MUST be 'review-running'; got {chained!r}"
+    )
+    assert teardown_calls == [1], (
+        f"APT-S2: teardown_accept_env MUST be called exactly once; got {len(teardown_calls)} call(s)"
+    )
+    assert verifier_calls == [1], (
+        f"APT-S2: invoke_verifier_for_accept_fail MUST be called exactly once; got {len(verifier_calls)} call(s)"
+    )
+    assert controller.cleanup_calls == [], (
+        f"APT-S2: cleanup_runner MUST NOT be awaited on non-terminal path; "
+        f"got {controller.cleanup_calls}"
+    )
+
+
+# ─── APT-S3: accept-env-up.fail → ESCALATED + cleanup retain_pvc ─────────────
+
+
+async def test_apt_s3_accept_env_up_fail_escalates_and_cleans_up(
+    monkeypatch,
+) -> None:
+    """
+    APT-S3: (ACCEPT_RUNNING, ACCEPT_ENV_UP_FAIL) → ESCALATED;
+    escalate MUST be called exactly once;
+    cleanup_runner(req_id, retain_pvc=True) MUST be awaited exactly once.
+    """
+    from orchestrator import engine
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    _patch_io(monkeypatch)
+
+    escalate_calls: list[int] = []
+    controller = _FakeController()
+    monkeypatch.setattr(engine.k8s_runner, "get_controller", lambda: controller)
+
+    async def _escalate(**_kw):
+        escalate_calls.append(1)
+        return {"escalated": True}
+
+    REGISTRY["escalate"] = _escalate
+
+    result = await _step(
+        cur_state=ReqState.ACCEPT_RUNNING,
+        event=Event.ACCEPT_ENV_UP_FAIL,
+    )
+
+    # Drain fire-and-forget cleanup task
+    await asyncio.sleep(0)
+
+    assert result.get("action") == "escalate", (
+        f"APT-S3: action MUST be 'escalate'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.ESCALATED.value, (
+        f"APT-S3: next_state MUST be 'escalated'; got {result!r}"
+    )
+    assert escalate_calls == [1], (
+        f"APT-S3: escalate MUST be called exactly once; got {len(escalate_calls)} call(s)"
+    )
+    assert len(controller.cleanup_calls) == 1, (
+        f"APT-S3: cleanup_runner MUST be awaited exactly once; "
+        f"got {len(controller.cleanup_calls)} call(s): {controller.cleanup_calls}"
+    )
+    cleanup_req_id, cleanup_retain = controller.cleanup_calls[0]
+    assert cleanup_req_id == _REQ_ID, (
+        f"APT-S3: cleanup_runner req_id MUST be {_REQ_ID!r}; got {cleanup_req_id!r}"
+    )
+    assert cleanup_retain is True, (
+        f"APT-S3: cleanup_runner MUST be called with retain_pvc=True; got {cleanup_retain!r}"
+    )
+
+
+# ─── APT-S4: teardown-done.pass → ARCHIVING ──────────────────────────────────
+
+
+async def test_apt_s4_teardown_done_pass_advances_to_archiving(
+    monkeypatch,
+) -> None:
+    """
+    APT-S4: (ACCEPT_TEARING_DOWN, TEARDOWN_DONE_PASS) → ARCHIVING;
+    done_archive MUST be called exactly once; cleanup_runner MUST NOT be awaited.
+    """
+    from orchestrator import engine
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    _patch_io(monkeypatch)
+
+    archive_calls: list[int] = []
+    controller = _FakeController()
+    monkeypatch.setattr(engine.k8s_runner, "get_controller", lambda: controller)
+
+    async def _archive(**_kw):
+        archive_calls.append(1)
+        return {"ok": True}
+
+    REGISTRY["done_archive"] = _archive
+
+    result = await _step(
+        cur_state=ReqState.ACCEPT_TEARING_DOWN,
+        event=Event.TEARDOWN_DONE_PASS,
+    )
+
+    await asyncio.sleep(0)
+
+    assert result.get("action") == "done_archive", (
+        f"APT-S4: action MUST be 'done_archive'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.ARCHIVING.value, (
+        f"APT-S4: next_state MUST be 'archiving'; got {result!r}"
+    )
+    assert archive_calls == [1], (
+        f"APT-S4: done_archive MUST be called exactly once; got {len(archive_calls)} call(s)"
+    )
+    assert controller.cleanup_calls == [], (
+        f"APT-S4: cleanup_runner MUST NOT be awaited — ARCHIVING is not terminal; "
+        f"got {controller.cleanup_calls}"
+    )
+
+
+# ─── APT-S5: teardown-done.fail → REVIEW_RUNNING ─────────────────────────────
+
+
+async def test_apt_s5_teardown_done_fail_routes_to_verifier(
+    monkeypatch,
+) -> None:
+    """
+    APT-S5: (ACCEPT_TEARING_DOWN, TEARDOWN_DONE_FAIL) → REVIEW_RUNNING;
+    invoke_verifier_for_accept_fail MUST be called exactly once;
+    cleanup_runner MUST NOT be awaited.
+    """
+    from orchestrator import engine
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    _patch_io(monkeypatch)
+
+    verifier_calls: list[int] = []
+    controller = _FakeController()
+    monkeypatch.setattr(engine.k8s_runner, "get_controller", lambda: controller)
+
+    async def _verifier(**_kw):
+        verifier_calls.append(1)
+        return {"ok": True}
+
+    REGISTRY["invoke_verifier_for_accept_fail"] = _verifier
+
+    result = await _step(
+        cur_state=ReqState.ACCEPT_TEARING_DOWN,
+        event=Event.TEARDOWN_DONE_FAIL,
+    )
+
+    await asyncio.sleep(0)
+
+    assert result.get("action") == "invoke_verifier_for_accept_fail", (
+        f"APT-S5: action MUST be 'invoke_verifier_for_accept_fail'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.REVIEW_RUNNING.value, (
+        f"APT-S5: next_state MUST be 'review-running'; got {result!r}"
+    )
+    assert verifier_calls == [1], (
+        f"APT-S5: invoke_verifier_for_accept_fail MUST be called exactly once; "
+        f"got {len(verifier_calls)} call(s)"
+    )
+    assert controller.cleanup_calls == [], (
+        f"APT-S5: cleanup_runner MUST NOT be awaited — REVIEW_RUNNING is not terminal; "
+        f"got {controller.cleanup_calls}"
+    )
+
+
+# ─── APT-S6: session.failed at ACCEPT_RUNNING self-loops ─────────────────────
+
+
+async def test_apt_s6_session_failed_at_accept_running_self_loops(
+    monkeypatch,
+) -> None:
+    """
+    APT-S6: (ACCEPT_RUNNING, SESSION_FAILED) → self-loop next_state=ACCEPT_RUNNING;
+    escalate MUST be called exactly once; cleanup_runner MUST NOT be awaited.
+    """
+    from orchestrator import engine
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    _patch_io(monkeypatch)
+
+    escalate_calls: list[int] = []
+    controller = _FakeController()
+    monkeypatch.setattr(engine.k8s_runner, "get_controller", lambda: controller)
+
+    async def _escalate(**_kw):
+        escalate_calls.append(1)
+        return {"ok": True}
+
+    REGISTRY["escalate"] = _escalate
+
+    result = await _step(
+        cur_state=ReqState.ACCEPT_RUNNING,
+        event=Event.SESSION_FAILED,
+    )
+
+    await asyncio.sleep(0)
+
+    assert result.get("action") == "escalate", (
+        f"APT-S6: action MUST be 'escalate'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.ACCEPT_RUNNING.value, (
+        f"APT-S6: next_state MUST remain 'accept-running' (self-loop); got {result!r}"
+    )
+    assert escalate_calls == [1], (
+        f"APT-S6: escalate MUST be called exactly once; got {len(escalate_calls)} call(s)"
+    )
+    assert controller.cleanup_calls == [], (
+        f"APT-S6: cleanup_runner MUST NOT be awaited — ACCEPT_RUNNING is not terminal; "
+        f"got {controller.cleanup_calls}"
+    )
+
+
+# ─── APT-S7: session.failed at ACCEPT_TEARING_DOWN self-loops ────────────────
+
+
+async def test_apt_s7_session_failed_at_accept_tearing_down_self_loops(
+    monkeypatch,
+) -> None:
+    """
+    APT-S7: (ACCEPT_TEARING_DOWN, SESSION_FAILED) → self-loop next_state=ACCEPT_TEARING_DOWN;
+    escalate MUST be called exactly once; cleanup_runner MUST NOT be awaited.
+    """
+    from orchestrator import engine
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    _patch_io(monkeypatch)
+
+    escalate_calls: list[int] = []
+    controller = _FakeController()
+    monkeypatch.setattr(engine.k8s_runner, "get_controller", lambda: controller)
+
+    async def _escalate(**_kw):
+        escalate_calls.append(1)
+        return {"ok": True}
+
+    REGISTRY["escalate"] = _escalate
+
+    result = await _step(
+        cur_state=ReqState.ACCEPT_TEARING_DOWN,
+        event=Event.SESSION_FAILED,
+    )
+
+    await asyncio.sleep(0)
+
+    assert result.get("action") == "escalate", (
+        f"APT-S7: action MUST be 'escalate'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.ACCEPT_TEARING_DOWN.value, (
+        f"APT-S7: next_state MUST remain 'accept-tearing-down' (self-loop); got {result!r}"
+    )
+    assert escalate_calls == [1], (
+        f"APT-S7: escalate MUST be called exactly once; got {len(escalate_calls)} call(s)"
+    )
+    assert controller.cleanup_calls == [], (
+        f"APT-S7: cleanup_runner MUST NOT be awaited — ACCEPT_TEARING_DOWN is not terminal; "
+        f"got {controller.cleanup_calls}"
+    )

--- a/orchestrator/tests/test_contract_accept_phase_challenger.py
+++ b/orchestrator/tests/test_contract_accept_phase_challenger.py
@@ -118,7 +118,7 @@ async def test_apt_s1_accept_pass_chains_through_teardown_to_archiving(
     monkeypatch.setattr(
         engine.req_state,
         "get",
-        AsyncMock(return_value=type("Row", (), {"state": ReqState.ACCEPT_TEARING_DOWN.value, "context": {}})()),
+        AsyncMock(return_value=type("Row", (), {"state": ReqState.ACCEPT_TEARING_DOWN, "context": {}})()),
     )
 
     async def _teardown(**_kw):
@@ -191,7 +191,7 @@ async def test_apt_s2_accept_fail_chains_through_teardown_to_verifier(
     monkeypatch.setattr(
         engine.req_state,
         "get",
-        AsyncMock(return_value=type("Row", (), {"state": ReqState.ACCEPT_TEARING_DOWN.value, "context": {}})()),
+        AsyncMock(return_value=type("Row", (), {"state": ReqState.ACCEPT_TEARING_DOWN, "context": {}})()),
     )
 
     async def _teardown(**_kw):

--- a/orchestrator/tests/test_engine_accept_phase.py
+++ b/orchestrator/tests/test_engine_accept_phase.py
@@ -1,0 +1,342 @@
+"""Mock tests for the 7 accept-phase transitions (REQ-test-accept-phase-1777267654).
+
+Goal: cover every transition whose source state is ACCEPT_RUNNING or
+ACCEPT_TEARING_DOWN — accept 阶段是 happy-path 链路从 PR-CI 绿到 ARCHIVING 的最后
+一公里，之前一条单测都没有。所有 case 用 in-process FakePool + stub action，
+**不打 BKD / Postgres / K8s**。
+
+APT-S1..APT-S7 一一对应 spec scenario，见
+`openspec/changes/REQ-test-accept-phase-1777267654/specs/accept-phase-tests/spec.md`。
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# 复用 test_engine.py 里的 FakePool / FakeReq / _drain_tasks —— 它们就是 engine
+# 状态机层 mock 测的标准 stub，跟 test_engine_adversarial.py 同一接入方式。
+from test_engine import FakePool, FakeReq, _drain_tasks  # type: ignore[import-not-found]
+
+from orchestrator import engine, k8s_runner
+from orchestrator.actions import ACTION_META, REGISTRY
+from orchestrator.state import Event, ReqState
+
+
+@pytest.fixture
+def stub_actions():
+    """clear REGISTRY / ACTION_META，测后还原。"""
+    saved_reg = dict(REGISTRY)
+    saved_meta = dict(ACTION_META)
+    REGISTRY.clear()
+    ACTION_META.clear()
+    yield REGISTRY
+    REGISTRY.clear()
+    ACTION_META.clear()
+    REGISTRY.update(saved_reg)
+    ACTION_META.update(saved_meta)
+
+
+@pytest.fixture
+def mock_runner_controller():
+    """注入 fake k8s_runner controller，断言 cleanup_runner 是否被调。"""
+    fake = MagicMock()
+    fake.cleanup_runner = AsyncMock(return_value=None)
+    k8s_runner.set_controller(fake)
+    yield fake
+    k8s_runner.set_controller(None)
+
+
+def _body(**attrs):
+    """构造一个 minimal body 对象（webhook payload stub）。"""
+    return type("B", (), attrs)()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# APT-S1：(ACCEPT_RUNNING, ACCEPT_PASS) + emit teardown-done.pass → ARCHIVING
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apt_s1_accept_pass_advances_through_teardown_to_archiving(
+    stub_actions, mock_runner_controller,
+):
+    """Spec APT-S1: accept.pass → teardown_accept_env → 链式 teardown-done.pass → done_archive。"""
+    teardown_calls = {"n": 0}
+    archive_calls = {"n": 0}
+
+    async def teardown_accept_env(*, body, req_id, tags, ctx):
+        teardown_calls["n"] += 1
+        return {"emit": Event.TEARDOWN_DONE_PASS.value, "accept_result": "pass"}
+
+    async def done_archive(*, body, req_id, tags, ctx):
+        archive_calls["n"] += 1
+        return {"ok": True}
+
+    stub_actions["teardown_accept_env"] = teardown_accept_env
+    stub_actions["done_archive"] = done_archive
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ACCEPT_RUNNING.value)})
+    body = _body(
+        issueId="accept-1", projectId="p", event="session.completed",
+    )
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["accept", "REQ-1", "result:pass"],
+        cur_state=ReqState.ACCEPT_RUNNING,
+        ctx={}, event=Event.ACCEPT_PASS,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "teardown_accept_env"
+    assert result["next_state"] == ReqState.ACCEPT_TEARING_DOWN.value
+    assert "chained" in result, "teardown emit teardown-done.pass 应触发链式 done_archive"
+    assert result["chained"]["action"] == "done_archive"
+    assert result["chained"]["next_state"] == ReqState.ARCHIVING.value
+    assert pool.rows["REQ-1"].state == ReqState.ARCHIVING.value
+    assert teardown_calls["n"] == 1
+    assert archive_calls["n"] == 1
+    # ACCEPT_TEARING_DOWN / ARCHIVING 都不是 terminal → engine 不应清 runner
+    mock_runner_controller.cleanup_runner.assert_not_awaited()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# APT-S2：(ACCEPT_RUNNING, ACCEPT_FAIL) + emit teardown-done.fail → REVIEW_RUNNING
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apt_s2_accept_fail_advances_through_teardown_to_verifier(
+    stub_actions, mock_runner_controller,
+):
+    """Spec APT-S2: accept.fail → teardown_accept_env → 链式 teardown-done.fail → invoke_verifier_for_accept_fail。"""
+    teardown_calls = {"n": 0}
+    verifier_calls = {"n": 0}
+
+    async def teardown_accept_env(*, body, req_id, tags, ctx):
+        teardown_calls["n"] += 1
+        return {"emit": Event.TEARDOWN_DONE_FAIL.value, "accept_result": "fail"}
+
+    async def invoke_verifier_for_accept_fail(*, body, req_id, tags, ctx):
+        verifier_calls["n"] += 1
+        return {"ok": True}
+
+    stub_actions["teardown_accept_env"] = teardown_accept_env
+    stub_actions["invoke_verifier_for_accept_fail"] = invoke_verifier_for_accept_fail
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ACCEPT_RUNNING.value)})
+    body = _body(
+        issueId="accept-1", projectId="p", event="session.completed",
+    )
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["accept", "REQ-1", "result:fail"],
+        cur_state=ReqState.ACCEPT_RUNNING,
+        ctx={}, event=Event.ACCEPT_FAIL,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "teardown_accept_env"
+    assert result["next_state"] == ReqState.ACCEPT_TEARING_DOWN.value
+    assert "chained" in result
+    assert result["chained"]["action"] == "invoke_verifier_for_accept_fail"
+    assert result["chained"]["next_state"] == ReqState.REVIEW_RUNNING.value
+    assert pool.rows["REQ-1"].state == ReqState.REVIEW_RUNNING.value
+    assert teardown_calls["n"] == 1
+    assert verifier_calls["n"] == 1
+    # REVIEW_RUNNING 非 terminal
+    mock_runner_controller.cleanup_runner.assert_not_awaited()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# APT-S3：(ACCEPT_RUNNING, ACCEPT_ENV_UP_FAIL) → ESCALATED + cleanup_runner(retain_pvc=True)
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apt_s3_accept_env_up_fail_escalates_and_cleans_up(
+    stub_actions, mock_runner_controller,
+):
+    """Spec APT-S3: lab 起不来 → ESCALATED 终态；engine 必须调一次 cleanup_runner(retain_pvc=True)。"""
+    escalate_calls = {"n": 0}
+
+    async def escalate(*, body, req_id, tags, ctx):
+        escalate_calls["n"] += 1
+        return {"escalated": True}
+
+    stub_actions["escalate"] = escalate
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ACCEPT_RUNNING.value)})
+    body = _body(
+        issueId="accept-1", projectId="p", event="accept-env-up.fail",
+    )
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["accept", "REQ-1"],
+        cur_state=ReqState.ACCEPT_RUNNING,
+        ctx={}, event=Event.ACCEPT_ENV_UP_FAIL,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "escalate"
+    assert result["next_state"] == ReqState.ESCALATED.value
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+    assert escalate_calls["n"] == 1
+    # ESCALATED 是 terminal，且 cur (ACCEPT_RUNNING) 非 terminal → engine 必须清 runner
+    # 且 retain_pvc=True（escalate 路径保 PVC 给人工 debug）
+    mock_runner_controller.cleanup_runner.assert_awaited_once_with(
+        "REQ-1", retain_pvc=True,
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# APT-S4：(ACCEPT_TEARING_DOWN, TEARDOWN_DONE_PASS) → ARCHIVING
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apt_s4_teardown_done_pass_advances_to_archiving(
+    stub_actions, mock_runner_controller,
+):
+    """Spec APT-S4: teardown-done.pass 直接入口（不经 teardown_accept_env emit）→ ARCHIVING。"""
+    archive_calls = {"n": 0}
+
+    async def done_archive(*, body, req_id, tags, ctx):
+        archive_calls["n"] += 1
+        return {"ok": True}
+
+    stub_actions["done_archive"] = done_archive
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ACCEPT_TEARING_DOWN.value)})
+    body = _body(
+        issueId="accept-1", projectId="p", event="teardown-done.pass",
+    )
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["accept", "REQ-1"],
+        cur_state=ReqState.ACCEPT_TEARING_DOWN,
+        ctx={}, event=Event.TEARDOWN_DONE_PASS,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "done_archive"
+    assert result["next_state"] == ReqState.ARCHIVING.value
+    assert pool.rows["REQ-1"].state == ReqState.ARCHIVING.value
+    assert archive_calls["n"] == 1
+    # ARCHIVING 不是 terminal（DONE 才是）→ 不应清 runner
+    mock_runner_controller.cleanup_runner.assert_not_awaited()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# APT-S5：(ACCEPT_TEARING_DOWN, TEARDOWN_DONE_FAIL) → REVIEW_RUNNING
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apt_s5_teardown_done_fail_routes_to_verifier(
+    stub_actions, mock_runner_controller,
+):
+    """Spec APT-S5: teardown-done.fail 直接入口 → REVIEW_RUNNING（接 verifier）。"""
+    verifier_calls = {"n": 0}
+
+    async def invoke_verifier_for_accept_fail(*, body, req_id, tags, ctx):
+        verifier_calls["n"] += 1
+        return {"ok": True}
+
+    stub_actions["invoke_verifier_for_accept_fail"] = invoke_verifier_for_accept_fail
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ACCEPT_TEARING_DOWN.value)})
+    body = _body(
+        issueId="accept-1", projectId="p", event="teardown-done.fail",
+    )
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["accept", "REQ-1"],
+        cur_state=ReqState.ACCEPT_TEARING_DOWN,
+        ctx={}, event=Event.TEARDOWN_DONE_FAIL,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "invoke_verifier_for_accept_fail"
+    assert result["next_state"] == ReqState.REVIEW_RUNNING.value
+    assert pool.rows["REQ-1"].state == ReqState.REVIEW_RUNNING.value
+    assert verifier_calls["n"] == 1
+    mock_runner_controller.cleanup_runner.assert_not_awaited()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# APT-S6：(ACCEPT_RUNNING, SESSION_FAILED) self-loop
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apt_s6_accept_running_session_failed_self_loop(
+    stub_actions, mock_runner_controller,
+):
+    """Spec APT-S6: BKD session crash → 转移表 self-loop；escalate action 自决是否真 escalate。"""
+    escalate_calls = {"n": 0}
+
+    async def escalate(*, body, req_id, tags, ctx):
+        escalate_calls["n"] += 1
+        # 真生产 escalate 可能 follow-up "continue"（auto-resume）或手 CAS 推 ESCALATED；
+        # mock 里只验 transition 表声明的 self-loop 行为，escalate stub 不动 state。
+        return {"ok": True}
+
+    stub_actions["escalate"] = escalate
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ACCEPT_RUNNING.value)})
+    body = _body(
+        issueId="accept-1", projectId="p", event="session.failed",
+    )
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["accept", "REQ-1"],
+        cur_state=ReqState.ACCEPT_RUNNING,
+        ctx={}, event=Event.SESSION_FAILED,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "escalate"
+    assert result["next_state"] == ReqState.ACCEPT_RUNNING.value
+    # transition 声明的 self-loop：state 保持
+    assert pool.rows["REQ-1"].state == ReqState.ACCEPT_RUNNING.value
+    assert escalate_calls["n"] == 1
+    # cur 非 terminal + next 非 terminal → 不清 runner（auto-resume 路径不能误删 pod）
+    mock_runner_controller.cleanup_runner.assert_not_awaited()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# APT-S7：(ACCEPT_TEARING_DOWN, SESSION_FAILED) self-loop
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apt_s7_accept_tearing_down_session_failed_self_loop(
+    stub_actions, mock_runner_controller,
+):
+    """Spec APT-S7: env-down 中 session crash → self-loop；escalate action 自决。"""
+    escalate_calls = {"n": 0}
+
+    async def escalate(*, body, req_id, tags, ctx):
+        escalate_calls["n"] += 1
+        return {"ok": True}
+
+    stub_actions["escalate"] = escalate
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ACCEPT_TEARING_DOWN.value)})
+    body = _body(
+        issueId="accept-1", projectId="p", event="session.failed",
+    )
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["accept", "REQ-1"],
+        cur_state=ReqState.ACCEPT_TEARING_DOWN,
+        ctx={}, event=Event.SESSION_FAILED,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "escalate"
+    assert result["next_state"] == ReqState.ACCEPT_TEARING_DOWN.value
+    assert pool.rows["REQ-1"].state == ReqState.ACCEPT_TEARING_DOWN.value
+    assert escalate_calls["n"] == 1
+    mock_runner_controller.cleanup_runner.assert_not_awaited()


### PR DESCRIPTION
## Summary

Add `orchestrator/tests/test_engine_accept_phase.py` with 7 mock test
cases (APT-S1..APT-S7) covering every transition whose source state is
`ACCEPT_RUNNING` or `ACCEPT_TEARING_DOWN` — accept 阶段是 happy-path 链路从
PR-CI 绿到 ARCHIVING 的最后一公里，之前一条单测都没有。

| ID | (cur_state, event) | next_state | action |
|---|---|---|---|
| APT-S1 | (ACCEPT_RUNNING, ACCEPT_PASS) | ACCEPT_TEARING_DOWN → chain → ARCHIVING | teardown_accept_env → done_archive |
| APT-S2 | (ACCEPT_RUNNING, ACCEPT_FAIL) | ACCEPT_TEARING_DOWN → chain → REVIEW_RUNNING | teardown_accept_env → invoke_verifier_for_accept_fail |
| APT-S3 | (ACCEPT_RUNNING, ACCEPT_ENV_UP_FAIL) | ESCALATED + cleanup_runner(retain_pvc=True) | escalate |
| APT-S4 | (ACCEPT_TEARING_DOWN, TEARDOWN_DONE_PASS) | ARCHIVING | done_archive |
| APT-S5 | (ACCEPT_TEARING_DOWN, TEARDOWN_DONE_FAIL) | REVIEW_RUNNING | invoke_verifier_for_accept_fail |
| APT-S6 | (ACCEPT_RUNNING, SESSION_FAILED) | self-loop | escalate |
| APT-S7 | (ACCEPT_TEARING_DOWN, SESSION_FAILED) | self-loop | escalate |

## 关键设计

- 所有 case 用 in-process `FakePool` + stub action — **不打 BKD / Postgres / K8s**
- 复用 `test_engine.py` 的 `FakePool` / `FakeReq` / `_drain_tasks` via direct
  import；与 `test_engine_adversarial.py` 同一接入方式，避免抄一份漂移
- S1/S2 还顺便验链式 emit：`teardown_accept_env` emit `teardown-done.pass` /
  `teardown-done.fail` → engine 链式推到 ARCHIVING / REVIEW_RUNNING
- S3 这条 terminal 边特别断言 `cleanup_runner(retain_pvc=True)` 被调一次
  （ESCALATED 必须留 PVC 给人工 debug）
- S6/S7 self-loop 显式断言 cleanup **不**被触发 —— `(ACCEPT_*, SESSION_FAILED)`
  在 transition 表是非 terminal self-loop，escalate action 自决是否真 escalate，
  engine 这层不能误清 pod

## 不做

- 不动 `engine.py` / `state.py` —— 全部用现有 API + fake stub
- 不增加新 ReqState / Event：纯测试增量
- 不写 integration test（M18 challenger 自己读 spec 黑盒写 contract test）

## Test plan

- [x] `cd orchestrator && uv run pytest tests/test_engine_accept_phase.py -v` → 7 passed
- [x] `cd orchestrator && uv run pytest tests/test_engine.py tests/test_engine_adversarial.py tests/test_engine_accept_phase.py` → 34 passed (no regression)
- [x] `cd orchestrator && uv run pytest tests/ -m "not integration"` → 1368 passed
- [x] `uv run ruff check tests/test_engine_accept_phase.py` → all checks passed
- [x] `openspec validate REQ-test-accept-phase-1777267654 --strict` → valid
- [x] `scripts/check-scenario-refs.sh` → 437 definitions, all references resolved

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-test-accept-phase-1777267654\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/phyb0f4p)