### PR TITLE
feat(watchdog): per-stage typed policy table (REQ-stage-watchdog-policy-full-1777280786)

### DIFF
--- a/openspec/changes/REQ-stage-watchdog-policy-full-1777280786/proposal.md
+++ b/openspec/changes/REQ-stage-watchdog-policy-full-1777280786/proposal.md
@@ -1,0 +1,98 @@
+# REQ-stage-watchdog-policy-full-1777280786: feat(watchdog): per-stage typed policy table — extend exemption/timeout to all states
+
+## 问题
+
+REQ-watchdog-stage-policy-1777269909（PR #161）只完成了 [docs/user-feedback-loop.md §1](../../../docs/user-feedback-loop.md) "Stage type taxonomy" 的最小 slice：把
+`INTAKING` 拉进 `_NO_WATCHDOG_STATES` set 拍平豁免。但设计文档列的"按 stage type
+分档"路线图——`STAGE_WATCHDOG_POLICY: dict[ReqState, dict | None]`——还没做：
+
+- 当前所有非 INTAKING 的 in-flight state 全部走同一个全局 `min(watchdog_session_ended_threshold_sec=300, watchdog_stuck_threshold_sec=3600)`
+  阈值。无法区分 deterministic-checker（应在秒-分级完）/ autonomous-bounded
+  （agent 跑 30min 内出结果）/ external-poll（PR CI 可能 4h+）的差异化容忍度。
+- 后续 `PENDING_USER_PR_REVIEW`（M0 §2）落地时还需要再加一个 human-in-loop state，
+  现在的 set 只能拍平豁免，不能在 set 之上分别约束 timeout——下次扩展又要改 watchdog 内部。
+- 现在 `_NO_WATCHDOG_STATES` 仅是 hint，没绑实际 timeout 语义：未来想把 PR_CI_RUNNING
+  的 ended-session escalate 拉到 4h（CI 真的可能跑 1h+），全局阈值改不了——会回归
+  其他 stage 5min 的 fast-lane 检测。
+
+## 方案
+
+把"是否豁免"和"什么阈值"统一成 stage-typed policy 表，policy 用 dataclass 表达
+两个轴：
+
+- `ended_sec: int` —— BKD session 进入非 running 状态（completed/failed/cancelled）后，
+  机械层等多久 escalate。这条线对所有非豁免 stage 必须存在（替代当前全局 fast lane）。
+- `stuck_sec: int | None` —— 不论 session 状态，stuck 超过此时长一律 escalate
+  （慢车道，杀真死的长尾）。`None` = 不开启 slow lane（保留"不杀 running"语义）。
+
+四类 stage 默认值（per docs/user-feedback-loop.md §1）：
+
+| stage type | 默认 policy | 例 state |
+|---|---|---|
+| `human-loop-conversation` | `None`（SQL 预过滤） | `INTAKING` |
+| `deterministic-checker` | `ended=300, stuck=300` | `SPEC_LINT_RUNNING` / `DEV_CROSS_CHECK_RUNNING` / `ANALYZE_ARTIFACT_CHECKING` |
+| `autonomous-bounded` | `ended=300, stuck=None` | `ANALYZING` / `CHALLENGER_RUNNING` / `ACCEPT_RUNNING` / `ACCEPT_TEARING_DOWN` / `ARCHIVING` / `FIXER_RUNNING` / `REVIEW_RUNNING` |
+| `external-poll` | `ended=300, stuck=14400` | `PR_CI_RUNNING` |
+
+`STAGING_TEST_RUNNING` 名义上是 deterministic-checker（kubectl exec），但单/集成
+测试常跑分钟级，把它单独归"宽松 deterministic"档：`ended=300, stuck=None`，避免
+误杀长跑测试套件。
+
+### 实现
+
+`orchestrator/src/orchestrator/watchdog.py`：
+
+1. 引入 `_StagePolicy` frozen dataclass + `_STAGE_POLICY: dict[ReqState, _StagePolicy | None]`
+   表，覆盖目前所有非终态 in-flight state（13 条）。
+2. `_NO_WATCHDOG_STATES` 退化为派生：`{state for state, policy in _STAGE_POLICY.items() if policy is None}`，
+   不再硬编码。其他模块 / 测试 import 这个 frozenset 仍可用（语义不变）。
+3. `_tick()` SQL 预过滤照旧把 `_SKIP_STATES ∪ _NO_WATCHDOG_STATES` 喂给 `state <> ALL($1)`。
+   threshold 取 `min(所有非 None policy 的 ended_sec) ∪ min(所有非 None policy 的 stuck_sec) ∪ 全局 ended/stuck`，
+   保证任一 stage 满足 escalate 条件的行都能被 SQL 返回（不会被 SQL 提前过滤掉）。
+4. `_check_and_escalate()`：先解析 `_STAGE_POLICY[state]`（找不到 → fallback 到全局
+   `watchdog_session_ended_threshold_sec` + `watchdog_stuck_threshold_sec`）。
+   - `policy is None`（SQL 已过滤但 belt-and-suspenders）→ skip
+   - 解析 BKD session 状态后：
+     * session running + `policy.stuck_sec` 为 None + 未到 stuck → skip（既有"不杀长尾"语义）
+     * session running + 到 `policy.stuck_sec` → escalate（慢车道触发）
+     * session ended (or 无 issue) + 到 `policy.ended_sec` → escalate（快车道触发）
+     * 其他 → skip（未到任一阈值）
+5. 全局 `watchdog_session_ended_threshold_sec` / `watchdog_stuck_threshold_sec`
+   保留作为 unmapped state 的 fallback——新增 `ReqState` 但忘补 policy 时，watchdog
+   仍按全局阈值兜底，不会出现"新 state 完全无 watchdog"的失误。
+
+### 取舍
+
+- **保留全局 fallback 阈值**：删了它们 = 新增 ReqState 忘补 policy 表会瞬间裸奔。
+  保留 = 安全网，且 backward-compat（既有 helm values 仍生效，操作员可灰度）。
+- **不引入 env-overridable per-stage 字典**：`STAGE_WATCHDOG_POLICY` 用 module 常量
+  表达，不走 pydantic Settings。原因：
+  1. `dict[ReqState, dict | None]` 的 env 序列化（json）写起来易错，运维不可读
+  2. 这层数据是"跟 stage 状态机紧耦合的代码常量"，换数值比改 helm values 更安全
+     （改完跟着 spec 测试失败立刻知道）
+  3. 真要 per-deployment override，操作员仍可改全局 `watchdog_*_threshold_sec`
+     压低/抬高所有 unmapped fallback；或开新 REQ 调表（这才是受控变更）
+- **autonomous-bounded `stuck_sec=None`，不跟 design doc 的 30min**：design doc 用
+  30min 作建议，但既有 `config.py:186` 注释明确写 "sonnet analyze long tail 经常
+  25-35min；30 min 阈值会 false-escalate 大量 dogfood REQ"。先把框架立起来，slow
+  lane 默认仍是 None（保留当前"不杀 running"语义），后续运维数据驱动决定是否压低。
+- **`STAGING_TEST_RUNNING` 单独归"宽松 deterministic"档**：理论是 mechanical checker
+  （`make ci-unit-test && make ci-integration-test` 经 kubectl exec），但实测整套常跑
+  10-20min。设 `stuck_sec=None` 跟 autonomous-bounded 一致，避免 false-escalate
+  慢测试套件。
+- **`PR_CI_RUNNING.stuck_sec=14400`（4h）是新引入的硬上限**：之前因为 per-row
+  unconditional skip running 实际上是无穷。GH Actions 极少跑超过 4h；超 4h 大概率
+  是 GHA self-hosted runner 死锁等。给个 hard cap 让 escalate 兜住，不至于 REQ 永远
+  挂 PR_CI_RUNNING。
+
+## 影响范围
+
+- `orchestrator/src/orchestrator/watchdog.py` —— 新增 `_StagePolicy` + `_STAGE_POLICY`
+  表，重构 `_tick()` SQL threshold 计算 + `_check_and_escalate()` per-stage 阈值判定，
+  `_NO_WATCHDOG_STATES` 改派生
+- `orchestrator/tests/test_watchdog.py` —— 新增 per-stage policy unit case，旧 case
+  断言 stuck_sec 改用 dataclass 描述
+- `orchestrator/tests/test_contract_watchdog_stage_policy_full.py` —— 新建合同测试
+  WSPF-S1..S8（覆盖每类 stage 的 ended/running 行为）
+- `openspec/changes/REQ-stage-watchdog-policy-full-1777280786/specs/watchdog-stage-policy-full/spec.md`
+  —— 落 ADDED Requirements + 8 个 scenarios

