### PR TITLE
test(engine): mock tests for verifier sub-chain + SESSION_FAILED fallback (REQ-test-verifier-loop-1777267725)

### DIFF
--- a/openspec/changes/REQ-test-verifier-loop-1777267725/proposal.md
+++ b/openspec/changes/REQ-test-verifier-loop-1777267725/proposal.md
@@ -1,0 +1,82 @@
+# REQ-test-verifier-loop-1777267725: 补 verifier 子链 + SESSION_FAILED 兜底 mock test
+
+## 问题
+
+`orchestrator/src/orchestrator/state.py` 的 transition 表里有两块"事故响应路径"：
+
+1. **verifier 子链**（M14b/c）
+   - 任一上游 stage（analyze_artifact_check / spec_lint / challenger / dev_cross_check
+     / staging_test / pr_ci / accept-teardown）失败 → `*_FAIL` 事件 → `REVIEW_RUNNING` +
+     `invoke_verifier_for_<stage>_fail` action
+   - `REVIEW_RUNNING` 出口 3 路：`VERIFY_PASS`(self-loop, action 内 CAS) /
+     `VERIFY_FIX_NEEDED` → `FIXER_RUNNING` / `VERIFY_ESCALATE` → `ESCALATED`
+   - `FIXER_RUNNING` 出口 2 路：`FIXER_DONE` 回 `REVIEW_RUNNING` /
+     `VERIFY_ESCALATE` → `ESCALATED`（round cap 触顶）
+   - 人工 resume 路径：`ESCALATED` + 3 个 verify 事件分别接到 `apply_verify_pass`
+     / `start_fixer` / 自循环 no-op
+
+2. **SESSION_FAILED 兜底**
+   - 13 个 `*_RUNNING` state 都有 `(st, SESSION_FAILED) → (st, "escalate")` self-loop
+     transition（dict-comprehension 写法），让 BKD agent 异常或 watchdog 兜底信号都能
+     进 escalate action 自决 auto-resume / 真 ESCALATE
+   - `INIT` / `GH_INCIDENT_OPEN` / `DONE` / `ESCALATED` **不在**列表 → 应当 skip 而不是
+     误进 escalate
+   - `escalate` action 内部对 `SESSION_FAILED` 类信号要手动 CAS 把 self-loop 推到
+     `ESCALATED`，配合 `VERIFY_ESCALATE` 类信号本身就是表里直跳
+
+现有 `test_engine.py` + `test_engine_adversarial.py` 只散落覆盖了:
+- spec-lint.pass → start_challenger 主链 happy path
+- (REVIEW_RUNNING, VERIFY_PASS) self-loop close orphan stage_run
+- 一条 SESSION_FAILED on REVIEW_RUNNING 不动 stage_run
+- DONE + SESSION_FAILED → skip (EAT-S11)
+- DONE + 任意 Event → skip (EAT-S12)
+
+**没有**对 verifier 子链的进入 / 出口 / 人工 resume / FIXER 路径，**也没有**对 13 个
+running state 的 SESSION_FAILED self-loop 做系统性 mock test 覆盖。一旦谁动了
+transition 表（漏挂某条 `*_FAIL` → verifier，或漏挂某 running state 的 SESSION_FAILED）
+单测照样绿，实测就会卡死或误路。
+
+## 方案
+
+新增 `orchestrator/tests/test_engine_verifier_loop.py`：16 条 scenario
+（VLT-S1..VLT-S16），全部用 in-process FakePool + stub action 隔离副作用，**不打 BKD
+不打 Postgres 不打 K8s**，复用 `test_engine.py` 已有的 `FakePool` / `FakeReq` / 同包
+import 模式（跟 `test_engine_adversarial.py` 一致），保证两边漂移成本接近 0。
+
+| ID | 场景 | 期望 |
+|---|---|---|
+| VLT-S1 | `(SPEC_LINT_RUNNING, SPEC_LINT_FAIL)` | dispatch `invoke_verifier_for_spec_lint_fail`，state → `REVIEW_RUNNING` |
+| VLT-S2 | `(DEV_CROSS_CHECK_RUNNING, DEV_CROSS_CHECK_FAIL)` | dispatch `invoke_verifier_for_dev_cross_check_fail`，state → `REVIEW_RUNNING` |
+| VLT-S3 | `(STAGING_TEST_RUNNING, STAGING_TEST_FAIL)` | dispatch `invoke_verifier_for_staging_test_fail`，state → `REVIEW_RUNNING` |
+| VLT-S4 | `(PR_CI_RUNNING, PR_CI_FAIL)` | dispatch `invoke_verifier_for_pr_ci_fail`，state → `REVIEW_RUNNING` |
+| VLT-S5 | `(ACCEPT_TEARING_DOWN, TEARDOWN_DONE_FAIL)` | dispatch `invoke_verifier_for_accept_fail`，state → `REVIEW_RUNNING` |
+| VLT-S6 | `(ANALYZE_ARTIFACT_CHECKING, ANALYZE_ARTIFACT_CHECK_FAIL)` | dispatch `invoke_verifier_for_analyze_artifact_check_fail`，state → `REVIEW_RUNNING` |
+| VLT-S7 | `(CHALLENGER_RUNNING, CHALLENGER_FAIL)` | dispatch `invoke_verifier_for_challenger_fail`，state → `REVIEW_RUNNING` |
+| VLT-S8 | `(REVIEW_RUNNING, VERIFY_FIX_NEEDED)` | dispatch `start_fixer`，state → `FIXER_RUNNING`，verifier stage_run close outcome=`fix`，fixer stage_run open |
+| VLT-S9 | `(REVIEW_RUNNING, VERIFY_ESCALATE)` | dispatch `escalate`，state → `ESCALATED`，触发 cleanup runner（fire-and-forget） |
+| VLT-S10 | `(FIXER_RUNNING, FIXER_DONE)` | dispatch `invoke_verifier_after_fix`，state → `REVIEW_RUNNING`，fixer outcome=`pass` |
+| VLT-S11 | `(FIXER_RUNNING, VERIFY_ESCALATE)` | dispatch `escalate`，state → `ESCALATED`（round cap 击顶逃生路径） |
+| VLT-S12 | `(ESCALATED, VERIFY_PASS)` resume | dispatch `apply_verify_pass`，state 仍 `ESCALATED`（self-loop；action 内自决推下一 stage） |
+| VLT-S13 | `(ESCALATED, VERIFY_FIX_NEEDED)` resume | dispatch `start_fixer`，state → `FIXER_RUNNING` |
+| VLT-S14 | `(ESCALATED, VERIFY_ESCALATE)` resume | action=None no-op，state 仍 `ESCALATED`，不重复 cleanup |
+| VLT-S15 | 13 个 `*_RUNNING` state 各 `+ SESSION_FAILED` | dispatch `escalate` self-loop（参数化覆盖） |
+| VLT-S16 | `(INIT, SESSION_FAILED)` | 无 transition → skip，escalate 不被调 |
+
+边界：
+- 用 stub `escalate` / `apply_verify_pass` / `invoke_verifier_*` —— 不验它们内部行为
+  （那是 `test_verifier.py` 的活），只验 engine.step 的 dispatch 决策跟 state CAS
+- VLT-S15 的 13 个 state 用 `pytest.parametrize` 拆成 13 条独立 case，便于失败定位
+- VLT-S9 + VLT-S14 都涉及 ESCALATED + cleanup 行为：S9 是 cur 非 terminal，应触发
+  cleanup；S14 是 cur 已 terminal self-loop，应**不**触发（已在 EAT-S7 覆盖，本测复测
+  保护回归）
+
+## 不做
+
+- **不验** action handler 内部行为（fan out / BKD issue 创建 / fixer round counter）—
+  那是 `test_verifier.py` 的范围，本测只看 engine 的 transition routing
+- **不验** stage_runs DB schema / outcome 标签的真实 SQL —— `test_store_stage_runs.py`
+  覆盖
+- **不验** webhook 解析 decision JSON 的逻辑 —— `test_router.py` /
+  `test_verifier.py` 已覆盖
+- **不为** 多语言 / runner pod / openspec validate 加新依赖 —— pure mock test
+- **不修** transition 表 / `_verifier.py` / `engine.py` —— 纯加测，不改产线

