### PR TITLE
test(engine): main-chain happy-path mock tests (REQ-test-main-chain-1777267689)

### DIFF
--- a/openspec/changes/REQ-test-main-chain-1777267689/proposal.md
+++ b/openspec/changes/REQ-test-main-chain-1777267689/proposal.md
@@ -1,0 +1,82 @@
+# REQ-test-main-chain-1777267689: test(engine): main-chain happy-path mock tests
+
+## 问题
+
+`orchestrator/src/orchestrator/state.py` 把状态机权威 transition table 写死，
+`engine.step` 是唯一的推进器。**主链 happy path** 11 条 transition（INIT →
+ANALYZING → ANALYZE_ARTIFACT_CHECKING → SPEC_LINT_RUNNING → CHALLENGER_RUNNING →
+DEV_CROSS_CHECK_RUNNING → STAGING_TEST_RUNNING → PR_CI_RUNNING → ACCEPT_RUNNING
+→ ACCEPT_TEARING_DOWN → ARCHIVING → DONE）覆盖**整个 REQ 生命周期**：任何一条
+推进失败都会让 REQ 卡死或漏走 stage。
+
+现状测试拆得碎：
+
+- `tests/test_state.py` 做静态断言，只检 `decide(state, event)` 的 `next_state`
+  / `action` 字段，**不真跑 `engine.step`**——CAS / record_stage_runs / dispatch
+  这一整段全 bypass，状态机层有 bug 也看不出来。
+- `tests/test_engine.py` 只覆盖了 11 条主链中的 #4（spec-lint.pass→challenger）
+  / #5（challenger.pass→dev-cross-check）+ 几条 cleanup / illegal / CAS 异常路
+  径。**1, 2, 3, 6, 8, 9, 10 这 7 条 happy-path transition 在 engine.step 层完全
+  没断言**——只有静态映射在 test_state，但映射对了 + dispatch 错了 / CAS 错了 /
+  stage_runs 写错了，目前没单测拦得住。
+- `tests/test_engine_adversarial.py` 走的是 EAT-S1..S12 反常输入，跟 happy path
+  相互不重叠、不替代。
+
+举个真实风险：M18 加 challenger stage 时改了 `(SPEC_LINT_RUNNING, SPEC_LINT_PASS)`
+的 `next_state`，如果当时漏了改 `_record_stage_transitions` 里 `STATE_TO_STAGE`
+映射，spec_lint 那条 stage_run 会 close 失败但 engine.step 仍 return success，
+test_state 的静态断言也通过——在线上要等 Q12/Q13 看板 orphan stage_run 才报。
+
+## 方案
+
+新增 `orchestrator/tests/test_engine_main_chain.py`：11 条 mock 用例
+（MCT-S1..MCT-S11），一对一覆盖主链 11 条 happy-path transition。复用
+`tests/test_engine.py` 已有的 `FakePool` / `FakeReq` / `stub_actions` fixture
+设计（直接 `from test_engine import …`，跟 `test_engine_adversarial.py` 同模式，
+避免抄一份让两边漂移）。
+
+每条 case 做 4 个断言：
+
+1. `engine.step` 返回 `action="<expected_action>"`（dispatch 进了正确 handler）
+2. `next_state="<expected_next_state>"`（CAS 推到正确目标）
+3. `pool.rows[req_id].state == expected_next_state`（FakePool 真把 row 更新了）
+4. stub action 被精确调用一次（不重不漏）
+
+| ID | (state, event) | 期望 next_state | action |
+|---|---|---|---|
+| MCT-S1 | (INIT, INTENT_ANALYZE) | ANALYZING | `start_analyze` |
+| MCT-S2 | (ANALYZING, ANALYZE_DONE) | ANALYZE_ARTIFACT_CHECKING | `create_analyze_artifact_check` |
+| MCT-S3 | (ANALYZE_ARTIFACT_CHECKING, ANALYZE_ARTIFACT_CHECK_PASS) | SPEC_LINT_RUNNING | `create_spec_lint` |
+| MCT-S4 | (SPEC_LINT_RUNNING, SPEC_LINT_PASS) | CHALLENGER_RUNNING | `start_challenger` |
+| MCT-S5 | (CHALLENGER_RUNNING, CHALLENGER_PASS) | DEV_CROSS_CHECK_RUNNING | `create_dev_cross_check` |
+| MCT-S6 | (DEV_CROSS_CHECK_RUNNING, DEV_CROSS_CHECK_PASS) | STAGING_TEST_RUNNING | `create_staging_test` |
+| MCT-S7 | (STAGING_TEST_RUNNING, STAGING_TEST_PASS) | PR_CI_RUNNING | `create_pr_ci_watch` |
+| MCT-S8 | (PR_CI_RUNNING, PR_CI_PASS) | ACCEPT_RUNNING | `create_accept` |
+| MCT-S9 | (ACCEPT_RUNNING, ACCEPT_PASS) | ACCEPT_TEARING_DOWN | `teardown_accept_env` |
+| MCT-S10 | (ACCEPT_TEARING_DOWN, TEARDOWN_DONE_PASS) | ARCHIVING | `done_archive` |
+| MCT-S11 | (ARCHIVING, ARCHIVE_DONE) | DONE | `None` (no-op terminal) |
+
+额外加一条 end-to-end 串联用例 MCT-CHAIN：用 stub action 每条都 `return
+{"emit": "<next-event>"}`，从 `(INIT, INTENT_ANALYZE)` 进 engine.step，验它能
+一路链式推到 DONE，11 个 stub action 各被调用一次，最终 row 状态为 `done`。这
+条用例覆盖"emit chain 在主链全长跑得通"——`test_engine.py` 现有 chain 测试只
+跨 1 步，深链 chain 没人验证。
+
+测试**只触 engine.py + state.py + actions.REGISTRY 替换**，不触真 BKD / Postgres
+/ K8s。在 BKD agent 的工具白名单里，配合 `make ci-unit-test` 在 runner pod
+跑过即可。
+
+## 不做
+
+- ❌ 不改 `engine.py` / `state.py` / 任何 prod 代码：纯测试增量
+- ❌ 不写 fail-path（fail 路径已由 test_state.py 静态映射覆盖；fail action
+  dispatch 由 test_actions_smoke 覆盖；fail → verifier 链由 test_verifier.py 覆盖）
+- ❌ 不写 INTAKING 入口（INTAKING → ANALYZING 已在 test_state.py 静态覆盖；
+  本 REQ 聚焦"主线 11 步" + 一条端到端 chain）
+- ❌ 不写 integration test（M18 challenger 写）
+
+## 影响
+
+- `orchestrator/tests/test_engine_main_chain.py` 新增 1 个文件 ≈ 280 行
+- 不动 prod 代码。不动 schema。不影响 runtime
+- CI 时长增量：12 个 mock case，全 in-process FakePool，单条 < 50ms，总 < 1s