--- a/openspec/changes/REQ-stage-watchdog-policy-full-1777280786/specs/watchdog-stage-policy-full/spec.md
+++ b/openspec/changes/REQ-stage-watchdog-policy-full-1777280786/specs/watchdog-stage-policy-full/spec.md
@@ -1,0 +1,120 @@
+## ADDED Requirements
+
+### Requirement: watchdog SHALL apply per-stage typed policy via STAGE_WATCHDOG_POLICY table
+
+The watchdog MUST resolve its escalation behavior from a per-stage policy
+table `orchestrator.watchdog._STAGE_POLICY: dict[ReqState, _StagePolicy | None]`.
+Each entry has the value semantics:
+
+- `None` — the state is fully exempt; SHALL be unioned into the SQL pre-filter
+  skip list so rows in this state are never returned by `pool.fetch()` and
+  never enter `_check_and_escalate()`. Used for `human-loop-conversation`
+  stages (currently only `INTAKING`).
+- `_StagePolicy(ended_sec=int, stuck_sec=int | None)` — per-stage thresholds:
+  * `ended_sec` MUST be applied when BKD reports `session_status` not in
+    `{"running"}` (or when no BKD issue is associated with the state). If
+    `stuck_sec_actual >= ended_sec`, the watchdog MUST escalate via
+    `engine.step` with `event=SESSION_FAILED`.
+  * `stuck_sec` MUST be applied when BKD reports `session_status == "running"`.
+    If `stuck_sec` is `None`, the watchdog MUST skip the row regardless of
+    duration (preserves the existing "do not kill long-tail running session"
+    semantics). If `stuck_sec` is an `int` and `stuck_sec_actual >= stuck_sec`,
+    the watchdog MUST escalate.
+
+States NOT present in `_STAGE_POLICY` MUST fall back to a synthesized policy
+of `_StagePolicy(ended_sec=settings.watchdog_session_ended_threshold_sec,
+stuck_sec=settings.watchdog_stuck_threshold_sec)`. This guarantees that adding
+a new `ReqState` without updating `_STAGE_POLICY` does not silently disable
+watchdog coverage for that state.
+
+`orchestrator.watchdog._NO_WATCHDOG_STATES` MUST be derived from `_STAGE_POLICY`
+as `frozenset(s for s, p in _STAGE_POLICY.items() if p is None)`. Other modules
+that import this set continue to work unchanged.
+
+#### Scenario: WSPF-S1 INTAKING (human-loop) excluded by SQL pre-filter
+
+- **GIVEN** `_STAGE_POLICY[ReqState.INTAKING]` is `None`
+- **WHEN** `watchdog._tick()` runs
+- **THEN** the first SQL parameter array passed to `pool.fetch()` MUST contain
+  the literal string `"intaking"`
+- **AND** `ReqState.INTAKING` MUST be a member of `watchdog._NO_WATCHDOG_STATES`
+
+#### Scenario: WSPF-S2 deterministic-checker stage with ended session escalates after ended_sec
+
+- **GIVEN** a REQ in state `SPEC_LINT_RUNNING` with `stuck_sec_actual=400`
+- **AND** `_STAGE_POLICY[ReqState.SPEC_LINT_RUNNING].ended_sec == 300`
+- **AND** the state has no associated BKD issue (`_STATE_ISSUE_KEY[SPEC_LINT_RUNNING] is None`)
+- **WHEN** `watchdog._tick()` runs
+- **THEN** `engine.step` MUST be called once with `event=SESSION_FAILED` and
+  `cur_state=ReqState.SPEC_LINT_RUNNING`
+- **AND** `body.event` MUST be `"watchdog.stuck"`
+
+#### Scenario: WSPF-S3 autonomous-bounded stage running indefinitely is NOT escalated (stuck_sec=None)
+
+- **GIVEN** a REQ in state `ANALYZING` with `stuck_sec_actual=10000` (~3h)
+- **AND** `_STAGE_POLICY[ReqState.ANALYZING].stuck_sec is None`
+- **AND** BKD reports `session_status="running"`
+- **WHEN** `watchdog._tick()` runs
+- **THEN** `engine.step` MUST NOT be called for this row
+- **AND** the row MUST NOT produce an `artifact_checks` insert
+
+#### Scenario: WSPF-S4 autonomous-bounded stage with ended session escalates after ended_sec
+
+- **GIVEN** a REQ in state `ANALYZING` with `stuck_sec_actual=320`
+- **AND** `_STAGE_POLICY[ReqState.ANALYZING].ended_sec == 300`
+- **AND** BKD reports `session_status="failed"`
+- **WHEN** `watchdog._tick()` runs
+- **THEN** `engine.step` MUST be called once with `event=SESSION_FAILED` and
+  `cur_state=ReqState.ANALYZING`
+
+#### Scenario: WSPF-S5 external-poll stage running long but under stuck_sec is NOT escalated
+
+- **GIVEN** a REQ in state `PR_CI_RUNNING` with `stuck_sec_actual=3600` (1h)
+- **AND** `_STAGE_POLICY[ReqState.PR_CI_RUNNING].stuck_sec == 14400` (4h)
+- **AND** BKD reports `session_status="running"`
+- **WHEN** `watchdog._tick()` runs
+- **THEN** `engine.step` MUST NOT be called for this row
+
+#### Scenario: WSPF-S6 external-poll stage running over stuck_sec is escalated
+
+- **GIVEN** a REQ in state `PR_CI_RUNNING` with `stuck_sec_actual=15000` (~4.2h)
+- **AND** `_STAGE_POLICY[ReqState.PR_CI_RUNNING].stuck_sec == 14400`
+- **AND** BKD reports `session_status="running"`
+- **WHEN** `watchdog._tick()` runs
+- **THEN** `engine.step` MUST be called once with `event=SESSION_FAILED` and
+  `cur_state=ReqState.PR_CI_RUNNING`
+- **AND** `body.event` MUST be `"watchdog.stuck"`
+
+#### Scenario: WSPF-S7 unmapped state falls back to global watchdog thresholds
+
+- **GIVEN** a hypothetical `ReqState` value `"new-future-stage"` not present in
+  `_STAGE_POLICY` AND not in `_SKIP_STATES`
+- **AND** `settings.watchdog_session_ended_threshold_sec == 300` and
+  `settings.watchdog_stuck_threshold_sec == 3600`
+- **WHEN** `_check_and_escalate()` resolves a row with this state
+- **THEN** the resolved policy MUST equal `_StagePolicy(ended_sec=300, stuck_sec=3600)`
+
+#### Scenario: WSPF-S8 SQL pre-filter threshold is min over all configured policy windows
+
+- **GIVEN** `_STAGE_POLICY` contains at least one policy with `ended_sec=300`
+- **WHEN** `watchdog._tick()` runs and we capture the second SQL parameter
+  (the threshold)
+- **THEN** the threshold MUST be `<= 300` to ensure no candidate row is
+  silently filtered out before per-row policy evaluation
+
+### Requirement: STAGING_TEST_RUNNING SHALL not kill long-running test suites by slow-lane
+
+The `_STAGE_POLICY[ReqState.STAGING_TEST_RUNNING]` entry MUST set `stuck_sec=None`
+even though the state is technically a `deterministic-checker`. The watchdog
+SHALL NOT escalate a `STAGING_TEST_RUNNING` row whose BKD session is `running`,
+regardless of how long it has been in that state. This preserves the prior
+contract that running BKD sessions for staging tests (which can include slow
+unit/integration suites) are not killed by watchdog timeouts.
+
+#### Scenario: WSPF-S3b STAGING_TEST_RUNNING running session is NOT escalated regardless of duration
+
+- **GIVEN** a REQ in state `STAGING_TEST_RUNNING` with `stuck_sec_actual=20000`
+- **AND** `_STAGE_POLICY[ReqState.STAGING_TEST_RUNNING].stuck_sec is None`
+- **AND** BKD reports `session_status="running"`
+- **WHEN** `watchdog._tick()` runs
+- **THEN** `engine.step` MUST NOT be called for this row