--- a/openspec/changes/REQ-test-verifier-loop-1777267725/specs/engine-verifier-loop-tests/spec.md
+++ b/openspec/changes/REQ-test-verifier-loop-1777267725/specs/engine-verifier-loop-tests/spec.md
@@ -1,0 +1,212 @@
+## ADDED Requirements
+
+### Requirement: Engine routes upstream stage failures into verifier sub-chain
+
+The state machine and engine MUST route every supported upstream stage-fail
+event from its corresponding running state to `REVIEW_RUNNING` and dispatch
+the matching `invoke_verifier_for_<stage>_fail` action. The supported stages
+are analyze-artifact-check, spec-lint, challenger, dev-cross-check,
+staging-test, pr-ci, and accept-teardown. A regression that drops or renames
+any of these transitions MUST be caught by mock tests; the engine MUST NOT
+silently skip a stage-fail event when it is fired from the matching running
+state.
+
+#### Scenario: VLT-S1 spec_lint fail enters review-running
+
+- **GIVEN** a row at state `SPEC_LINT_RUNNING` and a stub
+  `invoke_verifier_for_spec_lint_fail` registered in `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=SPEC_LINT_FAIL`
+- **THEN** the row's state MUST advance to `REVIEW_RUNNING`, the returned
+  dict MUST contain `action="invoke_verifier_for_spec_lint_fail"` and
+  `next_state="review-running"`, and the stub action MUST be awaited exactly
+  once
+
+#### Scenario: VLT-S2 dev_cross_check fail enters review-running
+
+- **GIVEN** a row at state `DEV_CROSS_CHECK_RUNNING` and a stub
+  `invoke_verifier_for_dev_cross_check_fail` registered in `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=DEV_CROSS_CHECK_FAIL`
+- **THEN** the row's state MUST advance to `REVIEW_RUNNING`, the returned
+  dict MUST contain `action="invoke_verifier_for_dev_cross_check_fail"`, and
+  the stub action MUST be awaited exactly once
+
+#### Scenario: VLT-S3 staging_test fail enters review-running
+
+- **GIVEN** a row at state `STAGING_TEST_RUNNING` and a stub
+  `invoke_verifier_for_staging_test_fail` registered in `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=STAGING_TEST_FAIL`
+- **THEN** the row's state MUST advance to `REVIEW_RUNNING`, the returned
+  dict MUST contain `action="invoke_verifier_for_staging_test_fail"`, and
+  the stub action MUST be awaited exactly once
+
+#### Scenario: VLT-S4 pr_ci fail enters review-running
+
+- **GIVEN** a row at state `PR_CI_RUNNING` and a stub
+  `invoke_verifier_for_pr_ci_fail` registered in `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=PR_CI_FAIL`
+- **THEN** the row's state MUST advance to `REVIEW_RUNNING`, the returned
+  dict MUST contain `action="invoke_verifier_for_pr_ci_fail"`, and the stub
+  action MUST be awaited exactly once
+
+#### Scenario: VLT-S5 accept teardown fail enters review-running
+
+- **GIVEN** a row at state `ACCEPT_TEARING_DOWN` and a stub
+  `invoke_verifier_for_accept_fail` registered in `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=TEARDOWN_DONE_FAIL`
+- **THEN** the row's state MUST advance to `REVIEW_RUNNING`, the returned
+  dict MUST contain `action="invoke_verifier_for_accept_fail"`, and the
+  stub action MUST be awaited exactly once
+
+#### Scenario: VLT-S6 analyze_artifact_check fail enters review-running
+
+- **GIVEN** a row at state `ANALYZE_ARTIFACT_CHECKING` and a stub
+  `invoke_verifier_for_analyze_artifact_check_fail` registered in
+  `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=ANALYZE_ARTIFACT_CHECK_FAIL`
+- **THEN** the row's state MUST advance to `REVIEW_RUNNING`, the returned
+  dict MUST contain
+  `action="invoke_verifier_for_analyze_artifact_check_fail"`, and the stub
+  action MUST be awaited exactly once
+
+#### Scenario: VLT-S7 challenger fail enters review-running
+
+- **GIVEN** a row at state `CHALLENGER_RUNNING` and a stub
+  `invoke_verifier_for_challenger_fail` registered in `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=CHALLENGER_FAIL`
+- **THEN** the row's state MUST advance to `REVIEW_RUNNING`, the returned
+  dict MUST contain `action="invoke_verifier_for_challenger_fail"`, and the
+  stub action MUST be awaited exactly once
+
+### Requirement: Engine routes verifier decisions out of review-running
+
+The engine MUST dispatch the verifier-decision events from `REVIEW_RUNNING`
+to the correct downstream state and action: `VERIFY_FIX_NEEDED` →
+`FIXER_RUNNING` via `start_fixer`, and `VERIFY_ESCALATE` → `ESCALATED` via
+`escalate`. The `VERIFY_FIX_NEEDED` path SHALL also close the `verifier`
+stage_run row with `outcome=fix` and open a fresh `fixer` stage_run row,
+because the transition crosses two distinct `*_RUNNING` states. The
+`VERIFY_ESCALATE` path SHALL fire-and-forget a `cleanup_runner` task because
+the transition enters a terminal state from a non-terminal state.
+
+#### Scenario: VLT-S8 verify fix needed enters fixer-running and rolls stage_runs
+
+- **GIVEN** a row at state `REVIEW_RUNNING` and a stub `start_fixer`
+  registered in `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=VERIFY_FIX_NEEDED`
+- **THEN** the row's state MUST advance to `FIXER_RUNNING`, the returned
+  dict MUST contain `action="start_fixer"`, exactly one stage_runs `close`
+  call MUST record `(stage="verifier", outcome="fix")`, and exactly one
+  stage_runs `insert` call MUST record `(stage="fixer")`
+
+#### Scenario: VLT-S9 verify escalate enters escalated and triggers cleanup
+
+- **GIVEN** a row at state `REVIEW_RUNNING`, a stub `escalate` registered
+  in `actions.REGISTRY`, and a fake k8s controller injected via
+  `k8s_runner.set_controller`
+- **WHEN** `engine.step` is called with `event=VERIFY_ESCALATE`
+- **THEN** the row's state MUST advance to `ESCALATED`, the returned dict
+  MUST contain `action="escalate"`, and after fire-and-forget tasks drain
+  the fake controller's `cleanup_runner` MUST have been awaited exactly
+  once with `retain_pvc=True`
+
+### Requirement: Engine handles fixer back-edge and round-cap escape
+
+The engine MUST dispatch `(FIXER_RUNNING, FIXER_DONE)` to `REVIEW_RUNNING`
+via `invoke_verifier_after_fix` so the post-fix re-verification loop runs
+through the engine like the original verifier path. The engine MUST also
+dispatch `(FIXER_RUNNING, VERIFY_ESCALATE)` to `ESCALATED` via `escalate`
+because `start_fixer` itself can emit `VERIFY_ESCALATE` when the round cap
+is hit and the engine needs a real transition to commit that decision.
+
+#### Scenario: VLT-S10 fixer done re-enters review-running
+
+- **GIVEN** a row at state `FIXER_RUNNING` and a stub
+  `invoke_verifier_after_fix` registered in `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=FIXER_DONE`
+- **THEN** the row's state MUST advance to `REVIEW_RUNNING`, the returned
+  dict MUST contain `action="invoke_verifier_after_fix"`, and exactly one
+  stage_runs `close` call MUST record `(stage="fixer", outcome="pass")`
+
+#### Scenario: VLT-S11 fixer round-cap escapes to escalated
+
+- **GIVEN** a row at state `FIXER_RUNNING` and a stub `escalate`
+  registered in `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=VERIFY_ESCALATE`
+- **THEN** the row's state MUST advance to `ESCALATED`, the returned dict
+  MUST contain `action="escalate"`, and the stub action MUST be awaited
+  exactly once
+
+### Requirement: Engine routes user-resume events from escalated state
+
+The engine MUST allow user-driven resumption from `ESCALATED` by accepting
+the three verifier-decision events fired from a follow-up `verifier`
+issue: `VERIFY_PASS` is a self-loop dispatched to `apply_verify_pass`
+(action internally CAS-advances to the appropriate `*_RUNNING` state),
+`VERIFY_FIX_NEEDED` advances to `FIXER_RUNNING` via `start_fixer`, and
+`VERIFY_ESCALATE` is a self-loop with `action=None` (no further action
+because the row is already escalated). The `VERIFY_ESCALATE` self-loop
+MUST NOT trigger a second `cleanup_runner` task — the prior escalate
+already cleaned up.
+
+#### Scenario: VLT-S12 escalated verify pass dispatches apply_verify_pass
+
+- **GIVEN** a row at state `ESCALATED` and a stub `apply_verify_pass`
+  registered in `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=VERIFY_PASS`
+- **THEN** the returned dict MUST contain `action="apply_verify_pass"`,
+  the row's state MUST remain `ESCALATED` (transition table self-loop;
+  the action stub does not internally CAS), and the stub action MUST be
+  awaited exactly once
+
+#### Scenario: VLT-S13 escalated verify fix needed enters fixer-running
+
+- **GIVEN** a row at state `ESCALATED` and a stub `start_fixer`
+  registered in `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=VERIFY_FIX_NEEDED`
+- **THEN** the row's state MUST advance to `FIXER_RUNNING`, the returned
+  dict MUST contain `action="start_fixer"`, and the stub action MUST be
+  awaited exactly once
+
+#### Scenario: VLT-S14 escalated verify escalate is a no-op self-loop
+
+- **GIVEN** a row at state `ESCALATED` and a fake k8s controller
+  injected via `k8s_runner.set_controller`
+- **WHEN** `engine.step` is called with `event=VERIFY_ESCALATE`
+- **THEN** the returned dict MUST contain `action="no-op"` and
+  `next_state="escalated"`, the row's state MUST remain `ESCALATED`,
+  and the fake controller's `cleanup_runner` MUST NOT have been awaited
+
+### Requirement: Engine routes SESSION_FAILED from every running state
+
+The state machine MUST register `(state, SESSION_FAILED) → (state,
+"escalate")` self-loop transitions for **every** non-terminal `*_RUNNING`
+state and for `INTAKING` / `ARCHIVING`. When `engine.step` receives
+`SESSION_FAILED` from any of those states it MUST dispatch the `escalate`
+action with the current state preserved (the `escalate` action internally
+decides auto-resume vs. real CAS to `ESCALATED`). States that are NOT in
+the `SESSION_FAILED` transition set (`INIT`, `GH_INCIDENT_OPEN`, `DONE`,
+`ESCALATED`) MUST cause `engine.step` to return `action="skip"` with a
+`no transition` reason — `escalate` MUST NOT be dispatched.
+
+#### Scenario: VLT-S15 SESSION_FAILED on every running state self-loops to escalate
+
+- **GIVEN** a row at any of the 13 in-flight states (`INTAKING`,
+  `ANALYZING`, `ANALYZE_ARTIFACT_CHECKING`, `SPEC_LINT_RUNNING`,
+  `CHALLENGER_RUNNING`, `DEV_CROSS_CHECK_RUNNING`,
+  `STAGING_TEST_RUNNING`, `PR_CI_RUNNING`, `ACCEPT_RUNNING`,
+  `ACCEPT_TEARING_DOWN`, `REVIEW_RUNNING`, `FIXER_RUNNING`, `ARCHIVING`)
+  and a stub `escalate` registered in `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=SESSION_FAILED`
+- **THEN** the returned dict MUST contain `action="escalate"` and
+  `next_state` equal to the same input state (transition table
+  self-loop; action stub does not CAS), and the stub action MUST be
+  awaited exactly once for each parametrized state
+
+#### Scenario: VLT-S16 SESSION_FAILED on INIT state is dropped
+
+- **GIVEN** a row at state `INIT` and a stub `escalate` registered in
+  `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=SESSION_FAILED`
+- **THEN** the returned dict MUST contain `action="skip"` and a `reason`
+  containing `"no transition init+session.failed"`, the row's state MUST
+  remain `INIT`, and the stub action MUST NOT have been awaited