--- a/openspec/changes/REQ-test-main-chain-1777267689/specs/engine-main-chain-tests/spec.md
+++ b/openspec/changes/REQ-test-main-chain-1777267689/specs/engine-main-chain-tests/spec.md
@@ -1,0 +1,218 @@
+## ADDED Requirements
+
+### Requirement: Engine.step advances INIT to ANALYZING on intent.analyze
+
+The state-machine engine (`orchestrator/src/orchestrator/engine.py::step`) SHALL
+advance a REQ from `INIT` to `ANALYZING` when it receives the `INTENT_ANALYZE`
+event, and MUST dispatch the registered `start_analyze` action exactly once.
+The CAS update MUST persist the new state to the underlying store before the
+action handler runs. This is the canonical entry point for the main-chain
+happy path; if this transition is broken, no REQ ever leaves the `INIT`
+bucket.
+
+#### Scenario: MCT-S1 INIT plus intent.analyze advances to ANALYZING
+
+- **GIVEN** a `FakePool` row at state `init` and a stub `start_analyze` action
+  registered in `REGISTRY`
+- **WHEN** `engine.step` is invoked with `cur_state=INIT` and
+  `event=INTENT_ANALYZE`
+- **THEN** the returned dict MUST contain `action="start_analyze"` and
+  `next_state="analyzing"`, the FakePool's row MUST have advanced to
+  `state="analyzing"`, and the stub MUST have been invoked exactly once
+
+### Requirement: Engine.step advances ANALYZING to ANALYZE_ARTIFACT_CHECKING on analyze.done
+
+`engine.step` SHALL advance a REQ from `ANALYZING` to
+`ANALYZE_ARTIFACT_CHECKING` when it receives the `ANALYZE_DONE` event, and
+MUST dispatch `create_analyze_artifact_check` exactly once. This transition
+inserts the post-analyze artifact gate that prevents agents from self-reporting
+`pass` while leaving `proposal.md` / `tasks.md` / `spec.md` empty
+(REQ-analyze-artifact-check-1777254586).
+
+#### Scenario: MCT-S2 ANALYZING plus analyze.done advances to ANALYZE_ARTIFACT_CHECKING
+
+- **GIVEN** a `FakePool` row at state `analyzing` and a stub
+  `create_analyze_artifact_check` action registered
+- **WHEN** `engine.step` is invoked with `cur_state=ANALYZING` and
+  `event=ANALYZE_DONE`
+- **THEN** the returned dict MUST contain
+  `action="create_analyze_artifact_check"` and
+  `next_state="analyze-artifact-checking"`, the row MUST be at
+  `state="analyze-artifact-checking"`, and the stub MUST have been called once
+
+### Requirement: Engine.step advances ANALYZE_ARTIFACT_CHECKING to SPEC_LINT_RUNNING on artifact-check pass
+
+`engine.step` SHALL advance a REQ from `ANALYZE_ARTIFACT_CHECKING` to
+`SPEC_LINT_RUNNING` when the artifact check passes
+(`ANALYZE_ARTIFACT_CHECK_PASS`), and MUST dispatch `create_spec_lint` exactly
+once. This is the gateway from analyze artifact validation into the
+machine-checker stack.
+
+#### Scenario: MCT-S3 ANALYZE_ARTIFACT_CHECKING plus check pass advances to SPEC_LINT_RUNNING
+
+- **GIVEN** a `FakePool` row at state `analyze-artifact-checking` and a stub
+  `create_spec_lint` action registered
+- **WHEN** `engine.step` is invoked with
+  `cur_state=ANALYZE_ARTIFACT_CHECKING` and
+  `event=ANALYZE_ARTIFACT_CHECK_PASS`
+- **THEN** the returned dict MUST contain `action="create_spec_lint"` and
+  `next_state="spec-lint-running"`, the row MUST be at
+  `state="spec-lint-running"`, and the stub MUST have been called once
+
+### Requirement: Engine.step advances SPEC_LINT_RUNNING to CHALLENGER_RUNNING on spec-lint pass
+
+`engine.step` SHALL advance a REQ from `SPEC_LINT_RUNNING` to
+`CHALLENGER_RUNNING` when `SPEC_LINT_PASS` arrives (M18 challenger between
+spec_lint and dev_cross_check), and MUST dispatch `start_challenger` exactly
+once.
+
+#### Scenario: MCT-S4 SPEC_LINT_RUNNING plus spec-lint pass advances to CHALLENGER_RUNNING
+
+- **GIVEN** a `FakePool` row at state `spec-lint-running` and a stub
+  `start_challenger` action registered
+- **WHEN** `engine.step` is invoked with `cur_state=SPEC_LINT_RUNNING` and
+  `event=SPEC_LINT_PASS`
+- **THEN** the returned dict MUST contain `action="start_challenger"` and
+  `next_state="challenger-running"`, the row MUST be at
+  `state="challenger-running"`, and the stub MUST have been called once
+
+### Requirement: Engine.step advances CHALLENGER_RUNNING to DEV_CROSS_CHECK_RUNNING on challenger pass
+
+`engine.step` SHALL advance a REQ from `CHALLENGER_RUNNING` to
+`DEV_CROSS_CHECK_RUNNING` when `CHALLENGER_PASS` arrives, and MUST dispatch
+`create_dev_cross_check` exactly once. The challenger's contract test commit
+on the feat branch is the precondition the next stage's `make ci-lint` reads.
+
+#### Scenario: MCT-S5 CHALLENGER_RUNNING plus challenger pass advances to DEV_CROSS_CHECK_RUNNING
+
+- **GIVEN** a `FakePool` row at state `challenger-running` and a stub
+  `create_dev_cross_check` action registered
+- **WHEN** `engine.step` is invoked with `cur_state=CHALLENGER_RUNNING` and
+  `event=CHALLENGER_PASS`
+- **THEN** the returned dict MUST contain `action="create_dev_cross_check"`
+  and `next_state="dev-cross-check-running"`, the row MUST be at
+  `state="dev-cross-check-running"`, and the stub MUST have been called once
+
+### Requirement: Engine.step advances DEV_CROSS_CHECK_RUNNING to STAGING_TEST_RUNNING on dev-cross-check pass
+
+`engine.step` SHALL advance a REQ from `DEV_CROSS_CHECK_RUNNING` to
+`STAGING_TEST_RUNNING` when `DEV_CROSS_CHECK_PASS` arrives, and MUST dispatch
+`create_staging_test` exactly once.
+
+#### Scenario: MCT-S6 DEV_CROSS_CHECK_RUNNING plus dev-cross-check pass advances to STAGING_TEST_RUNNING
+
+- **GIVEN** a `FakePool` row at state `dev-cross-check-running` and a stub
+  `create_staging_test` action registered
+- **WHEN** `engine.step` is invoked with `cur_state=DEV_CROSS_CHECK_RUNNING`
+  and `event=DEV_CROSS_CHECK_PASS`
+- **THEN** the returned dict MUST contain `action="create_staging_test"` and
+  `next_state="staging-test-running"`, the row MUST be at
+  `state="staging-test-running"`, and the stub MUST have been called once
+
+### Requirement: Engine.step advances STAGING_TEST_RUNNING to PR_CI_RUNNING on staging-test pass
+
+`engine.step` SHALL advance a REQ from `STAGING_TEST_RUNNING` to
+`PR_CI_RUNNING` when `STAGING_TEST_PASS` arrives, and MUST dispatch
+`create_pr_ci_watch` exactly once. This is the bridge from internal staging
+to GitHub-side PR CI watching.
+
+#### Scenario: MCT-S7 STAGING_TEST_RUNNING plus staging-test pass advances to PR_CI_RUNNING
+
+- **GIVEN** a `FakePool` row at state `staging-test-running` and a stub
+  `create_pr_ci_watch` action registered
+- **WHEN** `engine.step` is invoked with `cur_state=STAGING_TEST_RUNNING` and
+  `event=STAGING_TEST_PASS`
+- **THEN** the returned dict MUST contain `action="create_pr_ci_watch"` and
+  `next_state="pr-ci-running"`, the row MUST be at `state="pr-ci-running"`,
+  and the stub MUST have been called once
+
+### Requirement: Engine.step advances PR_CI_RUNNING to ACCEPT_RUNNING on pr-ci pass
+
+`engine.step` SHALL advance a REQ from `PR_CI_RUNNING` to `ACCEPT_RUNNING`
+when `PR_CI_PASS` arrives, and MUST dispatch `create_accept` exactly once.
+
+#### Scenario: MCT-S8 PR_CI_RUNNING plus pr-ci pass advances to ACCEPT_RUNNING
+
+- **GIVEN** a `FakePool` row at state `pr-ci-running` and a stub
+  `create_accept` action registered
+- **WHEN** `engine.step` is invoked with `cur_state=PR_CI_RUNNING` and
+  `event=PR_CI_PASS`
+- **THEN** the returned dict MUST contain `action="create_accept"` and
+  `next_state="accept-running"`, the row MUST be at `state="accept-running"`,
+  and the stub MUST have been called once
+
+### Requirement: Engine.step advances ACCEPT_RUNNING to ACCEPT_TEARING_DOWN on accept pass
+
+`engine.step` SHALL advance a REQ from `ACCEPT_RUNNING` to
+`ACCEPT_TEARING_DOWN` when `ACCEPT_PASS` arrives, and MUST dispatch
+`teardown_accept_env` exactly once. The teardown must precede archive even on
+pass — `make accept-env-down` is non-optional (REQ-accept-contract-docs).
+
+#### Scenario: MCT-S9 ACCEPT_RUNNING plus accept pass advances to ACCEPT_TEARING_DOWN
+
+- **GIVEN** a `FakePool` row at state `accept-running` and a stub
+  `teardown_accept_env` action registered
+- **WHEN** `engine.step` is invoked with `cur_state=ACCEPT_RUNNING` and
+  `event=ACCEPT_PASS`
+- **THEN** the returned dict MUST contain `action="teardown_accept_env"` and
+  `next_state="accept-tearing-down"`, the row MUST be at
+  `state="accept-tearing-down"`, and the stub MUST have been called once
+
+### Requirement: Engine.step advances ACCEPT_TEARING_DOWN to ARCHIVING on teardown done pass
+
+`engine.step` SHALL advance a REQ from `ACCEPT_TEARING_DOWN` to `ARCHIVING`
+when `TEARDOWN_DONE_PASS` arrives (only after a preceding `accept.pass`),
+and MUST dispatch `done_archive` exactly once.
+
+#### Scenario: MCT-S10 ACCEPT_TEARING_DOWN plus teardown done pass advances to ARCHIVING
+
+- **GIVEN** a `FakePool` row at state `accept-tearing-down` and a stub
+  `done_archive` action registered
+- **WHEN** `engine.step` is invoked with `cur_state=ACCEPT_TEARING_DOWN` and
+  `event=TEARDOWN_DONE_PASS`
+- **THEN** the returned dict MUST contain `action="done_archive"` and
+  `next_state="archiving"`, the row MUST be at `state="archiving"`, and the
+  stub MUST have been called once
+
+### Requirement: Engine.step advances ARCHIVING to DONE on archive done
+
+`engine.step` SHALL advance a REQ from `ARCHIVING` to the terminal `DONE`
+state when `ARCHIVE_DONE` arrives. The transition has no `action`
+(transition table declares `action=None`), so the engine MUST return
+`action="no-op"` and `next_state="done"` without dispatching any handler.
+This is the only happy-path transition that lands in a terminal state.
+
+#### Scenario: MCT-S11 ARCHIVING plus archive done advances to DONE with no-op
+
+- **GIVEN** a `FakePool` row at state `archiving` and an empty `REGISTRY`
+- **WHEN** `engine.step` is invoked with `cur_state=ARCHIVING` and
+  `event=ARCHIVE_DONE`
+- **THEN** the returned dict MUST contain `action="no-op"` and
+  `next_state="done"`, and the row MUST be at `state="done"`
+
+### Requirement: Engine.step chains the entire main chain via emit recursion
+
+`engine.step` SHALL recursively follow `result["emit"]` chained event names
+through all 10 main-chain action transitions when each handler emits the
+next event in the canonical happy-path sequence, ultimately landing the row
+at the terminal `DONE` state. This contract test ensures the full chain
+INIT → ANALYZING → ANALYZE_ARTIFACT_CHECKING → SPEC_LINT_RUNNING →
+CHALLENGER_RUNNING → DEV_CROSS_CHECK_RUNNING → STAGING_TEST_RUNNING →
+PR_CI_RUNNING → ACCEPT_RUNNING → ACCEPT_TEARING_DOWN → ARCHIVING → DONE
+is internally consistent at runtime, not just statically in the transition
+table.
+
+#### Scenario: MCT-CHAIN INIT to DONE via 11 chained emits
+
+- **GIVEN** a `FakePool` row at state `init` and ten stub actions registered
+  (`start_analyze`, `create_analyze_artifact_check`, `create_spec_lint`,
+  `start_challenger`, `create_dev_cross_check`, `create_staging_test`,
+  `create_pr_ci_watch`, `create_accept`, `teardown_accept_env`,
+  `done_archive`), each returning `{"emit": "<next-canonical-event>"}` per
+  the main-chain happy path
+- **WHEN** `engine.step` is invoked once at `cur_state=INIT` with
+  `event=INTENT_ANALYZE`
+- **THEN** the call MUST NOT raise, the FakePool's row MUST end at
+  `state="done"`, each of the ten action stubs MUST have been called
+  exactly once, and the recursion guard MUST NOT have fired
+  (no `recursion >12` error in the returned chain)