--- a/openspec/changes/REQ-stage-watchdog-policy-full-1777280786/tasks.md
+++ b/openspec/changes/REQ-stage-watchdog-policy-full-1777280786/tasks.md
@@ -1,0 +1,23 @@
+# tasks — REQ-stage-watchdog-policy-full-1777280786
+
+## Stage: contract / spec
+- [x] author specs/watchdog-stage-policy-full/spec.md（ADDED Requirements + 8 个 scenarios WSPF-S1..S8）
+- [x] proposal.md 写清动机、方案、取舍、影响范围
+
+## Stage: implementation
+- [x] orchestrator/src/orchestrator/watchdog.py：新增 `_StagePolicy` frozen dataclass
+- [x] orchestrator/src/orchestrator/watchdog.py：新增 `_STAGE_POLICY: dict[ReqState, _StagePolicy | None]` 表（13 条）
+- [x] orchestrator/src/orchestrator/watchdog.py：`_NO_WATCHDOG_STATES` 改派生（policy is None）
+- [x] orchestrator/src/orchestrator/watchdog.py：`_tick()` SQL threshold 取 `min(所有 policy + 全局 fallback)`
+- [x] orchestrator/src/orchestrator/watchdog.py：`_check_and_escalate()` 按 per-stage `_StagePolicy` 判定 escalate / skip
+- [x] orchestrator/src/orchestrator/watchdog.py：unmapped state fallback 到全局 `watchdog_session_ended_threshold_sec` + `watchdog_stuck_threshold_sec`
+
+## Stage: test
+- [x] orchestrator/tests/test_contract_watchdog_stage_policy_full.py：新建合同测试，覆盖 WSPF-S1..S8
+- [x] orchestrator/tests/test_watchdog.py：现有 case 跑通（无回归）
+- [x] make ci-lint 全绿
+- [x] make ci-unit-test 全绿
+
+## Stage: PR
+- [x] git push feat/REQ-stage-watchdog-policy-full-1777280786
+- [x] gh pr create --label sisyphus + sisyphus footer

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -6,8 +6,8 @@ M4 retry policy 假设"失败事件总会到"被打破 — watchdog 作为独立
 
 每 N 秒扫一次 req_state，发现某 REQ：
 1. state 在 in-flight（非 done / 非 escalated / 非 init / 非 human-in-loop）
-2. updated_at 距今超过 min(ended_threshold, stuck_threshold)（SQL 预滤）
-3. 关联 BKD issue 的 session_status 不在 'running' 状态
+2. updated_at 距今超过 SQL 预滤阈值（min over 所有 stage policy 的 ended/stuck）
+3. 关联 BKD issue 的 session_status 不在 'running' 状态 OR 触发本 stage 慢车道
 
 → 写一条 artifact_checks 记录 + 通过 engine.step 发 SESSION_FAILED 走 escalate。
 