--- a/openspec/changes/REQ-test-verifier-loop-1777267725/tasks.md
+++ b/openspec/changes/REQ-test-verifier-loop-1777267725/tasks.md
@@ -1,0 +1,36 @@
+# Tasks for REQ-test-verifier-loop-1777267725
+
+## Stage: contract / spec
+
+- [x] author `proposal.md` —— 描述 16 条 verifier 子链 + SESSION_FAILED scenario 范围 + 不做清单
+- [x] author `specs/engine-verifier-loop-tests/spec.md` ADDED delta：
+      列出 VLT-S1..VLT-S16 全部 GIVEN/WHEN/THEN
+
+## Stage: implementation
+
+- [x] 新增 `orchestrator/tests/test_engine_verifier_loop.py`：
+  - 复用 `test_engine.py` 的 `FakePool` / `FakeReq` / `_drain_tasks`
+    （直接 `from test_engine import ...`，跟 `test_engine_adversarial.py` 同模式）
+  - 16 条 case 一一对应 VLT-S1..VLT-S16 scenario
+  - 所有 case 用 `pytest.mark.asyncio`，不依赖真 DB / BKD / K8s
+- [x] VLT-S1：spec_lint fail → REVIEW_RUNNING (invoke_verifier_for_spec_lint_fail)
+- [x] VLT-S2：dev_cross_check fail → REVIEW_RUNNING
+- [x] VLT-S3：staging_test fail → REVIEW_RUNNING
+- [x] VLT-S4：pr_ci fail → REVIEW_RUNNING
+- [x] VLT-S5：accept teardown fail → REVIEW_RUNNING
+- [x] VLT-S6：analyze_artifact_check fail → REVIEW_RUNNING
+- [x] VLT-S7：challenger fail → REVIEW_RUNNING
+- [x] VLT-S8：REVIEW_RUNNING + VERIFY_FIX_NEEDED → FIXER_RUNNING + stage_runs close/open
+- [x] VLT-S9：REVIEW_RUNNING + VERIFY_ESCALATE → ESCALATED + cleanup runner
+- [x] VLT-S10：FIXER_RUNNING + FIXER_DONE → REVIEW_RUNNING
+- [x] VLT-S11：FIXER_RUNNING + VERIFY_ESCALATE → ESCALATED (round cap escape)
+- [x] VLT-S12：ESCALATED + VERIFY_PASS resume → apply_verify_pass dispatched
+- [x] VLT-S13：ESCALATED + VERIFY_FIX_NEEDED resume → FIXER_RUNNING
+- [x] VLT-S14：ESCALATED + VERIFY_ESCALATE resume → no-op，no extra cleanup
+- [x] VLT-S15：每个 *_RUNNING state + SESSION_FAILED → escalate self-loop（参数化 13 状态）
+- [x] VLT-S16：INIT + SESSION_FAILED → skip（INIT 不在 SESSION_FAILED 集合）
+
+## Stage: PR
+
+- [x] git push feat/REQ-test-verifier-loop-1777267725
+- [x] gh pr create --label sisyphus（PR body 写动机 + 测试方案）

