### PR TITLE
test(engine): ESCALATED resume + 47/47 transition coverage (REQ-test-coverage-escalated-resume-1777281969)

### DIFF
--- a/openspec/changes/REQ-test-coverage-escalated-resume-1777281969/proposal.md
+++ b/openspec/changes/REQ-test-coverage-escalated-resume-1777281969/proposal.md
@@ -1,0 +1,60 @@
+# REQ-test-coverage-escalated-resume-1777281969: 收口 47/47 transition 的 engine.step mock 覆盖 + 加深 ESCALATED resume 路径
+
+## 问题
+
+最近三个 PR 把 engine.step mock 测试覆盖推进到了 41/47：
+
+- `test_engine_main_chain.py` (#159)：MCT-S1..MCT-S11，11 条 happy-path 主链
+- `test_engine_accept_phase.py` (#158)：APT-S1..APT-S7，7 条 accept 阶段
+- `test_engine_verifier_loop.py` (#160)：VLT-S1..VLT-S16，16 条 verifier 子链 +
+  SESSION_FAILED 兜底（含 13 个 *_RUNNING state 的 self-loop 参数化）
+
+从 `state.TRANSITIONS` 静态扫描 47 条 transition 减去三家覆盖之后，剩 6 条**没有**
+任何 engine.step 级 mock 测试覆盖：
+
+| # | transition | next_state | action |
+|---|---|---|---|
+| 1 | `(INIT, INTENT_INTAKE)` | INTAKING | `start_intake` |
+| 2 | `(INTAKING, INTAKE_PASS)` | ANALYZING | `start_analyze_with_finalized_intent` |
+| 3 | `(INTAKING, INTAKE_FAIL)` | ESCALATED | `escalate` |
+| 4 | `(INTAKING, VERIFY_ESCALATE)` | ESCALATED | `escalate` |
+| 5 | `(ANALYZING, VERIFY_ESCALATE)` | ESCALATED | `escalate` |
+| 6 | `(PR_CI_RUNNING, PR_CI_TIMEOUT)` | ESCALATED | `escalate` |
+
+而 `(ESCALATED, VERIFY_PASS)` / `(ESCALATED, VERIFY_FIX_NEEDED)` 这两条**人工
+resume 路径**虽然在 VLT-S12 / VLT-S13 已被 dispatch 级覆盖，但只验"action 名 +
+state 不变"——并没验真正"resume from ESCALATED 把 REQ 推到下一 stage"的端到端
+路由（apply_verify_pass action 内部会 CAS `ESCALATED → STAGING_TEST_RUNNING`
+然后 chain emit `STAGING_TEST_PASS`，engine 链式 dispatch `create_pr_ci_watch`）。
+这条 chain 是 sisyphus 唯一让人手把"卡死"REQ 续起来的路径，回归一次代价就是
+所有 escalate 的 REQ 全部失活——必须有专门的端到端 mock 测试钉死它。
+
+## 方案
+
+新增 `orchestrator/tests/test_engine_escalated_resume.py`，9 条 scenario
+（ERT-S1..ERT-S9），全部用 in-process FakePool + stub action 隔离副作用，**不打
+BKD / Postgres / K8s**。复用 `test_engine.py` 的 `FakePool` / `FakeReq` /
+`_drain_tasks`（直接 `from test_engine import ...`，跟 `test_engine_adversarial.py`
+/ `_main_chain` / `_verifier_loop` 同模式）。
+
+| ID | 场景 | 期望 |
+|---|---|---|
+| ERT-S1 | `(INIT, INTENT_INTAKE)` | dispatch `start_intake`，state → `INTAKING` |
+| ERT-S2 | `(INTAKING, INTAKE_PASS)` | dispatch `start_analyze_with_finalized_intent`，state → `ANALYZING` |
+| ERT-S3 | `(INTAKING, INTAKE_FAIL)` | dispatch `escalate`，state → `ESCALATED`，cleanup_runner(retain_pvc=True) 被 await 一次 |
+| ERT-S4 | `(INTAKING, VERIFY_ESCALATE)` | dispatch `escalate`，state → `ESCALATED`，cleanup_runner(retain_pvc=True) 被 await 一次 |
+| ERT-S5 | `(ANALYZING, VERIFY_ESCALATE)` | dispatch `escalate`，state → `ESCALATED`，cleanup_runner(retain_pvc=True) 被 await 一次 |
+| ERT-S6 | `(PR_CI_RUNNING, PR_CI_TIMEOUT)` | dispatch `escalate`，state → `ESCALATED`，cleanup_runner(retain_pvc=True) 被 await 一次 |
+| ERT-S7 | ESCALATED + VERIFY_PASS **端到端 resume** | apply_verify_pass stub 内部 CAS `ESCALATED → STAGING_TEST_RUNNING` 并 `emit STAGING_TEST_PASS`；engine 链式调 `create_pr_ci_watch`；最终 row state = `PR_CI_RUNNING` |
+| ERT-S8 | ESCALATED + VERIFY_FIX_NEEDED **tag 透传** | start_fixer 收到的 tags 含 `verify:staging_test`、ctx 含 `verifier_stage=staging_test`，state → `FIXER_RUNNING` |
+| ERT-S9 | 47/47 静态 sweep | 参数化遍历 `state.TRANSITIONS` 全 47 项，每项构造 stub action，`engine.step` 必须返 `action == transition.action`（或 `no-op` if `transition.action is None`）+ `next_state == transition.next_state.value` |
+
+## 边界 & 不做
+
+- **不验** action handler 内部行为 —— 已被 `test_verifier.py` /
+  `test_actions_start_analyze.py` / `test_intake.py` 覆盖
+- **不修** `state.TRANSITIONS` / engine.py / actions —— 纯加测，不改产线代码
+- **不为** sweep 测试加入 stage_runs 副作用断言 —— 那是 `test_store_stage_runs.py`
+  的范围；本 sweep 只校"engine.step 把表里声明的每条 transition 都跑得通"
+- ERT-S9 是 **defense-in-depth** —— 即便单粒度 ERT-S1..S6 / VLT / MCT / APT
+  漏了某条 case，sweep 也会 fail

--- a/openspec/changes/REQ-test-coverage-escalated-resume-1777281969/specs/engine-escalated-resume-tests/spec.md
+++ b/openspec/changes/REQ-test-coverage-escalated-resume-1777281969/specs/engine-escalated-resume-tests/spec.md
@@ -1,0 +1,162 @@
+## ADDED Requirements
+
+### Requirement: Engine routes intake-phase transitions through engine.step
+
+The engine MUST dispatch the four intake-phase transitions through
+`engine.step` exactly as `state.TRANSITIONS` declares: `(INIT,
+INTENT_INTAKE) → INTAKING` via `start_intake`; `(INTAKING, INTAKE_PASS)
+→ ANALYZING` via `start_analyze_with_finalized_intent`; `(INTAKING,
+INTAKE_FAIL) → ESCALATED` via `escalate`; and `(INTAKING,
+VERIFY_ESCALATE) → ESCALATED` via `escalate`. The two transitions that
+land in `ESCALATED` MUST also fire-and-forget a `cleanup_runner` task
+with `retain_pvc=True` because they cross from a non-terminal state
+into a terminal one. A regression that drops or renames any of these
+transitions MUST be caught by mock tests; intake is a human-in-loop
+stage and a missed transition silently strands the REQ before any work
+gets done.
+
+#### Scenario: ERT-S1 init intent_intake enters intaking
+
+- **GIVEN** a row at state `INIT` and a stub `start_intake` registered
+  in `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=INTENT_INTAKE`
+- **THEN** the row's state MUST advance to `INTAKING`, the returned
+  dict MUST contain `action="start_intake"` and `next_state="intaking"`,
+  and the stub action MUST be awaited exactly once
+
+#### Scenario: ERT-S2 intaking intake_pass enters analyzing
+
+- **GIVEN** a row at state `INTAKING` and a stub
+  `start_analyze_with_finalized_intent` registered in `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=INTAKE_PASS`
+- **THEN** the row's state MUST advance to `ANALYZING`, the returned
+  dict MUST contain `action="start_analyze_with_finalized_intent"` and
+  `next_state="analyzing"`, and the stub action MUST be awaited exactly
+  once
+
+#### Scenario: ERT-S3 intaking intake_fail enters escalated and triggers cleanup
+
+- **GIVEN** a row at state `INTAKING`, a stub `escalate` registered in
+  `actions.REGISTRY`, and a fake k8s controller injected via
+  `k8s_runner.set_controller`
+- **WHEN** `engine.step` is called with `event=INTAKE_FAIL`
+- **THEN** the row's state MUST advance to `ESCALATED`, the returned
+  dict MUST contain `action="escalate"`, the stub action MUST be
+  awaited exactly once, and after fire-and-forget tasks drain the fake
+  controller's `cleanup_runner` MUST have been awaited exactly once
+  with `retain_pvc=True`
+
+#### Scenario: ERT-S4 intaking verify_escalate enters escalated and triggers cleanup
+
+- **GIVEN** a row at state `INTAKING`, a stub `escalate` registered in
+  `actions.REGISTRY`, and a fake k8s controller injected via
+  `k8s_runner.set_controller`
+- **WHEN** `engine.step` is called with `event=VERIFY_ESCALATE`
+- **THEN** the row's state MUST advance to `ESCALATED`, the returned
+  dict MUST contain `action="escalate"`, the stub action MUST be
+  awaited exactly once, and after fire-and-forget tasks drain the fake
+  controller's `cleanup_runner` MUST have been awaited exactly once
+  with `retain_pvc=True`
+
+### Requirement: Engine routes analyze-phase escalation through engine.step
+
+The engine MUST dispatch `(ANALYZING, VERIFY_ESCALATE)` and `(PR_CI_RUNNING,
+PR_CI_TIMEOUT)` to `ESCALATED` via the `escalate` action through
+`engine.step`. These two transitions are reached when an analyze action
+internally emits `VERIFY_ESCALATE` (clone failure, missing finalized
+intent) or when the pr-ci checker times out waiting for GitHub check-runs.
+Both MUST trigger a fire-and-forget `cleanup_runner(retain_pvc=True)`
+because they cross into a terminal state.
+
+#### Scenario: ERT-S5 analyzing verify_escalate enters escalated and triggers cleanup
+
+- **GIVEN** a row at state `ANALYZING`, a stub `escalate` registered in
+  `actions.REGISTRY`, and a fake k8s controller injected via
+  `k8s_runner.set_controller`
+- **WHEN** `engine.step` is called with `event=VERIFY_ESCALATE`
+- **THEN** the row's state MUST advance to `ESCALATED`, the returned
+  dict MUST contain `action="escalate"`, and after fire-and-forget
+  tasks drain the fake controller's `cleanup_runner` MUST have been
+  awaited exactly once with `retain_pvc=True`
+
+#### Scenario: ERT-S6 pr_ci timeout enters escalated and triggers cleanup
+
+- **GIVEN** a row at state `PR_CI_RUNNING`, a stub `escalate`
+  registered in `actions.REGISTRY`, and a fake k8s controller injected
+  via `k8s_runner.set_controller`
+- **WHEN** `engine.step` is called with `event=PR_CI_TIMEOUT`
+- **THEN** the row's state MUST advance to `ESCALATED`, the returned
+  dict MUST contain `action="escalate"`, and after fire-and-forget
+  tasks drain the fake controller's `cleanup_runner` MUST have been
+  awaited exactly once with `retain_pvc=True`
+
+### Requirement: Engine completes ESCALATED resume end-to-end through chain emit
+
+The engine MUST allow `apply_verify_pass` to resume a REQ from
+`ESCALATED` end-to-end: the action internally CAS-advances from
+`ESCALATED` to the appropriate `*_RUNNING` state and emits the
+corresponding upstream pass event; the engine MUST then chain-dispatch
+the next-stage action through the main-chain transition. This proves
+the human-driven follow-up path (BKD UI follow-up on an escalated
+verifier issue → new `decision.action=pass` → engine resume)
+end-to-end, beyond the dispatch-only surface that VLT-S12 covers.
+
+The engine MUST also forward the `verify:<stage>` tag and ctx
+`verifier_stage` through to the `start_fixer` handler when resuming
+from `ESCALATED` via `VERIFY_FIX_NEEDED`, because `start_fixer` reads
+the stage from the issue tag (multi-verifier-concurrent ctx race).
+
+#### Scenario: ERT-S7 escalated verify_pass chains to next stage end-to-end
+
+- **GIVEN** a row at state `ESCALATED`, a stub `apply_verify_pass`
+  registered in `actions.REGISTRY` that internally CAS-advances the
+  pool row from `ESCALATED` to `STAGING_TEST_RUNNING` and returns
+  `{"emit": "staging-test.pass"}`, and a stub `create_pr_ci_watch`
+  registered in `actions.REGISTRY`
+- **WHEN** `engine.step` is called with `event=VERIFY_PASS` and
+  `tags=["verifier", "REQ-1", "verify:staging_test"]`
+- **THEN** the returned dict MUST contain `action="apply_verify_pass"`
+  with a `chained` sub-result whose `action` is `"create_pr_ci_watch"`
+  and whose `next_state` is `"pr-ci-running"`, the row's state MUST
+  end at `PR_CI_RUNNING`, and both stub actions MUST be awaited
+  exactly once
+
+#### Scenario: ERT-S8 escalated verify_fix_needed forwards stage tag
+
+- **GIVEN** a row at state `ESCALATED` and a stub `start_fixer`
+  registered in `actions.REGISTRY` that records the `tags` and `ctx`
+  it receives
+- **WHEN** `engine.step` is called with `event=VERIFY_FIX_NEEDED`,
+  `tags=["verifier", "REQ-1", "verify:staging_test"]`, and
+  `ctx={"verifier_stage": "staging_test", "verifier_fixer": "dev"}`
+- **THEN** the row's state MUST advance to `FIXER_RUNNING`, the
+  returned dict MUST contain `action="start_fixer"`, the stub MUST be
+  awaited exactly once, and the recorded `tags` MUST contain
+  `"verify:staging_test"` and the recorded `ctx` MUST contain
+  `verifier_stage="staging_test"`
+
+### Requirement: Engine.step routes every declared transition correctly (47/47 sweep)
+
+The engine MUST honor every entry in `state.TRANSITIONS` when invoked
+through `engine.step`: for each `(state, event)` key the engine MUST
+either dispatch the declared `action` (when non-None) or return
+`action="no-op"` (when the transition's action is None), and the row's
+state MUST advance to the declared `next_state`. This is the
+defense-in-depth catch-all that fires if any granular per-transition
+test (in `test_engine_main_chain.py`, `test_engine_accept_phase.py`,
+`test_engine_verifier_loop.py`, or this file) drifts away from the
+transition table.
+
+#### Scenario: ERT-S9 every TRANSITIONS entry round-trips through engine.step
+
+- **GIVEN** the static `state.TRANSITIONS` mapping containing all
+  declared `(state, event) → Transition` rows, and a generic stub
+  registered in `actions.REGISTRY` for every `transition.action` value
+  encountered
+- **WHEN** `engine.step` is called once per `(state, event)` row with
+  `cur_state=state` and `event=event`
+- **THEN** for every iteration the returned dict MUST contain
+  `action == transition.action` (or `action == "no-op"` when
+  `transition.action is None`), `next_state == transition.next_state.value`,
+  and the pool row state MUST equal `transition.next_state.value` after
+  the step

--- a/openspec/changes/REQ-test-coverage-escalated-resume-1777281969/tasks.md
+++ b/openspec/changes/REQ-test-coverage-escalated-resume-1777281969/tasks.md
@@ -1,0 +1,31 @@
+# Tasks for REQ-test-coverage-escalated-resume-1777281969
+
+## Stage: contract / spec
+
+- [x] author `proposal.md` —— 列 6 条没人覆盖的 transition + 加深 ESCALATED resume + 47/47 静态 sweep 范围
+- [x] author `specs/engine-escalated-resume-tests/spec.md` ADDED delta：
+      列出 ERT-S1..ERT-S9 全部 GIVEN/WHEN/THEN
+
+## Stage: implementation
+
+- [x] 新增 `orchestrator/tests/test_engine_escalated_resume.py`：
+  - 复用 `test_engine.py` 的 `FakePool` / `FakeReq` / `_drain_tasks`
+    （直接 `from test_engine import ...`，跟 `_main_chain` / `_accept_phase` /
+    `_verifier_loop` 同模式）
+  - 9 条 case 一一对应 ERT-S1..ERT-S9 scenario
+  - 所有 case 用 `pytest.mark.asyncio`，不依赖真 DB / BKD / K8s
+- [x] ERT-S1：(INIT, INTENT_INTAKE) → INTAKING + start_intake
+- [x] ERT-S2：(INTAKING, INTAKE_PASS) → ANALYZING + start_analyze_with_finalized_intent
+- [x] ERT-S3：(INTAKING, INTAKE_FAIL) → ESCALATED + escalate + cleanup_runner
+- [x] ERT-S4：(INTAKING, VERIFY_ESCALATE) → ESCALATED + escalate + cleanup_runner
+- [x] ERT-S5：(ANALYZING, VERIFY_ESCALATE) → ESCALATED + escalate + cleanup_runner
+- [x] ERT-S6：(PR_CI_RUNNING, PR_CI_TIMEOUT) → ESCALATED + escalate + cleanup_runner
+- [x] ERT-S7：ESCALATED + VERIFY_PASS 端到端 resume（apply_verify_pass 内部 CAS + chain emit → PR_CI_RUNNING）
+- [x] ERT-S8：ESCALATED + VERIFY_FIX_NEEDED tag 透传 → FIXER_RUNNING
+- [x] ERT-S9：参数化遍历 47 条 transition，每条 engine.step 必须返
+      `transition.action`（or `no-op` if `None`）+ `next_state == transition.next_state`
+
+## Stage: PR
+
+- [x] git push feat/REQ-test-coverage-escalated-resume-1777281969
+- [x] gh pr create --label sisyphus（PR body 写动机 + 测试方案 + 引用前 3 条 PR）

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -53,6 +53,9 @@ select = ["E", "F", "I", "B", "UP", "RUF"]
 # 中文 docstring/注释里全角标点不算问题；E501 长行让 prompt 模板和长 SQL 喘口气
 ignore = ["RUF001", "RUF002", "RUF003", "E501"]
 
+[tool.ruff.lint.isort]
+known-first-party = ["orchestrator"]
+
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",

--- a/orchestrator/tests/test_contract_engine_escalated_resume_challenger.py
+++ b/orchestrator/tests/test_contract_engine_escalated_resume_challenger.py
@@ -1,0 +1,441 @@
+"""Challenger contract tests for REQ-test-coverage-escalated-resume-1777281969.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-test-coverage-escalated-resume-1777281969/specs/engine-escalated-resume-tests/spec.md
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is truly wrong, escalate to spec_fixer to correct the spec, not the test.
+
+Scenarios covered:
+  ERT-S1  (INIT, INTENT_INTAKE) → INTAKING + start_intake dispatched exactly once
+  ERT-S2  (INTAKING, INTAKE_PASS) → ANALYZING + start_analyze_with_finalized_intent dispatched
+  ERT-S3  (INTAKING, INTAKE_FAIL) → ESCALATED + escalate + cleanup_runner(retain_pvc=True)
+  ERT-S4  (INTAKING, VERIFY_ESCALATE) → ESCALATED + escalate + cleanup_runner(retain_pvc=True)
+  ERT-S5  (ANALYZING, VERIFY_ESCALATE) → ESCALATED + escalate + cleanup_runner(retain_pvc=True)
+  ERT-S6  (PR_CI_RUNNING, PR_CI_TIMEOUT) → ESCALATED + escalate + cleanup_runner(retain_pvc=True)
+  ERT-S7  ESCALATED + VERIFY_PASS → apply_verify_pass chains to create_pr_ci_watch, final PR_CI_RUNNING
+  ERT-S8  ESCALATED + VERIFY_FIX_NEEDED → FIXER_RUNNING, start_fixer receives verify:staging_test tag + ctx
+  ERT-S9  47/47 TRANSITIONS sweep — every declared transition round-trips through engine.step
+
+Module contract under test: orchestrator.engine.step
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+# ─── Shared helpers ───────────────────────────────────────────────────────────
+
+_POOL = object()  # sentinel; all DB calls are patched away
+_REQ_ID = "REQ-test-coverage-escalated-resume-1777281969"
+_PROJECT = "proj-ert"
+
+
+class _Body:
+    issueId = "bkd-ert-test"
+    projectId = _PROJECT
+
+
+class _FakeRow:
+    def __init__(self, state, context=None):
+        self.state = state
+        self.context = context or {}
+
+
+def _patch_io(
+    monkeypatch,
+    *,
+    get_side_effects=None,
+    cas_return: bool = True,
+) -> tuple[AsyncMock, AsyncMock]:
+    """Patch all engine external I/O. Returns (cas_mock, get_mock)."""
+    from orchestrator import engine
+
+    cas = AsyncMock(return_value=cas_return)
+    monkeypatch.setattr(engine.req_state, "cas_transition", cas)
+
+    get = (
+        AsyncMock(side_effect=list(get_side_effects))
+        if get_side_effects is not None
+        else AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(engine.req_state, "get", get)
+
+    monkeypatch.setattr(engine.stage_runs, "close_latest_stage_run", AsyncMock())
+    monkeypatch.setattr(engine.stage_runs, "insert_stage_run", AsyncMock())
+    monkeypatch.setattr(engine.obs, "record_event", AsyncMock())
+
+    return cas, get
+
+
+@pytest.fixture(autouse=True)
+def _restore_registry():
+    """Snapshot and restore REGISTRY + ACTION_META around each test."""
+    from orchestrator.actions import ACTION_META, REGISTRY
+
+    snap_reg = dict(REGISTRY)
+    snap_meta = dict(ACTION_META)
+    yield
+    REGISTRY.clear()
+    ACTION_META.clear()
+    REGISTRY.update(snap_reg)
+    ACTION_META.update(snap_meta)
+
+
+async def _step(**overrides):
+    from orchestrator.engine import step
+    from orchestrator.state import Event, ReqState
+
+    defaults: dict = dict(
+        pool=_POOL,
+        body=_Body(),
+        req_id=_REQ_ID,
+        project_id=_PROJECT,
+        tags=[_REQ_ID],
+        cur_state=ReqState.SPEC_LINT_RUNNING,
+        ctx={},
+        event=Event.SPEC_LINT_FAIL,
+        depth=0,
+    )
+    defaults.update(overrides)
+    return await step(**defaults)
+
+
+# ─── ERT-S1: (INIT, INTENT_INTAKE) → INTAKING + start_intake ─────────────────
+
+
+async def test_ert_s1_init_intent_intake_enters_intaking(monkeypatch) -> None:
+    """ERT-S1: (INIT, INTENT_INTAKE) → INTAKING via start_intake dispatched exactly once.
+    Intake is the human-in-loop clarification gate; a missing transition silently strands
+    the REQ before any work begins."""
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    cas, _ = _patch_io(monkeypatch)
+    calls: list[str] = []
+
+    async def _stub(**_kw):
+        calls.append("start_intake")
+        return {}
+
+    REGISTRY["start_intake"] = _stub
+
+    result = await _step(cur_state=ReqState.INIT, event=Event.INTENT_INTAKE)
+
+    assert result.get("action") == "start_intake", (
+        f"ERT-S1: action MUST be 'start_intake'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.INTAKING.value, (
+        f"ERT-S1: next_state MUST be {ReqState.INTAKING.value!r}; got {result!r}"
+    )
+    assert len(calls) == 1, (
+        f"ERT-S1: start_intake MUST be awaited exactly once; called {len(calls)} time(s)"
+    )
+    assert cas.called, "ERT-S1: cas_transition MUST have been called"
+    cas_next = cas.call_args.args[3]
+    assert cas_next == ReqState.INTAKING, (
+        f"ERT-S1: CAS MUST advance to INTAKING; got {cas_next!r}"
+    )
+
+
+# ─── ERT-S2: (INTAKING, INTAKE_PASS) → ANALYZING + start_analyze_with_finalized_intent ──
+
+
+async def test_ert_s2_intaking_intake_pass_enters_analyzing(monkeypatch) -> None:
+    """ERT-S2: (INTAKING, INTAKE_PASS) → ANALYZING via start_analyze_with_finalized_intent.
+    Intake clarification succeeded; finalized intent is forwarded to the analyze phase."""
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    cas, _ = _patch_io(monkeypatch)
+    calls: list[str] = []
+
+    async def _stub(**_kw):
+        calls.append("start_analyze_with_finalized_intent")
+        return {}
+
+    REGISTRY["start_analyze_with_finalized_intent"] = _stub
+
+    result = await _step(cur_state=ReqState.INTAKING, event=Event.INTAKE_PASS)
+
+    assert result.get("action") == "start_analyze_with_finalized_intent", (
+        f"ERT-S2: action MUST be 'start_analyze_with_finalized_intent'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.ANALYZING.value, (
+        f"ERT-S2: next_state MUST be {ReqState.ANALYZING.value!r}; got {result!r}"
+    )
+    assert len(calls) == 1, (
+        f"ERT-S2: stub MUST be awaited exactly once; called {len(calls)} time(s)"
+    )
+    cas_next = cas.call_args.args[3]
+    assert cas_next == ReqState.ANALYZING, (
+        f"ERT-S2: CAS MUST advance to ANALYZING; got {cas_next!r}"
+    )
+
+
+# ─── ERT-S3..S6: four escalate paths + cleanup_runner(retain_pvc=True) ───────
+
+
+_ESCALATE_CASES = [
+    pytest.param(
+        "INTAKING", "INTAKE_FAIL",
+        id="ERT-S3-intaking_intake_fail",
+    ),
+    pytest.param(
+        "INTAKING", "VERIFY_ESCALATE",
+        id="ERT-S4-intaking_verify_escalate",
+    ),
+    pytest.param(
+        "ANALYZING", "VERIFY_ESCALATE",
+        id="ERT-S5-analyzing_verify_escalate",
+    ),
+    pytest.param(
+        "PR_CI_RUNNING", "PR_CI_TIMEOUT",
+        id="ERT-S6-pr_ci_timeout",
+    ),
+]
+
+
+@pytest.mark.parametrize("state_name,event_name", _ESCALATE_CASES)
+async def test_ert_s3_to_s6_non_terminal_escalate_triggers_cleanup(
+    monkeypatch, state_name, event_name,
+) -> None:
+    """ERT-S3..S6: (INTAKING|ANALYZING|PR_CI_RUNNING, *) → ESCALATED via escalate.
+    Non-terminal → terminal transition MUST fire-and-forget cleanup_runner(retain_pvc=True)
+    because the runner PVC must be preserved for post-mortem inspection."""
+    from orchestrator import engine
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    cas, _ = _patch_io(monkeypatch)
+    cleanup_calls: list[tuple] = []
+
+    class _FakeController:
+        async def cleanup_runner(self, req_id, *, retain_pvc=False):
+            cleanup_calls.append((req_id, retain_pvc))
+
+    monkeypatch.setattr(engine.k8s_runner, "get_controller", lambda: _FakeController())
+
+    calls: list[str] = []
+
+    async def _stub(**_kw):
+        calls.append("escalate")
+        return {}
+
+    REGISTRY["escalate"] = _stub
+
+    cur = ReqState[state_name]
+    evt = Event[event_name]
+
+    result = await _step(cur_state=cur, event=evt, tags=[_REQ_ID])
+    await asyncio.sleep(0)
+
+    tag = f"[{state_name}+{event_name}]"
+
+    assert result.get("action") == "escalate", (
+        f"{tag}: action MUST be 'escalate'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.ESCALATED.value, (
+        f"{tag}: next_state MUST be {ReqState.ESCALATED.value!r}; got {result!r}"
+    )
+    assert len(calls) == 1, (
+        f"{tag}: escalate MUST be awaited exactly once; called {len(calls)} time(s)"
+    )
+    assert cas.called, f"{tag}: cas_transition MUST have been called"
+    cas_next = cas.call_args.args[3]
+    assert cas_next == ReqState.ESCALATED, (
+        f"{tag}: CAS MUST advance to ESCALATED; got {cas_next!r}"
+    )
+    assert len(cleanup_calls) == 1, (
+        f"{tag}: cleanup_runner MUST be called exactly once; got {cleanup_calls!r}"
+    )
+    assert cleanup_calls[0] == (_REQ_ID, True), (
+        f"{tag}: cleanup_runner MUST be called with (req_id, retain_pvc=True); "
+        f"got {cleanup_calls[0]!r}"
+    )
+
+
+# ─── ERT-S7: ESCALATED + VERIFY_PASS chains end-to-end to PR_CI_RUNNING ──────
+
+
+async def test_ert_s7_escalated_verify_pass_chains_to_pr_ci_running(monkeypatch) -> None:
+    """ERT-S7: ESCALATED + VERIFY_PASS → apply_verify_pass chains to create_pr_ci_watch.
+    apply_verify_pass internally CAS-advances to STAGING_TEST_RUNNING and emits
+    staging-test.pass; engine MUST chain-dispatch create_pr_ci_watch; final state = PR_CI_RUNNING.
+    This is the sole human-driven path to resume a stranded REQ end-to-end."""
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    _patch_io(
+        monkeypatch,
+        get_side_effects=[_FakeRow(ReqState.STAGING_TEST_RUNNING)],
+    )
+
+    avp_calls: list[int] = []
+    cpcw_calls: list[int] = []
+
+    async def _apply_verify_pass(**_kw):
+        avp_calls.append(1)
+        return {"emit": "staging-test.pass"}
+
+    async def _create_pr_ci_watch(**_kw):
+        cpcw_calls.append(1)
+        return {}
+
+    REGISTRY["apply_verify_pass"] = _apply_verify_pass
+    REGISTRY["create_pr_ci_watch"] = _create_pr_ci_watch
+
+    result = await _step(
+        cur_state=ReqState.ESCALATED,
+        event=Event.VERIFY_PASS,
+        tags=["verifier", _REQ_ID, "verify:staging_test"],
+        ctx={"verifier_stage": "staging_test"},
+    )
+
+    assert result.get("action") == "apply_verify_pass", (
+        f"ERT-S7: action MUST be 'apply_verify_pass'; got {result!r}"
+    )
+    assert len(avp_calls) == 1, (
+        f"ERT-S7: apply_verify_pass MUST be awaited exactly once; got {len(avp_calls)}"
+    )
+    assert len(cpcw_calls) == 1, (
+        f"ERT-S7: create_pr_ci_watch MUST be awaited exactly once (chained); got {len(cpcw_calls)}"
+    )
+
+    chained = result.get("chained")
+    assert chained is not None, (
+        f"ERT-S7: result MUST contain 'chained' sub-result; got {result!r}"
+    )
+    assert chained.get("action") == "create_pr_ci_watch", (
+        f"ERT-S7: chained.action MUST be 'create_pr_ci_watch'; got chained={chained!r}"
+    )
+    assert chained.get("next_state") == ReqState.PR_CI_RUNNING.value, (
+        f"ERT-S7: chained.next_state MUST be {ReqState.PR_CI_RUNNING.value!r}; "
+        f"got chained={chained!r}"
+    )
+
+
+# ─── ERT-S8: ESCALATED + VERIFY_FIX_NEEDED → FIXER_RUNNING + tag forwarding ──
+
+
+async def test_ert_s8_escalated_verify_fix_needed_forwards_stage_tag_to_fixer(
+    monkeypatch,
+) -> None:
+    """ERT-S8: ESCALATED + VERIFY_FIX_NEEDED → FIXER_RUNNING via start_fixer.
+    Engine MUST forward verify:staging_test tag and ctx verifier_stage=staging_test
+    to start_fixer, because start_fixer reads stage from the issue tag to resolve
+    multi-verifier-concurrent ctx race."""
+    from orchestrator.actions import REGISTRY
+    from orchestrator.state import Event, ReqState
+
+    cas, _ = _patch_io(monkeypatch)
+    recorded: dict = {}
+
+    async def _stub(**kw):
+        recorded["tags"] = list(kw.get("tags", []))
+        recorded["ctx"] = dict(kw.get("ctx", {}))
+        return {}
+
+    REGISTRY["start_fixer"] = _stub
+
+    result = await _step(
+        cur_state=ReqState.ESCALATED,
+        event=Event.VERIFY_FIX_NEEDED,
+        tags=["verifier", _REQ_ID, "verify:staging_test"],
+        ctx={"verifier_stage": "staging_test", "verifier_fixer": "dev"},
+    )
+
+    assert result.get("action") == "start_fixer", (
+        f"ERT-S8: action MUST be 'start_fixer'; got {result!r}"
+    )
+    assert result.get("next_state") == ReqState.FIXER_RUNNING.value, (
+        f"ERT-S8: next_state MUST be {ReqState.FIXER_RUNNING.value!r}; got {result!r}"
+    )
+    cas_next = cas.call_args.args[3]
+    assert cas_next == ReqState.FIXER_RUNNING, (
+        f"ERT-S8: CAS MUST advance to FIXER_RUNNING; got {cas_next!r}"
+    )
+
+    tags = recorded.get("tags", [])
+    assert "verify:staging_test" in tags, (
+        f"ERT-S8: start_fixer MUST receive 'verify:staging_test' tag; got tags={tags!r}"
+    )
+    ctx = recorded.get("ctx", {})
+    assert ctx.get("verifier_stage") == "staging_test", (
+        f"ERT-S8: start_fixer MUST receive ctx.verifier_stage='staging_test'; got ctx={ctx!r}"
+    )
+
+
+# ─── ERT-S9: 47/47 TRANSITIONS sweep ─────────────────────────────────────────
+
+
+async def test_ert_s9_all_transitions_round_trip_engine_step(monkeypatch) -> None:
+    """ERT-S9: every entry in state.TRANSITIONS round-trips through engine.step.
+    Defense-in-depth sweep: if any granular per-transition test (ERT-S1..S8, VLT, MCT, APT)
+    drifts away from the transition table, this test catches the regression."""
+    from orchestrator import engine
+    from orchestrator.actions import ACTION_META, REGISTRY
+    from orchestrator.state import TRANSITIONS
+
+    _patch_io(monkeypatch)
+
+    class _FakeController:
+        async def cleanup_runner(self, req_id, *, retain_pvc=False):
+            pass
+
+    monkeypatch.setattr(engine.k8s_runner, "get_controller", lambda: _FakeController())
+
+    failures: list[str] = []
+
+    for (state, event), transition in TRANSITIONS.items():
+        snap_reg = dict(REGISTRY)
+        snap_meta = dict(ACTION_META)
+        try:
+            action_name = transition.action
+
+            if action_name is not None:
+                async def _stub(_a=action_name, **_kw):
+                    return {}
+                REGISTRY[action_name] = _stub
+
+            result = await _step(
+                cur_state=state,
+                event=event,
+                tags=[_REQ_ID],
+                ctx={},
+            )
+            await asyncio.sleep(0)
+
+            expected_action = action_name if action_name is not None else "no-op"
+            got_action = result.get("action")
+            got_next = result.get("next_state")
+            expected_next = transition.next_state.value
+
+            if got_action != expected_action:
+                failures.append(
+                    f"({state.value}, {event.value}): "
+                    f"action MUST be {expected_action!r}; got {got_action!r}"
+                )
+            if got_next != expected_next:
+                failures.append(
+                    f"({state.value}, {event.value}): "
+                    f"next_state MUST be {expected_next!r}; got {got_next!r}"
+                )
+
+        except Exception as exc:
+            failures.append(
+                f"({state.value}, {event.value}): raised {type(exc).__name__}: {exc}"
+            )
+        finally:
+            REGISTRY.clear()
+            ACTION_META.clear()
+            REGISTRY.update(snap_reg)
+            ACTION_META.update(snap_meta)
+
+    if failures:
+        pytest.fail(
+            f"ERT-S9: {len(failures)} transition(s) failed out of {len(TRANSITIONS)}:\n"
+            + "\n".join(failures)
+        )

--- a/orchestrator/tests/test_engine_escalated_resume.py
+++ b/orchestrator/tests/test_engine_escalated_resume.py
@@ -1,0 +1,452 @@
+"""Mock tests for ESCALATED resume + remaining engine.step transition gaps
+(REQ-test-coverage-escalated-resume-1777281969).
+
+This file closes the engine.step mock-test coverage gap to 47/47 of
+`state.TRANSITIONS`:
+
+- ERT-S1..ERT-S6: the 6 transitions that no other engine.step mock test
+  covered (intake-phase routing + pr_ci timeout + verify_escalate from
+  intake/analyze).
+- ERT-S7..ERT-S8: deeper coverage of the **ESCALATED resume** paths
+  beyond the dispatch-level smoke checks in test_engine_verifier_loop
+  VLT-S12/VLT-S13 — proving the chain emit re-enters main chain after
+  apply_verify_pass internally CAS-advances and that start_fixer
+  receives the verify:<stage> tag from the verifier issue.
+- ERT-S9: defense-in-depth parametrized sweep over the entire
+  `state.TRANSITIONS` table — every (state, event) round-trips through
+  engine.step.
+
+Stubs replace every action via REGISTRY shim; the engine's own
+`_record_stage_transitions` and terminal-cleanup branches still run
+because they only depend on FakePool / k8s_runner.set_controller.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Reuse FakePool / FakeReq / _drain_tasks from test_engine.py — same pattern as
+# test_engine_main_chain.py / test_engine_accept_phase.py / test_engine_verifier_loop.py.
+from test_engine import FakePool, FakeReq, _drain_tasks  # type: ignore[import-not-found]
+
+from orchestrator import engine, k8s_runner
+from orchestrator import state as state_mod
+from orchestrator.actions import ACTION_META, REGISTRY
+from orchestrator.state import Event, ReqState
+
+# ─── 共享 fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def stub_actions():
+    """Save+clear REGISTRY / ACTION_META; restore on teardown."""
+    saved_reg = dict(REGISTRY)
+    saved_meta = dict(ACTION_META)
+    REGISTRY.clear()
+    ACTION_META.clear()
+    yield REGISTRY
+    REGISTRY.clear()
+    ACTION_META.clear()
+    REGISTRY.update(saved_reg)
+    ACTION_META.update(saved_meta)
+
+
+@pytest.fixture
+def mock_runner_controller():
+    """Inject fake k8s controller; assert cleanup_runner calls."""
+    fake = MagicMock()
+    fake.cleanup_runner = AsyncMock(return_value=None)
+    k8s_runner.set_controller(fake)
+    yield fake
+    k8s_runner.set_controller(None)
+
+
+def _body(**attrs):
+    return type("B", (), attrs)()
+
+
+def _make_recorder(name: str, calls: list):
+    async def _rec(*, body, req_id, tags, ctx):
+        calls.append({"action": name, "tags": list(tags or []), "ctx": dict(ctx or {})})
+        return {"ok": True}
+    return _rec
+
+
+# ───────────────────────────────────────────────────────────────────────
+# ERT-S1: (INIT, INTENT_INTAKE) → INTAKING + start_intake
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ert_s1_init_intent_intake_enters_intaking(stub_actions):
+    """Spec ERT-S1: 物理隔离的 intake 入口（intent:intake tag → INTAKING）。"""
+    calls: list = []
+    stub_actions["start_intake"] = _make_recorder("start_intake", calls)
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.INIT.value)})
+    body = _body(issueId="src-1", projectId="p", event="intent.intake")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["intent:intake", "REQ-1"],
+        cur_state=ReqState.INIT, ctx={}, event=Event.INTENT_INTAKE,
+    )
+
+    assert result["action"] == "start_intake"
+    assert result["next_state"] == ReqState.INTAKING.value
+    assert pool.rows["REQ-1"].state == ReqState.INTAKING.value
+    assert len(calls) == 1
+
+
+# ───────────────────────────────────────────────────────────────────────
+# ERT-S2: (INTAKING, INTAKE_PASS) → ANALYZING + start_analyze_with_finalized_intent
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ert_s2_intaking_intake_pass_enters_analyzing(stub_actions):
+    """Spec ERT-S2: intake 完成 + finalized intent → 接力到 analyze。"""
+    calls: list = []
+    stub_actions["start_analyze_with_finalized_intent"] = _make_recorder(
+        "start_analyze_with_finalized_intent", calls,
+    )
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.INTAKING.value)})
+    body = _body(issueId="intake-1", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["intake", "REQ-1"],
+        cur_state=ReqState.INTAKING, ctx={}, event=Event.INTAKE_PASS,
+    )
+
+    assert result["action"] == "start_analyze_with_finalized_intent"
+    assert result["next_state"] == ReqState.ANALYZING.value
+    assert pool.rows["REQ-1"].state == ReqState.ANALYZING.value
+    assert len(calls) == 1
+
+
+# ───────────────────────────────────────────────────────────────────────
+# ERT-S3: (INTAKING, INTAKE_FAIL) → ESCALATED + escalate (with cleanup)
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ert_s3_intaking_intake_fail_escalates_with_cleanup(
+    stub_actions, mock_runner_controller,
+):
+    """Spec ERT-S3: intake 异常 / 用户放弃 → ESCALATED + cleanup_runner(retain_pvc=True)。"""
+    calls: list = []
+    stub_actions["escalate"] = _make_recorder("escalate", calls)
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.INTAKING.value)})
+    body = _body(issueId="intake-1", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["intake", "REQ-1"],
+        cur_state=ReqState.INTAKING, ctx={}, event=Event.INTAKE_FAIL,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "escalate"
+    assert result["next_state"] == ReqState.ESCALATED.value
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+    assert len(calls) == 1
+    mock_runner_controller.cleanup_runner.assert_awaited_once_with(
+        "REQ-1", retain_pvc=True,
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# ERT-S4: (INTAKING, VERIFY_ESCALATE) → ESCALATED + escalate (with cleanup)
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ert_s4_intaking_verify_escalate_escalates_with_cleanup(
+    stub_actions, mock_runner_controller,
+):
+    """Spec ERT-S4: start_analyze_with_finalized_intent 内部判 escalate（intent 缺字段
+    / clone failed 等）→ ESCALATED + cleanup。"""
+    calls: list = []
+    stub_actions["escalate"] = _make_recorder("escalate", calls)
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.INTAKING.value)})
+    body = _body(issueId="intake-1", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["intake", "REQ-1"],
+        cur_state=ReqState.INTAKING, ctx={}, event=Event.VERIFY_ESCALATE,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "escalate"
+    assert result["next_state"] == ReqState.ESCALATED.value
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+    assert len(calls) == 1
+    mock_runner_controller.cleanup_runner.assert_awaited_once_with(
+        "REQ-1", retain_pvc=True,
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# ERT-S5: (ANALYZING, VERIFY_ESCALATE) → ESCALATED + escalate (with cleanup)
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ert_s5_analyzing_verify_escalate_escalates_with_cleanup(
+    stub_actions, mock_runner_controller,
+):
+    """Spec ERT-S5: start_analyze 内部判 escalate（clone_involved_repos 失败等）→
+    ESCALATED + cleanup。实证背景：REQ-ttpos-pat-validate (2026-04-26) 漏挂这条
+    transition 时 REQ 卡 ANALYZING 60min，靠 watchdog auto_resume 才推进。"""
+    calls: list = []
+    stub_actions["escalate"] = _make_recorder("escalate", calls)
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ANALYZING.value)})
+    body = _body(issueId="analyze-1", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["analyze", "REQ-1"],
+        cur_state=ReqState.ANALYZING, ctx={}, event=Event.VERIFY_ESCALATE,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "escalate"
+    assert result["next_state"] == ReqState.ESCALATED.value
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+    assert len(calls) == 1
+    mock_runner_controller.cleanup_runner.assert_awaited_once_with(
+        "REQ-1", retain_pvc=True,
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# ERT-S6: (PR_CI_RUNNING, PR_CI_TIMEOUT) → ESCALATED + escalate (with cleanup)
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ert_s6_pr_ci_timeout_escalates_with_cleanup(
+    stub_actions, mock_runner_controller,
+):
+    """Spec ERT-S6: pr_ci_watch 轮 GitHub 长时间没 check-run → ESCALATED + cleanup。
+    可能 repo 没配 GHA 模板；sisyphus 不机制性兜 retry，escalate 给人。"""
+    calls: list = []
+    stub_actions["escalate"] = _make_recorder("escalate", calls)
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.PR_CI_RUNNING.value)})
+    body = _body(issueId="prci-1", projectId="p", event="pr-ci.timeout")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["pr-ci", "REQ-1"],
+        cur_state=ReqState.PR_CI_RUNNING, ctx={}, event=Event.PR_CI_TIMEOUT,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "escalate"
+    assert result["next_state"] == ReqState.ESCALATED.value
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+    assert len(calls) == 1
+    mock_runner_controller.cleanup_runner.assert_awaited_once_with(
+        "REQ-1", retain_pvc=True,
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# ERT-S7: ESCALATED + VERIFY_PASS — end-to-end resume to next stage via chain emit
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ert_s7_escalated_verify_pass_chains_to_next_stage(
+    stub_actions, mock_runner_controller,
+):
+    """Spec ERT-S7: 人工 resume from ESCALATED 端到端。
+    apply_verify_pass stub 模拟生产 action 行为：内部 CAS ESCALATED→STAGING_TEST_RUNNING
+    + emit STAGING_TEST_PASS。engine 必须 chain-dispatch create_pr_ci_watch，最终
+    pool row state = PR_CI_RUNNING。
+
+    这是 sisyphus 唯一让人手把"卡死"REQ 续起来的路径，dispatch-level 测（VLT-S12）
+    没法证明 chain emit 真把 REQ 推过 ESCALATED 边界 —— 必须有专门的端到端断言。
+    """
+    apply_calls: list = []
+    pr_ci_calls: list = []
+
+    async def apply_verify_pass(*, body, req_id, tags, ctx):
+        # 模拟生产 apply_verify_pass：手 CAS ESCALATED → 下游 stage_running。
+        # FakePool.fetchrow 在 UPDATE req_state 分支按 expected==actual 做 CAS。
+        from orchestrator.store import req_state as rs
+        ok = await rs.cas_transition(
+            pool, req_id, ReqState.ESCALATED, ReqState.STAGING_TEST_RUNNING,
+            Event.VERIFY_PASS, "apply_verify_pass",
+        )
+        assert ok, "stub apply_verify_pass: ESCALATED→STAGING_TEST_RUNNING CAS must succeed"
+        apply_calls.append({"tags": list(tags or []), "ctx": dict(ctx or {})})
+        return {"emit": Event.STAGING_TEST_PASS.value}
+
+    async def create_pr_ci_watch(*, body, req_id, tags, ctx):
+        pr_ci_calls.append({"tags": list(tags or [])})
+        return {"ok": True}
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ESCALATED.value)})
+    stub_actions["apply_verify_pass"] = apply_verify_pass
+    stub_actions["create_pr_ci_watch"] = create_pr_ci_watch
+
+    body = _body(issueId="vfy-resume", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["verifier", "REQ-1", "verify:staging_test"],
+        cur_state=ReqState.ESCALATED,
+        ctx={"verifier_stage": "staging_test"},
+        event=Event.VERIFY_PASS,
+    )
+    await _drain_tasks()
+
+    # 顶层 step：apply_verify_pass dispatched, transition 表声明 self-loop
+    assert result["action"] == "apply_verify_pass"
+    assert result["next_state"] == ReqState.ESCALATED.value
+
+    # chain：staging-test.pass → create_pr_ci_watch → PR_CI_RUNNING
+    assert "chained" in result, f"chain emit lost: {result!r}"
+    assert result["chained"]["action"] == "create_pr_ci_watch"
+    assert result["chained"]["next_state"] == ReqState.PR_CI_RUNNING.value
+
+    # 端到端：行真被推到 PR_CI_RUNNING
+    assert pool.rows["REQ-1"].state == ReqState.PR_CI_RUNNING.value
+    assert len(apply_calls) == 1
+    assert len(pr_ci_calls) == 1
+
+    # cur 已是 terminal (ESCALATED) → engine 跳过 cleanup（防误删 resume 路径拉的 pod）
+    mock_runner_controller.cleanup_runner.assert_not_awaited()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# ERT-S8: ESCALATED + VERIFY_FIX_NEEDED — verify:<stage> tag forwarded to start_fixer
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ert_s8_escalated_verify_fix_needed_forwards_stage_tag(stub_actions):
+    """Spec ERT-S8: start_fixer 必须能从触发本次 transition 的 verifier issue tag 读
+    `verify:<stage>` —— 多 verifier 并发时 ctx.verifier_stage 会被后来者覆盖，issue
+    tag 是无歧义真相。本 case 同时穿 ctx.verifier_stage 和 verify:staging_test tag，
+    断言两者都能从 engine 传给 handler。"""
+    calls: list = []
+
+    async def start_fixer(*, body, req_id, tags, ctx):
+        calls.append({"tags": list(tags or []), "ctx": dict(ctx or {})})
+        return {"ok": True}
+
+    stub_actions["start_fixer"] = start_fixer
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ESCALATED.value)})
+    body = _body(issueId="vfy-resume", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["verifier", "REQ-1", "verify:staging_test"],
+        cur_state=ReqState.ESCALATED,
+        ctx={"verifier_stage": "staging_test", "verifier_fixer": "dev"},
+        event=Event.VERIFY_FIX_NEEDED,
+    )
+
+    assert result["action"] == "start_fixer"
+    assert result["next_state"] == ReqState.FIXER_RUNNING.value
+    assert pool.rows["REQ-1"].state == ReqState.FIXER_RUNNING.value
+    assert len(calls) == 1
+    assert "verify:staging_test" in calls[0]["tags"], (
+        f"engine must forward verify:<stage> tag, got {calls[0]['tags']!r}"
+    )
+    assert calls[0]["ctx"].get("verifier_stage") == "staging_test"
+    assert calls[0]["ctx"].get("verifier_fixer") == "dev"
+
+
+# ───────────────────────────────────────────────────────────────────────
+# ERT-S9: 47/47 sweep — every TRANSITIONS entry round-trips through engine.step
+# ───────────────────────────────────────────────────────────────────────
+
+
+def _all_transitions_params():
+    """Build pytest params for every (state, event) → Transition row."""
+    return [
+        pytest.param(
+            st, ev, t.action, t.next_state.value,
+            id=f"{st.value}+{ev.value}",
+        )
+        for (st, ev), t in sorted(
+            state_mod.TRANSITIONS.items(),
+            key=lambda kv: (kv[0][0].value, kv[0][1].value),
+        )
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cur_state,event,expected_action,expected_next_state",
+    _all_transitions_params(),
+)
+async def test_ert_s9_full_transition_sweep(
+    stub_actions, mock_runner_controller,
+    cur_state, event, expected_action, expected_next_state,
+):
+    """Spec ERT-S9: 参数化遍历 state.TRANSITIONS 全 47 项。每项构造对应 stub action，
+    engine.step 必须返 transition.action（或 no-op 若 None）+ row state advance 到
+    transition.next_state.value。
+
+    Defense-in-depth: 即便 ERT-S1..S8 / VLT / MCT / APT 漏了某条 case，sweep 也会
+    fail。新增 transition 自动入参（pytest 生成对应 sub-case），无需手维护。"""
+    calls: list = []
+
+    if expected_action is not None:
+        stub_actions[expected_action] = _make_recorder(expected_action, calls)
+
+    pool = FakePool({"REQ-1": FakeReq(state=cur_state.value)})
+    body = _body(issueId="sweep-x", projectId="p", event="sweep")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p", tags=[],
+        cur_state=cur_state, ctx={}, event=event,
+    )
+    await _drain_tasks()
+
+    if expected_action is None:
+        assert result["action"] == "no-op", (
+            f"{cur_state.value}+{event.value}: expected no-op got {result!r}"
+        )
+        assert calls == [], (
+            f"{cur_state.value}+{event.value}: no action means no dispatch, got {calls!r}"
+        )
+    else:
+        assert result["action"] == expected_action, (
+            f"{cur_state.value}+{event.value}: expected action={expected_action} got {result!r}"
+        )
+        assert len(calls) == 1, (
+            f"{cur_state.value}+{event.value}: stub call count {calls!r}"
+        )
+        assert calls[0]["action"] == expected_action
+
+    assert result["next_state"] == expected_next_state, (
+        f"{cur_state.value}+{event.value}: next_state {result!r}"
+    )
+    assert pool.rows["REQ-1"].state == expected_next_state, (
+        f"{cur_state.value}+{event.value}: pool row state "
+        f"{pool.rows['REQ-1'].state!r}"
+    )
+
+
+def test_ert_s9_sweep_covers_exactly_47():
+    """Sanity: TRANSITIONS 必须正好 47 条 —— 加 / 减 transition 时这条 fail 提醒
+    review 是否同步加 spec scenario / 文档（state-machine.md / dump_transitions）。"""
+    assert len(state_mod.TRANSITIONS) == 47, (
+        f"expected 47 transitions, got {len(state_mod.TRANSITIONS)}; "
+        "if you intentionally added/removed a transition, update this assertion "
+        "AND add granular ERT/MCT/APT/VLT scenario coverage for it."
+    )