@@ -19,6 +19,12 @@ in-loop `still_running → return` 无条件 skip，保护长尾真分析。
 REQ-watchdog-stage-policy-1777269909（2026-04-27）：按 stage type 走差异化
 策略 —— `_NO_WATCHDOG_STATES` 收 human-in-loop state（目前仅 INTAKING），
 SQL 预滤直接跳过它们，机械层不杀人在思考的 stage。
+
+REQ-stage-watchdog-policy-full-1777280786（2026-04-27）：把 INTAKING-only
+exempt set 升级成 stage-typed `_STAGE_POLICY` 表，每 stage 两个轴
+（ended_sec / stuck_sec）。`_NO_WATCHDOG_STATES` 退化为派生集合（policy is None
+的 stage）。unmapped state fallback 全局阈值，避免新增 ReqState 漏配时裸奔。
+详见 docs/user-feedback-loop.md §1。
 
 不 restart agent（restart 归 M4 retry policy 管），只 escalate。
 """
@@ -73,12 +79,99 @@ _SKIP_STATES = {
     ReqState.INIT.value,
 }
 
-# REQ-watchdog-stage-policy-1777269909：human-in-loop stages 完全豁免 watchdog。
-# 这类 stage 的进程靠人推（多轮 chat 等用户回复），机械超时杀掉是错的；人若
-# 觉得真死了走 admin/resume 终止。INTAKING 是当前唯一这类 state。
-_NO_WATCHDOG_STATES: frozenset[ReqState] = frozenset({
-    ReqState.INTAKING,
-})
+
+@dataclass(frozen=True)
+class _StagePolicy:
+    """REQ-stage-watchdog-policy-full-1777280786：单 stage 的 watchdog 策略。
+
+    两个轴解耦"BKD session 已 ended"和"长尾真死"两种 escalate 触发条件：
+
+    - ended_sec: BKD 报 session_status != "running"（completed/failed/cancelled/
+      issue 不存在）后等多久 escalate。本质是"BKD agent 死了但 webhook 没到"
+      的检测延迟。所有非豁免 stage 必须设。
+    - stuck_sec: 不论 session 状态，stuck 超过该时长一律 escalate。`None` =
+      不开启慢车道（保留"BKD running session 永远不杀"的长尾保护语义）。
+      设具体数值则相当于"哪怕 BKD 还在 running，超时也认账"，目前仅
+      external-poll 的 PR_CI_RUNNING 配 4h 上限。
+    """
+    ended_sec: int
+    stuck_sec: int | None
+
+
+# REQ-stage-watchdog-policy-full-1777280786：per-stage typed policy 表。
+# 默认值依据 docs/user-feedback-loop.md §1 stage type taxonomy：
+# - human-loop-conversation → None（SQL 预过滤）
+# - deterministic-checker   → ended=300, stuck=300（除 STAGING_TEST 见下）
+# - autonomous-bounded      → ended=300, stuck=None（保留不杀长尾，30min hard
+#                             cap 留给运维数据驱动决策；config.py:186 写过
+#                             30min 实测 false-escalate 长尾 sonnet ANALYZING）
+# - external-poll           → ended=300, stuck=14400（4h CI hard cap）
+#
+# STAGING_TEST_RUNNING 名义是 deterministic-checker（kubectl exec），但单/集成
+# 测试整套常跑分钟级，特别归"宽松 deterministic"档（stuck=None），避免误杀。
+_STAGE_POLICY: dict[ReqState, _StagePolicy | None] = {
+    # human-loop-conversation
+    ReqState.INTAKING: None,
+    # deterministic-checker（紧 5min ended + 5min stuck 双线）
+    ReqState.SPEC_LINT_RUNNING: _StagePolicy(ended_sec=300, stuck_sec=300),
+    ReqState.DEV_CROSS_CHECK_RUNNING: _StagePolicy(ended_sec=300, stuck_sec=300),
+    ReqState.ANALYZE_ARTIFACT_CHECKING: _StagePolicy(ended_sec=300, stuck_sec=300),
+    # deterministic-checker（宽松：测试套件常跑长）
+    ReqState.STAGING_TEST_RUNNING: _StagePolicy(ended_sec=300, stuck_sec=None),
+    # autonomous-bounded
+    ReqState.ANALYZING: _StagePolicy(ended_sec=300, stuck_sec=None),
+    ReqState.CHALLENGER_RUNNING: _StagePolicy(ended_sec=300, stuck_sec=None),
+    ReqState.ACCEPT_RUNNING: _StagePolicy(ended_sec=300, stuck_sec=None),
+    ReqState.ACCEPT_TEARING_DOWN: _StagePolicy(ended_sec=300, stuck_sec=None),
+    ReqState.ARCHIVING: _StagePolicy(ended_sec=300, stuck_sec=None),
+    ReqState.FIXER_RUNNING: _StagePolicy(ended_sec=300, stuck_sec=None),
+    ReqState.REVIEW_RUNNING: _StagePolicy(ended_sec=300, stuck_sec=None),
+    # external-poll
+    ReqState.PR_CI_RUNNING: _StagePolicy(ended_sec=300, stuck_sec=14400),
+}
+
+
+# 派生：policy is None 的 stage 集合，SQL 预过滤直接跳过。
+# 其他模块（含测试）可能 import 这个 set，保留导出并保持语义不变。
+_NO_WATCHDOG_STATES: frozenset[ReqState] = frozenset(
+    s for s, p in _STAGE_POLICY.items() if p is None
+)
+
+
+def _resolve_policy(state: ReqState) -> _StagePolicy | None:
+    """REQ-stage-watchdog-policy-full-1777280786：解析 stage 的 watchdog policy。
+
+    - 表里显式列了 → 直接用（含 None / 显式 _StagePolicy）
+    - 表里没列    → 用全局 `watchdog_session_ended_threshold_sec` +
+                    `watchdog_stuck_threshold_sec` 合成 fallback policy。
+                    安全网兜底：新加 ReqState 忘补表也不会裸奔无 watchdog。
+    """
+    if state in _STAGE_POLICY:
+        return _STAGE_POLICY[state]
+    return _StagePolicy(
+        ended_sec=settings.watchdog_session_ended_threshold_sec,
+        stuck_sec=settings.watchdog_stuck_threshold_sec,
+    )
+
+
+def _sql_prefilter_threshold() -> int:
+    """SQL 预过滤的最低 stuck 阈值。
+
+    取 `min(所有非 None policy 的 ended_sec ∪ stuck_sec ∪ 全局 fallback ended/stuck)`。
+    保证任一 stage 的 escalate 触发条件都能让对应 row 进入 SQL 返回集（per-row
+    逻辑再按 stage policy 精判）。
+    """
+    candidates: list[int] = [
+        settings.watchdog_session_ended_threshold_sec,
+        settings.watchdog_stuck_threshold_sec,
+    ]
+    for p in _STAGE_POLICY.values():
+        if p is None:
+            continue
+        candidates.append(p.ended_sec)
+        if p.stuck_sec is not None:
+            candidates.append(p.stuck_sec)
+    return min(candidates)
 
 
 @dataclass
@@ -92,14 +185,7 @@ class _SyntheticBody:
 async def _tick() -> dict:
     """单次扫描 + escalate 卡死 REQ。返回 {checked, escalated}。"""
     pool = db.get_pool()
-    # SQL 预滤用两个阈值的较小值。fast (ended_threshold) 让 BKD 已结束的
-    # session 在 ~5min 内被兜底；slow (stuck_threshold) 是 legacy 上限。
-    # 仍 running 的 session 由 _check_and_escalate 里的 still_running → skip
-    # 无条件保护，不会被 fast lane 误伤。
-    threshold = min(
-        settings.watchdog_session_ended_threshold_sec,
-        settings.watchdog_stuck_threshold_sec,
-    )
+    threshold = _sql_prefilter_threshold()
     # 终态 / 未入链 + human-in-loop 一起塞进 SQL skip 列表
     skip_arr = list(_SKIP_STATES | {s.value for s in _NO_WATCHDOG_STATES})
     # psql 语法：INTERVAL '1 second' * N 把 int 参数转成 interval
@@ -121,7 +207,7 @@ async def _tick() -> dict:
 
 
 async def _check_and_escalate(row) -> bool:
-    """检查一条 stuck row：session 仍 running 就 skip，否则 escalate。返 True = 真 escalate。"""
+    """检查一条 stuck row，按 stage policy 决定 skip / escalate。返 True = 真 escalate。"""
     req_id = row["req_id"]
     project_id = row["project_id"]
     state_str = row["state"]
@@ -134,6 +220,15 @@ async def _check_and_escalate(row) -> bool:
         state = ReqState(state_str)
     except ValueError:
         log.warning("watchdog.unknown_state", req_id=req_id, state=state_str)
+        return False
+
+    policy = _resolve_policy(state)
+    if policy is None:
+        # belt-and-suspenders：SQL 预过滤已排除，这里再保险
+        log.debug(
+            "watchdog.policy_exempt", req_id=req_id, state=state_str,
+            stuck_sec=stuck_sec,
+        )
         return False
 
     issue_key = _STATE_ISSUE_KEY.get(state)
@@ -149,22 +244,36 @@ async def _check_and_escalate(row) -> bool:
                 issue = await bkd.get_issue(project_id, issue_id)
             if issue.session_status == "running":
                 still_running = True
-                log.debug(
-                    "watchdog.still_running",
-                    req_id=req_id, state=state_str,
-                    issue_id=issue_id, stuck_sec=stuck_sec,
-                )
         except Exception as e:
-            # 查不到（issue 删了 / BKD 挂了）→ 保守按 failed 处理，走 escalate
+            # 查不到（issue 删了 / BKD 挂了）→ 保守按 ended 处理（走 ended_sec 阈值）
             log.warning(
                 "watchdog.bkd_get_issue_failed",
                 req_id=req_id, issue_id=issue_id, error=str(e),
             )
 
+    # 2. 按 policy 决定是否 escalate
     if still_running:
-        return False
+        if policy.stuck_sec is None or stuck_sec < policy.stuck_sec:
+            # 慢车道未开启或未到 → 不杀长尾运行 session
+            log.debug(
+                "watchdog.still_running",
+                req_id=req_id, state=state_str,
+                issue_id=issue_id, stuck_sec=stuck_sec,
+                stuck_cap=policy.stuck_sec,
+            )
+            return False
+        # 慢车道触发：BKD running 但已超过 stage 设的 stuck 上限
+    else:
+        # session ended 或无 issue：走 ended_sec 快车道
+        if stuck_sec < policy.ended_sec:
+            log.debug(
+                "watchdog.below_ended_threshold",
+                req_id=req_id, state=state_str,
+                stuck_sec=stuck_sec, ended_cap=policy.ended_sec,
+            )
+            return False
 
-    # 2. 选 body.event：ARCHIVING 用专属 archive.failed，其他通用 watchdog.stuck
+    # 3. 选 body.event：ARCHIVING 用专属 archive.failed，其他通用 watchdog.stuck
     body_event = _STATE_FAILURE_EVENT.get(state, "watchdog.stuck")
     reason = "watchdog_stuck"
     stage_label = f"watchdog:{state_str}"
@@ -188,7 +297,7 @@ async def _check_and_escalate(row) -> bool:
             log.warning("watchdog.fixer_round_cap_tag_failed",
                         req_id=req_id, error=str(e))
 
-    # 3. 写 artifact_checks 记一笔，给 dashboard M7 04-fail-kind-distribution 抓
+    # 4. 写 artifact_checks 记一笔，给 dashboard M7 04-fail-kind-distribution 抓
     check = CheckResult(
         passed=False,
         exit_code=-1,
@@ -203,7 +312,7 @@ async def _check_and_escalate(row) -> bool:
     except Exception as e:
         log.warning("watchdog.artifact_insert_failed", req_id=req_id, error=str(e))
 
-    # 4. 通过 engine.step 发 SESSION_FAILED → 走 escalate transition
+    # 5. 通过 engine.step 发 SESSION_FAILED → 走 escalate transition
     body = _SyntheticBody(
         projectId=project_id,
         issueId=issue_id or ctx.get("intent_issue_id") or "",

--- a/orchestrator/tests/test_contract_watchdog_stage_policy_full.py
+++ b/orchestrator/tests/test_contract_watchdog_stage_policy_full.py
@@ -1,0 +1,371 @@
+"""Contract tests for REQ-stage-watchdog-policy-full-1777280786.
+
+Black-box behavioral contracts derived from:
+  openspec/changes/REQ-stage-watchdog-policy-full-1777280786/specs/watchdog-stage-policy-full/spec.md
+
+Scenarios:
+  WSPF-S1   INTAKING (human-loop) excluded by SQL pre-filter
+  WSPF-S2   deterministic-checker stage with ended session escalates after ended_sec
+  WSPF-S3   autonomous-bounded running session with stuck_sec=None NOT escalated
+  WSPF-S3b  STAGING_TEST_RUNNING running session NOT escalated regardless of duration
+  WSPF-S4   autonomous-bounded ended session escalates after ended_sec
+  WSPF-S5   external-poll running under stuck_sec NOT escalated
+  WSPF-S6   external-poll running over stuck_sec IS escalated
+  WSPF-S7   unmapped state falls back to global watchdog thresholds
+  WSPF-S8   SQL pre-filter threshold is min over all configured policy windows
+"""
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock
+
+import pytest
+
+# ─── shared fakes ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakePool:
+    rows: list = field(default_factory=list)
+    fetch_calls: list = field(default_factory=list)
+    executed: list = field(default_factory=list)
+
+    async def fetch(self, sql, *args):
+        self.fetch_calls.append((sql, args))
+        return self.rows
+
+    async def execute(self, sql, *args):
+        self.executed.append((sql, args))
+
+
+@dataclass
+class _FakeIssue:
+    session_status: str | None = "failed"
+    id: str = "issue-1"
+    project_id: str = "proj-1"
+    issue_number: int = 0
+    title: str = ""
+    status_id: str = "todo"
+    tags: list = field(default_factory=list)
+
+
+def _make_row(state: str, *, req_id="REQ-x", project_id="proj-1",
+              ctx: dict | None = None, stuck_sec: int = 7200):
+    return {
+        "req_id": req_id,
+        "project_id": project_id,
+        "state": state,
+        "context": json.dumps(ctx or {}),
+        "stuck_sec": stuck_sec,
+    }
+
+
+def _patch_pool(monkeypatch, pool):
+    monkeypatch.setattr("orchestrator.watchdog.db.get_pool", lambda: pool)
+
+
+def _patch_bkd(monkeypatch, issue: _FakeIssue | None):
+    fake = AsyncMock()
+    fake.get_issue = AsyncMock(return_value=issue)
+
+    @asynccontextmanager
+    async def _ctx(*a, **kw):
+        yield fake
+
+    monkeypatch.setattr("orchestrator.watchdog.BKDClient", _ctx)
+    return fake
+
+
+def _patch_engine(monkeypatch):
+    calls: list = []
+
+    async def fake_step(pool, *, body, req_id, project_id, tags, cur_state,
+                        ctx, event, depth=0):
+        calls.append({
+            "req_id": req_id,
+            "cur_state": cur_state,
+            "event": event,
+            "body_event": getattr(body, "event", None),
+        })
+        return {}
+
+    monkeypatch.setattr("orchestrator.watchdog.engine.step", fake_step)
+    return calls
+
+
+def _patch_artifact(monkeypatch):
+    calls: list = []
+
+    async def fake_insert(pool, req_id, stage, result):
+        calls.append({"req_id": req_id, "stage": stage, "result": result})
+
+    monkeypatch.setattr(
+        "orchestrator.watchdog.artifact_checks.insert_check", fake_insert,
+    )
+    return calls
+
+
+# ─── WSPF-S1: INTAKING excluded by SQL pre-filter ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_s1_intaking_excluded_by_sql_prefilter(monkeypatch):
+    """WSPF-S1: _STAGE_POLICY[INTAKING] is None → SQL skip_arr contains 'intaking'."""
+    from orchestrator import watchdog
+    from orchestrator.state import ReqState
+
+    pool = _FakePool(rows=[])
+    _patch_pool(monkeypatch, pool)
+
+    await watchdog._tick()
+
+    assert pool.fetch_calls, "watchdog must issue at least one SQL fetch"
+    skip_arr, _threshold = pool.fetch_calls[0][1]
+    assert "intaking" in skip_arr, (
+        f"WSPF-S1: SQL skip_arr must include 'intaking'. Got: {skip_arr!r}"
+    )
+    # _STAGE_POLICY 表里 INTAKING 必须显式标 None
+    assert watchdog._STAGE_POLICY[ReqState.INTAKING] is None
+    # 派生的 _NO_WATCHDOG_STATES 必须包含 INTAKING
+    assert ReqState.INTAKING in watchdog._NO_WATCHDOG_STATES
+
+
+# ─── WSPF-S2: deterministic-checker stage with ended session escalates ──────
+
+
+@pytest.mark.asyncio
+async def test_s2_deterministic_checker_ended_session_escalates(monkeypatch):
+    """WSPF-S2: SPEC_LINT_RUNNING + stuck=400 (≥ ended_sec=300) + no BKD issue → escalate."""
+    from orchestrator import watchdog
+    from orchestrator.state import Event, ReqState
+
+    pool = _FakePool(rows=[
+        _make_row(
+            ReqState.SPEC_LINT_RUNNING.value,
+            req_id="REQ-s2",
+            ctx={"intent_issue_id": "intent-s2"},
+            stuck_sec=400,
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    fake_bkd = _patch_bkd(monkeypatch, _FakeIssue(session_status="running"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}, f"got {result}"
+    # SPEC_LINT_RUNNING 在 _STATE_ISSUE_KEY 中是 None → 跳过 BKD 查询
+    fake_bkd.get_issue.assert_not_called()
+    assert len(step_calls) == 1
+    assert step_calls[0]["event"] == Event.SESSION_FAILED
+    assert step_calls[0]["cur_state"] == ReqState.SPEC_LINT_RUNNING
+    assert step_calls[0]["body_event"] == "watchdog.stuck"
+
+
+# ─── WSPF-S3: autonomous-bounded running with stuck_sec=None NOT escalated ──
+
+
+@pytest.mark.asyncio
+async def test_s3_autonomous_bounded_running_not_escalated(monkeypatch):
+    """WSPF-S3: ANALYZING + session=running + 任意长 stuck → policy.stuck_sec=None → skip."""
+    from orchestrator import watchdog
+    from orchestrator.state import ReqState
+
+    pool = _FakePool(rows=[
+        _make_row(
+            ReqState.ANALYZING.value,
+            req_id="REQ-s3",
+            ctx={"intent_issue_id": "intent-s3"},
+            stuck_sec=10000,
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, _FakeIssue(session_status="running"))
+    step_calls = _patch_engine(monkeypatch)
+    art_calls = _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 0}
+    assert step_calls == []
+    assert art_calls == []
+    # 验证 policy 形状
+    policy = watchdog._STAGE_POLICY[ReqState.ANALYZING]
+    assert policy is not None and policy.stuck_sec is None
+
+
+# ─── WSPF-S3b: STAGING_TEST_RUNNING running session NOT escalated ───────────
+
+
+@pytest.mark.asyncio
+async def test_s3b_staging_test_running_not_escalated(monkeypatch):
+    """WSPF-S3b: STAGING_TEST_RUNNING 名义是 deterministic-checker 但 stuck_sec=None
+    保留长跑测试套件不被 watchdog 杀的语义。"""
+    from orchestrator import watchdog
+    from orchestrator.state import ReqState
+
+    pool = _FakePool(rows=[
+        _make_row(
+            ReqState.STAGING_TEST_RUNNING.value,
+            req_id="REQ-s3b",
+            ctx={"staging_test_issue_id": "st-s3b"},
+            stuck_sec=20000,
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, _FakeIssue(session_status="running", id="st-s3b"))
+    step_calls = _patch_engine(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 0}
+    assert step_calls == []
+    policy = watchdog._STAGE_POLICY[ReqState.STAGING_TEST_RUNNING]
+    assert policy is not None and policy.stuck_sec is None
+
+
+# ─── WSPF-S4: autonomous-bounded ended session escalates after ended_sec ────
+
+
+@pytest.mark.asyncio
+async def test_s4_autonomous_bounded_ended_session_escalates(monkeypatch):
+    """WSPF-S4: ANALYZING + stuck=320 (≥ ended_sec=300) + session=failed → escalate."""
+    from orchestrator import watchdog
+    from orchestrator.state import Event, ReqState
+
+    pool = _FakePool(rows=[
+        _make_row(
+            ReqState.ANALYZING.value,
+            req_id="REQ-s4",
+            ctx={"intent_issue_id": "intent-s4"},
+            stuck_sec=320,
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, _FakeIssue(session_status="failed", id="intent-s4"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    assert len(step_calls) == 1
+    assert step_calls[0]["event"] == Event.SESSION_FAILED
+    assert step_calls[0]["cur_state"] == ReqState.ANALYZING
+
+
+# ─── WSPF-S5: external-poll running under stuck_sec NOT escalated ───────────
+
+
+@pytest.mark.asyncio
+async def test_s5_external_poll_under_cap_not_escalated(monkeypatch):
+    """WSPF-S5: PR_CI_RUNNING + stuck=3600 < stuck_sec=14400 + session=running → skip."""
+    from orchestrator import watchdog
+    from orchestrator.state import ReqState
+
+    pool = _FakePool(rows=[
+        _make_row(
+            ReqState.PR_CI_RUNNING.value,
+            req_id="REQ-s5",
+            ctx={"pr_ci_watch_issue_id": "ci-s5"},
+            stuck_sec=3600,
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, _FakeIssue(session_status="running", id="ci-s5"))
+    step_calls = _patch_engine(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 0}
+    assert step_calls == []
+    policy = watchdog._STAGE_POLICY[ReqState.PR_CI_RUNNING]
+    assert policy is not None and policy.stuck_sec == 14400
+
+
+# ─── WSPF-S6: external-poll running over stuck_sec IS escalated ─────────────
+
+
+@pytest.mark.asyncio
+async def test_s6_external_poll_over_cap_escalates(monkeypatch):
+    """WSPF-S6: PR_CI_RUNNING + stuck=15000 ≥ stuck_sec=14400 + session=running → escalate."""
+    from orchestrator import watchdog
+    from orchestrator.state import Event, ReqState
+
+    pool = _FakePool(rows=[
+        _make_row(
+            ReqState.PR_CI_RUNNING.value,
+            req_id="REQ-s6",
+            ctx={"pr_ci_watch_issue_id": "ci-s6"},
+            stuck_sec=15000,
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, _FakeIssue(session_status="running", id="ci-s6"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    assert len(step_calls) == 1
+    assert step_calls[0]["event"] == Event.SESSION_FAILED
+    assert step_calls[0]["cur_state"] == ReqState.PR_CI_RUNNING
+    assert step_calls[0]["body_event"] == "watchdog.stuck"
+
+
+# ─── WSPF-S7: unmapped state falls back to global thresholds ────────────────
+
+
+def test_s7_unmapped_state_falls_back_to_global_thresholds(monkeypatch):
+    """WSPF-S7: 不在 _STAGE_POLICY 的 state → fallback _StagePolicy(ended=settings, stuck=settings)."""
+    from orchestrator import watchdog
+
+    monkeypatch.setattr(
+        "orchestrator.watchdog.settings.watchdog_session_ended_threshold_sec", 300,
+    )
+    monkeypatch.setattr(
+        "orchestrator.watchdog.settings.watchdog_stuck_threshold_sec", 3600,
+    )
+
+    # 用一个肯定不在 _STAGE_POLICY 表的"未来 state"占位（直接传字符串绕过 enum）
+    class _Fake:
+        pass
+
+    fake_state = _Fake()  # not equal to any ReqState member → not in _STAGE_POLICY
+    resolved = watchdog._resolve_policy(fake_state)
+    assert resolved is not None
+    assert resolved.ended_sec == 300
+    assert resolved.stuck_sec == 3600
+
+
+# ─── WSPF-S8: SQL pre-filter threshold is min over all policy windows ───────
+
+
+@pytest.mark.asyncio
+async def test_s8_sql_threshold_is_min_over_policy_windows(monkeypatch):
+    """WSPF-S8: SQL threshold ≤ min(ended_sec across all policies)."""
+    from orchestrator import watchdog
+
+    pool = _FakePool(rows=[])
+    _patch_pool(monkeypatch, pool)
+    # 把全局阈值故意调高，验证 SQL threshold 还是被 stage policy 拉低
+    monkeypatch.setattr(
+        "orchestrator.watchdog.settings.watchdog_session_ended_threshold_sec", 9000,
+    )
+    monkeypatch.setattr(
+        "orchestrator.watchdog.settings.watchdog_stuck_threshold_sec", 9000,
+    )
+
+    await watchdog._tick()
+
+    assert pool.fetch_calls
+    _skip_arr, threshold = pool.fetch_calls[0][1]
+    # 表里至少有一条 ended_sec=300 → threshold 必须 ≤ 300
+    assert threshold <= 300, (
+        f"WSPF-S8: SQL threshold should be ≤ 300 (min ended_sec across stage policies), "
+        f"got {threshold}"
+    )

--- a/orchestrator/tests/test_watchdog.py
+++ b/orchestrator/tests/test_watchdog.py
@@ -238,7 +238,10 @@ async def test_tick_passes_skip_states_and_threshold_to_sql(monkeypatch):
             return []
 
     _patch_pool(monkeypatch, _CapturingPool())
-    # 让 fast/slow 都 >=1800 且 fast 是较小值，验 min(fast, slow) 拿 1800
+    # 把全局阈值都拉得很大，验证 SQL threshold 取 min(stage policy ∪ 全局)，
+    # 应该被 stage policy 中最小的 ended_sec/stuck_sec 拉下来（≤ 300）。
+    # REQ-stage-watchdog-policy-full-1777280786：threshold 不再是 settings
+    # 字段简单 min，而是 stage 表 + 全局 fallback 全集 min。
     monkeypatch.setattr(
         "orchestrator.watchdog.settings.watchdog_stuck_threshold_sec", 3600,
     )
@@ -249,7 +252,8 @@ async def test_tick_passes_skip_states_and_threshold_to_sql(monkeypatch):
     await watchdog._tick()
 
     skip_arr, threshold = captured["args"]
-    assert threshold == 1800
+    # threshold ≤ 300（被 deterministic-checker 的 ended/stuck=300 拉下来）
+    assert threshold <= 300
     assert "done" in skip_arr
     assert "escalated" in skip_arr
     assert "init" in skip_arr
@@ -338,7 +342,11 @@ async def test_intaking_state_excluded_from_sql_fetch(monkeypatch):
 
 
 def test_no_watchdog_states_set_contains_only_intaking():
-    """_NO_WATCHDOG_STATES 当前只豁免 INTAKING；扩展时记得补本测试 + spec。"""
+    """_NO_WATCHDOG_STATES 当前只豁免 INTAKING；扩展时记得补本测试 + spec。
+
+    REQ-stage-watchdog-policy-full-1777280786 起这个 set 不再硬编码，而是从
+    `_STAGE_POLICY` 中 `policy is None` 的 stage 派生；语义和导出名不变。
+    """
     assert watchdog._NO_WATCHDOG_STATES == frozenset({ReqState.INTAKING})
 
 
@@ -491,8 +499,11 @@ async def test_sql_filter_uses_min_of_fast_and_slow_thresholds(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_sql_filter_picks_slow_when_smaller(monkeypatch):
-    """WFD-S2：operator 把 fast 调到 1800（>slow=600）→ SQL 仍用较小的 600。
-    保证拆双阈值后旧 helm values（仅设 stuck）行为可控。"""
+    """WFD-S2：operator 把 fast 调到 1800、slow 调到 600 → SQL 用 min(全集) ≤ 600。
+
+    REQ-stage-watchdog-policy-full-1777280786 之后 threshold 还要 min 进 stage
+    policy 集合，但本测试目的是"settings 字段被 SQL 计算 consume"——只需断言
+    threshold ≤ min(settings) 即可。"""
     captured: dict = {}
 
     class _CapturingPool:
@@ -511,7 +522,8 @@ async def test_sql_filter_picks_slow_when_smaller(monkeypatch):
     await watchdog._tick()
 
     _skip_arr, threshold = captured["args"]
-    assert threshold == 600
+    # threshold ≤ min(settings) ∩ min(stage policy) ≤ 600
+    assert threshold <= 600
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 动机

[REQ-watchdog-stage-policy-1777269909](https://github.com/phona/sisyphus/pull/161) 已把 `INTAKING` 拉进 `_NO_WATCHDOG_STATES` set 简单豁免，但 [docs/user-feedback-loop.md §1](../blob/main/docs/user-feedback-loop.md) 设计的 stage-typed `STAGE_WATCHDOG_POLICY` 框架（4 类 stage × 不同 timeout）还没落地。本 REQ 完成 full 实现：

- 把 `_NO_WATCHDOG_STATES` 从硬编码 set 升级成派生集合（policy is None 的 stage）
- 每个 in-flight state 都给一条显式 policy（13 条），按 `human-loop-conversation` / `deterministic-checker` / `autonomous-bounded` / `external-poll` 4 档分配 timeout
- 给 `PR_CI_RUNNING` 加 4h hard cap（之前因 per-row 永远 skip running session 实际是 ∞）
- 未来加新 `ReqState` 忘补表 → 自动 fallback 全局阈值，不会出现"裸奔无 watchdog"

## 改动

- `orchestrator/src/orchestrator/watchdog.py`：
  - 新增 `_StagePolicy` frozen dataclass（`ended_sec` + `stuck_sec`）
  - 新增 `_STAGE_POLICY: dict[ReqState, _StagePolicy | None]` 表（13 条覆盖现有所有 in-flight state）
  - `_NO_WATCHDOG_STATES` 改派生
  - 新增 `_resolve_policy()` + `_sql_prefilter_threshold()` helpers
  - `_check_and_escalate()` 按 per-stage policy 决定 skip / escalate
- `orchestrator/tests/test_contract_watchdog_stage_policy_full.py`：新合同测试 9 场景（WSPF-S1..S8 + S3b），覆盖每类 stage 的 ended/running 路径 + unmapped fallback
- `orchestrator/tests/test_watchdog.py`：2 个 SQL threshold 测试断言改成"≤ 旧值"（threshold 现在还要 min 进 stage policy 表，比单纯 min(全局) 更小）
- `openspec/changes/REQ-stage-watchdog-policy-full-1777280786/`：proposal + spec（ADDED Requirements + 9 scenarios）+ tasks

## Test plan

- [x] `make ci-lint` 全绿
- [x] `make ci-unit-test` 全绿（1452 passed，含原 watchdog suite + 新 contract 9 case）
- [x] `openspec validate REQ-stage-watchdog-policy-full-1777280786` 通过
- [x] `scripts/check-scenario-refs.sh` 通过（所有 scenario 引用解析）
- [ ] sisyphus pipeline staging-test → pr-ci → accept（自 dogfood）

## 取舍

- **autonomous-bounded `stuck_sec=None`**：design doc 推荐 30min，但 [config.py:186](../blob/main/orchestrator/src/orchestrator/config.py#L186) 注释明确写"30 min 阈值会 false-escalate 大量 dogfood REQ"。先把框架立起来，slow lane 仍保留"不杀 running"语义，后续运维数据驱动决定是否压低
- **`STAGING_TEST_RUNNING.stuck_sec=None`**：名义 deterministic-checker，但单/集成测试常跑分钟级；`stuck=300` 会误杀慢测试套件，归"宽松 deterministic"档
- **不引入 env-overridable per-stage 字典**：复杂 dict 的 env 序列化运维不可读；表是 module 常量，改值跟着 spec 测试失败立刻知道
- **保留全局 fallback 阈值**：unmapped state 安全网，避免新 ReqState 漏配时裸奔

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-stage-watchdog-policy-full-1777280786\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/jazevwrl)