--- a/openspec/changes/REQ-test-main-chain-1777267689/tasks.md
+++ b/openspec/changes/REQ-test-main-chain-1777267689/tasks.md
@@ -1,0 +1,35 @@
+# Tasks for REQ-test-main-chain-1777267689
+
+## Stage: contract / spec
+
+- [x] author `proposal.md` —— 描述 11 条主链 happy-path scenario 范围 + 不做清单
+- [x] author `specs/engine-main-chain-tests/spec.md` ADDED delta：
+      列出 MCT-S1..MCT-S11 + MCT-CHAIN 全部 GIVEN/WHEN/THEN
+
+## Stage: implementation
+
+- [x] 新增 `orchestrator/tests/test_engine_main_chain.py`：
+  - 复用 `test_engine.py` 已有的 `FakePool` + `FakeReq` 设计
+    （`from test_engine import FakePool, FakeReq` —— 跟 `test_engine_adversarial.py` 同模式）
+  - 局部 `stub_actions` fixture 隔离 `REGISTRY` / `ACTION_META`，测后还原
+  - 11 条单 transition mock 用例（MCT-S1..MCT-S11）
+  - 1 条端到端 chain 用例（MCT-CHAIN）—— stub 每个 action emit 下一事件，
+    验从 INIT 一路推到 DONE
+  - 所有 case 用 `pytest.mark.asyncio`，不依赖真 DB / BKD / K8s
+- [x] MCT-S1：`(INIT, INTENT_ANALYZE)` → `ANALYZING` + `start_analyze`
+- [x] MCT-S2：`(ANALYZING, ANALYZE_DONE)` → `ANALYZE_ARTIFACT_CHECKING` + `create_analyze_artifact_check`
+- [x] MCT-S3：`(ANALYZE_ARTIFACT_CHECKING, ANALYZE_ARTIFACT_CHECK_PASS)` → `SPEC_LINT_RUNNING` + `create_spec_lint`
+- [x] MCT-S4：`(SPEC_LINT_RUNNING, SPEC_LINT_PASS)` → `CHALLENGER_RUNNING` + `start_challenger`
+- [x] MCT-S5：`(CHALLENGER_RUNNING, CHALLENGER_PASS)` → `DEV_CROSS_CHECK_RUNNING` + `create_dev_cross_check`
+- [x] MCT-S6：`(DEV_CROSS_CHECK_RUNNING, DEV_CROSS_CHECK_PASS)` → `STAGING_TEST_RUNNING` + `create_staging_test`
+- [x] MCT-S7：`(STAGING_TEST_RUNNING, STAGING_TEST_PASS)` → `PR_CI_RUNNING` + `create_pr_ci_watch`
+- [x] MCT-S8：`(PR_CI_RUNNING, PR_CI_PASS)` → `ACCEPT_RUNNING` + `create_accept`
+- [x] MCT-S9：`(ACCEPT_RUNNING, ACCEPT_PASS)` → `ACCEPT_TEARING_DOWN` + `teardown_accept_env`
+- [x] MCT-S10：`(ACCEPT_TEARING_DOWN, TEARDOWN_DONE_PASS)` → `ARCHIVING` + `done_archive`
+- [x] MCT-S11：`(ARCHIVING, ARCHIVE_DONE)` → `DONE` + `None` (no-op)
+- [x] MCT-CHAIN：从 `(INIT, INTENT_ANALYZE)` 一路 emit 链推到 `DONE`
+
+## Stage: PR
+
+- [x] git push feat/REQ-test-main-chain-1777267689
+- [x] gh pr create --label sisyphus（PR body 写动机 + 测试方案）