--- a/orchestrator/tests/test_contract_engine_verifier_loop_challenger.py
+++ b/orchestrator/tests/test_contract_engine_verifier_loop_challenger.py
@@ -1,0 +1,687 @@
+"""Challenger contract tests for REQ-test-verifier-loop-1777267725.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-test-verifier-loop-1777267725/specs/engine-verifier-loop-tests/spec.md
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is truly wrong, escalate to spec_fixer to correct the spec, not the test.
+
+Scenarios covered:
+  VLT-S1   (SPEC_LINT_RUNNING, SPEC_LINT_FAIL) → REVIEW_RUNNING + invoke_verifier_for_spec_lint_fail
+  VLT-S2   (DEV_CROSS_CHECK_RUNNING, DEV_CROSS_CHECK_FAIL) → REVIEW_RUNNING + invoke_verifier_for_dev_cross_check_fail
+  VLT-S3   (STAGING_TEST_RUNNING, STAGING_TEST_FAIL) → REVIEW_RUNNING + invoke_verifier_for_staging_test_fail
+  VLT-S4   (PR_CI_RUNNING, PR_CI_FAIL) → REVIEW_RUNNING + invoke_verifier_for_pr_ci_fail
+  VLT-S5   (ACCEPT_TEARING_DOWN, TEARDOWN_DONE_FAIL) → REVIEW_RUNNING + invoke_verifier_for_accept_fail
+  VLT-S6   (ANALYZE_ARTIFACT_CHECKING, ANALYZE_ARTIFACT_CHECK_FAIL) → REVIEW_RUNNING + invoke_verifier_for_analyze_artifact_check_fail
+  VLT-S7   (CHALLENGER_RUNNING, CHALLENGER_FAIL) → REVIEW_RUNNING + invoke_verifier_for_challenger_fail
+  VLT-S8   (REVIEW_RUNNING, VERIFY_FIX_NEEDED) → FIXER_RUNNING, stage_runs: close verifier/fix + insert fixer
+  VLT-S9   (REVIEW_RUNNING, VERIFY_ESCALATE) → ESCALATED + cleanup_runner fire-and-forget
+  VLT-S10  (FIXER_RUNNING, FIXER_DONE) → REVIEW_RUNNING, stage_runs: close fixer/pass + insert verifier
+  VLT-S11  (FIXER_RUNNING, VERIFY_ESCALATE) → ESCALATED + escalate dispatched
+  VLT-S12  (ESCALATED, VERIFY_PASS) → ESCALATED self-loop + apply_verify_pass dispatched, no cleanup
+  VLT-S13  (ESCALATED, VERIFY_FIX_NEEDED) → FIXER_RUNNING + start_fixer dispatched
+  VLT-S14  (ESCALATED, VERIFY_ESCALATE) → ESCALATED no-op self-loop, no cleanup_runner
+  VLT-S15  13× (*_RUNNING, SESSION_FAILED) → self-loop + escalate dispatch, no cleanup
+  VLT-S16  (INIT, SESSION_FAILED) → skip, reason contains "no transition init+session.failed"
+
+Module contract under test: orchestrator.engine.step
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ─── Shared helpers ───────────────────────────────────────────────────────────
+
+_POOL = object()  # sentinel; DB layer is fully patched
+_REQ_ID = "REQ-test-verifier-loop-1777267725"
+_PROJECT = "proj-vlt"
+
+
+class _Body:
+    issueId = "bkd-vlt-test"
+    projectId = _PROJECT
+
+
+def _patch_io(
+    monkeypatch,
+    *,
+    cas_return: bool = True,
+    stage_raises: Exception | None = None,
+) -> AsyncMock:
+    """Patch all engine external I/O. Returns cas_mock."""
+    from orchestrator import engine
+
+    cas = AsyncMock(return_value=cas_return)
+    monkeypatch.setattr(engine.req_state, "cas_transition", cas)
+    monkeypatch.setattr(engine.req_state, "get", AsyncMock(return_value=None))
+
+    if stage_raises is not None:
+        monkeypatch.setattr(
+            engine.stage_runs, "close_latest_stage_run", AsyncMock(side_effect=stage_raises),
+        )
+        monkeypatch.setattr(
+            engine.stage_runs, "insert_stage_run", AsyncMock(side_effect=stage_raises),
+        )
+    else:
+        monkeypatch.setattr(engine.stage_runs, "close_latest_stage_run", AsyncMock())
+        monkeypatch.setattr(engine.stage_runs, "insert_stage_run", AsyncMock())
+
+    monkeypatch.setattr(engine.obs, "record_event", AsyncMock())
+    return cas
+
+
+@pytest.fixture(autouse=True)
+def _restore_registry():
+    """Snapshot and restore REGISTRY around each test."""
+    from orchestrator.actions import ACTION_META, REGISTRY
+
+    snap_reg = dict(REGISTRY)
+    snap_meta = dict(ACTION_META)
+    yield
+    REGISTRY.clear()
+    ACTION_META.clear()
+    REGISTRY.update(snap_reg)
+    ACTION_META.update(snap_meta)
+
+
+async def _step(**overrides):
+    from orchestrator.engine import step
+    from orchestrator.state import Event, ReqState
+
+    defaults: dict = dict(
+        pool=_POOL,
+        body=_Body(),
+        req_id=_REQ_ID,
+        project_id=_PROJECT,
+        tags=[_REQ_ID],
+        cur_state=ReqState.SPEC_LINT_RUNNING,
+        ctx={},
+        event=Event.SPEC_LINT_FAIL,
+        depth=0,
+    )
+    defaults.update(overrides)
+    return await step(**defaults)
+
+
+# ─── VLT-S1..S7: upstream *_FAIL → REVIEW_RUNNING + invoke_verifier_for_<stage>_fail ──
+
+
+_ENTRY_CASES = [
+    pytest.param(
+        "SPEC_LINT_RUNNING", "SPEC_LINT_FAIL",
+        "invoke_verifier_for_spec_lint_fail",
+        id="VLT-S1-spec_lint_fail",
+    ),
+    pytest.param(
+        "DEV_CROSS_CHECK_RUNNING", "DEV_CROSS_CHECK_FAIL",
+        "invoke_verifier_for_dev_cross_check_fail",
+        id="VLT-S2-dev_cross_check_fail",
+    ),
+    pytest.param(
+        "STAGING_TEST_RUNNING", "STAGING_TEST_FAIL",
+        "invoke_verifier_for_staging_test_fail",
+        id="VLT-S3-staging_test_fail",
+    ),
+    pytest.param(
+        "PR_CI_RUNNING", "PR_CI_FAIL",
+        "invoke_verifier_for_pr_ci_fail",
+        id="VLT-S4-pr_ci_fail",
+    ),
+    pytest.param(
+        "ACCEPT_TEARING_DOWN", "TEARDOWN_DONE_FAIL",
+        "invoke_verifier_for_accept_fail",
+        id="VLT-S5-accept_teardown_fail",
+    ),
+    pytest.param(
+        "ANALYZE_ARTIFACT_CHECKING", "ANALYZE_ARTIFACT_CHECK_FAIL",
+        "invoke_verifier_for_analyze_artifact_check_fail",
+        id="VLT-S6-analyze_artifact_check_fail",
+    ),
+    pytest.param(
+        "CHALLENGER_RUNNING", "CHALLENGER_FAIL",
+        "invoke_verifier_for_challenger_fail",
+        id="VLT-S7-challenger_fail",
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state_name,event_name,expected_action", _ENTRY_CASES)
+async def test_vlt_s1_to_s7_upstream_fail_enters_review_running(
+    monkeypatch, state_name, event_name, expected_action,
+) -> None:
+    """VLT-S1..S7: every upstream *_FAIL dispatches invoke_verifier_for_<stage>_fail
+    and CAS-advances to REVIEW_RUNNING."""
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    cas = _patch_io(monkeypatch)
+    calls: list[str] = []
+
+    async def _stub(**_kw):
+        calls.append(expected_action)
+        return {}
+
+    REGISTRY[expected_action] = _stub
+
+    cur = ReqState[state_name]
+    evt = Event[event_name]
+
+    result = await _step(cur_state=cur, event=evt, tags=[_REQ_ID])
+
+    assert result.get("action") == expected_action, (
+        f"{state_name}: action MUST be '{expected_action}'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.REVIEW_RUNNING.value, (
+        f"{state_name}: next_state MUST be 'review-running'; got {result!r}"
+    )
+    assert len(calls) == 1, (
+        f"{state_name}: stub MUST be awaited exactly once; called {len(calls)} time(s)"
+    )
+    # CAS must commit to REVIEW_RUNNING
+    assert cas.called, f"{state_name}: cas_transition MUST have been called"
+    cas_next = cas.call_args.args[3]
+    assert cas_next == ReqState.REVIEW_RUNNING, (
+        f"{state_name}: CAS MUST advance to REVIEW_RUNNING; got {cas_next!r}"
+    )
+
+
+# ─── VLT-S8: REVIEW_RUNNING + VERIFY_FIX_NEEDED → FIXER_RUNNING + stage_runs roll ──
+
+
+@pytest.mark.asyncio
+async def test_vlt_s8_verify_fix_needed_enters_fixer_running_with_stage_runs(
+    monkeypatch,
+) -> None:
+    """VLT-S8: (REVIEW_RUNNING, VERIFY_FIX_NEEDED) → FIXER_RUNNING via start_fixer.
+    Engine MUST close verifier stage_run (outcome=fix) and insert a fixer stage_run."""
+    from orchestrator import engine
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    cas = _patch_io(monkeypatch)
+    close_mock = engine.stage_runs.close_latest_stage_run
+    insert_mock = engine.stage_runs.insert_stage_run
+
+    calls: list[str] = []
+
+    async def _stub(**_kw):
+        calls.append("start_fixer")
+        return {}
+
+    REGISTRY["start_fixer"] = _stub
+
+    result = await _step(
+        cur_state=ReqState.REVIEW_RUNNING,
+        event=Event.VERIFY_FIX_NEEDED,
+        tags=["verifier", _REQ_ID, "verify:dev_cross_check"],
+        ctx={"verifier_stage": "dev_cross_check"},
+    )
+
+    assert result.get("action") == "start_fixer", (
+        f"VLT-S8: action MUST be 'start_fixer'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.FIXER_RUNNING.value, (
+        f"VLT-S8: next_state MUST be 'fixer-running'; got {result!r}"
+    )
+    assert len(calls) == 1, f"VLT-S8: start_fixer MUST be awaited exactly once"
+
+    cas_next = cas.call_args.args[3]
+    assert cas_next == ReqState.FIXER_RUNNING, (
+        f"VLT-S8: CAS MUST advance to FIXER_RUNNING; got {cas_next!r}"
+    )
+
+    close_calls = close_mock.call_args_list
+    insert_calls = insert_mock.call_args_list
+    assert len(close_calls) == 1, (
+        f"VLT-S8: exactly 1 stage_run close MUST be recorded; got {close_calls!r}"
+    )
+    assert len(insert_calls) == 1, (
+        f"VLT-S8: exactly 1 stage_run insert MUST be recorded; got {insert_calls!r}"
+    )
+    # signature: close_latest_stage_run(pool, req_id, stage, *, outcome=...)
+    close_call = close_calls[0]
+    assert close_call.args[2] == "verifier", (
+        f"VLT-S8: close MUST target stage='verifier'; got args={close_call.args!r}"
+    )
+    assert close_call.kwargs.get("outcome") == "fix", (
+        f"VLT-S8: close MUST record outcome='fix'; got kwargs={close_call.kwargs!r}"
+    )
+    # signature: insert_stage_run(pool, req_id, stage, ...)
+    insert_call = insert_calls[0]
+    assert insert_call.args[2] == "fixer", (
+        f"VLT-S8: insert MUST target stage='fixer'; got args={insert_call.args!r}"
+    )
+
+
+# ─── VLT-S9: REVIEW_RUNNING + VERIFY_ESCALATE → ESCALATED + cleanup_runner ──
+
+
+@pytest.mark.asyncio
+async def test_vlt_s9_verify_escalate_enters_escalated_and_triggers_cleanup(
+    monkeypatch,
+) -> None:
+    """VLT-S9: (REVIEW_RUNNING, VERIFY_ESCALATE) → ESCALATED via escalate.
+    Non-terminal → terminal: engine MUST fire-and-forget cleanup_runner(retain_pvc=True)."""
+    from orchestrator import engine
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    _patch_io(monkeypatch)
+
+    cleanup_calls: list[tuple] = []
+
+    class _FakeController:
+        async def cleanup_runner(self, req_id, *, retain_pvc=False):
+            cleanup_calls.append((req_id, retain_pvc))
+
+    monkeypatch.setattr(engine.k8s_runner, "get_controller", lambda: _FakeController())
+
+    calls: list[str] = []
+
+    async def _stub(**_kw):
+        calls.append("escalate")
+        return {}
+
+    REGISTRY["escalate"] = _stub
+
+    result = await _step(
+        cur_state=ReqState.REVIEW_RUNNING,
+        event=Event.VERIFY_ESCALATE,
+        tags=["verifier", _REQ_ID],
+        ctx={},
+    )
+    await asyncio.sleep(0)
+
+    assert result.get("action") == "escalate", (
+        f"VLT-S9: action MUST be 'escalate'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.ESCALATED.value, (
+        f"VLT-S9: next_state MUST be 'escalated'; got {result!r}"
+    )
+    assert len(calls) == 1, "VLT-S9: escalate MUST be awaited exactly once"
+    assert len(cleanup_calls) == 1, (
+        f"VLT-S9: cleanup_runner MUST be called exactly once; got {cleanup_calls!r}"
+    )
+    assert cleanup_calls[0] == (_REQ_ID, True), (
+        f"VLT-S9: cleanup_runner MUST be called with (req_id, retain_pvc=True); "
+        f"got {cleanup_calls[0]!r}"
+    )
+
+
+# ─── VLT-S10: FIXER_RUNNING + FIXER_DONE → REVIEW_RUNNING ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_vlt_s10_fixer_done_returns_to_review_running(monkeypatch) -> None:
+    """VLT-S10: (FIXER_RUNNING, FIXER_DONE) → REVIEW_RUNNING via invoke_verifier_after_fix.
+    Engine MUST close fixer stage_run (outcome=pass) and insert a verifier stage_run."""
+    from orchestrator import engine
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    cas = _patch_io(monkeypatch)
+    close_mock = engine.stage_runs.close_latest_stage_run
+    insert_mock = engine.stage_runs.insert_stage_run
+
+    calls: list[str] = []
+
+    async def _stub(**_kw):
+        calls.append("invoke_verifier_after_fix")
+        return {}
+
+    REGISTRY["invoke_verifier_after_fix"] = _stub
+
+    result = await _step(
+        cur_state=ReqState.FIXER_RUNNING,
+        event=Event.FIXER_DONE,
+        tags=["fixer", _REQ_ID, "parent-stage:dev_cross_check"],
+        ctx={"fixer_role": "dev"},
+    )
+
+    assert result.get("action") == "invoke_verifier_after_fix", (
+        f"VLT-S10: action MUST be 'invoke_verifier_after_fix'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.REVIEW_RUNNING.value, (
+        f"VLT-S10: next_state MUST be 'review-running'; got {result!r}"
+    )
+    assert len(calls) == 1, "VLT-S10: invoke_verifier_after_fix MUST be awaited exactly once"
+
+    cas_next = cas.call_args.args[3]
+    assert cas_next == ReqState.REVIEW_RUNNING, (
+        f"VLT-S10: CAS MUST advance to REVIEW_RUNNING; got {cas_next!r}"
+    )
+
+    close_calls = close_mock.call_args_list
+    insert_calls = insert_mock.call_args_list
+    assert len(close_calls) == 1, (
+        f"VLT-S10: exactly 1 close MUST be recorded; got {close_calls!r}"
+    )
+    assert len(insert_calls) == 1, (
+        f"VLT-S10: exactly 1 insert MUST be recorded; got {insert_calls!r}"
+    )
+    # signature: close_latest_stage_run(pool, req_id, stage, *, outcome=...)
+    close_call = close_calls[0]
+    assert close_call.args[2] == "fixer", (
+        f"VLT-S10: close MUST target stage='fixer'; got args={close_call.args!r}"
+    )
+    assert close_call.kwargs.get("outcome") == "pass", (
+        f"VLT-S10: close MUST record outcome='pass'; got kwargs={close_call.kwargs!r}"
+    )
+    # signature: insert_stage_run(pool, req_id, stage, ...)
+    insert_call = insert_calls[0]
+    assert insert_call.args[2] == "verifier", (
+        f"VLT-S10: insert MUST target stage='verifier'; got args={insert_call.args!r}"
+    )
+
+
+# ─── VLT-S11: FIXER_RUNNING + VERIFY_ESCALATE → ESCALATED (round-cap escape) ─
+
+
+@pytest.mark.asyncio
+async def test_vlt_s11_fixer_round_cap_escapes_to_escalated(monkeypatch) -> None:
+    """VLT-S11: (FIXER_RUNNING, VERIFY_ESCALATE) → ESCALATED via escalate.
+    Round-cap escape path: start_fixer itself emits VERIFY_ESCALATE when cap hit."""
+    from orchestrator import engine
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    _patch_io(monkeypatch)
+
+    cleanup_calls: list[tuple] = []
+
+    class _FakeController:
+        async def cleanup_runner(self, req_id, *, retain_pvc=False):
+            cleanup_calls.append((req_id, retain_pvc))
+
+    monkeypatch.setattr(engine.k8s_runner, "get_controller", lambda: _FakeController())
+
+    calls: list[str] = []
+
+    async def _stub(**_kw):
+        calls.append("escalate")
+        return {}
+
+    REGISTRY["escalate"] = _stub
+
+    result = await _step(
+        cur_state=ReqState.FIXER_RUNNING,
+        event=Event.VERIFY_ESCALATE,
+        tags=["fixer", _REQ_ID],
+        ctx={"fixer_round": 5},
+    )
+    await asyncio.sleep(0)
+
+    assert result.get("action") == "escalate", (
+        f"VLT-S11: action MUST be 'escalate'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.ESCALATED.value, (
+        f"VLT-S11: next_state MUST be 'escalated'; got {result!r}"
+    )
+    assert len(calls) == 1, "VLT-S11: escalate MUST be awaited exactly once"
+    assert len(cleanup_calls) == 1, (
+        f"VLT-S11: cleanup_runner MUST fire-and-forget once; got {cleanup_calls!r}"
+    )
+
+
+# ─── VLT-S12: ESCALATED + VERIFY_PASS → self-loop, apply_verify_pass ─────────
+
+
+@pytest.mark.asyncio
+async def test_vlt_s12_escalated_verify_pass_dispatches_apply_verify_pass(
+    monkeypatch,
+) -> None:
+    """VLT-S12: (ESCALATED, VERIFY_PASS) → ESCALATED self-loop + apply_verify_pass.
+    cur_state is terminal → engine MUST NOT trigger cleanup_runner."""
+    from orchestrator import engine
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    cas = _patch_io(monkeypatch)
+
+    cleanup_calls: list[tuple] = []
+
+    class _FakeController:
+        async def cleanup_runner(self, req_id, *, retain_pvc=False):
+            cleanup_calls.append((req_id, retain_pvc))
+
+    monkeypatch.setattr(engine.k8s_runner, "get_controller", lambda: _FakeController())
+
+    calls: list[str] = []
+
+    async def _stub(**_kw):
+        calls.append("apply_verify_pass")
+        return {}
+
+    REGISTRY["apply_verify_pass"] = _stub
+
+    result = await _step(
+        cur_state=ReqState.ESCALATED,
+        event=Event.VERIFY_PASS,
+        tags=["verifier", _REQ_ID, "verify:pr_ci"],
+        ctx={"verifier_stage": "pr_ci"},
+    )
+    await asyncio.sleep(0)
+
+    assert result.get("action") == "apply_verify_pass", (
+        f"VLT-S12: action MUST be 'apply_verify_pass'; got {result!r}"
+    )
+    # self-loop: CAS next_state == ESCALATED
+    cas_next = cas.call_args.args[3]
+    assert cas_next == ReqState.ESCALATED, (
+        f"VLT-S12: CAS MUST be self-loop to ESCALATED; got {cas_next!r}"
+    )
+    assert len(calls) == 1, "VLT-S12: apply_verify_pass MUST be awaited exactly once"
+    assert cleanup_calls == [], (
+        f"VLT-S12: cleanup_runner MUST NOT be triggered (cur is terminal); "
+        f"got {cleanup_calls!r}"
+    )
+
+
+# ─── VLT-S13: ESCALATED + VERIFY_FIX_NEEDED → FIXER_RUNNING ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_vlt_s13_escalated_verify_fix_needed_enters_fixer_running(
+    monkeypatch,
+) -> None:
+    """VLT-S13: (ESCALATED, VERIFY_FIX_NEEDED) → FIXER_RUNNING via start_fixer.
+    Human-resume path: user re-opens verifier from ESCALATED and decides fix."""
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    cas = _patch_io(monkeypatch)
+    calls: list[str] = []
+
+    async def _stub(**_kw):
+        calls.append("start_fixer")
+        return {}
+
+    REGISTRY["start_fixer"] = _stub
+
+    result = await _step(
+        cur_state=ReqState.ESCALATED,
+        event=Event.VERIFY_FIX_NEEDED,
+        tags=["verifier", _REQ_ID, "verify:staging_test"],
+        ctx={"verifier_stage": "staging_test", "verifier_fixer": "dev"},
+    )
+
+    assert result.get("action") == "start_fixer", (
+        f"VLT-S13: action MUST be 'start_fixer'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.FIXER_RUNNING.value, (
+        f"VLT-S13: next_state MUST be 'fixer-running'; got {result!r}"
+    )
+    assert len(calls) == 1, "VLT-S13: start_fixer MUST be awaited exactly once"
+
+    cas_next = cas.call_args.args[3]
+    assert cas_next == ReqState.FIXER_RUNNING, (
+        f"VLT-S13: CAS MUST advance to FIXER_RUNNING; got {cas_next!r}"
+    )
+
+
+# ─── VLT-S14: ESCALATED + VERIFY_ESCALATE → no-op self-loop, no cleanup ─────
+
+
+@pytest.mark.asyncio
+async def test_vlt_s14_escalated_verify_escalate_is_no_op_no_cleanup(monkeypatch) -> None:
+    """VLT-S14: (ESCALATED, VERIFY_ESCALATE) → ESCALATED self-loop, action=no-op.
+    Terminal self-loop: cleanup_runner MUST NOT be triggered (already cleaned up)."""
+    from orchestrator import engine
+    from orchestrator.state import Event, ReqState
+
+    _patch_io(monkeypatch)
+
+    cleanup_calls: list[tuple] = []
+
+    class _FakeController:
+        async def cleanup_runner(self, req_id, *, retain_pvc=False):
+            cleanup_calls.append((req_id, retain_pvc))
+
+    monkeypatch.setattr(engine.k8s_runner, "get_controller", lambda: _FakeController())
+
+    result = await _step(
+        cur_state=ReqState.ESCALATED,
+        event=Event.VERIFY_ESCALATE,
+        tags=["verifier", _REQ_ID],
+        ctx={},
+    )
+    await asyncio.sleep(0)
+
+    assert result.get("action") == "no-op", (
+        f"VLT-S14: action MUST be 'no-op'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.ESCALATED.value, (
+        f"VLT-S14: next_state MUST remain 'escalated'; got {result!r}"
+    )
+    assert cleanup_calls == [], (
+        f"VLT-S14: cleanup_runner MUST NOT be called on terminal self-loop; "
+        f"got {cleanup_calls!r}"
+    )
+
+
+# ─── VLT-S15: SESSION_FAILED self-loops on every *_RUNNING state ─────────────
+
+
+_SESSION_FAILED_STATE_NAMES = [
+    "INTAKING",
+    "ANALYZING",
+    "ANALYZE_ARTIFACT_CHECKING",
+    "SPEC_LINT_RUNNING",
+    "CHALLENGER_RUNNING",
+    "DEV_CROSS_CHECK_RUNNING",
+    "STAGING_TEST_RUNNING",
+    "PR_CI_RUNNING",
+    "ACCEPT_RUNNING",
+    "ACCEPT_TEARING_DOWN",
+    "REVIEW_RUNNING",
+    "FIXER_RUNNING",
+    "ARCHIVING",
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state_name",
+    [pytest.param(s, id=f"VLT-S15-{s}") for s in _SESSION_FAILED_STATE_NAMES],
+)
+async def test_vlt_s15_session_failed_self_loops_to_escalate(
+    monkeypatch, state_name,
+) -> None:
+    """VLT-S15: (state, SESSION_FAILED) MUST dispatch escalate and remain in same state.
+    Parametrized across all 13 in-flight states. Self-loop: no cleanup_runner."""
+    from orchestrator import engine
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    cas = _patch_io(monkeypatch)
+
+    cleanup_calls: list[tuple] = []
+
+    class _FakeController:
+        async def cleanup_runner(self, req_id, *, retain_pvc=False):
+            cleanup_calls.append((req_id, retain_pvc))
+
+    monkeypatch.setattr(engine.k8s_runner, "get_controller", lambda: _FakeController())
+
+    calls: list[str] = []
+
+    async def _stub(**_kw):
+        calls.append("escalate")
+        return {}
+
+    REGISTRY["escalate"] = _stub
+
+    cur = ReqState[state_name]
+
+    result = await _step(
+        cur_state=cur,
+        event=Event.SESSION_FAILED,
+        tags=[_REQ_ID],
+        ctx={},
+    )
+    await asyncio.sleep(0)
+
+    assert result.get("action") == "escalate", (
+        f"VLT-S15 [{state_name}]: action MUST be 'escalate'; got {result!r}"
+    )
+    assert result.get("next_state") == cur.value, (
+        f"VLT-S15 [{state_name}]: SESSION_FAILED MUST be a self-loop (next_state == cur); "
+        f"got next_state={result.get('next_state')!r}"
+    )
+    assert len(calls) == 1, (
+        f"VLT-S15 [{state_name}]: escalate MUST be awaited exactly once; "
+        f"called {len(calls)} time(s)"
+    )
+    cas_next = cas.call_args.args[3]
+    assert cas_next == cur, (
+        f"VLT-S15 [{state_name}]: CAS MUST commit self-loop (next_state == cur); "
+        f"got {cas_next!r}"
+    )
+    assert cleanup_calls == [], (
+        f"VLT-S15 [{state_name}]: SESSION_FAILED self-loop MUST NOT trigger cleanup; "
+        f"got {cleanup_calls!r}"
+    )
+
+
+# ─── VLT-S16: INIT + SESSION_FAILED → skip, no escalate ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_vlt_s16_session_failed_on_init_is_dropped(monkeypatch) -> None:
+    """VLT-S16: (INIT, SESSION_FAILED) → action='skip', no transition.
+    INIT is not in the SESSION_FAILED transition set: escalate MUST NOT be dispatched."""
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    _patch_io(monkeypatch)
+
+    escalate_calls: list[int] = []
+
+    async def _fake_escalate(**_kw):
+        escalate_calls.append(1)
+        return {}
+
+    REGISTRY["escalate"] = _fake_escalate
+
+    result = await _step(
+        cur_state=ReqState.INIT,
+        event=Event.SESSION_FAILED,
+        tags=[_REQ_ID],
+        ctx={},
+    )
+
+    assert result.get("action") == "skip", (
+        f"VLT-S16: action MUST be 'skip'; got {result!r}"
+    )
+    reason = result.get("reason") or ""
+    assert "no transition init+session.failed" in reason, (
+        f"VLT-S16: reason MUST contain 'no transition init+session.failed'; got {reason!r}"
+    )
+    assert escalate_calls == [], (
+        f"VLT-S16: escalate MUST NOT be dispatched on INIT + SESSION_FAILED; "
+        f"got {len(escalate_calls)} call(s)"
+    )

--- a/orchestrator/tests/test_contract_engine_verifier_loop_challenger.py
+++ b/orchestrator/tests/test_contract_engine_verifier_loop_challenger.py
@@ -29,7 +29,7 @@ Module contract under test: orchestrator.engine.step
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -227,7 +227,7 @@ async def test_vlt_s8_verify_fix_needed_enters_fixer_running_with_stage_runs(
     assert result.get("next_state") == ReqState.FIXER_RUNNING.value, (
         f"VLT-S8: next_state MUST be 'fixer-running'; got {result!r}"
     )
-    assert len(calls) == 1, f"VLT-S8: start_fixer MUST be awaited exactly once"
+    assert len(calls) == 1, "VLT-S8: start_fixer MUST be awaited exactly once"
 
     cas_next = cas.call_args.args[3]
     assert cas_next == ReqState.FIXER_RUNNING, (

--- a/orchestrator/tests/test_engine_verifier_loop.py
+++ b/orchestrator/tests/test_engine_verifier_loop.py
@@ -1,0 +1,449 @@
+"""Mock tests for engine.step on verifier sub-chain + SESSION_FAILED fallback
+(REQ-test-verifier-loop-1777267725).
+
+Goal: pin down the routing decisions in `state.TRANSITIONS` for the two
+"事故响应路径" — verifier loop (entry / decision out / fixer back-edge /
+ESCALATED resume) and SESSION_FAILED self-loop on every in-flight state —
+so that a regression in the transition table is caught by mock tests
+**without** booting BKD / Postgres / K8s.
+
+Stubs replace every action with a recorder; the engine's own
+`_record_stage_transitions` and terminal-cleanup branches still run because
+they only depend on FakePool / k8s_runner.set_controller.
+
+VLT-S1..S16 一一对应 spec scenario, see
+`openspec/changes/REQ-test-verifier-loop-1777267725/specs/engine-verifier-loop-tests/spec.md`.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# 复用 test_engine.py 的 FakePool / FakeReq / _drain_tasks，
+# 跟 test_engine_adversarial.py 同套路（pytest rootdir 把 tests/ 拍平到 sys.path）。
+from test_engine import FakePool, FakeReq, _drain_tasks  # type: ignore[import-not-found]
+
+from orchestrator import engine, k8s_runner
+from orchestrator.actions import ACTION_META, REGISTRY
+from orchestrator.state import Event, ReqState
+
+# ─── 共享 fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def stub_actions():
+    """Save+clear REGISTRY / ACTION_META; restore on teardown."""
+    saved_reg = dict(REGISTRY)
+    saved_meta = dict(ACTION_META)
+    REGISTRY.clear()
+    ACTION_META.clear()
+    yield REGISTRY
+    REGISTRY.clear()
+    ACTION_META.clear()
+    REGISTRY.update(saved_reg)
+    ACTION_META.update(saved_meta)
+
+
+@pytest.fixture
+def mock_runner_controller():
+    """Inject a fake k8s controller; assert cleanup_runner calls."""
+    fake = MagicMock()
+    fake.cleanup_runner = AsyncMock(return_value=None)
+    k8s_runner.set_controller(fake)
+    yield fake
+    k8s_runner.set_controller(None)
+
+
+def _body(**attrs):
+    return type("B", (), attrs)()
+
+
+def _make_recorder(name: str, calls: list):
+    async def _rec(*, body, req_id, tags, ctx):
+        calls.append({"action": name, "req_id": req_id, "tags": list(tags or [])})
+        return {"ok": True}
+    return _rec
+
+
+# ───────────────────────────────────────────────────────────────────────
+# VLT-S1..S7: 上游 *_FAIL → REVIEW_RUNNING + invoke_verifier_for_<stage>_fail
+# ───────────────────────────────────────────────────────────────────────
+
+
+_ENTRY_CASES = [
+    pytest.param(
+        ReqState.SPEC_LINT_RUNNING, Event.SPEC_LINT_FAIL,
+        "invoke_verifier_for_spec_lint_fail",
+        id="VLT-S1-spec_lint_fail",
+    ),
+    pytest.param(
+        ReqState.DEV_CROSS_CHECK_RUNNING, Event.DEV_CROSS_CHECK_FAIL,
+        "invoke_verifier_for_dev_cross_check_fail",
+        id="VLT-S2-dev_cross_check_fail",
+    ),
+    pytest.param(
+        ReqState.STAGING_TEST_RUNNING, Event.STAGING_TEST_FAIL,
+        "invoke_verifier_for_staging_test_fail",
+        id="VLT-S3-staging_test_fail",
+    ),
+    pytest.param(
+        ReqState.PR_CI_RUNNING, Event.PR_CI_FAIL,
+        "invoke_verifier_for_pr_ci_fail",
+        id="VLT-S4-pr_ci_fail",
+    ),
+    pytest.param(
+        ReqState.ACCEPT_TEARING_DOWN, Event.TEARDOWN_DONE_FAIL,
+        "invoke_verifier_for_accept_fail",
+        id="VLT-S5-accept_teardown_fail",
+    ),
+    pytest.param(
+        ReqState.ANALYZE_ARTIFACT_CHECKING, Event.ANALYZE_ARTIFACT_CHECK_FAIL,
+        "invoke_verifier_for_analyze_artifact_check_fail",
+        id="VLT-S6-analyze_artifact_check_fail",
+    ),
+    pytest.param(
+        ReqState.CHALLENGER_RUNNING, Event.CHALLENGER_FAIL,
+        "invoke_verifier_for_challenger_fail",
+        id="VLT-S7-challenger_fail",
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cur_state,event,expected_action", _ENTRY_CASES)
+async def test_vlt_s1_to_s7_upstream_fail_enters_review_running(
+    stub_actions, cur_state, event, expected_action,
+):
+    """Spec VLT-S1..S7: 每个上游 *_FAIL 都从对应 *_RUNNING 路由到 REVIEW_RUNNING +
+    dispatch 该 stage 专用 invoke_verifier_for_<stage>_fail action。"""
+    calls: list = []
+    stub_actions[expected_action] = _make_recorder(expected_action, calls)
+
+    pool = FakePool({"REQ-1": FakeReq(state=cur_state.value)})
+    body = _body(issueId="src-1", projectId="p", event="check.failed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=cur_state, ctx={}, event=event,
+    )
+
+    assert result["action"] == expected_action
+    assert result["next_state"] == ReqState.REVIEW_RUNNING.value
+    assert pool.rows["REQ-1"].state == ReqState.REVIEW_RUNNING.value
+    assert len(calls) == 1, f"{expected_action} should be awaited exactly once"
+    assert calls[0]["action"] == expected_action
+
+
+# ───────────────────────────────────────────────────────────────────────
+# VLT-S8: REVIEW_RUNNING + VERIFY_FIX_NEEDED → FIXER_RUNNING + stage_runs roll
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_vlt_s8_verify_fix_needed_enters_fixer_running(stub_actions):
+    """Spec VLT-S8: REVIEW_RUNNING + VERIFY_FIX_NEEDED → FIXER_RUNNING via start_fixer。
+    跨 *_RUNNING state → engine 必须 close verifier(outcome=fix) + open fixer。"""
+    calls: list = []
+    stub_actions["start_fixer"] = _make_recorder("start_fixer", calls)
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.REVIEW_RUNNING.value)})
+    body = _body(issueId="vfy-1", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["verifier", "REQ-1", "verify:dev_cross_check"],
+        cur_state=ReqState.REVIEW_RUNNING,
+        ctx={"verifier_stage": "dev_cross_check"},
+        event=Event.VERIFY_FIX_NEEDED,
+    )
+
+    assert result["action"] == "start_fixer"
+    assert result["next_state"] == ReqState.FIXER_RUNNING.value
+    assert pool.rows["REQ-1"].state == ReqState.FIXER_RUNNING.value
+
+    closes = [c for c in pool.stage_runs_calls if c[0] == "close"]
+    inserts = [c for c in pool.stage_runs_calls if c[0] == "insert"]
+    assert len(closes) == 1, f"expected exactly 1 close, got {pool.stage_runs_calls!r}"
+    close_args = closes[0][2]
+    # close_latest_stage_run signature: (req_id, stage, outcome, fail_reason)
+    assert close_args[1] == "verifier"
+    assert close_args[2] == "fix"
+    assert len(inserts) == 1, f"expected exactly 1 insert, got {pool.stage_runs_calls!r}"
+    insert_args = inserts[0][2]
+    # insert_stage_run signature: (req_id, stage, agent_type, ...)
+    assert insert_args[1] == "fixer"
+
+
+# ───────────────────────────────────────────────────────────────────────
+# VLT-S9: REVIEW_RUNNING + VERIFY_ESCALATE → ESCALATED + cleanup
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_vlt_s9_verify_escalate_enters_escalated_with_cleanup(
+    stub_actions, mock_runner_controller,
+):
+    """Spec VLT-S9: REVIEW_RUNNING + VERIFY_ESCALATE → ESCALATED via escalate；
+    进 terminal state（cur 非 terminal）→ engine 触发 fire-and-forget cleanup_runner。"""
+    calls: list = []
+    stub_actions["escalate"] = _make_recorder("escalate", calls)
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.REVIEW_RUNNING.value)})
+    body = _body(issueId="vfy-1", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["verifier", "REQ-1"],
+        cur_state=ReqState.REVIEW_RUNNING, ctx={},
+        event=Event.VERIFY_ESCALATE,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "escalate"
+    assert result["next_state"] == ReqState.ESCALATED.value
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+    assert len(calls) == 1
+    mock_runner_controller.cleanup_runner.assert_awaited_once_with(
+        "REQ-1", retain_pvc=True,
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# VLT-S10: FIXER_RUNNING + FIXER_DONE → REVIEW_RUNNING (re-verify back-edge)
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_vlt_s10_fixer_done_returns_to_review_running(stub_actions):
+    """Spec VLT-S10: FIXER_RUNNING + FIXER_DONE → REVIEW_RUNNING via
+    invoke_verifier_after_fix。stage_runs：fixer close outcome=pass + verifier insert。"""
+    calls: list = []
+    stub_actions["invoke_verifier_after_fix"] = _make_recorder(
+        "invoke_verifier_after_fix", calls,
+    )
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.FIXER_RUNNING.value)})
+    body = _body(issueId="fix-1", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["fixer", "REQ-1", "parent-stage:dev_cross_check"],
+        cur_state=ReqState.FIXER_RUNNING,
+        ctx={"fixer_role": "dev"},
+        event=Event.FIXER_DONE,
+    )
+
+    assert result["action"] == "invoke_verifier_after_fix"
+    assert result["next_state"] == ReqState.REVIEW_RUNNING.value
+    assert pool.rows["REQ-1"].state == ReqState.REVIEW_RUNNING.value
+    assert len(calls) == 1
+
+    closes = [c for c in pool.stage_runs_calls if c[0] == "close"]
+    inserts = [c for c in pool.stage_runs_calls if c[0] == "insert"]
+    assert len(closes) == 1, pool.stage_runs_calls
+    close_args = closes[0][2]
+    assert close_args[1] == "fixer"
+    assert close_args[2] == "pass"
+    assert len(inserts) == 1
+    assert inserts[0][2][1] == "verifier"
+
+
+# ───────────────────────────────────────────────────────────────────────
+# VLT-S11: FIXER_RUNNING + VERIFY_ESCALATE → ESCALATED (round cap escape)
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_vlt_s11_fixer_round_cap_escapes_to_escalated(
+    stub_actions, mock_runner_controller,
+):
+    """Spec VLT-S11: FIXER_RUNNING + VERIFY_ESCALATE → ESCALATED via escalate。
+    用于 start_fixer 自检 round cap 击顶时 emit VERIFY_ESCALATE 的兜底 transition。"""
+    calls: list = []
+    stub_actions["escalate"] = _make_recorder("escalate", calls)
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.FIXER_RUNNING.value)})
+    body = _body(issueId="fix-1", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["fixer", "REQ-1"],
+        cur_state=ReqState.FIXER_RUNNING, ctx={"fixer_round": 5},
+        event=Event.VERIFY_ESCALATE,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "escalate"
+    assert result["next_state"] == ReqState.ESCALATED.value
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+    assert len(calls) == 1
+    mock_runner_controller.cleanup_runner.assert_awaited_once_with(
+        "REQ-1", retain_pvc=True,
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# VLT-S12: ESCALATED + VERIFY_PASS resume (apply_verify_pass self-loop)
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_vlt_s12_escalated_verify_pass_dispatches_apply(
+    stub_actions, mock_runner_controller,
+):
+    """Spec VLT-S12: ESCALATED + VERIFY_PASS → ESCALATED self-loop, action=apply_verify_pass。
+    用户在 BKD UI follow-up escalate 的 verifier issue 写新 decision=pass 触发；
+    engine 仅 dispatch action（实际 CAS 推下游 state 是 action 内部职责）。
+    自循环且 cur 已 terminal → engine 不应再触发 cleanup。"""
+    calls: list = []
+    stub_actions["apply_verify_pass"] = _make_recorder("apply_verify_pass", calls)
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ESCALATED.value)})
+    body = _body(issueId="vfy-resume", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["verifier", "REQ-1", "verify:pr_ci"],
+        cur_state=ReqState.ESCALATED, ctx={"verifier_stage": "pr_ci"},
+        event=Event.VERIFY_PASS,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "apply_verify_pass"
+    # transition 表声明的 self-loop：state 不动（stub 不内部 CAS）
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+    assert len(calls) == 1
+    # cur 已 terminal → engine 跳过 cleanup
+    mock_runner_controller.cleanup_runner.assert_not_awaited()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# VLT-S13: ESCALATED + VERIFY_FIX_NEEDED resume
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_vlt_s13_escalated_verify_fix_needed_enters_fixer_running(stub_actions):
+    """Spec VLT-S13: ESCALATED + VERIFY_FIX_NEEDED → FIXER_RUNNING via start_fixer。
+    人工 resume 路径：从 ESCALATED 起 fixer，复用主链 start_fixer。"""
+    calls: list = []
+    stub_actions["start_fixer"] = _make_recorder("start_fixer", calls)
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ESCALATED.value)})
+    body = _body(issueId="vfy-resume", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["verifier", "REQ-1", "verify:staging_test"],
+        cur_state=ReqState.ESCALATED,
+        ctx={"verifier_stage": "staging_test", "verifier_fixer": "dev"},
+        event=Event.VERIFY_FIX_NEEDED,
+    )
+
+    assert result["action"] == "start_fixer"
+    assert result["next_state"] == ReqState.FIXER_RUNNING.value
+    assert pool.rows["REQ-1"].state == ReqState.FIXER_RUNNING.value
+    assert len(calls) == 1
+
+
+# ───────────────────────────────────────────────────────────────────────
+# VLT-S14: ESCALATED + VERIFY_ESCALATE no-op self-loop
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_vlt_s14_escalated_verify_escalate_is_no_op(
+    stub_actions, mock_runner_controller,
+):
+    """Spec VLT-S14: ESCALATED + VERIFY_ESCALATE → ESCALATED self-loop, action=None。
+    用户续了 verifier 但仍判 escalate → 留原地。terminal self-loop **不**重复 cleanup。"""
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ESCALATED.value)})
+    body = _body(issueId="vfy-resume", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["verifier", "REQ-1"],
+        cur_state=ReqState.ESCALATED, ctx={},
+        event=Event.VERIFY_ESCALATE,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "no-op"
+    assert result["next_state"] == ReqState.ESCALATED.value
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+    mock_runner_controller.cleanup_runner.assert_not_awaited()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# VLT-S15: SESSION_FAILED self-loop on every *_RUNNING state
+# ───────────────────────────────────────────────────────────────────────
+
+
+_SESSION_FAILED_STATES = [
+    pytest.param(s, id=f"VLT-S15-{s.value}")
+    for s in [
+        ReqState.INTAKING, ReqState.ANALYZING,
+        ReqState.ANALYZE_ARTIFACT_CHECKING,
+        ReqState.SPEC_LINT_RUNNING, ReqState.CHALLENGER_RUNNING,
+        ReqState.DEV_CROSS_CHECK_RUNNING,
+        ReqState.STAGING_TEST_RUNNING, ReqState.PR_CI_RUNNING,
+        ReqState.ACCEPT_RUNNING, ReqState.ACCEPT_TEARING_DOWN,
+        ReqState.REVIEW_RUNNING, ReqState.FIXER_RUNNING,
+        ReqState.ARCHIVING,
+    ]
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", _SESSION_FAILED_STATES)
+async def test_vlt_s15_session_failed_self_loops_to_escalate(
+    stub_actions, mock_runner_controller, state,
+):
+    """Spec VLT-S15: 13 个 *_RUNNING state 每个 + SESSION_FAILED → 自循环 + dispatch
+    escalate action。state 不动（self-loop；stub 不 CAS），escalate 内部决定真 ESCALATE。
+    自循环 cur=next 都非 terminal → engine 也不触发 cleanup。"""
+    calls: list = []
+    stub_actions["escalate"] = _make_recorder("escalate", calls)
+
+    pool = FakePool({"REQ-1": FakeReq(state=state.value)})
+    body = _body(issueId="x", projectId="p", event="session.failed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=state, ctx={}, event=Event.SESSION_FAILED,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "escalate", f"{state.value} should dispatch escalate"
+    assert result["next_state"] == state.value, "SESSION_FAILED is a self-loop"
+    assert pool.rows["REQ-1"].state == state.value
+    assert len(calls) == 1
+    # cur=next 非 terminal → 不 cleanup
+    mock_runner_controller.cleanup_runner.assert_not_awaited()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# VLT-S16: INIT + SESSION_FAILED → skip (INIT not in SESSION_FAILED set)
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_vlt_s16_session_failed_on_init_is_dropped(stub_actions):
+    """Spec VLT-S16: INIT 不在 SESSION_FAILED transition 集合（只有 *_RUNNING + INTAKING
+    + ARCHIVING 在）→ engine 应返 skip 而不是误进 escalate。"""
+    calls: list = []
+    stub_actions["escalate"] = _make_recorder("escalate", calls)
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.INIT.value)})
+    body = _body(issueId="x", projectId="p", event="session.failed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=ReqState.INIT, ctx={}, event=Event.SESSION_FAILED,
+    )
+
+    assert result["action"] == "skip"
+    assert "no transition init+session.failed" in result["reason"]
+    assert pool.rows["REQ-1"].state == ReqState.INIT.value
+    assert calls == [], "escalate must NOT be dispatched on INIT + SESSION_FAILED"