### PR DESCRIPTION
## Summary

- Adds `orchestrator/tests/test_engine_escalated_resume.py` with 8 granular ERT-S1..S8 cases plus a parametrized sweep, completing engine.step mock-test coverage of `state.TRANSITIONS` to 47/47 (last 6 gaps + deeper ESCALATED resume).
- ERT-S7 proves the human-resume path end-to-end: stub `apply_verify_pass` internally CAS-advances `ESCALATED → STAGING_TEST_RUNNING` and emits `staging-test.pass`; the engine chain-dispatches `create_pr_ci_watch` and the row lands at `PR_CI_RUNNING` (VLT-S12 only verified dispatch).
- Adds openspec change `REQ-test-coverage-escalated-resume-1777281969` (`engine-escalated-resume-tests` capability, 9 scenarios) describing the new behaviour.

## Coverage gap closed (the 6 transitions no other engine.step mock test had)

| transition | next_state | action |
|---|---|---|
| (INIT, INTENT_INTAKE) | INTAKING | start_intake |
| (INTAKING, INTAKE_PASS) | ANALYZING | start_analyze_with_finalized_intent |
| (INTAKING, INTAKE_FAIL) | ESCALATED | escalate |
| (INTAKING, VERIFY_ESCALATE) | ESCALATED | escalate |
| (ANALYZING, VERIFY_ESCALATE) | ESCALATED | escalate |
| (PR_CI_RUNNING, PR_CI_TIMEOUT) | ESCALATED | escalate |

Combined with #158 (APT, accept-phase), #159 (MCT, main-chain), #160 (VLT, verifier-loop + SESSION_FAILED) this brings engine.step mock coverage to all 47 declared transitions.

## Test plan

- [x] `uv run pytest tests/test_engine_escalated_resume.py -v` → 56 passed (8 ERT + 47 sweep + 1 sanity).
- [x] `uv run pytest tests/test_engine*.py tests/test_state.py` → 176 passed (no regression in sibling test files).
- [x] `uv run pytest -m "not integration"` → 1499 passed.
- [x] `uv run ruff check tests/test_engine_escalated_resume.py` → clean.
- [x] `openspec validate --strict REQ-test-coverage-escalated-resume-1777281969` → valid.
- [x] `scripts/check-scenario-refs.sh` → OK.

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-test-coverage-escalated-resume-1777281969\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/r5b5uj8i)