--- a/orchestrator/tests/test_engine_main_chain.py
+++ b/orchestrator/tests/test_engine_main_chain.py
@@ -1,0 +1,353 @@
+"""Main-chain happy-path mock tests for engine.step (REQ-test-main-chain-1777267689).
+
+11 个 mock 用例（MCT-S1..MCT-S11）一对一覆盖主链 11 条 happy-path transition。
++1 条 end-to-end chain 用例（MCT-CHAIN）验 emit 链能从 INIT 一路推到 DONE。
+
+复用 ``test_engine.py`` 已有的 FakePool / FakeReq —— 跟 test_engine_adversarial.py
+同模式（``from test_engine import ...``），不抄一份避免漂移。
+
+每条 case 4 个断言：
+  1. ``engine.step`` 返回 ``action="<expected_action>"``
+  2. ``next_state="<expected_next_state>"``
+  3. ``pool.rows[req_id].state`` 真被 CAS 推到目标
+  4. stub action 被精确调用一次
+
+不打 BKD / Postgres / K8s。
+"""
+from __future__ import annotations
+
+import pytest
+
+# 跟 test_engine_adversarial.py 同模式：直接 import test_engine 的私有 FakePool/FakeReq
+from test_engine import FakePool, FakeReq  # type: ignore[import-not-found]
+
+from orchestrator import engine
+from orchestrator.actions import ACTION_META, REGISTRY
+from orchestrator.state import Event, ReqState
+
+
+# ─── 局部 stub_actions fixture（与 test_engine_adversarial.py 同设计） ──────
+@pytest.fixture
+def stub_actions():
+    """clear REGISTRY / ACTION_META，测后还原。"""
+    saved_reg = dict(REGISTRY)
+    saved_meta = dict(ACTION_META)
+    REGISTRY.clear()
+    ACTION_META.clear()
+    yield REGISTRY
+    REGISTRY.clear()
+    ACTION_META.clear()
+    REGISTRY.update(saved_reg)
+    ACTION_META.update(saved_meta)
+
+
+def _body(**attrs):
+    return type("B", (), attrs)()
+
+
+async def _run_single_transition(
+    *,
+    stub_actions: dict,
+    cur_state: ReqState,
+    event: Event,
+    expected_next_state: ReqState,
+    expected_action: str | None,
+):
+    """通用单 transition 验：配 stub action（如 expected_action 非 None）+ engine.step + 4 断言。
+
+    返回 (result_dict, calls_list) 给调用方做额外断言（一般用不上）。
+    """
+    calls: list[str] = []
+
+    if expected_action is not None:
+        async def stub(*, body, req_id, tags, ctx):
+            calls.append(expected_action)
+            return {"ok": True}
+
+        stub_actions[expected_action] = stub
+
+    pool = FakePool({"REQ-1": FakeReq(state=cur_state.value)})
+    result = await engine.step(
+        pool,
+        body=_body(issueId="x", projectId="p", event="check.passed"),
+        req_id="REQ-1",
+        project_id="p",
+        tags=["main-chain", "REQ-1"],
+        cur_state=cur_state,
+        ctx={},
+        event=event,
+    )
+
+    if expected_action is None:
+        # ARCHIVE_DONE 这条 transition.action 是 None，engine 返 action="no-op"
+        assert result["action"] == "no-op", (
+            f"{cur_state.value}+{event.value}: expected action=no-op, got {result!r}"
+        )
+        assert calls == [], "no-op transition shouldn't dispatch any handler"
+    else:
+        assert result["action"] == expected_action, (
+            f"{cur_state.value}+{event.value}: expected action={expected_action}, got {result!r}"
+        )
+        assert calls == [expected_action], (
+            f"{cur_state.value}+{event.value}: stub call mismatch, got {calls!r}"
+        )
+
+    assert result["next_state"] == expected_next_state.value, (
+        f"{cur_state.value}+{event.value}: next_state mismatch ({result!r})"
+    )
+    assert pool.rows["REQ-1"].state == expected_next_state.value, (
+        f"{cur_state.value}+{event.value}: row state not advanced ({pool.rows['REQ-1'].state!r})"
+    )
+    return result, calls
+
+
+# ───────────────────────────────────────────────────────────────────────
+# MCT-S1：(INIT, INTENT_ANALYZE) → ANALYZING + start_analyze
+# ───────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_mct_s1_init_intent_analyze_to_analyzing(stub_actions):
+    """Spec MCT-S1: 主链入口，REQ 离开 INIT 必经此路。"""
+    await _run_single_transition(
+        stub_actions=stub_actions,
+        cur_state=ReqState.INIT,
+        event=Event.INTENT_ANALYZE,
+        expected_next_state=ReqState.ANALYZING,
+        expected_action="start_analyze",
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# MCT-S2：(ANALYZING, ANALYZE_DONE) → ANALYZE_ARTIFACT_CHECKING + create_analyze_artifact_check
+# ───────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_mct_s2_analyzing_done_to_artifact_checking(stub_actions):
+    """Spec MCT-S2: REQ-analyze-artifact-check 引入的产物结构性检查关口。"""
+    await _run_single_transition(
+        stub_actions=stub_actions,
+        cur_state=ReqState.ANALYZING,
+        event=Event.ANALYZE_DONE,
+        expected_next_state=ReqState.ANALYZE_ARTIFACT_CHECKING,
+        expected_action="create_analyze_artifact_check",
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# MCT-S3：(ANALYZE_ARTIFACT_CHECKING, ANALYZE_ARTIFACT_CHECK_PASS)
+#         → SPEC_LINT_RUNNING + create_spec_lint
+# ───────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_mct_s3_artifact_check_pass_to_spec_lint(stub_actions):
+    """Spec MCT-S3: 产物齐 → 进入机械 checker 阶段。"""
+    await _run_single_transition(
+        stub_actions=stub_actions,
+        cur_state=ReqState.ANALYZE_ARTIFACT_CHECKING,
+        event=Event.ANALYZE_ARTIFACT_CHECK_PASS,
+        expected_next_state=ReqState.SPEC_LINT_RUNNING,
+        expected_action="create_spec_lint",
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# MCT-S4：(SPEC_LINT_RUNNING, SPEC_LINT_PASS) → CHALLENGER_RUNNING + start_challenger
+# ───────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_mct_s4_spec_lint_pass_to_challenger(stub_actions):
+    """Spec MCT-S4: M18 challenger 写 contract test（在 spec_lint 与 dev_cross_check 之间）。"""
+    await _run_single_transition(
+        stub_actions=stub_actions,
+        cur_state=ReqState.SPEC_LINT_RUNNING,
+        event=Event.SPEC_LINT_PASS,
+        expected_next_state=ReqState.CHALLENGER_RUNNING,
+        expected_action="start_challenger",
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# MCT-S5：(CHALLENGER_RUNNING, CHALLENGER_PASS)
+#         → DEV_CROSS_CHECK_RUNNING + create_dev_cross_check
+# ───────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_mct_s5_challenger_pass_to_dev_cross_check(stub_actions):
+    """Spec MCT-S5: challenger 推完 contract test → 跑 ci-lint 交叉验证。"""
+    await _run_single_transition(
+        stub_actions=stub_actions,
+        cur_state=ReqState.CHALLENGER_RUNNING,
+        event=Event.CHALLENGER_PASS,
+        expected_next_state=ReqState.DEV_CROSS_CHECK_RUNNING,
+        expected_action="create_dev_cross_check",
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# MCT-S6：(DEV_CROSS_CHECK_RUNNING, DEV_CROSS_CHECK_PASS)
+#         → STAGING_TEST_RUNNING + create_staging_test
+# ───────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_mct_s6_dev_cross_check_pass_to_staging_test(stub_actions):
+    """Spec MCT-S6: ci-lint 通过 → 跑 ci-unit-test + ci-integration-test。"""
+    await _run_single_transition(
+        stub_actions=stub_actions,
+        cur_state=ReqState.DEV_CROSS_CHECK_RUNNING,
+        event=Event.DEV_CROSS_CHECK_PASS,
+        expected_next_state=ReqState.STAGING_TEST_RUNNING,
+        expected_action="create_staging_test",
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# MCT-S7：(STAGING_TEST_RUNNING, STAGING_TEST_PASS)
+#         → PR_CI_RUNNING + create_pr_ci_watch
+# ───────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_mct_s7_staging_test_pass_to_pr_ci(stub_actions):
+    """Spec MCT-S7: 内部 staging 绿 → 跨过 GitHub-side PR CI 网关。"""
+    await _run_single_transition(
+        stub_actions=stub_actions,
+        cur_state=ReqState.STAGING_TEST_RUNNING,
+        event=Event.STAGING_TEST_PASS,
+        expected_next_state=ReqState.PR_CI_RUNNING,
+        expected_action="create_pr_ci_watch",
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# MCT-S8：(PR_CI_RUNNING, PR_CI_PASS) → ACCEPT_RUNNING + create_accept
+# ───────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_mct_s8_pr_ci_pass_to_accept(stub_actions):
+    """Spec MCT-S8: GHA 全套绿 → 进 lab + accept-agent 跑 FEATURE-A*。"""
+    await _run_single_transition(
+        stub_actions=stub_actions,
+        cur_state=ReqState.PR_CI_RUNNING,
+        event=Event.PR_CI_PASS,
+        expected_next_state=ReqState.ACCEPT_RUNNING,
+        expected_action="create_accept",
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# MCT-S9：(ACCEPT_RUNNING, ACCEPT_PASS) → ACCEPT_TEARING_DOWN + teardown_accept_env
+# ───────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_mct_s9_accept_pass_to_tearing_down(stub_actions):
+    """Spec MCT-S9: accept 全过 → 强制 teardown lab（accept-env-down 非可选）。"""
+    await _run_single_transition(
+        stub_actions=stub_actions,
+        cur_state=ReqState.ACCEPT_RUNNING,
+        event=Event.ACCEPT_PASS,
+        expected_next_state=ReqState.ACCEPT_TEARING_DOWN,
+        expected_action="teardown_accept_env",
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# MCT-S10：(ACCEPT_TEARING_DOWN, TEARDOWN_DONE_PASS) → ARCHIVING + done_archive
+# ───────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_mct_s10_teardown_done_pass_to_archiving(stub_actions):
+    """Spec MCT-S10: lab 清完 + 上一步 accept.pass → done-archive 起。"""
+    await _run_single_transition(
+        stub_actions=stub_actions,
+        cur_state=ReqState.ACCEPT_TEARING_DOWN,
+        event=Event.TEARDOWN_DONE_PASS,
+        expected_next_state=ReqState.ARCHIVING,
+        expected_action="done_archive",
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# MCT-S11：(ARCHIVING, ARCHIVE_DONE) → DONE + None (no-op terminal)
+# ───────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_mct_s11_archive_done_to_done(stub_actions):
+    """Spec MCT-S11: 唯一 transition.action=None 的主链 transition；engine 应返 no-op。"""
+    await _run_single_transition(
+        stub_actions=stub_actions,
+        cur_state=ReqState.ARCHIVING,
+        event=Event.ARCHIVE_DONE,
+        expected_next_state=ReqState.DONE,
+        expected_action=None,
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# MCT-CHAIN：从 INIT 一路 emit 链推到 DONE
+# ───────────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_mct_chain_full_main_chain_via_emit(stub_actions):
+    """Spec MCT-CHAIN: 10 个 stub action 各 emit 下一事件，单次 engine.step 推完整条主链。
+
+    主链：
+      INIT --INTENT_ANALYZE--> ANALYZING --ANALYZE_DONE-->
+      ANALYZE_ARTIFACT_CHECKING --ANALYZE_ARTIFACT_CHECK_PASS-->
+      SPEC_LINT_RUNNING --SPEC_LINT_PASS-->
+      CHALLENGER_RUNNING --CHALLENGER_PASS-->
+      DEV_CROSS_CHECK_RUNNING --DEV_CROSS_CHECK_PASS-->
+      STAGING_TEST_RUNNING --STAGING_TEST_PASS-->
+      PR_CI_RUNNING --PR_CI_PASS-->
+      ACCEPT_RUNNING --ACCEPT_PASS-->
+      ACCEPT_TEARING_DOWN --TEARDOWN_DONE_PASS-->
+      ARCHIVING --ARCHIVE_DONE--> DONE
+
+    10 个 emit 链，加上 ARCHIVING→DONE 这条无 action 的 terminal 跳转 = 11 条
+    transition 全过。
+    """
+    calls: list[str] = []
+
+    # action_name → next event 串成完整主链
+    action_to_next_event: dict[str, Event] = {
+        "start_analyze":                 Event.ANALYZE_DONE,
+        "create_analyze_artifact_check": Event.ANALYZE_ARTIFACT_CHECK_PASS,
+        "create_spec_lint":              Event.SPEC_LINT_PASS,
+        "start_challenger":              Event.CHALLENGER_PASS,
+        "create_dev_cross_check":        Event.DEV_CROSS_CHECK_PASS,
+        "create_staging_test":           Event.STAGING_TEST_PASS,
+        "create_pr_ci_watch":            Event.PR_CI_PASS,
+        "create_accept":                 Event.ACCEPT_PASS,
+        "teardown_accept_env":           Event.TEARDOWN_DONE_PASS,
+        "done_archive":                  Event.ARCHIVE_DONE,
+    }
+
+    def _make_stub(name: str, emit_event: Event):
+        async def _stub(*, body, req_id, tags, ctx):
+            calls.append(name)
+            return {"emit": emit_event.value}
+        return _stub
+
+    for name, ev in action_to_next_event.items():
+        stub_actions[name] = _make_stub(name, ev)
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.INIT.value)})
+    result = await engine.step(
+        pool,
+        body=_body(issueId="x", projectId="p", event="intent.analyze"),
+        req_id="REQ-1",
+        project_id="p",
+        tags=["main-chain", "REQ-1"],
+        cur_state=ReqState.INIT,
+        ctx={},
+        event=Event.INTENT_ANALYZE,
+    )
+
+    # 1) 全 10 个 stub action 各调一次（顺序按主链）
+    assert calls == list(action_to_next_event.keys()), (
+        f"action call sequence wrong: {calls!r}"
+    )
+
+    # 2) row 终态为 DONE
+    assert pool.rows["REQ-1"].state == ReqState.DONE.value, (
+        f"row not at DONE: {pool.rows['REQ-1'].state!r}"
+    )
+
+    # 3) 整条 chained 链里不应该出现 recursion guard error
+    cur = result
+    for _ in range(20):  # 超过 11 步说明跑飞了
+        if cur.get("action") == "error" and "recursion" in str(cur.get("reason", "")):
+            pytest.fail(f"recursion guard fired during main chain: {cur!r}")
+        cur = cur.get("chained")
+        if not cur:
+            break
+
+    # 4) 顶层 step 是 start_analyze（INIT 入口）
+    assert result["action"] == "start_analyze"
+    assert result["next_state"] == ReqState.ANALYZING.value


### PR DESCRIPTION
## Summary

补主链 11 条 happy-path transition 在 `engine.step` 层的 mock 测试覆盖：

```
INIT --INTENT_ANALYZE--> ANALYZING --ANALYZE_DONE-->
ANALYZE_ARTIFACT_CHECKING --ANALYZE_ARTIFACT_CHECK_PASS-->
SPEC_LINT_RUNNING --SPEC_LINT_PASS-->
CHALLENGER_RUNNING --CHALLENGER_PASS-->
DEV_CROSS_CHECK_RUNNING --DEV_CROSS_CHECK_PASS-->
STAGING_TEST_RUNNING --STAGING_TEST_PASS-->
PR_CI_RUNNING --PR_CI_PASS-->
ACCEPT_RUNNING --ACCEPT_PASS-->
ACCEPT_TEARING_DOWN --TEARDOWN_DONE_PASS-->
ARCHIVING --ARCHIVE_DONE--> DONE
```

之前测试拆得碎：`tests/test_state.py` 只做静态 `decide(state, event)` 映射断言（**bypass** CAS / `_record_stage_transitions` / dispatch）；`tests/test_engine.py` 在 `engine.step` 层只覆盖了 11 条主链中的 #4（spec-lint→challenger）/ #5（challenger→dev-cross-check）+ 几条 cleanup / illegal / CAS race。**剩 7 条主链 transition 在 engine.step 层没单测拦截**——映射对了 + dispatch 写错了 / `STATE_TO_STAGE` 漏配 / CAS race 被吃掉，目前没本地单测看得见。

新增 `orchestrator/tests/test_engine_main_chain.py`（12 条 case，全 in-process FakePool）：

| ID | (state, event) | 期望 next_state | action |
|---|---|---|---|
| MCT-S1 | (INIT, INTENT_ANALYZE) | ANALYZING | start_analyze |
| MCT-S2 | (ANALYZING, ANALYZE_DONE) | ANALYZE_ARTIFACT_CHECKING | create_analyze_artifact_check |
| MCT-S3 | (ANALYZE_ARTIFACT_CHECKING, ANALYZE_ARTIFACT_CHECK_PASS) | SPEC_LINT_RUNNING | create_spec_lint |
| MCT-S4 | (SPEC_LINT_RUNNING, SPEC_LINT_PASS) | CHALLENGER_RUNNING | start_challenger |
| MCT-S5 | (CHALLENGER_RUNNING, CHALLENGER_PASS) | DEV_CROSS_CHECK_RUNNING | create_dev_cross_check |
| MCT-S6 | (DEV_CROSS_CHECK_RUNNING, DEV_CROSS_CHECK_PASS) | STAGING_TEST_RUNNING | create_staging_test |
| MCT-S7 | (STAGING_TEST_RUNNING, STAGING_TEST_PASS) | PR_CI_RUNNING | create_pr_ci_watch |
| MCT-S8 | (PR_CI_RUNNING, PR_CI_PASS) | ACCEPT_RUNNING | create_accept |
| MCT-S9 | (ACCEPT_RUNNING, ACCEPT_PASS) | ACCEPT_TEARING_DOWN | teardown_accept_env |
| MCT-S10 | (ACCEPT_TEARING_DOWN, TEARDOWN_DONE_PASS) | ARCHIVING | done_archive |
| MCT-S11 | (ARCHIVING, ARCHIVE_DONE) | DONE | None (no-op) |
| MCT-CHAIN | INIT 一路 emit 链推到 DONE | DONE | 10 个 stub action 各调一次 |

每条 case 4 个断言：返回 dict 的 `action` / `next_state` + FakePool row 真被 CAS 推到目标 + stub action 调用次数。

不动 prod 代码（engine.py / state.py / actions/ 都没碰）。复用 `test_engine.py` 的 `FakePool` / `FakeReq`（跟 `test_engine_adversarial.py` 同模式 `from test_engine import ...`），不抄一份避免漂移。

## Test plan

- [x] `uv run pytest orchestrator/tests/test_engine_main_chain.py -q` → 12 passed (4.9s)
- [x] `uv run pytest -m "not integration" -q` → 1373 passed, 2 deselected
- [x] `uv run ruff check orchestrator/tests/test_engine_main_chain.py` → All checks passed
- [x] `openspec validate REQ-test-main-chain-1777267689 --strict` → valid
- [x] `scripts/check-scenario-refs.sh` → 全 441 个 scenario 引用都在 specs 中找到

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-test-main-chain-1777267689`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/35vtzeyn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