### PR DESCRIPTION
## Motivation

`state.TRANSITIONS` 表里有两块"事故响应路径"过去靠人肉读 transition 表保证正确：

1. **verifier 子链**（M14b/c）—— 7 个上游 stage 的 `*_FAIL` 进 `REVIEW_RUNNING`、3 路决策
   出口（pass / fix / escalate）、`FIXER_RUNNING` back-edge + round-cap 逃生、3 条
   ESCALATED → resume transition。
2. **SESSION_FAILED 兜底** —— 13 个 in-flight state 的 self-loop 给 `escalate` action 自决
   auto-resume / 真 ESCALATE；`INIT` / `DONE` / `ESCALATED` / `GH_INCIDENT_OPEN` 必须 skip。

现有 `test_engine.py` + `test_engine_adversarial.py` 只散落覆盖了几条主链 + 一两条 fail
路径。漏挂某条 `*_FAIL → verifier` 或漏挂某 running state 的 SESSION_FAILED self-loop，
单测仍绿，实测会卡死 / 误路（事故复盘多次踩过类似坑）。

## 改了什么

新增 `orchestrator/tests/test_engine_verifier_loop.py`：

- 16 条 scenario（VLT-S1..VLT-S16），全部 pure mock，复用 `test_engine.py` 的 `FakePool`
  + `_drain_tasks` —— 跟 `test_engine_adversarial.py` 同套路
- VLT-S15（SESSION_FAILED 自循环）`pytest.parametrize` 跑全 13 个 in-flight state，
  共 28 条独立 test case
- VLT-S1..S7：每个上游 `*_FAIL` 都路由到 `REVIEW_RUNNING` + 该 stage 专用
  `invoke_verifier_for_<stage>_fail` action
- VLT-S8/S9：`REVIEW_RUNNING` 出口的 fix / escalate 路径，附 stage_runs roll +
  cleanup_runner 验证
- VLT-S10/S11：`FIXER_RUNNING` back-edge + round-cap escape
- VLT-S12/S13/S14：`ESCALATED` resume 三路（apply_verify_pass / start_fixer / no-op）
- VLT-S15：13 个 in-flight state 的 SESSION_FAILED self-loop
- VLT-S16：`INIT` 不在 SESSION_FAILED 集合 → skip（捍卫 transition table 边界）

附 openspec change folder（proposal / tasks / spec ADDED delta）。

## 不改产线

纯加测，不动 `state.py` / `engine.py` / `_verifier.py`。

## Test plan

- [x] `cd orchestrator && uv run pytest tests/test_engine_verifier_loop.py -v` —— 28 passed
- [x] `cd orchestrator && uv run pytest -m "not integration"` —— 1389 passed, 2 deselected
- [x] `cd orchestrator && uv run ruff check src/ tests/test_engine_verifier_loop.py` —— clean
- [x] `openspec change validate REQ-test-verifier-loop-1777267725` —— valid
- [x] `bash scripts/check-scenario-refs.sh` —— 446 scenario 引用全 OK

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-test-verifier-loop-1777267725\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/f45lr90m)