### PR TITLE
feat(thanatos): M0 module scaffold (REQ-thanatos-m0-scaffold-v6-1777283112)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,32 +27,42 @@ ci-lint: ## ruff lint；BASE_REV 非空 → 仅 lint 变更 *.py
 	@if [ -z "$$BASE_REV" ]; then \
 		echo "ci-lint: full scan (BASE_REV empty)"; \
 		cd orchestrator && uv run ruff check src/ tests/; \
+		cd $(SCRIPT_DIR)/thanatos && uv run ruff check src/ tests/; \
 	else \
-		files=$$(git diff --name-only --diff-filter=ACMR "$$BASE_REV"...HEAD -- 'orchestrator/src/**.py' 'orchestrator/tests/**.py' 2>/dev/null || true); \
-		if [ -z "$$files" ]; then \
+		orch_files=$$(git diff --name-only --diff-filter=ACMR "$$BASE_REV"...HEAD -- 'orchestrator/src/**.py' 'orchestrator/tests/**.py' 2>/dev/null || true); \
+		thanatos_files=$$(git diff --name-only --diff-filter=ACMR "$$BASE_REV"...HEAD -- 'thanatos/src/**.py' 'thanatos/tests/**.py' 2>/dev/null || true); \
+		if [ -z "$$orch_files" ] && [ -z "$$thanatos_files" ]; then \
 			echo "ci-lint: no Python files changed in scope (BASE_REV=$$BASE_REV)"; \
 			exit 0; \
 		fi; \
-		echo "ci-lint: scoped to $$(echo "$$files" | wc -l) file(s) (BASE_REV=$$BASE_REV)"; \
-		rel=$$(echo "$$files" | sed 's|^orchestrator/||'); \
-		cd orchestrator && uv run ruff check $$rel; \
+		if [ -n "$$orch_files" ]; then \
+			echo "ci-lint(orchestrator): scoped to $$(echo "$$orch_files" | wc -l) file(s) (BASE_REV=$$BASE_REV)"; \
+			rel=$$(echo "$$orch_files" | sed 's|^orchestrator/||'); \
+			(cd orchestrator && uv run ruff check $$rel); \
+		fi; \
+		if [ -n "$$thanatos_files" ]; then \
+			echo "ci-lint(thanatos): scoped to $$(echo "$$thanatos_files" | wc -l) file(s) (BASE_REV=$$BASE_REV)"; \
+			rel=$$(echo "$$thanatos_files" | sed 's|^thanatos/||'); \
+			(cd thanatos && uv run ruff check $$rel); \
+		fi; \
 	fi
 
 ci-unit-test: ## pytest 单测套件（排除 integration marker）
 	cd orchestrator && uv run pytest -m "not integration"
+	cd $(SCRIPT_DIR)/thanatos && uv run pytest -m "not integration"
 
 ci-integration-test: ## pytest 集成测试（integration marker；零收集视为 pass）
 	@if ! python3 -c 'import socket,os,re; dsn=os.environ.get("SISYPHUS_PG_DSN","postgresql://test:test@localhost/test"); m=re.search(r"@([^:/]+):?(\d+)?/",dsn); s=socket.create_connection((m.group(1),int(m.group(2) or 5432)),timeout=2); s.close()' 2>/dev/null; then \
-		echo "ci-integration-test: no integration tests collected (exit 5 → pass) — PostgreSQL not reachable"; \
-		exit 0; \
-	fi; \
-	cd orchestrator && set +e; uv run pytest -m integration; rc=$$?; \
-	if [ $$rc -eq 0 ] || [ $$rc -eq 5 ]; then \
-		[ $$rc -eq 5 ] && echo "ci-integration-test: no integration tests collected (exit 5 → pass)"; \
-		exit 0; \
+		echo "ci-integration-test(orchestrator): no integration tests collected (exit 5 → pass) — PostgreSQL not reachable"; \
 	else \
-		exit $$rc; \
+		cd orchestrator && set +e; uv run pytest -m integration; rc=$$?; \
+		if [ $$rc -ne 0 ] && [ $$rc -ne 5 ]; then exit $$rc; fi; \
+		[ $$rc -eq 5 ] && echo "ci-integration-test(orchestrator): no integration tests collected (exit 5 → pass)"; \
 	fi
+	@cd $(SCRIPT_DIR)/thanatos && set +e; uv run pytest -m integration; rc=$$?; \
+	if [ $$rc -ne 0 ] && [ $$rc -ne 5 ]; then exit $$rc; fi; \
+	[ $$rc -eq 5 ] && echo "ci-integration-test(thanatos): no integration tests collected (exit 5 → pass)"; \
+	exit 0
 
 # ========== ttpos-ci accept env target（self-dogfood; integration repo 契约） ==========
 # REQ-self-accept-stage-1777121797: sisyphus 自己同时充当 source repo 和 integration repo

--- a/deploy/charts/thanatos/Chart.yaml
+++ b/deploy/charts/thanatos/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: thanatos
+description: Sisyphus acceptance harness — MCP stdio server (+ optional redroid sidecar for adb driver)
+type: application
+version: 0.0.1
+appVersion: dev
+keywords:
+  - sisyphus
+  - acceptance
+  - mcp
+home: https://github.com/phona/sisyphus
+maintainers:
+  - name: phona/sisyphus team

--- a/deploy/charts/thanatos/README.md
+++ b/deploy/charts/thanatos/README.md
@@ -1,0 +1,50 @@
+# thanatos helm chart
+
+Sisyphus 验收 harness 的 helm chart。M0 留在仓内（不发 OCI），业务仓
+`accept-env-up` 在 M1 阶段会 `helm install` 这个 chart。
+
+## driver 选择
+
+`values.yaml` 顶层 `driver:` 决定 pod 拓扑：
+
+| driver | Pod 形态 | container |
+|---|---|---|
+| `playwright` | 单容器 | `thanatos`（chromium subprocess inside python） |
+| `http` | 单容器 | `thanatos` |
+| `adb` | 双容器 | `redroid` (privileged, adb tcp:5555) + `thanatos`（sidecar，连 localhost:5555） |
+
+`driver` 取其他值 `helm template` 直接 `fail`：
+
+```
+$ helm template . --set driver=desktop
+Error: execution error at (...): thanatos.driver must be one of playwright|adb|http, got "desktop"
+```
+
+## 关键 values
+
+| 字段 | 默认 | 说明 |
+|---|---|---|
+| `driver` | `playwright` | 见上 |
+| `image.repository` | `ghcr.io/phona/thanatos` | M0 镜像不发 OCI；业务仓 override 自家镜像 |
+| `image.tag` | `dev` | M0 |
+| `redroid.image` | `redroid/redroid:11.0.0-latest` | 社区版默认；自托管换 `--set redroid.image=...` |
+| `redroid.port` | `5555` | adb tcp 端口 |
+| `service.type` / `service.port` | `ClusterIP` / `7000` | 只 debug 用，accept-agent 走 `kubectl exec` 不依赖 |
+
+## 本地渲染检查
+
+```bash
+cd deploy/charts/thanatos
+helm template . --set driver=playwright > /tmp/thanatos-pw.yaml
+helm template . --set driver=adb        > /tmp/thanatos-adb.yaml
+helm template . --set driver=http       > /tmp/thanatos-http.yaml
+```
+
+三条都 0 退码就 OK。`adb` 模式 deployment 应该有两个 container，其他模式只
+有一个。
+
+## 跟 lab chart 的关系
+
+不做 sub-chart 关系。业务仓 `accept-env-up` 串联两次 `helm install`：先 lab
+chart（integration repo 的），再 thanatos chart（这个）。owner / review 边
+界跟着 chart 仓走。

--- a/deploy/charts/thanatos/templates/NOTES.txt
+++ b/deploy/charts/thanatos/templates/NOTES.txt
@@ -1,0 +1,21 @@
+Thanatos {{ .Chart.AppVersion }} is now installed in namespace {{ .Release.Namespace }}.
+
+Driver: {{ .Values.driver }}
+
+Driver topology:
+{{- if eq .Values.driver "adb" }}
+  - Pod: 2 containers ({{ include "thanatos.fullname" . }} runs `redroid` + `thanatos` as a sidecar pair).
+  - thanatos talks to redroid over localhost:{{ .Values.redroid.port }} (ADB_SERVER_ADDR is wired up automatically).
+{{- else }}
+  - Pod: 1 container ({{ include "thanatos.fullname" . }} runs `thanatos` only).
+{{- end }}
+
+Reach the MCP server (accept-agent does this; this is here for debug):
+
+  kubectl -n {{ .Release.Namespace }} exec -i \
+      $(kubectl -n {{ .Release.Namespace }} get pod -l app.kubernetes.io/name={{ include "thanatos.name" . }} -o name | head -1) \
+      -c thanatos -- python -m thanatos.server
+
+For port-forwarded debug:
+
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "thanatos.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}

--- a/deploy/charts/thanatos/templates/_helpers.tpl
+++ b/deploy/charts/thanatos/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "thanatos.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name. Truncated at 63 chars (DNS-1123 limit).
+*/}}
+{{- define "thanatos.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart label.
+*/}}
+{{- define "thanatos.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "thanatos.labels" -}}
+helm.sh/chart: {{ include "thanatos.chart" . }}
+{{ include "thanatos.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+sisyphus.phona/component: acceptance-harness
+sisyphus.phona/driver: {{ .Values.driver | quote }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "thanatos.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "thanatos.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Driver guard. helm template fails fast if driver is not in the allow-list.
+*/}}
+{{- define "thanatos.assertDriver" -}}
+{{- $allowed := list "playwright" "adb" "http" -}}
+{{- if not (has .Values.driver $allowed) -}}
+{{- fail (printf "thanatos.driver must be one of playwright|adb|http, got %q" .Values.driver) -}}
+{{- end -}}
+{{- if and (eq .Values.driver "adb") (empty .Values.redroid.image) -}}
+{{- fail "thanatos.driver=adb requires redroid.image to be set" -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/thanatos/templates/deployment.yaml
+++ b/deploy/charts/thanatos/templates/deployment.yaml
@@ -1,0 +1,67 @@
+{{- include "thanatos.assertDriver" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "thanatos.fullname" . }}
+  labels:
+    {{- include "thanatos.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "thanatos.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "thanatos.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        {{- if eq .Values.driver "adb" }}
+        - name: redroid
+          image: {{ .Values.redroid.image | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            privileged: true
+          ports:
+            - name: adb
+              containerPort: {{ .Values.redroid.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.redroid.resources | nindent 12 }}
+        {{- end }}
+        - name: thanatos
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # MCP stdio server — accept-agent talks to it via `kubectl exec`,
+          # so we don't expose any TCP listener from the container itself.
+          command: ["python", "-m", "thanatos.server"]
+          stdin: true
+          tty: false
+          env:
+            - name: THANATOS_DRIVER
+              value: {{ .Values.driver | quote }}
+            {{- if eq .Values.driver "adb" }}
+            - name: ADB_SERVER_ADDR
+              value: "localhost:{{ .Values.redroid.port }}"
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/thanatos/templates/service.yaml
+++ b/deploy/charts/thanatos/templates/service.yaml
@@ -1,0 +1,20 @@
+{{- include "thanatos.assertDriver" . -}}
+# Service is debug-only: kubectl port-forward + a local MCP client.
+# accept-agent reaches the pod via `kubectl exec` and does not depend on this
+# Service. Kept in the chart so devs can `kubectl port-forward svc/thanatos`
+# without inventing extra YAML.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "thanatos.fullname" . }}
+  labels:
+    {{- include "thanatos.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: mcp-debug
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+  selector:
+    {{- include "thanatos.selectorLabels" . | nindent 4 }}

--- a/deploy/charts/thanatos/values.yaml
+++ b/deploy/charts/thanatos/values.yaml
@@ -1,0 +1,44 @@
+# Thanatos helm chart values.
+#
+# driver toggles the deployment topology:
+#   playwright | http  → single container Pod (thanatos)
+#   adb                → two-container Pod (redroid sidecar + thanatos)
+#
+# Anything else fails `helm template` with a clear message.
+
+driver: playwright
+
+image:
+  repository: ghcr.io/phona/thanatos
+  tag: dev
+  pullPolicy: IfNotPresent
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits: {}
+
+service:
+  # Debug only: kubectl port-forward + local mcp client. accept-agent reaches
+  # the pod via `kubectl exec`, so service is not required for the happy path.
+  type: ClusterIP
+  port: 7000
+
+# redroid sidecar settings (only used when driver=adb).
+redroid:
+  image: redroid/redroid:11.0.0-latest
+  port: 5555
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+
+# Pod-level options
+imagePullSecrets: []
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Extra env vars applied to the thanatos container.
+extraEnv: []

--- a/docs/thanatos.md
+++ b/docs/thanatos.md
@@ -1,0 +1,297 @@
+# Thanatos —— Sisyphus 验收能力层
+
+> AI-native acceptance layer。给 sisyphus accept stage 一套"读 spec → 操作真实环境 → 判 pass/fail → 沉淀产品知识"的能力。
+
+## 1. 定位
+
+**做什么**：accept-agent 通过 MCP 调 thanatos，自动跑 spec.md 里的 scenario block，输出结构化 pass/fail + 证据，并把每次跑出的产品知识写回业务仓 `.thanatos/`。
+
+**不做什么**：
+- 不是测试框架（不写断言 DSL，不跑 jest/pytest）
+- 不是录制回放
+- 不是通用浏览器 agent
+- 不替 verifier-agent 判主观分类（业务 bug / spec 错 / env 起不来 / flaky 由 verifier 看证据自己判）
+- 不做 LLM 适配层（不重复 mobilerun 干的事）
+
+## 1b. 设计原则
+
+1. **不抢 AI 决定权**（继承 sisyphus）—— pass/fail 是事实陈述，主观判断让 verifier-agent 做
+2. **Semantic-first, runtime-identical** —— 验收的产物 = 用户拿到的产物。不搞 acceptance build / debug flavor / 测试钩子注入。唯一约束是产品代码该有的语义信息要有
+3. **JIT instrumentation** —— 不预先全量改造产品，scenario 走到哪、覆盖到哪、语义 instrumentation 到哪。前期集中改核心流，长尾按需补
+4. **截图是兜底，不是驱动** —— 语义层（a11y tree / view tree）是一等观察手段，截图只在语义观察失败时作为证据。不走"vision agent + 坐标点击"路线
+
+## 2. 仓库布局
+
+thanatos 代码在 sisyphus 仓内，与 orchestrator/runner 同级；产品知识在各业务仓 `.thanatos/`，无独立 KB 仓。
+
+```
+sisyphus/                                # 主代码仓
+├── thanatos/                            # 新增模块
+│   ├── src/thanatos/
+│   │   ├── server.py                    # MCP server (stdio)
+│   │   ├── runner.py                    # scenario 执行器
+│   │   ├── skill.py                     # 加载 .thanatos/skill.yaml + 笔记
+│   │   ├── scenario.py                  # 解析 spec.md (gherkin code-block + bullet 两种)
+│   │   └── drivers/
+│   │       ├── base.py                  # Driver Protocol
+│   │       ├── playwright.py            # web
+│   │       ├── adb.py                   # android via redroid
+│   │       └── http.py                  # API
+│   ├── docs/semantic-contracts/         # 每个 driver 的"产品方需要做的"清单
+│   ├── Dockerfile                       # playwright + adb + python
+│   └── pyproject.toml
+├── orchestrator/src/orchestrator/prompts/
+│   └── accept.md.j2                     # 改：调 thanatos.run_scenario，commit kb_updates
+├── deploy/templates/
+│   └── thanatos.yaml                    # per-REQ Deployment
+└── docs/thanatos.md                     # 本文档
+
+phona/<business-repo>/                   # 每个业务仓
+├── src/...
+├── openspec/changes/<REQ>/specs/.../spec.md
+└── .thanatos/                           # 跟代码同进同退
+    ├── skill.yaml                       # driver + entry + 登录 fixture
+    ├── anchors.md                       # widget 语义名
+    ├── flows.md                         # 已知流程
+    └── pitfalls.md                      # 踩过的坑
+```
+
+## 3. 部署拓扑（driver-conditional sidecar）
+
+业务仓 `accept-env-up` 起完后，per-REQ namespace 形态按 driver 不同：
+
+| Driver | Pod 形态 | 容器 |
+|---|---|---|
+| `playwright` | 单容器 pod | `thanatos`（playwright 跑 chromium 进程内 subprocess） |
+| `adb` | 双容器 pod | `redroid`（android-in-container, adb tcp:5555）+ `thanatos`（sidecar，连 localhost:5555） |
+| `http` | 单容器 pod | `thanatos` |
+
+```
+namespace: req-<REQ_ID>            （accept-env-up 起完，accept-env-down 清完）
+├── lab pod                        （integration repo helm chart 起的 backend stack）
+└── env pod (driver-conditional)
+    ├── [driver=adb]       redroid container + thanatos container (sidecar)
+    └── [driver=playwright|http]  thanatos container 单独
+
+sisyphus runner pod                 （只读 checker）
+└── make accept-env-up / down       不调 thanatos
+
+BKD Coder workspace                 （写权限那侧，gh auth）
+└── accept-agent
+    ├── kubectl exec thanatos-pod -- thanatos-mcp-server   ← stdio MCP
+    ├── 拿 results → 报 BKD issue（既有契约）
+    └── 拿 kb_updates → 写入 source repo checkout → commit + push 到 feature 分支
+```
+
+**为啥按 driver 拆**：mobile (adb) 模式 thanatos 跟 redroid 1:1 同生死，sidecar 共享 localhost 省掉 service 发现 + RBAC + 一个 pod；playwright 默认就在 driver 进程里 spawn chromium，根本没 peer container 可 sidecar；http 单容器最简。
+
+约束：
+- thanatos pod 只读连接外部环境（lab/redroid）
+- thanatos pod 不做 GH 写（坚守 sisyphus "K8s 内只读"原则）
+- 所有 GH 写发生在 Coder workspace
+
+## 4. MCP 接口（最小集）
+
+```python
+thanatos.run_scenario(
+  skill_path: str,          # 业务仓 .thanatos/ 在 runner pod 里的绝对路径
+  spec_path: str,           # spec.md 绝对路径
+  scenario_id: str,         # "REQ-1004-S1" / "Desktop collapse/expand" / spec 作者自定义
+  endpoint: str,            # accept-env-up 吐的
+) -> {
+  scenario_id: str,
+  pass: bool,
+  steps: [{step, ok, evidence: {dom?, network?, screenshot?}}],
+  kb_updates: [             # ← agent 必须 commit 到 feature 分支
+    {path: ".thanatos/anchors.md", action: "patch"|"append", content: str}
+  ],
+  failure_hint: str | null  # 给 verifier 参考，不强加分类
+}
+
+thanatos.run_all(skill_path, spec_path, endpoint) -> list[run_scenario result]
+
+thanatos.recall(skill_path, intent: str) -> [{kind, snippet, freshness}]
+```
+
+第一版只暴露 scenario 粒度，不暴露 observe/act/assert 原语。等真有需要 agent 介入控制再加。
+
+## 4b. Driver 三层观察策略
+
+每个 driver 必须实现"语义观察 → 截图"两段降级：
+
+| Driver | 语义层（一等） | 失败 → 截图（二等） |
+|---|---|---|
+| playwright | `page.accessibility.snapshot()` | `page.screenshot()` |
+| adb | `uiautomator dump` → XML view tree | `adb exec-out screencap -p` |
+| http | response body + headers | n/a |
+
+**触发降级**（命中任一）：
+- 语义观察返回空 / 节点 < 5 / 超时
+- 按 anchor 定位失败（role+name / resource-id+text 都没 match）
+- 动作发出后预期变更没出现（点了按钮但视图树没变）
+
+截图只是 evidence，不用截图驱动动作。坐标兜底默认关闭。
+
+## 4c. 产品语义契约（最小集）
+
+每个 driver 配一份"产品需要满足的最小语义"清单（`thanatos/docs/semantic-contracts/`）：
+
+| Driver | 产品方要做 |
+|---|---|
+| playwright (web) | 用 HTML 语义元素；icon-only 按钮加 `aria-label`；form 字段绑 `<label>`；heading 层级 |
+| adb (android native) | `android:contentDescription`；`importantForAccessibility="yes"`；resource-id 不混淆 |
+| adb (flutter) | 关键交互 widget 加 `Semantics(label, button:true,...)` 或 `semanticsLabel` |
+| http (API) | 无 |
+
+执行机制：每个 scenario 跑前 driver 跑 preflight（最简版："a11y/view tree 节点 ≥ N"），不达标直接 fail，failure_hint 指向对应契约文档。preflight 失败由 verifier escalate，dev 起小 PR 加 Semantics。
+
+**不**做：业务仓 GHA lint 强制全量 instrumentation（违反 JIT 原则）。
+
+## 5. Skill 格式
+
+`<business-repo>/.thanatos/skill.yaml`：
+
+```yaml
+name: pytoya-web
+driver: playwright              # playwright | adb | http
+entry: $ENDPOINT                # accept-env-up 吐的 endpoint，thanatos 注入
+fixtures:
+  admin_login:
+    user: admin
+    pass: admin
+preflight:                      # 可选，第一版用默认
+  - assert: "a11y_node_count > 5"
+```
+
+`anchors.md` / `flows.md` / `pitfalls.md`：自由 markdown，agent 读 + thanatos 写，无 schema 约束。
+
+## 6. Scenario 来源（thanatos 必须吃两种格式）
+
+**A. Gherkin code-block（API/后端 spec）**
+
+````markdown
+#### Scenario: REQ-1004-S1 — desc
+```gherkin
+Given ...
+When ...
+Then ...
+```
+````
+
+**B. Markdown bullet（UI spec）**
+
+```markdown
+#### Scenario: Desktop collapse/expand
+- **GIVEN** ...
+- **WHEN** ...
+- **THEN** ...
+```
+
+`scenario.py` 兼容两种，输出统一的 `{scenario_id, given[], when[], then[]}` 给 driver 用。
+
+## 7. 数据流（per-REQ accept 一次）
+
+```
+sisyphus engine 进 accept stage
+  ↓ make accept-env-up                        起 lab + (redroid?) + thanatos
+sisyphus 派 accept-agent
+  ↓
+accept-agent (Coder)
+  ↓ 1. clone source repo（含 .thanatos/）
+  ↓ 2. 读 spec.md 找所有 #### Scenario:
+  ↓ 3. for scenario:
+        kubectl exec thanatos-pod -- thanatos run_scenario ...
+        ↓ thanatos: load skill → pick driver → preflight → drive 环境
+        ↓ thanatos: 跑 GIVEN/WHEN/THEN，低置信截图
+        ↓ thanatos: 返回 {pass, evidence, kb_updates}
+  ↓ 4. 汇总 results → BKD follow-up "Accept Result"
+  ↓ 5. 把所有 kb_updates 应用到 source repo working tree
+  ↓ 6. git add .thanatos/ && git commit && git push origin feat/REQ-x
+  ↓ 7. tags=[accept,REQ,result:pass|fail], statusId=review
+sisyphus engine
+  ↓ make accept-env-down                       清 namespace
+  ↓ archive 或 REVIEW_RUNNING
+```
+
+人参与点：只看 BKD follow-up + feature PR diff。无第二个审 KB 的 PR。
+
+## 8. KB 写入策略
+
+只一种模式：thanatos 算 delta，agent 顺手 commit 到当前 feature 分支。
+
+- 无 propose/auto-refresh 二分
+- 无 PR review gate
+- 无 sisyphus checker 卡未提交
+
+漂移自愈：KB 没更新 → 下次 recall miss → thanatos 重新探索 → 重新吐 update。坏不了大事。
+
+## 9. Sisyphus 改动点
+
+### 9a. 责任三分（accept-env-up 拆 helm install）
+
+| 层 | 谁的 | 内容 |
+|---|---|---|
+| Lab stack（被验产品本体） | integration 仓（如 ttpos-arch-lab） | helm chart：业务自己的 backend / DB / cache / mq |
+| Acceptance harness（验收工具人） | sisyphus 仓 | helm chart：thanatos 容器（+ adb 模式时 redroid sidecar） |
+| Glue / 入口契约 | 业务仓（如 ttpos-flutter） | `make accept-env-up` / `down` —— 顺序 `helm install lab` + `helm install thanatos`；选 driver；产 endpoint |
+
+owner 边界跟 review 边界对齐：sisyphus team review thanatos chart，lab team review lab chart，业务仓只 review 自己的 values.yaml + Makefile。两 chart 不做 sub-chart 关系，各发各的版本号，业务仓自己钉。
+
+### 9b. 文件改动表
+
+| 文件 | 改动 |
+|---|---|
+| `sisyphus/thanatos/` | 新建模块（代码） |
+| `sisyphus/thanatos/docs/semantic-contracts/` | 三份契约清单（web / android / flutter） |
+| `sisyphus/deploy/templates/thanatos.yaml` | per-REQ Deployment |
+| `orchestrator/src/orchestrator/prompts/accept.md.j2` | 调 thanatos MCP，commit kb_updates |
+| `docs/integration-contracts.md` | 加 `.thanatos/` 目录约定 |
+| `docs/cookbook/ttpos-arch-lab-accept-env.md` | accept-env-up 多起一个 thanatos |
+| `docs/thanatos.md` | 本文档 |
+
+无新机械 checker、无新 verifier 模板、无新 stage、无新 state。
+
+## 10. v1 不做（明确砍掉）
+
+- 跨 product 共性 pitfall 抽取
+- KB schema 校验 / lint
+- 自动主动 explore（产品大遍历）
+- failure_class 自动分类
+- 视觉 baseline / phash diff
+- iOS / desktop driver
+- 通用 LLM 适配层
+- 业务仓 GHA "thanatos lint" 强制全量 a11y instrumentation
+- 暴露 observe/act/assert 细颗粒原语
+
+## 11. v1 happy path
+
+REQ-XXXX（pytoya web 加新表单字段）：
+
+1. dev 推 `feat/REQ-XXXX`，含 code + spec.md（3 个 `#### Scenario`）
+2. sisyphus 跑 staging-test、pr-ci-watch，过
+3. accept stage：
+   - accept-env-up 起 pytoya lab + thanatos pod
+   - accept-agent 派下来
+   - thanatos.run_all 跑 3 个 scenario，2 pass 1 fail（按钮文案对不上）
+   - 失败 scenario evidence 含截图 + 网络日志
+   - kb_updates: anchors.md 修正按钮真实文案 + pitfalls.md 加表单字段顺序坑
+4. accept-agent commit kb_updates 推到 feat/REQ-XXXX，BKD 标 result:fail
+5. verifier-agent 看 evidence 判 fix（fixer=dev 改文案 / fixer=spec 改 spec）
+6. fix 后下一轮 accept，3 个全 pass，archive
+
+## 12. 决策记录
+
+| # | 问题 | 决定 |
+|---|---|---|
+| 1 | thanatos 代码住哪 | sisyphus 仓内 `thanatos/` 模块 |
+| 2 | KB 住哪 | 各业务仓 `.thanatos/`，跟代码同 PR |
+| 3 | thanatos pod 镜像 | 独立（playwright + adb 体积大） |
+| 4 | MCP transport | stdio over `kubectl exec`（白嫖 K8s 鉴权） |
+| 5 | thanatos pod 生命周期 | per-REQ，跟 lab/redroid 同生死 |
+| 6 | 一个 pod 多 driver | 三合一（playwright + adb + http） |
+| 7 | MCP 暴露粒度 | scenario 级（v1） |
+| 8 | 失败截图存哪 | sisyphus runner PVC，URL 写进 evidence |
+| 9 | flutter 无 Semantics | preflight 卡死，要求产品方先开 Semantics |
+| 10 | 是否加业务仓 a11y lint | 不加。preflight 驱动 JIT 即可 |
+| 11 | mobilerun 定位 | 退役，能力并入 thanatos |
+| 12 | 第一个落地 product | pytoya-web（UI scenario 多） |

--- a/openspec/changes/REQ-thanatos-m0-scaffold-v6-1777283112/design.md
+++ b/openspec/changes/REQ-thanatos-m0-scaffold-v6-1777283112/design.md
@@ -1,0 +1,92 @@
+# design — REQ-thanatos-m0-scaffold-v6-1777283112
+
+权威设计在仓库根 [`docs/thanatos.md`](../../../docs/thanatos.md)（M0 同步入仓）。
+本文档记录把那个设计落到代码 / spec / chart 时的关键决策，给 reviewer 跟 future
+maintainer 留 paper trail。
+
+## 决策 1 ─ thanatos 不写 `thanatos/Makefile`，由顶层 Makefile 串 ci-* 三条
+
+**Why**：`ci-lint` / `ci-unit-test` / `ci-integration-test` 是
+[docs/integration-contracts.md](../../../docs/integration-contracts.md) 给**独立
+source repo** 的契约（sisyphus 机械 checker `dev_cross_check` / `staging_test` 跑
+`/workspace/source/<repo>/Makefile` 的这三个 target）。thanatos 不是独立 repo，
+它住 sisyphus 仓内，跟 orchestrator 同级。
+
+如果 thanatos 自己有 Makefile 但顶层 Makefile 没调它，那它的 lint / test 完全不
+在 sisyphus CI 路径上 = 跟没 CI 一样。
+
+**怎么落**：顶层 `Makefile` 既有 `ci-lint` 在 `cd orchestrator && uv run ruff
+check ...` 之后多加一行 `cd thanatos && uv run ruff check src/ tests/`，
+`ci-unit-test` 同理多加 `cd thanatos && uv run pytest -m "not integration"`，
+`ci-integration-test` 同理多加 `cd thanatos && uv run pytest -m integration` 并
+沿用顶层既有 "exit 5 视为 pass" pattern（M0 thanatos 没 integration test，pytest
+exit 5 等于 pass）。
+
+`thanatos/pyproject.toml` 仍单独保留：以后装 playwright/chromium / adb-tools 不
+污染 orchestrator 环境。
+
+## 决策 2 ─ driver 全 `raise NotImplementedError("M0: scaffold only")`
+
+**Why**：避免"空函数体 silent-pass"。M1 真填 driver 实现时，任何忘补的方法直接
+炸一个非常清晰的 `NotImplementedError`，不会让 acceptance 跑过 stub 路径误以为
+pass。错误信息固定字符串 `"M0: scaffold only"` 也方便 grep。
+
+**Tradeoff**：丧失"任何方法可被 mock 替换"的灵活度——不接受。M0 测试不需要
+mock driver，scenario parser + skill loader 是测试焦点。
+
+## 决策 3 ─ MCP SDK 用官方 `mcp>=1.2`
+
+**Why**：[`orchestrator/pyproject.toml`](../../../orchestrator/pyproject.toml)
+已经声明 `mcp>=1.2`，整仓只一份依赖。手写 JSON-RPC 没收益，徒增维护成本。
+
+## 决策 4 ─ scenario parser 真业务码 + ≥10 测试 case
+
+**Why**：parser 是 M1+ driver 跑通 GIVEN/WHEN/THEN 的喂料源。设计上要兼容两种
+spec 格式（gherkin code-block / markdown bullet）。这两个格式都已经在 sisyphus 现
+有 spec.md 里出现，提前测够省 M1 debug 时间。
+
+**测试覆盖**（详见 `thanatos/tests/test_scenario_parser.py`）：
+- gherkin 单 scenario / 多 scenario / Given-And-When-And-Then 链 / 大小写不敏感
+- bullet 单 / 多 / 多 GIVEN-WHEN-THEN 累加
+- 错误：mixed 格式 / 重复 id / 空块
+- 边界：`#### Scenario:` 出现在 fenced code block 内被忽略 / 中文 unicode 描述
+
+## 决策 5 ─ helm chart `.Values.driver` 用 `{{ fail }}` 守卫，不要静默回 default
+
+**Why**：无效 driver 值（`desktop` / 拼错 / 空字符串）必须立刻让 `helm template`
+红，不然装出去得到一个空 Pod，accept 阶段才发现就晚了。`templates/_helpers.tpl`
+的 `thanatos.assertDriver` 模板做这个守门 —— 每个 yaml template 都先 include
+它。同时 driver=adb 时 `redroid.image` 不能空（同样 `fail`）。
+
+## 决策 6 ─ `service.yaml` 留下但只 debug 用
+
+**Why**：accept-agent 走 `kubectl exec` 直接拿 stdio MCP 流，不通过 service。
+但保留 `ClusterIP` 的 service 让开发本地能 `kubectl port-forward svc/thanatos`
+调一个 MCP 客户端做 sanity check —— 不留就要每次手写 Service yaml。
+
+## 决策 7 ─ M0 不发 OCI，chart 不 push registry
+
+**Why**：thanatos:dev 镜像 build 出来后只在 K3s pod 内用 `python -m
+thanatos.server` 跑。没有 chart 仓 / OCI 注册需求，留在仓内 `deploy/charts/`
+即可。M1 业务仓 `accept-env-up` 接 `helm install` 时再决定要不要发 OCI。
+
+## 决策 8 ─ `involved_repos: []` 走 helm L4 兜底
+
+**Why**：sisyphus dogfood 部署的 `values.yaml` 里
+`default_involved_repos: [phona/sisyphus]` 是单仓部署的 boilerplate 兜底。本
+REQ 涉及单仓 phona/sisyphus，显式写 `["phona/sisyphus"]` 跟兜底重复。intake JSON
+schema 强 require 6 字段但允许空 list。
+
+**长远**：sisyphus 切多仓部署时这个字段会重新有意义。M0 不为多仓部署提前防御。
+
+## 不做（明确砍掉）
+
+- 不动 `accept.md.j2` / state machine / actions / checkers / verifier prompt /
+  runner Dockerfile —— M0 不接 accept stage 调用链
+- 不写真实 driver 运行时（playwright spawn chromium / adb shell / http client）
+- 不写 preflight 节点数 / a11y tree 探查
+- 不写 screenshot 兜底
+- 不写 kb_updates 真生成（`run_scenario` 永远返回 `kb_updates: []`）
+- 不写 recall 真实索引（永远返回 `[]`）
+- 不写业务仓 GHA "thanatos lint" 强制全量 a11y
+- 不引入新 stage / state / event / mechanical checker / verifier 模板

--- a/openspec/changes/REQ-thanatos-m0-scaffold-v6-1777283112/proposal.md
+++ b/openspec/changes/REQ-thanatos-m0-scaffold-v6-1777283112/proposal.md
@@ -1,0 +1,130 @@
+# REQ-thanatos-m0-scaffold-v6-1777283112: feat(thanatos): M0 module scaffold per docs/thanatos.md
+
+## 问题
+
+sisyphus 的 accept stage 当前没有验收能力层 —— accept-agent 只能跑 prompt，
+没有结构化 "读 spec → 操作真实环境 → 判 pass/fail → 沉淀产品知识" 的工具链。
+[docs/thanatos.md](../../../docs/thanatos.md) 已定义这一层（thanatos：MCP stdio
+server + scenario parser + driver Protocol + helm chart），需要先把骨架进仓让
+后续 milestones（M1 接 accept stage 调用链、M2 driver 真实实现、…）有承载点。
+
+v1..v5 起伏：
+- **v1** (`REQ-thanatos-m0-scaffold-1777219498`)：plan 锁了 25 文件，但 analyze 漏推
+  feat 分支 + `docs/thanatos.md` 没入仓，spec_lint vacuous-pass 然后 escalate。
+- **v2-v5**：各种 dispatch / state-machine 角度的重试，没有产出。
+
+v6 = 直接吃 v3 intake 已 finalize 的 design（24 新增文件 + 顶层 Makefile 改动），
+**全责交付** —— spec + code + PR 一站到位，feat 分支真 push、PR 真开、
+`docs/thanatos.md` 真入仓。
+
+## 方案
+
+### M0 范围（24 新增文件 + 1 既有 Makefile 改动）
+
+```
+sisyphus/
+├── docs/thanatos.md                                # 设计权威同步入仓
+├── thanatos/                                       # 新模块
+│   ├── README.md / pyproject.toml / Dockerfile
+│   ├── src/thanatos/
+│   │   ├── __init__.py / __main__.py
+│   │   ├── server.py          MCP stdio server，注册 3 tool（全 stub）
+│   │   ├── runner.py          run_scenario / run_all 调度
+│   │   ├── scenario.py        ⭐ 真实 parser（gherkin + bullet 两种格式）
+│   │   ├── skill.py           ⭐ 真实 yaml loader（pydantic 校验）
+│   │   ├── result.py          dataclasses
+│   │   └── drivers/
+│   │       ├── base.py        Driver Protocol（5 方法 async）
+│   │       ├── playwright.py  全 NotImplementedError("M0: scaffold only")
+│   │       ├── adb.py         同上
+│   │       └── http.py        同上
+│   ├── docs/semantic-contracts/  README + web/android/flutter 三份契约
+│   └── tests/
+│       ├── test_scenario_parser.py   ≥10 case
+│       └── test_skill_loader.py      合法 + 缺 driver / 未知 driver / 缺 entry
+├── deploy/charts/thanatos/                          # helm chart
+│   ├── Chart.yaml / values.yaml / README.md
+│   └── templates/_helpers.tpl / deployment.yaml / service.yaml / NOTES.txt
+└── openspec/changes/REQ-thanatos-m0-scaffold-v6-1777283112/   # 本 change
+```
+
+顶层 `Makefile` 既有的 `ci-lint` / `ci-unit-test` / `ci-integration-test` 三条
+target 各加一行 `cd thanatos && uv run ...`，把 thanatos 的 lint / 单测 / 集成测
+跟 orchestrator 一起串进 sisyphus 自己的 `staging_test` / `dev_cross_check` 检查。
+
+### MCP 接口契约（`server.py` + `specs/thanatos/contract.spec.yaml`）
+
+```python
+run_scenario(skill_path, spec_path, scenario_id, endpoint) -> ScenarioResult
+run_all(skill_path, spec_path, endpoint)                   -> list[ScenarioResult]
+recall(skill_path, intent)                                 -> list[dict]
+```
+
+M0 三个 tool **全部 stub**：`run_scenario` / `run_all` 解析参数 → load skill →
+parse spec → 选 driver class，但**不**调任何 driver 方法，直接返回
+`pass=False, failure_hint="M0: thanatos scaffold only, drivers not implemented"`。
+`recall` 永远返回 `[]`。
+
+### scenario parser（`scenario.py`）= M0 唯一真业务码
+
+支持两种 `#### Scenario:` 块：
+- gherkin code block：` ```gherkin Given/When/Then ``` `
+- markdown bullet：`- **GIVEN** ...`
+
+输出统一 `ParsedScenario(scenario_id, description, given, when, then, source_format)`。
+错误情况：mixed 格式 / 重复 id / 空块都 raise（`ScenarioFormatError` /
+`EmptyScenarioError`）。`#### Scenario:` 出现在 fenced code block 内会被忽略（不
+当真 scenario 识别）。
+
+### Driver Protocol（`drivers/base.py`）
+
+```python
+class Driver(Protocol):
+    name: str
+    async def preflight(self, endpoint: str) -> PreflightResult
+    async def observe(self) -> SemanticTree
+    async def act(self, step: str) -> ActResult
+    async def assert_(self, step: str) -> AssertResult
+    async def capture_evidence(self) -> Evidence
+```
+
+M0 三个 driver class（`PlaywrightDriver` / `AdbDriver` / `HttpDriver`）五方法
+**全部** `raise NotImplementedError("M0: scaffold only")`。Protocol 形状是 M0 冻
+结的契约，方法体在 M1 才填。
+
+### helm chart（`deploy/charts/thanatos/`）
+
+`.Values.driver` toggle 三种拓扑：
+- `playwright` / `http` → 单容器 Pod（仅 thanatos）
+- `adb` → 双容器 Pod（redroid sidecar privileged + thanatos 连 localhost:5555）
+- 其他值 → `helm template` 直接 `fail "thanatos.driver must be ..."`
+
+不发 OCI、不动 `runner/Dockerfile`、不在业务仓 `accept-env-up` 调 helm install
+（M1+）。
+
+## 取舍
+
+- **`involved_repos: []`**：v3 intake 拍的 —— 跟 helm `default_involved_repos:
+  [phona/sisyphus]` 走 L4 兜底，单仓 dogfood 不重复声明。
+- **顶层 Makefile 串 thanatos 而非自带 ci-* target**：`ci-*` 是
+  [docs/integration-contracts.md](../../../docs/integration-contracts.md) 给独立
+  source repo 的契约，thanatos 是 sisyphus 同仓子模块。让顶层 Makefile 多调一行
+  `cd thanatos && uv run ...` 比新建 `thanatos/Makefile` 让 staging_test 看不见
+  正确得多。
+- **driver 全 NotImplementedError 而非空函数体**：明示"M0 scaffold only"，M1 跑
+  到这里如果忘补会立刻 fail，不会 silent-pass。
+- **scenario parser 写真而非 stub**：openspec spec.md 进 spec_lint
+  ([scripts/check-scenario-refs.sh](../../../scripts/check-scenario-refs.sh)) 已
+  经验证 scenario id 引用一致性；parser 真要在 M1+ 给 driver 喂 GIVEN/WHEN/THEN
+  数据，提前测够省 M1 debug 时间。
+
+## 影响范围
+
+- `docs/thanatos.md` —— 新增（设计权威）
+- `thanatos/` —— 新增模块（16 src + 4 docs + 2 tests + Dockerfile + pyproject + README）
+- `deploy/charts/thanatos/` —— 新增 helm chart（4 templates + values + Chart + README）
+- `openspec/changes/REQ-thanatos-m0-scaffold-v6-1777283112/` —— 本 change
+- `Makefile`（顶层）—— `ci-lint` / `ci-unit-test` / `ci-integration-test` 各扩一行
+
+**不**改：accept.md.j2 / state machine / actions / checkers / runner Dockerfile /
+业务仓 accept-env-up Makefile / `.github/workflows/`。这些都是 M1+ 范围。

--- a/openspec/changes/REQ-thanatos-m0-scaffold-v6-1777283112/specs/thanatos/contract.spec.yaml
+++ b/openspec/changes/REQ-thanatos-m0-scaffold-v6-1777283112/specs/thanatos/contract.spec.yaml
@@ -1,0 +1,123 @@
+# Thanatos MCP接口契约 — 三个 tool 的 input / output schema。
+#
+# transport: MCP stdio over `kubectl exec` (or `python -m thanatos.server` for
+# local debug). M0 三个 tool 全 stub —— schema 形状是 M0 冻结的契约，下游 caller
+# (accept-agent) 在 M1 接调用链时按此 schema 构造 request 即可。
+
+mcp_server:
+  name: thanatos
+  version: "0.0.1"
+  transport: stdio
+
+tools:
+  - name: run_scenario
+    description: |
+      Run a single scenario from a spec.md against an endpoint. M0 returns
+      pass=false with `failure_hint="M0: thanatos scaffold only, drivers not implemented"`.
+    input:
+      type: object
+      required: [skill_path, spec_path, scenario_id, endpoint]
+      properties:
+        skill_path:
+          type: string
+          description: Absolute path inside runner pod to .thanatos/skill.yaml
+        spec_path:
+          type: string
+          description: Absolute path to the openspec spec.md whose Scenario blocks should be parsed
+        scenario_id:
+          type: string
+          description: First-token id from `#### Scenario: <ID> [— <desc>]`
+        endpoint:
+          type: string
+          description: URL emitted by `make accept-env-up` last-line JSON
+    output:
+      type: object
+      required: [scenario_id, pass, steps, kb_updates]
+      properties:
+        scenario_id: { type: string }
+        pass: { type: boolean }
+        steps:
+          type: array
+          items:
+            type: object
+            required: [step, ok]
+            properties:
+              step: { type: string }
+              ok: { type: boolean }
+              evidence:
+                type: object
+                properties:
+                  dom: { type: string }
+                  network: { type: array }
+                  screenshot: { type: string }
+        kb_updates:
+          type: array
+          items:
+            type: object
+            required: [path, action, content]
+            properties:
+              path: { type: string }
+              action: { enum: [patch, append] }
+              content: { type: string }
+        failure_hint:
+          type: [string, "null"]
+
+  - name: run_all
+    description: |
+      Run every scenario in a spec.md against an endpoint. M0 returns one stub
+      ScenarioResult per parsed scenario.
+    input:
+      type: object
+      required: [skill_path, spec_path, endpoint]
+      properties:
+        skill_path: { type: string }
+        spec_path: { type: string }
+        endpoint: { type: string }
+    output:
+      type: array
+      items:
+        $ref: "#/tools/0/output"
+
+  - name: recall
+    description: |
+      Recall product knowledge fragments matching an intent. M0 always returns
+      an empty list.
+    input:
+      type: object
+      required: [skill_path, intent]
+      properties:
+        skill_path: { type: string }
+        intent: { type: string }
+    output:
+      type: array
+      items:
+        type: object
+        properties:
+          kind: { type: string }
+          snippet: { type: string }
+          freshness: { type: string }
+
+# Skill yaml schema — what `<repo>/.thanatos/skill.yaml` must look like.
+skill_yaml:
+  type: object
+  required: [name, driver, entry]
+  properties:
+    name:
+      type: string
+      description: Non-empty product name
+    driver:
+      enum: [playwright, adb, http]
+    entry:
+      type: string
+      description: '$ENDPOINT placeholder — replaced at run time with accept-env-up endpoint'
+    fixtures:
+      type: object
+      additionalProperties:
+        type: object
+    preflight:
+      type: array
+      items:
+        type: object
+        required: [assert]
+        properties:
+          assert: { type: string }

--- a/openspec/changes/REQ-thanatos-m0-scaffold-v6-1777283112/specs/thanatos/spec.md
+++ b/openspec/changes/REQ-thanatos-m0-scaffold-v6-1777283112/specs/thanatos/spec.md
@@ -1,0 +1,119 @@
+## ADDED Requirements
+
+### Requirement: thanatos exposes a stdio MCP server entrypoint
+
+The thanatos package SHALL expose a stdio MCP server entrypoint reachable as
+`python -m thanatos.server` (and `python -m thanatos`). The server MUST register
+exactly three tools — `run_scenario`, `run_all`, and `recall` — when its
+`list_tools` handler is invoked. Each tool's `inputSchema` MUST declare the
+`required` parameters listed in
+[`contract.spec.yaml`](./contract.spec.yaml).
+
+The Dockerfile SHALL set `python -m thanatos.server` as its entrypoint so that
+`docker run thanatos:dev` boots the server with no extra arguments.
+
+#### Scenario: THAN-S1 server module starts and registers three tools
+
+- **GIVEN** the thanatos package is installed and `python -m thanatos.server`
+  is invoked
+- **WHEN** an MCP client sends `initialize` followed by `tools/list`
+- **THEN** the response lists exactly the three tools `run_scenario`,
+  `run_all`, `recall`
+- **AND** every tool's `inputSchema` declares the `required` parameters
+  documented in `contract.spec.yaml`
+
+### Requirement: scenario parser supports gherkin code-block and bullet formats
+
+The `thanatos.scenario` module SHALL expose `parse_spec_text(text)` and
+`parse_spec_file(path)` functions that scan markdown for `#### Scenario:`
+headings and return a list of `ParsedScenario` records in source order. The
+parser MUST accept two mutually-exclusive step formats inside a single block:
+
+- a fenced code block whose info string is `gherkin`
+- markdown bullets of the form `- **GIVEN** ...` (case-insensitive on the
+  keyword)
+
+Each `ParsedScenario` MUST contain `scenario_id`, `description`, `given`,
+`when`, `then`, and `source_format`. `And`/`But` lines MUST extend whichever
+bucket (`given` / `when` / `then`) was last filled. The parser MUST raise
+`ScenarioFormatError` when a block mixes gherkin and bullet steps, or when two
+blocks share an id. The parser MUST raise `EmptyScenarioError` when a block
+contains no recognisable GIVEN/WHEN/THEN steps. `#### Scenario:` headings that
+appear inside a fenced code block (any info string other than `gherkin`) MUST
+be ignored.
+
+#### Scenario: THAN-S2 gherkin code block parses into structured fields
+
+- **GIVEN** a markdown document containing `#### Scenario: REQ-1004-S1` followed
+  by a ` ```gherkin` fence with `Given foo`, `When bar`, `Then baz`
+- **WHEN** `parse_spec_text` is invoked
+- **THEN** the returned `ParsedScenario` has `scenario_id="REQ-1004-S1"`,
+  `given=["foo"]`, `when=["bar"]`, `then=["baz"]`, and `source_format="gherkin"`
+
+#### Scenario: THAN-S3 bullet-format scenario parses with multiple GIVEN entries
+
+- **GIVEN** a markdown block with `#### Scenario: THAN-multi`
+- **AND** four bullets: two `- **GIVEN** ...`, one `- **WHEN** ...`, one
+  `- **THEN** ...`
+- **WHEN** `parse_spec_text` is invoked
+- **THEN** the returned `ParsedScenario.given` list has length 2 and
+  `source_format == "bullet"`
+
+#### Scenario: THAN-S4 mixed gherkin and bullet inside one block raises ScenarioFormatError
+
+- **GIVEN** a `#### Scenario: MIX-1` block that contains both a `- **GIVEN** ...`
+  bullet and a ` ```gherkin` fence with steps
+- **WHEN** `parse_spec_text` is invoked
+- **THEN** the parser raises `ScenarioFormatError` with a message containing
+  `mixes gherkin`
+
+### Requirement: Driver Protocol defines a five-method async contract
+
+The `thanatos.drivers.base` module SHALL declare a `Driver` Protocol whose
+methods are exactly `preflight(endpoint)`, `observe()`, `act(step)`,
+`assert_(step)`, and `capture_evidence()`, all async. The Protocol MUST carry a
+class-level `name: str` attribute. M0 SHALL ship three concrete driver classes
+— `PlaywrightDriver`, `AdbDriver`, `HttpDriver` — each importable from
+`thanatos.drivers`. Every method on every M0 driver class MUST raise
+`NotImplementedError("M0: scaffold only")`. No method body MAY contain real
+runtime logic in M0.
+
+#### Scenario: THAN-S5 each driver class raises NotImplementedError on every method
+
+- **GIVEN** an instance of `PlaywrightDriver`, `AdbDriver`, or `HttpDriver`
+- **WHEN** any of `preflight`, `observe`, `act`, `assert_`, or
+  `capture_evidence` is awaited
+- **THEN** `NotImplementedError` is raised with the message
+  `"M0: scaffold only"`
+
+### Requirement: helm chart renders three driver-conditional pod topologies
+
+The chart at `deploy/charts/thanatos/` SHALL render successfully (exit 0) under
+`helm template . --set driver=<value>` for `<value> ∈ {playwright, adb, http}`.
+The rendered Deployment MUST contain exactly two containers (`redroid` and
+`thanatos`) when `driver=adb`, and exactly one container (`thanatos`) when
+`driver=playwright` or `driver=http`. The `redroid` container MUST be marked
+`securityContext.privileged: true` and expose container port `5555`. The
+`thanatos` container MUST set `command: ["python", "-m", "thanatos.server"]` in
+all three modes. Any `driver` value outside `{playwright, adb, http}` MUST cause
+`helm template` to fail with a non-zero exit code and an error message naming
+the allowed values.
+
+#### Scenario: THAN-S6 driver=adb emits a two-container Pod with redroid + thanatos
+
+- **GIVEN** the chart at `deploy/charts/thanatos/`
+- **WHEN** `helm template . --set driver=adb` is invoked
+- **THEN** the rendered manifest contains a Deployment whose pod spec lists
+  exactly two containers named `redroid` and `thanatos`
+- **AND** the `redroid` container has `securityContext.privileged: true`
+- **AND** the `thanatos` container has `ADB_SERVER_ADDR=localhost:5555` in its
+  env
+
+#### Scenario: THAN-S7 driver=playwright emits a single-container thanatos Pod
+
+- **GIVEN** the chart at `deploy/charts/thanatos/`
+- **WHEN** `helm template . --set driver=playwright` is invoked
+- **THEN** the rendered manifest contains a Deployment whose pod spec lists
+  exactly one container named `thanatos`
+- **AND** the `thanatos` container's `command` is
+  `["python", "-m", "thanatos.server"]`

--- a/openspec/changes/REQ-thanatos-m0-scaffold-v6-1777283112/tasks.md
+++ b/openspec/changes/REQ-thanatos-m0-scaffold-v6-1777283112/tasks.md
@@ -1,0 +1,51 @@
+# tasks — REQ-thanatos-m0-scaffold-v6-1777283112
+
+## Stage: contract / spec
+- [x] 在仓库根写 `docs/thanatos.md`（设计权威，v3 intake 锁定的全文）
+- [x] author `specs/thanatos/contract.spec.yaml`（MCP 接口 schema：run_scenario / run_all / recall）
+- [x] author `specs/thanatos/spec.md`（4 Requirement + 7 Scenario [THAN-S1..THAN-S7]，delta 格式）
+- [x] proposal.md（动机 + 方案 + 取舍 + 影响范围）
+- [x] design.md（关键决策记录 + tradeoff）
+
+## Stage: implementation — thanatos 模块
+- [x] `thanatos/pyproject.toml`（python>=3.12; mcp>=1.2 + pydantic + pyyaml；dev: pytest + ruff + mypy）
+- [x] `thanatos/Dockerfile`（python:3.12-slim + COPY src + entrypoint `python -m thanatos.server`）
+- [x] `thanatos/README.md`（M0 scope + build/test 命令）
+- [x] `thanatos/src/thanatos/__init__.py` / `__main__.py`（`python -m thanatos` alias）
+- [x] `thanatos/src/thanatos/result.py`（StepResult / ScenarioResult / Evidence / KbUpdate dataclasses + to_dict）
+- [x] `thanatos/src/thanatos/scenario.py`（**真实 parser**：gherkin code-block + markdown bullet 双格式 + ScenarioFormatError / EmptyScenarioError）
+- [x] `thanatos/src/thanatos/skill.py`（**真实 yaml loader**：pydantic Skill model，driver Literal["playwright","adb","http"]，缺 driver / 未知 driver / 缺 entry / 错 yaml 都 raise SkillLoadError）
+- [x] `thanatos/src/thanatos/runner.py`（run_scenario / run_all / recall 调度；M0 stub 返回 pass=False + failure_hint）
+- [x] `thanatos/src/thanatos/server.py`（MCP stdio server；list_tools 暴露 3 个 tool；call_tool 路由到 runner）
+- [x] `thanatos/src/thanatos/drivers/__init__.py`（导出 Driver Protocol + 3 个 driver class）
+- [x] `thanatos/src/thanatos/drivers/base.py`（Driver Protocol：preflight / observe / act / assert_ / capture_evidence；PreflightResult / SemanticTree / ActResult / AssertResult / Evidence dataclasses）
+- [x] `thanatos/src/thanatos/drivers/playwright.py`（PlaywrightDriver；五方法全 raise NotImplementedError("M0: scaffold only")）
+- [x] `thanatos/src/thanatos/drivers/adb.py`（同上 AdbDriver）
+- [x] `thanatos/src/thanatos/drivers/http.py`（同上 HttpDriver）
+- [x] `thanatos/docs/semantic-contracts/README.md`（总览 + 设计原则）
+- [x] `thanatos/docs/semantic-contracts/web.md`（playwright / a11y baseline）
+- [x] `thanatos/docs/semantic-contracts/android.md`（adb android native baseline）
+- [x] `thanatos/docs/semantic-contracts/flutter.md`（adb flutter baseline）
+
+## Stage: implementation — helm chart
+- [x] `deploy/charts/thanatos/Chart.yaml`（apiVersion v2, version 0.0.1, appVersion dev）
+- [x] `deploy/charts/thanatos/values.yaml`（driver default playwright / image / redroid 默认社区版）
+- [x] `deploy/charts/thanatos/README.md`（driver 选择 + values 字段 + 三种 helm template 检查命令）
+- [x] `deploy/charts/thanatos/templates/_helpers.tpl`（labels + assertDriver 守卫）
+- [x] `deploy/charts/thanatos/templates/deployment.yaml`（driver-conditional：adb 双容器，其他单容器）
+- [x] `deploy/charts/thanatos/templates/service.yaml`（debug ClusterIP）
+- [x] `deploy/charts/thanatos/templates/NOTES.txt`（kubectl exec 指令提示）
+
+## Stage: implementation — Makefile
+- [x] 顶层 `Makefile` `ci-lint` 加一行 `cd thanatos && uv run ruff check src/ tests/`
+- [x] 顶层 `Makefile` `ci-unit-test` 加一行 `cd thanatos && uv run pytest -m "not integration"`
+- [x] 顶层 `Makefile` `ci-integration-test` 加一行 `cd thanatos && uv run pytest -m integration`（exit 5 视为 pass）
+
+## Stage: tests
+- [x] `thanatos/tests/test_scenario_parser.py`（≥10 case：gherkin / bullet / 多 G-W-T / 大小写 / 链 And-But / mixed reject / 空块 reject / 重复 id reject / fenced code block 不识别 / unicode）
+- [x] `thanatos/tests/test_skill_loader.py`（合法 yaml + 缺 driver + 未知 driver + 缺 entry 各 1 case）
+
+## Stage: PR
+- [x] `git push origin feat/REQ-thanatos-m0-scaffold-v6-1777283112`
+- [x] `gh pr create --label sisyphus`（含 `<!-- sisyphus:cross-link -->` footer）
+- [x] BKD intent issue PATCH tags + statusId=review

--- a/thanatos/.gitignore
+++ b/thanatos/.gitignore
@@ -1,0 +1,23 @@
+# venv / build
+.venv/
+dist/
+build/
+*.egg-info/
+
+# pycache
+__pycache__/
+*.pyc
+*.pyo
+
+# tools cache
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+
+# coverage
+.coverage
+htmlcov/
+
+# secrets / local
+.env
+.env.local

--- a/thanatos/Dockerfile
+++ b/thanatos/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /opt/thanatos
+
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+RUN pip install --no-cache-dir .
+
+# Stdio MCP server. Drivers (playwright/adb-tools/etc.) are *not* installed in M0:
+# all driver methods raise NotImplementedError, so adding the heavy runtime now
+# would just bloat the image with unused capability.
+ENTRYPOINT ["python", "-m", "thanatos.server"]

--- a/thanatos/README.md
+++ b/thanatos/README.md
@@ -1,0 +1,33 @@
+# thanatos — sisyphus 验收能力层
+
+> M0 scaffold only。运行时 driver 全部未实现；只有 scenario parser + skill loader 是真代码。
+
+设计权威：[`docs/thanatos.md`](../docs/thanatos.md)（仓库根级，由 sisyphus engine 共享）。
+
+## M0 范围
+
+- ✅ MCP stdio server entrypoint（`python -m thanatos.server`）—— 注册 3 个 tool，全 stub
+- ✅ scenario parser（`thanatos.scenario`）—— 解析 spec.md 里 `#### Scenario:` 块的 gherkin / bullet 两种格式
+- ✅ skill loader（`thanatos.skill`）—— 校验 `.thanatos/skill.yaml`（必填 `driver` / `entry`，driver ∈ {playwright, adb, http}）
+- ✅ Driver Protocol（`thanatos.drivers.base`）—— `preflight / observe / act / assert_ / capture_evidence` 五方法 async 契约
+- ❌ Driver 实现（playwright / adb / http）—— 全部 `raise NotImplementedError("M0: scaffold only")`
+- ❌ KB 更新真实生成（`run_scenario` 永远返回 `kb_updates: []`）
+- ❌ recall 索引（永远返回 `[]`）
+
+## Build / test / run
+
+```bash
+# lint
+cd thanatos && uv run ruff check src/ tests/
+
+# unit tests（≥10 parser case + skill loader case）
+cd thanatos && uv run pytest -m "not integration"
+
+# 镜像 build
+docker build thanatos/ -t thanatos:dev
+
+# MCP banner sanity check
+docker run --rm -i thanatos:dev python -m thanatos.server <<< '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+```
+
+顶层 sisyphus Makefile 已经把 thanatos 的 lint / unit-test / integration-test 串进 `make ci-lint / ci-unit-test / ci-integration-test` —— 跟 orchestrator 一起被 sisyphus 自己的 staging_test / dev_cross_check 覆盖。

--- a/thanatos/docs/semantic-contracts/README.md
+++ b/thanatos/docs/semantic-contracts/README.md
@@ -1,0 +1,29 @@
+# Thanatos semantic contracts
+
+每个 driver 跑 scenario 前都做 **preflight**：抽业务前端 / API 的语义层快照，
+节点数 / 关键签名不到阈值就直接 fail —— `failure_hint` 指向对应 driver 的契约
+（这个目录下的子文档），让 verifier-agent 转发给 dev 起小 PR 加 Semantics。
+
+## 设计原则（来自 docs/thanatos.md §1b §4c）
+
+1. **JIT instrumentation** —— 不预先全量改造产品；scenario 触及的节点必须有，
+   长尾按需补。
+2. **不卡 GHA** —— 不在业务仓 GitHub Actions 加 "thanatos lint" 强制全量
+   a11y。preflight 失败的反馈环（accept fail → verifier escalate → dev PR）
+   就够了。
+3. **Semantic-first，截图兜底** —— 三个 driver 都先抓语义层（a11y tree / view
+   tree / response body），抓不到才退到截图，截图只当 evidence。
+
+## 文档
+
+- [`web.md`](./web.md) —— playwright driver
+- [`android.md`](./android.md) —— adb driver（android native）
+- [`flutter.md`](./flutter.md) —— adb driver（flutter android）
+
+API driver（http）没有产品方契约（response body 自然就是语义层）。
+
+## M0 ≠ 强制项
+
+M0 只交付 driver Protocol 骨架 + 这些契约 markdown。`preflight` 真实判断节点
+数会在 M1 接 driver 时才生效。这些文档现在先入仓，让 dev 提前知道 M1+ 上线后
+产品代码的 baseline 是什么。

--- a/thanatos/docs/semantic-contracts/android.md
+++ b/thanatos/docs/semantic-contracts/android.md
@@ -1,0 +1,27 @@
+# Android (native) semantic contract（adb driver）
+
+adb driver 用 `uiautomator dump` 抓 view tree。下面是产品方需要保证的最小
+语义。
+
+## 基线
+
+| 项 | 要求 | 反例 |
+|---|---|---|
+| `android:contentDescription` | 任何无文字 / icon-only 按钮都有 `contentDescription` 描述用途 | `ImageButton` 不带 contentDescription |
+| `importantForAccessibility="yes"` | 关键交互 view 显式开 `yes`（默认 auto 在某些 ROM 上会被跳过） | 默认 auto |
+| 稳定 `resource-id` | 关键交互 view（按钮 / 输入框 / 列表项）有可读、稳定、不被 ProGuard 改的 resource-id | 用动态生成 id |
+| 非交互区域 mark `no` | 装饰性 view 用 `importantForAccessibility="no"` 减少噪音 | 全开 yes |
+| Toast / Snackbar | 提示文案能进 view tree（不是纯绘制层） | 自绘浮层无 contentDescription |
+
+## preflight 阈值（M1 上线后）
+
+- uiautomator dump 节点数 ≥ 5
+- 至少一个 view 有非空 `text` 或 `content-desc`
+- 关键交互按钮命中 `resource-id` 命名规范（业务仓 anchors.md 决定）
+
+## 失败时 dev 应该怎么改
+
+1. 在对应 layout xml / Compose 里加 `android:contentDescription` /
+   `Modifier.semantics { contentDescription = "..." }`
+2. 关键交互 view 加 `android:id="@+id/btn_submit"` 这样的稳定 id
+3. ProGuard 配置保留 `resource-id` 命名（res-id 默认不被混淆，但确认下规则）

--- a/thanatos/docs/semantic-contracts/flutter.md
+++ b/thanatos/docs/semantic-contracts/flutter.md
@@ -1,0 +1,27 @@
+# Flutter semantic contract（adb driver, flutter android target）
+
+flutter 默认产 platform view 不直接进 uiautomator view tree —— 必须显式
+`Semantics(...)` 或 `semanticsLabel` 才能被 adb driver 看到。
+
+## 基线
+
+| 项 | 要求 | 反例 |
+|---|---|---|
+| `Semantics(label, button: true, ...)` | 关键交互 widget（按钮、卡片、tap 区）都有 `Semantics` 包裹 | 裸 `GestureDetector` 没 Semantics |
+| `semanticsLabel:` 简写 | `Image(semanticsLabel: "头像")` / `Text` 自带 semanticsLabel | icon Widget 不传 label |
+| `MergeSemantics` | 一个父节点描述多 child 时用 `MergeSemantics` 防止 tree 爆炸 | 每个 icon + label 都自成 node |
+| `excludeSemantics` | 装饰元素 mark `excludeSemantics: true` 减噪 | 装饰图也进 tree |
+| 表单字段 | `TextField` 带 `decoration: InputDecoration(labelText: ...)` | 占位文字不算 label |
+
+## preflight 阈值（M1 上线后）
+
+- uiautomator dump 节点数 ≥ 5（注意 flutter app 默认可能只有一个 root view）
+- 至少一个 view 有非空 `content-desc`（说明有 Semantics 进了 a11y tree）
+
+## 失败时 dev 应该怎么改
+
+1. 找到对应 widget tree 节点
+2. 包一层 `Semantics(label: "…", button: true, child: …)` 或在 `IconButton` /
+   `Image` 直接传 `semanticsLabel`
+3. flutter widget inspector 跑一遍，确认对应 a11y label 显示
+4. 同 PR commit 进业务仓，sisyphus 下一轮 accept 重跑

--- a/thanatos/docs/semantic-contracts/web.md
+++ b/thanatos/docs/semantic-contracts/web.md
@@ -1,0 +1,27 @@
+# Web semantic contract（playwright driver）
+
+playwright driver 用 `page.accessibility.snapshot()` 抓 a11y tree。下面是产
+品方需要保证的最小语义。
+
+## 基线
+
+| 项 | 要求 | 反例 |
+|---|---|---|
+| 用 HTML 语义元素 | `<button>` / `<a>` / `<nav>` / `<main>` / `<form>` 而不是裸 `<div onclick>` | `<div class="btn-primary">提交</div>` 不算 button |
+| icon-only 按钮加 `aria-label` | 任何只有 icon 的可点击元素都有 `aria-label` 描述用途 | `<button><i class="trash"/></button>` 缺 `aria-label="删除"` |
+| form 字段绑 `<label>` | input/select 都跟一个 `<label for>` 关联，或被 `<label>` 包住，或带 `aria-label` | 裸 `<input placeholder="邮箱">` 不达标 |
+| heading 层级 | 页面顶级使用 h1/h2/h3 形成层级，不跳级 | 全用 `<div class="title-lg">` |
+| 表格用 `<table>` | 数据表用真 table + `<th scope>` | 用 `<div class="row">` 拼出表格 |
+| modal / popover | 用 `role="dialog"` + `aria-labelledby` | div 浮层无 role |
+
+## preflight 阈值（M1 上线后）
+
+- a11y snapshot 节点数 ≥ 5（页面加载到首屏后）
+- 至少一个 `role: heading` 出现
+- 表单页：每个 input 都有可关联 label
+
+## 失败时 dev 应该怎么改
+
+1. 找 `failure_hint` 提到的节点（路径或 selector）
+2. 把对应组件加 `aria-label` / `<label>` / 换语义元素
+3. 起 1-2 个文件级别小 PR，跟主 feature PR 平行 review

--- a/thanatos/pyproject.toml
+++ b/thanatos/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "thanatos"
+version = "0.0.1"
+description = "Sisyphus acceptance layer (MCP stdio server + scenario parser + driver protocol)."
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "Apache-2.0" }
+authors = [{ name = "phona" }]
+dependencies = [
+    "mcp>=1.2",
+    "pydantic>=2.9",
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.3",
+    "pytest-asyncio>=0.24",
+    "ruff>=0.7",
+    "mypy>=1.13",
+]
+
+[project.scripts]
+thanatos-server = "thanatos.server:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/thanatos"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP", "N", "RUF"]
+ignore = ["E501"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "integration: integration tests requiring external infra",
+]
+asyncio_mode = "auto"
+
+[tool.mypy]
+python_version = "3.12"
+strict = false
+warn_unused_configs = true
+disallow_untyped_defs = false

--- a/thanatos/src/thanatos/__init__.py
+++ b/thanatos/src/thanatos/__init__.py
@@ -1,0 +1,3 @@
+"""Thanatos — sisyphus acceptance layer (M0 scaffold)."""
+
+__version__ = "0.0.1"

--- a/thanatos/src/thanatos/__main__.py
+++ b/thanatos/src/thanatos/__main__.py
@@ -1,0 +1,6 @@
+"""Allow `python -m thanatos` to launch the MCP stdio server."""
+
+from thanatos.server import main
+
+if __name__ == "__main__":
+    main()

--- a/thanatos/src/thanatos/drivers/__init__.py
+++ b/thanatos/src/thanatos/drivers/__init__.py
@@ -1,0 +1,30 @@
+"""Driver implementations.
+
+M0: every driver method raises ``NotImplementedError``. The intent is to
+freeze the Protocol shape and the per-driver class boundaries before the
+real runtime work in M1.
+"""
+
+from thanatos.drivers.adb import AdbDriver
+from thanatos.drivers.base import (
+    ActResult,
+    AssertResult,
+    Driver,
+    DriverError,
+    PreflightResult,
+    SemanticTree,
+)
+from thanatos.drivers.http import HttpDriver
+from thanatos.drivers.playwright import PlaywrightDriver
+
+__all__ = [
+    "ActResult",
+    "AdbDriver",
+    "AssertResult",
+    "Driver",
+    "DriverError",
+    "HttpDriver",
+    "PlaywrightDriver",
+    "PreflightResult",
+    "SemanticTree",
+]

--- a/thanatos/src/thanatos/drivers/adb.py
+++ b/thanatos/src/thanatos/drivers/adb.py
@@ -1,0 +1,32 @@
+"""ADB driver — Android via redroid (sidecar pod) — M0 stub."""
+
+from __future__ import annotations
+
+from thanatos.drivers.base import (
+    ActResult,
+    AssertResult,
+    Evidence,
+    PreflightResult,
+    SemanticTree,
+)
+
+_M0_MSG = "M0: scaffold only"
+
+
+class AdbDriver:
+    name: str = "adb"
+
+    async def preflight(self, endpoint: str) -> PreflightResult:
+        raise NotImplementedError(_M0_MSG)
+
+    async def observe(self) -> SemanticTree:
+        raise NotImplementedError(_M0_MSG)
+
+    async def act(self, step: str) -> ActResult:
+        raise NotImplementedError(_M0_MSG)
+
+    async def assert_(self, step: str) -> AssertResult:
+        raise NotImplementedError(_M0_MSG)
+
+    async def capture_evidence(self) -> Evidence:
+        raise NotImplementedError(_M0_MSG)

--- a/thanatos/src/thanatos/drivers/base.py
+++ b/thanatos/src/thanatos/drivers/base.py
@@ -1,0 +1,84 @@
+"""Driver Protocol — five-method async contract.
+
+The Protocol shape is the *contract* M0 freezes; the three concrete drivers
+(``playwright``, ``adb``, ``http``) raise ``NotImplementedError`` on every
+method until M1 fills them in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol, runtime_checkable
+
+
+@dataclass
+class PreflightResult:
+    """Returned by :py:meth:`Driver.preflight`."""
+
+    ok: bool
+    failure_hint: str | None = None
+    a11y_node_count: int | None = None
+
+
+@dataclass
+class SemanticTree:
+    """A driver-specific snapshot of the semantic layer.
+
+    For ``playwright``: a11y snapshot dict.
+    For ``adb``: parsed uiautomator XML.
+    For ``http``: response body + headers.
+    """
+
+    kind: Literal["a11y", "uiautomator", "http"]
+    payload: Any
+    captured_at_ms: int = 0
+
+
+@dataclass
+class ActResult:
+    ok: bool
+    failure_hint: str | None = None
+
+
+@dataclass
+class AssertResult:
+    ok: bool
+    failure_hint: str | None = None
+
+
+@dataclass
+class Evidence:
+    """Driver-captured evidence attached to a step / scenario result."""
+
+    dom: str | None = None
+    network: list[dict[str, Any]] = field(default_factory=list)
+    screenshot: str | None = None  # base64-png or url
+
+
+class DriverError(Exception):
+    """Base class for driver-level errors. M0 doesn't subclass this anywhere."""
+
+
+@runtime_checkable
+class Driver(Protocol):
+    """The five-method async contract every driver implements.
+
+    M0 freezes the shape. Real implementations land in M1.
+    """
+
+    name: str
+
+    async def preflight(self, endpoint: str) -> PreflightResult:  # pragma: no cover
+        ...
+
+    async def observe(self) -> SemanticTree:  # pragma: no cover
+        ...
+
+    async def act(self, step: str) -> ActResult:  # pragma: no cover
+        ...
+
+    async def assert_(self, step: str) -> AssertResult:  # pragma: no cover
+        ...
+
+    async def capture_evidence(self) -> Evidence:  # pragma: no cover
+        ...

--- a/thanatos/src/thanatos/drivers/http.py
+++ b/thanatos/src/thanatos/drivers/http.py
@@ -1,0 +1,32 @@
+"""HTTP driver — REST/JSON API — M0 stub."""
+
+from __future__ import annotations
+
+from thanatos.drivers.base import (
+    ActResult,
+    AssertResult,
+    Evidence,
+    PreflightResult,
+    SemanticTree,
+)
+
+_M0_MSG = "M0: scaffold only"
+
+
+class HttpDriver:
+    name: str = "http"
+
+    async def preflight(self, endpoint: str) -> PreflightResult:
+        raise NotImplementedError(_M0_MSG)
+
+    async def observe(self) -> SemanticTree:
+        raise NotImplementedError(_M0_MSG)
+
+    async def act(self, step: str) -> ActResult:
+        raise NotImplementedError(_M0_MSG)
+
+    async def assert_(self, step: str) -> AssertResult:
+        raise NotImplementedError(_M0_MSG)
+
+    async def capture_evidence(self) -> Evidence:
+        raise NotImplementedError(_M0_MSG)

--- a/thanatos/src/thanatos/drivers/playwright.py
+++ b/thanatos/src/thanatos/drivers/playwright.py
@@ -1,0 +1,32 @@
+"""Playwright driver — web (chromium subprocess) — M0 stub."""
+
+from __future__ import annotations
+
+from thanatos.drivers.base import (
+    ActResult,
+    AssertResult,
+    Evidence,
+    PreflightResult,
+    SemanticTree,
+)
+
+_M0_MSG = "M0: scaffold only"
+
+
+class PlaywrightDriver:
+    name: str = "playwright"
+
+    async def preflight(self, endpoint: str) -> PreflightResult:
+        raise NotImplementedError(_M0_MSG)
+
+    async def observe(self) -> SemanticTree:
+        raise NotImplementedError(_M0_MSG)
+
+    async def act(self, step: str) -> ActResult:
+        raise NotImplementedError(_M0_MSG)
+
+    async def assert_(self, step: str) -> AssertResult:
+        raise NotImplementedError(_M0_MSG)
+
+    async def capture_evidence(self) -> Evidence:
+        raise NotImplementedError(_M0_MSG)

--- a/thanatos/src/thanatos/result.py
+++ b/thanatos/src/thanatos/result.py
@@ -1,0 +1,63 @@
+"""Typed result dataclasses returned by `run_scenario` / `run_all`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+@dataclass
+class Evidence:
+    dom: str | None = None
+    network: list[dict[str, Any]] | None = None
+    screenshot: str | None = None  # base64 png or runner-PVC URL
+
+
+@dataclass
+class StepResult:
+    step: str
+    ok: bool
+    evidence: Evidence = field(default_factory=Evidence)
+
+
+@dataclass
+class KbUpdate:
+    path: str  # relative to source repo root, e.g. ".thanatos/anchors.md"
+    action: Literal["patch", "append"]
+    content: str
+
+
+@dataclass
+class ScenarioResult:
+    scenario_id: str
+    passed: bool
+    steps: list[StepResult] = field(default_factory=list)
+    kb_updates: list[KbUpdate] = field(default_factory=list)
+    failure_hint: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "pass": self.passed,
+            "steps": [
+                {
+                    "step": s.step,
+                    "ok": s.ok,
+                    "evidence": {
+                        k: v
+                        for k, v in {
+                            "dom": s.evidence.dom,
+                            "network": s.evidence.network,
+                            "screenshot": s.evidence.screenshot,
+                        }.items()
+                        if v is not None
+                    },
+                }
+                for s in self.steps
+            ],
+            "kb_updates": [
+                {"path": u.path, "action": u.action, "content": u.content}
+                for u in self.kb_updates
+            ],
+            "failure_hint": self.failure_hint,
+        }

--- a/thanatos/src/thanatos/runner.py
+++ b/thanatos/src/thanatos/runner.py
@@ -1,0 +1,69 @@
+"""Scenario runner.
+
+M0 dispatch: load skill → pick driver class by ``skill.driver`` → return a
+``ScenarioResult`` with ``passed=False`` and a ``failure_hint`` explaining the
+M0 stub. The scenario parser *is* called for real (so a malformed spec.md
+errors before MCP returns), but no driver method is invoked.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from thanatos.drivers import AdbDriver, Driver, HttpDriver, PlaywrightDriver
+from thanatos.result import ScenarioResult
+from thanatos.scenario import parse_spec_file
+from thanatos.skill import load_skill
+
+if TYPE_CHECKING:
+    pass
+
+_M0_HINT = "M0: thanatos scaffold only, drivers not implemented"
+
+
+def _pick_driver(driver_name: str) -> Driver:
+    if driver_name == "playwright":
+        return PlaywrightDriver()
+    if driver_name == "adb":
+        return AdbDriver()
+    if driver_name == "http":
+        return HttpDriver()
+    raise ValueError(f"unknown driver: {driver_name!r}")
+
+
+def run_scenario(
+    skill_path: str, spec_path: str, scenario_id: str, endpoint: str
+) -> ScenarioResult:
+    """Run a single scenario by id. M0: stub — parser runs, drivers don't."""
+    skill = load_skill(skill_path)
+    parsed = parse_spec_file(spec_path)
+    found = next((s for s in parsed if s.scenario_id == scenario_id), None)
+    if found is None:
+        return ScenarioResult(
+            scenario_id=scenario_id,
+            passed=False,
+            failure_hint=f"scenario id {scenario_id!r} not found in {spec_path}",
+        )
+    # In M1 we'd: pick driver, preflight, then for each step act/assert with
+    # capture_evidence on failure. M0 records the dispatch decision without
+    # actually invoking the driver.
+    _ = _pick_driver(skill.driver)
+    return ScenarioResult(
+        scenario_id=scenario_id,
+        passed=False,
+        failure_hint=_M0_HINT,
+    )
+
+
+def run_all(skill_path: str, spec_path: str, endpoint: str) -> list[ScenarioResult]:
+    """Run every scenario in a spec. M0: parses then stubs each one."""
+    parsed = parse_spec_file(spec_path)
+    return [
+        run_scenario(skill_path, spec_path, p.scenario_id, endpoint) for p in parsed
+    ]
+
+
+def recall(skill_path: str, intent: str) -> list[dict]:
+    """Look up product knowledge by intent. M0: always returns empty list."""
+    _ = (skill_path, intent)
+    return []

--- a/thanatos/src/thanatos/scenario.py
+++ b/thanatos/src/thanatos/scenario.py
@@ -1,0 +1,248 @@
+"""Parse `#### Scenario:` blocks out of an openspec spec.md.
+
+Two block formats are supported:
+
+A. gherkin code-block (API/back-end specs)::
+
+    #### Scenario: REQ-1004-S1 — short description
+    ```gherkin
+    Given foo
+    When bar
+    Then baz
+    ```
+
+B. markdown bullet (UI specs)::
+
+    #### Scenario: Desktop collapse/expand
+    - **GIVEN** ...
+    - **WHEN** ...
+    - **THEN** ...
+
+The two formats are mutually exclusive within a single block. Mixing them
+raises ``ScenarioFormatError``. Empty blocks (no GIVEN at all) raise
+``EmptyScenarioError``. Duplicate scenario ids raise ``ScenarioFormatError``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+# Heading: `#### Scenario: <ID>[ <description>]`
+# - exactly four `#`, exactly the literal "Scenario:" (case-sensitive — sisyphus
+#   check-scenario-refs.sh is also case-sensitive on this token)
+# - id = first whitespace-separated token after the colon
+# - everything after the id is the description (with an optional em-dash /
+#   hyphen separator stripped at the start)
+_SCENARIO_HEADING = re.compile(
+    r"^####\s+Scenario:\s+(?P<id>\S+)(?:\s+(?P<rest>.*?))?\s*$"
+)
+_DESC_SEPARATOR = re.compile(r"^[—-]\s+")
+
+# Bullet step:  - **GIVEN** ...   |   - **When** ...
+_BULLET_STEP = re.compile(
+    r"^\s*-\s+\*\*(?P<kw>given|when|then|and|but)\*\*\s+(?P<text>.+?)\s*$",
+    re.IGNORECASE,
+)
+
+# Plain gherkin step inside a fenced code block
+_GHERKIN_STEP = re.compile(
+    r"^\s*(?P<kw>given|when|then|and|but)\b\s+(?P<text>.+?)\s*$",
+    re.IGNORECASE,
+)
+
+
+class ScenarioParseError(Exception):
+    """Base class for scenario.py parser errors."""
+
+
+class ScenarioFormatError(ScenarioParseError):
+    """Block uses both gherkin and bullet, or two blocks share an id."""
+
+
+class EmptyScenarioError(ScenarioParseError):
+    """Block has no recognisable GIVEN/WHEN/THEN steps at all."""
+
+
+SourceFormat = Literal["gherkin", "bullet"]
+
+
+@dataclass
+class ParsedScenario:
+    scenario_id: str
+    description: str
+    given: list[str] = field(default_factory=list)
+    when: list[str] = field(default_factory=list)
+    then: list[str] = field(default_factory=list)
+    source_format: SourceFormat = "bullet"
+
+
+def parse_spec_text(text: str) -> list[ParsedScenario]:
+    """Parse spec markdown text and return all scenarios in source order.
+
+    Lines inside fenced code blocks that aren't ``gherkin`` (e.g. ``json``,
+    ``yaml``, ``python``) are skipped — only ``#### Scenario:`` headings sitting
+    at top-level markdown count, and only ``gherkin`` fences inside an active
+    scenario block contribute steps.
+    """
+    lines = text.splitlines()
+    scenarios: list[ParsedScenario] = []
+    seen_ids: dict[str, int] = {}  # id -> first line number
+
+    i = 0
+    in_code_fence: str | None = None  # info string, e.g. "gherkin" / "json" / ""
+    fence_start_line = 0
+    while i < len(lines):
+        raw = lines[i]
+        line_no = i + 1
+
+        # Track fenced code blocks at top-level: a line starting with ``` opens
+        # or closes a fence. We *don't* match `#### Scenario:` while inside a
+        # non-gherkin fence (that's just example markdown / json).
+        stripped = raw.lstrip()
+        if stripped.startswith("```"):
+            info = stripped[3:].strip()
+            if in_code_fence is None:
+                in_code_fence = info
+                fence_start_line = line_no
+            else:
+                in_code_fence = None
+            i += 1
+            continue
+
+        if in_code_fence is not None:
+            # heading inside a fence is just example text — skip
+            i += 1
+            continue
+
+        m = _SCENARIO_HEADING.match(raw)
+        if m is None:
+            i += 1
+            continue
+
+        scen_id = m.group("id")
+        rest = (m.group("rest") or "").strip()
+        desc = _DESC_SEPARATOR.sub("", rest, count=1).strip()
+
+        if scen_id in seen_ids:
+            raise ScenarioFormatError(
+                f"duplicate scenario id {scen_id!r}: "
+                f"first at line {seen_ids[scen_id]}, again at line {line_no}"
+            )
+        seen_ids[scen_id] = line_no
+
+        scen, consumed = _parse_block_body(lines, i + 1, scen_id, desc)
+        scenarios.append(scen)
+        i = consumed
+
+    if in_code_fence is not None:
+        # unterminated fence isn't fatal for scenario parsing — just warn-by-ignore
+        del fence_start_line  # keep `fence_start_line` referenced
+    return scenarios
+
+
+def parse_spec_file(path: str | Path) -> list[ParsedScenario]:
+    """Convenience wrapper: read a path and feed it to :func:`parse_spec_text`."""
+    return parse_spec_text(Path(path).read_text(encoding="utf-8"))
+
+
+def _parse_block_body(
+    lines: list[str], start: int, scen_id: str, desc: str
+) -> tuple[ParsedScenario, int]:
+    """Parse the body of a scenario block until the next ``####``-heading or EOF."""
+    given: list[str] = []
+    when: list[str] = []
+    then: list[str] = []
+    saw_bullet = False
+    saw_gherkin = False
+    in_gherkin_fence = False
+    in_other_fence = False
+
+    j = start
+    while j < len(lines):
+        raw = lines[j]
+        stripped = raw.lstrip()
+
+        # next scenario / next top-level heading at same depth ends this block
+        if not in_gherkin_fence and not in_other_fence:
+            if stripped.startswith("#### ") or stripped.startswith("### ") or stripped.startswith("## ") or stripped.startswith("# "):
+                break
+
+        if stripped.startswith("```"):
+            info = stripped[3:].strip().lower()
+            if not in_gherkin_fence and not in_other_fence:
+                if info == "gherkin":
+                    in_gherkin_fence = True
+                    saw_gherkin = True
+                else:
+                    in_other_fence = True
+            elif in_gherkin_fence:
+                in_gherkin_fence = False
+            elif in_other_fence:
+                in_other_fence = False
+            j += 1
+            continue
+
+        if in_gherkin_fence:
+            m = _GHERKIN_STEP.match(raw)
+            if m is not None:
+                _route_step(m.group("kw"), m.group("text"), given, when, then)
+            j += 1
+            continue
+
+        if in_other_fence:
+            j += 1
+            continue
+
+        m = _BULLET_STEP.match(raw)
+        if m is not None:
+            saw_bullet = True
+            _route_step(m.group("kw"), m.group("text"), given, when, then)
+
+        j += 1
+
+    if saw_bullet and saw_gherkin:
+        raise ScenarioFormatError(
+            f"scenario {scen_id!r} mixes gherkin code-block and bullet steps "
+            f"(line {start})"
+        )
+
+    if not (given or when or then):
+        raise EmptyScenarioError(
+            f"scenario {scen_id!r} has no GIVEN/WHEN/THEN steps (line {start})"
+        )
+
+    return (
+        ParsedScenario(
+            scenario_id=scen_id,
+            description=desc,
+            given=given,
+            when=when,
+            then=then,
+            source_format="gherkin" if saw_gherkin else "bullet",
+        ),
+        j,
+    )
+
+
+def _route_step(
+    kw: str, text: str, given: list[str], when: list[str], then: list[str]
+) -> None:
+    kw_l = kw.lower()
+    if kw_l == "given":
+        given.append(text)
+    elif kw_l == "when":
+        when.append(text)
+    elif kw_l == "then":
+        then.append(text)
+    elif kw_l in ("and", "but"):
+        # "And"/"But" tail-extend whichever bucket we last filled. If nothing has
+        # been seen yet, default to GIVEN — same behaviour as cucumber.
+        if then:
+            then.append(text)
+        elif when:
+            when.append(text)
+        else:
+            given.append(text)

--- a/thanatos/src/thanatos/server.py
+++ b/thanatos/src/thanatos/server.py
@@ -1,0 +1,122 @@
+"""MCP stdio server entrypoint.
+
+Registers three tools: ``run_scenario`` / ``run_all`` / ``recall``. All three
+dispatch to :mod:`thanatos.runner` (M0 stub — see ``run_scenario`` body).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import TextContent, Tool
+
+from thanatos import __version__
+from thanatos.runner import recall as _recall
+from thanatos.runner import run_all as _run_all
+from thanatos.runner import run_scenario as _run_scenario
+
+
+def _build_server() -> Server:
+    server: Server = Server(name="thanatos", version=__version__)
+
+    @server.list_tools()
+    async def _list_tools() -> list[Tool]:
+        return [
+            Tool(
+                name="run_scenario",
+                description=(
+                    "Run a single scenario from a spec.md against an endpoint. "
+                    "M0 returns pass=false with a scaffold-only hint."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["skill_path", "spec_path", "scenario_id", "endpoint"],
+                    "properties": {
+                        "skill_path": {"type": "string"},
+                        "spec_path": {"type": "string"},
+                        "scenario_id": {"type": "string"},
+                        "endpoint": {"type": "string"},
+                    },
+                },
+            ),
+            Tool(
+                name="run_all",
+                description=(
+                    "Run every scenario in a spec.md against an endpoint. "
+                    "M0 returns one stub result per scenario."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["skill_path", "spec_path", "endpoint"],
+                    "properties": {
+                        "skill_path": {"type": "string"},
+                        "spec_path": {"type": "string"},
+                        "endpoint": {"type": "string"},
+                    },
+                },
+            ),
+            Tool(
+                name="recall",
+                description=(
+                    "Recall product knowledge fragments matching an intent. "
+                    "M0 always returns an empty list."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["skill_path", "intent"],
+                    "properties": {
+                        "skill_path": {"type": "string"},
+                        "intent": {"type": "string"},
+                    },
+                },
+            ),
+        ]
+
+    @server.call_tool()
+    async def _call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        import json as _json
+
+        if name == "run_scenario":
+            res = _run_scenario(
+                arguments["skill_path"],
+                arguments["spec_path"],
+                arguments["scenario_id"],
+                arguments["endpoint"],
+            )
+            return [TextContent(type="text", text=_json.dumps(res.to_dict()))]
+        if name == "run_all":
+            results = _run_all(
+                arguments["skill_path"],
+                arguments["spec_path"],
+                arguments["endpoint"],
+            )
+            return [
+                TextContent(
+                    type="text",
+                    text=_json.dumps([r.to_dict() for r in results]),
+                )
+            ]
+        if name == "recall":
+            hits = _recall(arguments["skill_path"], arguments["intent"])
+            return [TextContent(type="text", text=_json.dumps(hits))]
+        raise ValueError(f"unknown tool: {name!r}")
+
+    return server
+
+
+async def _serve() -> None:
+    server = _build_server()
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+
+def main() -> None:
+    """Synchronous entrypoint used by ``python -m thanatos.server`` / Dockerfile."""
+    asyncio.run(_serve())
+
+
+if __name__ == "__main__":
+    main()

--- a/thanatos/src/thanatos/skill.py
+++ b/thanatos/src/thanatos/skill.py
@@ -1,0 +1,57 @@
+"""Load and validate ``<repo>/.thanatos/skill.yaml``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+DriverName = Literal["playwright", "adb", "http"]
+
+
+class PreflightCheck(BaseModel):
+    assert_: str = Field(alias="assert")
+
+    model_config = {"populate_by_name": True}
+
+
+class Skill(BaseModel):
+    name: str
+    driver: DriverName
+    entry: str
+    fixtures: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    preflight: list[PreflightCheck] = Field(default_factory=list)
+
+    @field_validator("name")
+    @classmethod
+    def _name_non_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("skill.name must be non-empty")
+        return v
+
+
+class SkillLoadError(Exception):
+    """Raised when skill.yaml is missing or fails schema validation."""
+
+
+def load_skill(path: str | Path) -> Skill:
+    """Load skill.yaml from a path.
+
+    Raises :class:`SkillLoadError` for missing files, malformed yaml, or schema
+    violations (missing ``driver`` / unknown driver / missing ``entry``, etc.).
+    """
+    p = Path(path)
+    if not p.is_file():
+        raise SkillLoadError(f"skill file not found: {p}")
+    try:
+        raw: Any = yaml.safe_load(p.read_text(encoding="utf-8"))
+    except yaml.YAMLError as e:
+        raise SkillLoadError(f"invalid yaml in {p}: {e}") from e
+    if not isinstance(raw, dict):
+        raise SkillLoadError(f"skill yaml must be a mapping, got {type(raw).__name__}")
+    try:
+        return Skill.model_validate(raw)
+    except ValidationError as e:
+        raise SkillLoadError(f"skill schema error in {p}:\n{e}") from e

--- a/thanatos/tests/test_contract_thanatos.py
+++ b/thanatos/tests/test_contract_thanatos.py
@@ -1,0 +1,253 @@
+"""
+Contract tests for REQ-thanatos-m0-scaffold-v6-1777283112 — THAN-S1 through THAN-S7.
+
+Black-box only: public API, CLI, and MCP protocol. No internal implementation details.
+All tests are marked @pytest.mark.integration — run via `uv run pytest -m integration`.
+"""
+
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).parents[2]
+CHART_PATH = REPO_ROOT / "deploy" / "charts" / "thanatos"
+
+
+# ─── THAN-S1: MCP server registers exactly three tools ───────────────────────
+
+
+@pytest.mark.integration
+async def test_than_s1_server_registers_three_tools():
+    """THAN-S1: tools/list returns exactly run_scenario, run_all, recall with required params."""
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "thanatos.server"],
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.list_tools()
+            tools = {t.name: t for t in result.tools}
+
+    assert set(tools.keys()) == {"run_scenario", "run_all", "recall"}, (
+        f"Expected exactly 3 tools, got: {sorted(tools.keys())}"
+    )
+
+    # run_scenario required params per contract.spec.yaml
+    rs_schema = tools["run_scenario"].inputSchema
+    rs_required = set(rs_schema.get("required", []))
+    assert rs_required >= {"skill_path", "spec_path", "scenario_id", "endpoint"}, (
+        f"run_scenario missing required params, declared: {rs_required}"
+    )
+
+    # run_all required params
+    ra_schema = tools["run_all"].inputSchema
+    ra_required = set(ra_schema.get("required", []))
+    assert ra_required >= {"skill_path", "spec_path", "endpoint"}, (
+        f"run_all missing required params, declared: {ra_required}"
+    )
+
+    # recall required params
+    rc_schema = tools["recall"].inputSchema
+    rc_required = set(rc_schema.get("required", []))
+    assert rc_required >= {"skill_path", "intent"}, (
+        f"recall missing required params, declared: {rc_required}"
+    )
+
+
+# ─── THAN-S2: gherkin code block parses into structured fields ───────────────
+
+
+@pytest.mark.integration
+def test_than_s2_gherkin_block_parses():
+    """THAN-S2: gherkin fence → scenario_id, given, when, then, source_format."""
+    from thanatos.scenario import parse_spec_text
+
+    doc = textwrap.dedent("""\
+        #### Scenario: REQ-1004-S1 basic gherkin
+
+        ```gherkin
+        Given foo
+        When bar
+        Then baz
+        ```
+    """)
+    results = parse_spec_text(doc)
+    assert len(results) == 1
+    sc = results[0]
+    assert sc.scenario_id == "REQ-1004-S1"
+    assert sc.given == ["foo"]
+    assert sc.when == ["bar"]
+    assert sc.then == ["baz"]
+    assert sc.source_format == "gherkin"
+
+
+# ─── THAN-S3: bullet-format with multiple GIVEN entries ──────────────────────
+
+
+@pytest.mark.integration
+def test_than_s3_bullet_multiple_given():
+    """THAN-S3: bullet format → given list has length 2, source_format == 'bullet'."""
+    from thanatos.scenario import parse_spec_text
+
+    doc = textwrap.dedent("""\
+        #### Scenario: THAN-multi multiple given bullets
+
+        - **GIVEN** first condition
+        - **GIVEN** second condition
+        - **WHEN** something happens
+        - **THEN** result expected
+    """)
+    results = parse_spec_text(doc)
+    assert len(results) == 1
+    sc = results[0]
+    assert len(sc.given) == 2, f"Expected 2 given entries, got {sc.given}"
+    assert sc.source_format == "bullet"
+
+
+# ─── THAN-S4: mixed gherkin + bullet raises ScenarioFormatError ──────────────
+
+
+@pytest.mark.integration
+def test_than_s4_mixed_format_raises():
+    """THAN-S4: gherkin fence + bullet step in one block → ScenarioFormatError."""
+    from thanatos.scenario import ScenarioFormatError, parse_spec_text
+
+    doc = textwrap.dedent("""\
+        #### Scenario: MIX-1 mixed formats
+
+        - **GIVEN** a bullet step
+
+        ```gherkin
+        Given also a gherkin step
+        ```
+    """)
+    with pytest.raises(ScenarioFormatError) as exc_info:
+        parse_spec_text(doc)
+    assert "mixes gherkin" in str(exc_info.value).lower(), (
+        f"Expected error containing 'mixes gherkin', got: {exc_info.value}"
+    )
+
+
+# ─── THAN-S5: every M0 driver method raises NotImplementedError ──────────────
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("driver_name", ["PlaywrightDriver", "AdbDriver", "HttpDriver"])
+@pytest.mark.parametrize(
+    "method_name", ["preflight", "observe", "act", "assert_", "capture_evidence"]
+)
+async def test_than_s5_driver_raises_not_implemented(driver_name, method_name):
+    """THAN-S5: every M0 driver method raises NotImplementedError('M0: scaffold only')."""
+    import importlib
+
+    drivers_mod = importlib.import_module("thanatos.drivers")
+    DriverClass = getattr(drivers_mod, driver_name)
+    instance = DriverClass()
+    method = getattr(instance, method_name)
+
+    if method_name == "preflight":
+        coro = method("http://localhost")
+    elif method_name in ("act", "assert_"):
+        coro = method("some step")
+    else:
+        coro = method()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await coro
+    assert str(exc_info.value) == "M0: scaffold only", (
+        f"{driver_name}.{method_name}: got '{exc_info.value}'"
+    )
+
+
+# ─── THAN-S6: driver=adb → two-container Pod (redroid + thanatos) ─────────────
+
+
+@pytest.mark.integration
+def test_than_s6_helm_adb_two_containers():
+    """THAN-S6: helm template --set driver=adb → Deployment with redroid + thanatos."""
+    import yaml
+
+    if not CHART_PATH.exists():
+        pytest.skip(f"helm chart not found at {CHART_PATH}")
+
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "thanatos",
+            str(CHART_PATH),
+            "--set",
+            "driver=adb",
+            "--set",
+            "redroid.image=redroid/redroid:13.0.0-amd64",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"helm template failed:\n{result.stderr}"
+
+    deployments = [
+        m for m in yaml.safe_load_all(result.stdout) if m and m.get("kind") == "Deployment"
+    ]
+    assert deployments, "No Deployment found in rendered chart"
+
+    containers = deployments[0]["spec"]["template"]["spec"]["containers"]
+    names = [c["name"] for c in containers]
+    assert len(containers) == 2, f"Expected 2 containers, got {names}"
+    assert "redroid" in names, f"'redroid' not in containers: {names}"
+    assert "thanatos" in names, f"'thanatos' not in containers: {names}"
+
+    redroid = next(c for c in containers if c["name"] == "redroid")
+    assert redroid.get("securityContext", {}).get("privileged") is True, (
+        "redroid container must have securityContext.privileged: true"
+    )
+
+    thanatos = next(c for c in containers if c["name"] == "thanatos")
+    env_map = {e["name"]: e.get("value", "") for e in thanatos.get("env", [])}
+    assert "ADB_SERVER_ADDR" in env_map, (
+        f"ADB_SERVER_ADDR not in thanatos env: {sorted(env_map)}"
+    )
+
+
+# ─── THAN-S7: driver=playwright → single thanatos container ──────────────────
+
+
+@pytest.mark.integration
+def test_than_s7_helm_playwright_single_container():
+    """THAN-S7: helm template --set driver=playwright → exactly one container named thanatos."""
+    import yaml
+
+    if not CHART_PATH.exists():
+        pytest.skip(f"helm chart not found at {CHART_PATH}")
+
+    result = subprocess.run(
+        ["helm", "template", "thanatos", str(CHART_PATH), "--set", "driver=playwright"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"helm template failed:\n{result.stderr}"
+
+    deployments = [
+        m for m in yaml.safe_load_all(result.stdout) if m and m.get("kind") == "Deployment"
+    ]
+    assert deployments, "No Deployment found in rendered chart"
+
+    containers = deployments[0]["spec"]["template"]["spec"]["containers"]
+    assert len(containers) == 1, (
+        f"Expected 1 container, got {[c['name'] for c in containers]}"
+    )
+    assert containers[0]["name"] == "thanatos", (
+        f"Expected container named 'thanatos', got '{containers[0]['name']}'"
+    )
+    assert containers[0].get("command") == ["python", "-m", "thanatos.server"], (
+        f"thanatos command mismatch: {containers[0].get('command')}"
+    )

--- a/thanatos/tests/test_contract_thanatos.py
+++ b/thanatos/tests/test_contract_thanatos.py
@@ -148,8 +148,8 @@ async def test_than_s5_driver_raises_not_implemented(driver_name, method_name):
     import importlib
 
     drivers_mod = importlib.import_module("thanatos.drivers")
-    DriverClass = getattr(drivers_mod, driver_name)
-    instance = DriverClass()
+    driver_class = getattr(drivers_mod, driver_name)
+    instance = driver_class()
     method = getattr(instance, method_name)
 
     if method_name == "preflight":

--- a/thanatos/tests/test_scenario_parser.py
+++ b/thanatos/tests/test_scenario_parser.py
@@ -1,0 +1,228 @@
+"""Tests for thanatos.scenario.parse_spec_text.
+
+Covers gherkin / bullet / mixed-reject / case-insensitivity / multiple
+GIVEN-WHEN-THEN / empty-block reject / duplicate-id reject / heading inside
+fenced code-block ignored / unicode descriptions.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from thanatos.scenario import (
+    EmptyScenarioError,
+    ScenarioFormatError,
+    parse_spec_text,
+)
+
+
+def _dedent(s: str) -> str:
+    return textwrap.dedent(s).lstrip("\n")
+
+
+def test_gherkin_codeblock_single_scenario() -> None:
+    src = _dedent(
+        """
+        # Spec
+
+        ## Requirement: foo
+
+        #### Scenario: REQ-1004-S1 — happy path
+        ```gherkin
+        Given the system is up
+        When the client posts /foo
+        Then the response is 200
+        ```
+        """
+    )
+    out = parse_spec_text(src)
+    assert len(out) == 1
+    s = out[0]
+    assert s.scenario_id == "REQ-1004-S1"
+    assert s.description == "happy path"
+    assert s.given == ["the system is up"]
+    assert s.when == ["the client posts /foo"]
+    assert s.then == ["the response is 200"]
+    assert s.source_format == "gherkin"
+
+
+def test_bullet_format_single_scenario() -> None:
+    src = _dedent(
+        """
+        #### Scenario: Desktop collapse/expand
+        - **GIVEN** sidebar is expanded
+        - **WHEN** user clicks the toggle
+        - **THEN** sidebar collapses
+        """
+    )
+    out = parse_spec_text(src)
+    assert len(out) == 1
+    assert out[0].scenario_id == "Desktop"
+    # description picked up from `Scenario: Desktop collapse/expand` is empty
+    # (no em-dash separator). Steps are correct.
+    assert out[0].source_format == "bullet"
+    assert out[0].given == ["sidebar is expanded"]
+    assert out[0].when == ["user clicks the toggle"]
+    assert out[0].then == ["sidebar collapses"]
+
+
+def test_multiple_given_when_then_accumulate() -> None:
+    src = _dedent(
+        """
+        #### Scenario: THAN-multi
+        - **GIVEN** a
+        - **GIVEN** b
+        - **WHEN** c
+        - **WHEN** d
+        - **THEN** e
+        - **THEN** f
+        """
+    )
+    s = parse_spec_text(src)[0]
+    assert s.given == ["a", "b"]
+    assert s.when == ["c", "d"]
+    assert s.then == ["e", "f"]
+
+
+def test_case_insensitive_keywords() -> None:
+    src = _dedent(
+        """
+        #### Scenario: ci-1
+        ```gherkin
+        given lowercase
+        WHEN UPPER
+        Then Title
+        ```
+        """
+    )
+    s = parse_spec_text(src)[0]
+    assert s.given == ["lowercase"]
+    assert s.when == ["UPPER"]
+    assert s.then == ["Title"]
+
+
+def test_and_but_extends_last_bucket() -> None:
+    src = _dedent(
+        """
+        #### Scenario: chained
+        ```gherkin
+        Given foo
+        And bar
+        When baz
+        And qux
+        Then result
+        And another result
+        ```
+        """
+    )
+    s = parse_spec_text(src)[0]
+    assert s.given == ["foo", "bar"]
+    assert s.when == ["baz", "qux"]
+    assert s.then == ["result", "another result"]
+
+
+def test_mixed_format_within_block_rejected() -> None:
+    src = _dedent(
+        """
+        #### Scenario: MIX-1
+        - **GIVEN** mixed bullet
+        ```gherkin
+        When also gherkin
+        Then nope
+        ```
+        """
+    )
+    with pytest.raises(ScenarioFormatError, match="mixes gherkin"):
+        parse_spec_text(src)
+
+
+def test_empty_scenario_rejected() -> None:
+    src = _dedent(
+        """
+        #### Scenario: EMPTY-1 — no steps at all
+        Just prose, no GIVEN.
+        """
+    )
+    with pytest.raises(EmptyScenarioError):
+        parse_spec_text(src)
+
+
+def test_duplicate_scenario_id_rejected() -> None:
+    src = _dedent(
+        """
+        #### Scenario: DUP-1
+        - **GIVEN** first
+        - **WHEN** wat
+        - **THEN** ok
+
+        #### Scenario: DUP-1
+        - **GIVEN** second
+        - **WHEN** also wat
+        - **THEN** ok
+        """
+    )
+    with pytest.raises(ScenarioFormatError, match="duplicate scenario id"):
+        parse_spec_text(src)
+
+
+def test_scenario_heading_inside_codeblock_ignored() -> None:
+    src = _dedent(
+        """
+        # Some prose
+
+        Here is an example of what scenario syntax looks like:
+
+        ```markdown
+        #### Scenario: NOT-A-REAL-ID
+        - **GIVEN** this is documentation, not a real scenario
+        ```
+
+        #### Scenario: REAL-1
+        - **GIVEN** real
+        - **WHEN** also real
+        - **THEN** real result
+        """
+    )
+    out = parse_spec_text(src)
+    assert len(out) == 1
+    assert out[0].scenario_id == "REAL-1"
+
+
+def test_multiple_scenarios_returned_in_source_order() -> None:
+    src = _dedent(
+        """
+        #### Scenario: A1
+        - **GIVEN** a
+        - **WHEN** b
+        - **THEN** c
+
+        Some prose between scenarios.
+
+        #### Scenario: A2
+        ```gherkin
+        Given x
+        When y
+        Then z
+        ```
+        """
+    )
+    out = parse_spec_text(src)
+    assert [s.scenario_id for s in out] == ["A1", "A2"]
+    assert out[0].source_format == "bullet"
+    assert out[1].source_format == "gherkin"
+
+
+def test_unicode_description_passes_through() -> None:
+    src = _dedent(
+        """
+        #### Scenario: UNI-1 — 中文 desc with emoji 🚀
+        - **GIVEN** unicode body 漢字
+        - **WHEN** 处理
+        - **THEN** 結果
+        """
+    )
+    s = parse_spec_text(src)[0]
+    assert s.description == "中文 desc with emoji 🚀"
+    assert s.given == ["unicode body 漢字"]

--- a/thanatos/tests/test_skill_loader.py
+++ b/thanatos/tests/test_skill_loader.py
@@ -1,0 +1,77 @@
+"""Tests for thanatos.skill.load_skill."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from thanatos.skill import Skill, SkillLoadError, load_skill
+
+
+def _write(tmp: Path, body: str) -> Path:
+    p = tmp / "skill.yaml"
+    p.write_text(textwrap.dedent(body).lstrip("\n"), encoding="utf-8")
+    return p
+
+
+def test_valid_skill_loads(tmp_path: Path) -> None:
+    p = _write(
+        tmp_path,
+        """
+        name: pytoya-web
+        driver: playwright
+        entry: $ENDPOINT
+        fixtures:
+          admin_login:
+            user: admin
+            pass: admin
+        preflight:
+          - assert: "a11y_node_count > 5"
+        """,
+    )
+    skill = load_skill(p)
+    assert isinstance(skill, Skill)
+    assert skill.name == "pytoya-web"
+    assert skill.driver == "playwright"
+    assert skill.entry == "$ENDPOINT"
+    assert skill.fixtures["admin_login"]["user"] == "admin"
+    assert skill.preflight[0].assert_ == "a11y_node_count > 5"
+
+
+def test_missing_driver_rejected(tmp_path: Path) -> None:
+    p = _write(
+        tmp_path,
+        """
+        name: foo
+        entry: $ENDPOINT
+        """,
+    )
+    with pytest.raises(SkillLoadError, match="driver"):
+        load_skill(p)
+
+
+def test_unknown_driver_rejected(tmp_path: Path) -> None:
+    p = _write(
+        tmp_path,
+        """
+        name: foo
+        driver: ios
+        entry: $ENDPOINT
+        """,
+    )
+    with pytest.raises(SkillLoadError):
+        load_skill(p)
+
+
+def test_missing_entry_rejected(tmp_path: Path) -> None:
+    p = _write(
+        tmp_path,
+        """
+        name: foo
+        driver: http
+        """,
+    )
+    with pytest.raises(SkillLoadError, match="entry"):
+        load_skill(p)

--- a/thanatos/uv.lock
+++ b/thanatos/uv.lock
@@ -1,0 +1,888 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "47.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0", size = 7912214, upload-time = "2026-04-24T19:53:03.864Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ed/5f524db1fade9c013aa618e1c99c6ed05e8ffc9ceee6cda22fed22dda3f4/cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203", size = 3258581, upload-time = "2026-04-24T19:53:31.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/1b901990b174786569029f67542b3edf72ac068b6c3c8683c17e6a2f5363/cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa", size = 3775309, upload-time = "2026-04-24T19:53:33.054Z" },
+    { url = "https://files.pythonhosted.org/packages/14/88/7aa18ad9c11bc87689affa5ce4368d884b517502d75739d475fc6f4a03c7/cryptography-47.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0", size = 7904299, upload-time = "2026-04-24T19:53:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/07/55/c18f75724544872f234678fdedc871391722cb34a2aee19faa9f63100bb2/cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7", size = 4631180, upload-time = "2026-04-24T19:53:37.517Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/65/31a5cc0eaca99cec5bafffe155d407115d96136bb161e8b49e0ef73f09a7/cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1", size = 4653529, upload-time = "2026-04-24T19:53:39.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/bc/641c0519a495f3bfd0421b48d7cd325c4336578523ccd76ea322b6c29c7a/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c", size = 4638570, upload-time = "2026-04-24T19:53:42.129Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f2/300327b0a47f6dc94dd8b71b57052aefe178bb51745073d73d80604f11ab/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829", size = 5238019, upload-time = "2026-04-24T19:53:44.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/5b5cf994391d4bf9d9c7efd4c66aabe4d95227256627f8fea6cff7dfadbd/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7", size = 4686832, upload-time = "2026-04-24T19:53:47.015Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2c/ae950e28fd6475c852fc21a44db3e6b5bcc1261d1e370f2b6e42fa800fef/cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923", size = 4269301, upload-time = "2026-04-24T19:53:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/67/fb/6a39782e150ffe5cc1b0018cb6ddc48bf7ca62b498d7539ffc8a758e977d/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab", size = 4638110, upload-time = "2026-04-24T19:53:51.011Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d7/0b3c71090a76e5c203164a47688b697635ece006dcd2499ab3a4dbd3f0bd/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736", size = 5194988, upload-time = "2026-04-24T19:53:52.962Z" },
+    { url = "https://files.pythonhosted.org/packages/63/33/63a961498a9df51721ab578c5a2622661411fc520e00bd83b0cc64eb20c4/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7", size = 4686563, upload-time = "2026-04-24T19:53:55.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/5ee5b145248f92250de86145d1c1d6edebbd57a7fe7caa4dedb5d4cf06a1/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52", size = 4770094, upload-time = "2026-04-24T19:53:57.753Z" },
+    { url = "https://files.pythonhosted.org/packages/92/43/21d220b2da5d517773894dacdcdb5c682c28d3fffce65548cb06e87d5501/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd", size = 4913811, upload-time = "2026-04-24T19:54:00.236Z" },
+    { url = "https://files.pythonhosted.org/packages/31/98/dc4ad376ac5f1a1a7d4a83f7b0c6f2bcad36b5d2d8f30aeb482d3a7d9582/cryptography-47.0.0-cp314-cp314t-win32.whl", hash = "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63", size = 3237158, upload-time = "2026-04-24T19:54:02.606Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/da/97f62d18306b5133468bc3f8cc73a3111e8cdc8cf8d3e69474d6e5fd2d1b/cryptography-47.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b", size = 3758706, upload-time = "2026-04-24T19:54:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4", size = 7904072, upload-time = "2026-04-24T19:54:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
+    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bd/0a9d3edbf5eadbac926d7b9b3cd0c4be584eeeae4a003d24d9eda4affbbd/cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310", size = 3248487, upload-time = "2026-04-24T19:54:33.494Z" },
+    { url = "https://files.pythonhosted.org/packages/60/80/5681af756d0da3a599b7bdb586fac5a1540f1bcefd2717a20e611ddade45/cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769", size = 3755737, upload-time = "2026-04-24T19:54:35.408Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/6b/3d5c13fb3e3c4f43206c8f9dfed13778c2ed4f000bacaa0b7ce3c402a265/librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d", size = 184368, upload-time = "2026-04-09T16:06:26.173Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/90/89ddba8e1c20b0922783cd93ed8e64f34dc05ab59c38a9c7e313632e20ff/librt-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b3e3bc363f71bda1639a4ee593cb78f7fbfeacc73411ec0d4c92f00730010a4", size = 68332, upload-time = "2026-04-09T16:05:00.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/7aa4da1fb08bdeeb540cb07bfc8207cb32c5c41642f2594dbd0098a0662d/librt-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a09c2f5869649101738653a9b7ab70cf045a1105ac66cbb8f4055e61df78f2d", size = 70581, upload-time = "2026-04-09T16:05:01.213Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/73a2187e1031041e93b7e3a25aae37aa6f13b838c550f7e0f06f66766212/librt-0.9.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ca8e133d799c948db2ab1afc081c333a825b5540475164726dcbf73537e5c2f", size = 203984, upload-time = "2026-04-09T16:05:02.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/3d/23460d571e9cbddb405b017681df04c142fb1b04cbfce77c54b08e28b108/librt-0.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:603138ee838ee1583f1b960b62d5d0007845c5c423feb68e44648b1359014e27", size = 215762, upload-time = "2026-04-09T16:05:04.127Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1e/42dc7f8ab63e65b20640d058e63e97fd3e482c1edbda3570d813b4d0b927/librt-0.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4003f70c56a5addd6aa0897f200dd59afd3bf7bcd5b3cce46dd21f925743bc2", size = 230288, upload-time = "2026-04-09T16:05:05.883Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/08/ca812b6d8259ad9ece703397f8ad5c03af5b5fedfce64279693d3ce4087c/librt-0.9.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78042f6facfd98ecb25e9829c7e37cce23363d9d7c83bc5f72702c5059eb082b", size = 224103, upload-time = "2026-04-09T16:05:07.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3f/620490fb2fa66ffd44e7f900254bc110ebec8dac6c1b7514d64662570e6f/librt-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a361c9434a64d70a7dbb771d1de302c0cc9f13c0bffe1cf7e642152814b35265", size = 232122, upload-time = "2026-04-09T16:05:08.386Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/83/12864700a1b6a8be458cf5d05db209b0d8e94ae281e7ec261dbe616597b4/librt-0.9.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:dd2c7e082b0b92e1baa4da28163a808672485617bc855cc22a2fd06978fa9084", size = 225045, upload-time = "2026-04-09T16:05:09.707Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1b/845d339c29dc7dbc87a2e992a1ba8d28d25d0e0372f9a0a2ecebde298186/librt-0.9.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7e6274fd33fc5b2a14d41c9119629d3ff395849d8bcbc80cf637d9e8d2034da8", size = 227372, upload-time = "2026-04-09T16:05:10.942Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fe/277985610269d926a64c606f761d58d3db67b956dbbf40024921e95e7fcb/librt-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5093043afb226ecfa1400120d1ebd4442b4f99977783e4f4f7248879009b227f", size = 248224, upload-time = "2026-04-09T16:05:12.254Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1b/ee486d244b8de6b8b5dbaefabe6bfdd4a72e08f6353edf7d16d27114da8d/librt-0.9.0-cp312-cp312-win32.whl", hash = "sha256:9edcc35d1cae9fd5320171b1a838c7da8a5c968af31e82ecc3dff30b4be0957f", size = 55986, upload-time = "2026-04-09T16:05:13.529Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/ba1737012308c17dc6d5516143b5dce9a2c7ba3474afd54e11f44a4d1ef3/librt-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc2917258e131ae5f958a4d872e07555b51cb7466a43433218061c74ef33745", size = 63260, upload-time = "2026-04-09T16:05:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e4/01752c113da15127f18f7bf11142f5640038f062407a611c059d0036c6aa/librt-0.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:90e6d5420fc8a300518d4d2288154ff45005e920425c22cbbfe8330f3f754bd9", size = 53694, upload-time = "2026-04-09T16:05:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d7/1b3e26fffde1452d82f5666164858a81c26ebe808e7ae8c9c88628981540/librt-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f29b68cd9714531672db62cc54f6e8ff981900f824d13fa0e00749189e13778e", size = 68367, upload-time = "2026-04-09T16:05:17.243Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/5b/c61b043ad2e091fbe1f2d35d14795e545d0b56b03edaa390fa1dcee3d160/librt-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d5c8a5929ac325729f6119802070b561f4db793dffc45e9ac750992a4ed4d22", size = 70595, upload-time = "2026-04-09T16:05:18.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/2448471196d8a73370aa2f23445455dc42712c21404081fcd7a03b9e0749/librt-0.9.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:756775d25ec8345b837ab52effee3ad2f3b2dfd6bbee3e3f029c517bd5d8f05a", size = 204354, upload-time = "2026-04-09T16:05:19.593Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5e/39fc4b153c78cfd2c8a2dcb32700f2d41d2312aa1050513183be4540930d/librt-0.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8f5d00b49818f4e2b1667db994488b045835e0ac16fe2f924f3871bd2b8ac5", size = 216238, upload-time = "2026-04-09T16:05:20.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/42/bc2d02d0fa7badfa63aa8d6dcd8793a9f7ef5a94396801684a51ed8d8287/librt-0.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c81aef782380f0f13ead670aae01825eb653b44b046aa0e5ebbb79f76ed4aa11", size = 230589, upload-time = "2026-04-09T16:05:22.305Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7b/e2d95cc513866373692aa5edf98080d5602dd07cabfb9e5d2f70df2f25f7/librt-0.9.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66b58fed90a545328e80d575467244de3741e088c1af928f0b489ebec3ef3858", size = 224610, upload-time = "2026-04-09T16:05:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d5/6cec4607e998eaba57564d06a1295c21b0a0c8de76e4e74d699e627bd98c/librt-0.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e78fb7419e07d98c2af4b8567b72b3eaf8cb05caad642e9963465569c8b2d87e", size = 232558, upload-time = "2026-04-09T16:05:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/95/8c/27f1d8d3aaf079d3eb26439bf0b32f1482340c3552e324f7db9dca858671/librt-0.9.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c3786f0f4490a5cd87f1ed6cefae833ad6b1060d52044ce0434a2e85893afd0", size = 225521, upload-time = "2026-04-09T16:05:26.311Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d8/1e0d43b1c329b416017619469b3c3801a25a6a4ef4a1c68332aeaa6f72ca/librt-0.9.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8494cfc61e03542f2d381e71804990b3931175a29b9278fdb4a5459948778dc2", size = 227789, upload-time = "2026-04-09T16:05:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/b4/d3d842e88610fcd4c8eec7067b0c23ef2d7d3bff31496eded6a83b0f99be/librt-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07cf11f769831186eeac424376e6189f20ace4f7263e2134bdb9757340d84d4d", size = 248616, upload-time = "2026-04-09T16:05:29.181Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/28/527df8ad0d1eb6c8bdfa82fc190f1f7c4cca5a1b6d7b36aeabf95b52d74d/librt-0.9.0-cp313-cp313-win32.whl", hash = "sha256:850d6d03177e52700af605fd60db7f37dcb89782049a149674d1a9649c2138fd", size = 56039, upload-time = "2026-04-09T16:05:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a7/413652ad0d92273ee5e30c000fc494b361171177c83e57c060ecd3c21538/librt-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a5af136bfba820d592f86c67affcef9b3ff4d4360ac3255e341e964489b48519", size = 63264, upload-time = "2026-04-09T16:05:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0a/92c244309b774e290ddb15e93363846ae7aa753d9586b8aad511c5e6145b/librt-0.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:4c4d0440a3a8e31d962340c3e1cc3fc9ee7febd34c8d8f770d06adb947779ea5", size = 53728, upload-time = "2026-04-09T16:05:33.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c1/184e539543f06ea2912f4b92a5ffaede4f9b392689e3f00acbf8134bee92/librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb", size = 67830, upload-time = "2026-04-09T16:05:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/23399bdcb7afca819acacdef31b37ee59de261bd66b503a7995c03c4b0dc/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499", size = 70280, upload-time = "2026-04-09T16:05:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/0b/4542dc5a2b8772dbf92cafb9194701230157e73c14b017b6961a23598b03/librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f", size = 201925, upload-time = "2026-04-09T16:05:36.739Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d4/8ee7358b08fd0cfce051ef96695380f09b3c2c11b77c9bfbc367c921cce5/librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1", size = 212381, upload-time = "2026-04-09T16:05:38.043Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/94/a2025fe442abedf8b038038dab3dba942009ad42b38ea064a1a9e6094241/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f", size = 227065, upload-time = "2026-04-09T16:05:39.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/e9/b9fcf6afa909f957cfbbf918802f9dada1bd5d3c1da43d722fd6a310dc3f/librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a", size = 221333, upload-time = "2026-04-09T16:05:40.999Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/7c/ba54cd6aa6a3c8cd12757a6870e0c79a64b1e6327f5248dcff98423f4d43/librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f", size = 229051, upload-time = "2026-04-09T16:05:42.605Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4b/8cfdbad314c8677a0148bf0b70591d6d18587f9884d930276098a235461b/librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845", size = 222492, upload-time = "2026-04-09T16:05:43.842Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/2eda69563a1a88706808decdce035e4b32755dbfbb0d05e1a65db9547ed1/librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b", size = 223849, upload-time = "2026-04-09T16:05:45.054Z" },
+    { url = "https://files.pythonhosted.org/packages/04/44/b2ed37df6be5b3d42cfe36318e0598e80843d5c6308dd63d0bf4e0ce5028/librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b", size = 245001, upload-time = "2026-04-09T16:05:46.34Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e7/617e412426df89169dd2a9ed0cc8752d5763336252c65dbf945199915119/librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9", size = 51799, upload-time = "2026-04-09T16:05:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ed/c22ca4db0ca3cbc285e4d9206108746beda561a9792289c3c31281d7e9df/librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e", size = 59165, upload-time = "2026-04-09T16:05:49.198Z" },
+    { url = "https://files.pythonhosted.org/packages/24/56/875398fafa4cbc8f15b89366fc3287304ddd3314d861f182a4b87595ace0/librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f", size = 49292, upload-time = "2026-04-09T16:05:50.362Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/61/bc448ecbf9b2d69c5cff88fe41496b19ab2a1cbda0065e47d4d0d51c0867/librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4", size = 70175, upload-time = "2026-04-09T16:05:51.564Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f2/c47bb71069a73e2f04e70acbd196c1e5cc411578ac99039a224b98920fd4/librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228", size = 72951, upload-time = "2026-04-09T16:05:52.699Z" },
+    { url = "https://files.pythonhosted.org/packages/29/19/0549df59060631732df758e8886d92088da5fdbedb35b80e4643664e8412/librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54", size = 225864, upload-time = "2026-04-09T16:05:53.895Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f8/3b144396d302ac08e50f89e64452c38db84bc7b23f6c60479c5d3abd303c/librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71", size = 241155, upload-time = "2026-04-09T16:05:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ce/ee67ec14581de4043e61d05786d2aed6c9b5338816b7859bcf07455c6a9f/librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938", size = 252235, upload-time = "2026-04-09T16:05:56.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fa/0ead15daa2b293a54101550b08d4bafe387b7d4a9fc6d2b985602bae69b6/librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3", size = 244963, upload-time = "2026-04-09T16:05:57.858Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/9fbf9a9aa704ba87689e40017e720aced8d9a4d2b46b82451d8142f91ec9/librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283", size = 257364, upload-time = "2026-04-09T16:05:59.686Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8d/9d60869f1b6716c762e45f66ed945b1e5dd649f7377684c3b176ae424648/librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee", size = 247661, upload-time = "2026-04-09T16:06:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/a5c365093962310bfdb4f6af256f191085078ffb529b3f0cbebb5b33ebe2/librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c", size = 248238, upload-time = "2026-04-09T16:06:02.537Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3c/2d34365177f412c9e19c0a29f969d70f5343f27634b76b765a54d8b27705/librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15", size = 269457, upload-time = "2026-04-09T16:06:03.833Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.20.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/4e/7560e4528db9e9b147e4c0f22660466bf30a0a1fe3d63d1b9d3b0fd354ee/mypy-1.20.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4dbfcf869f6b0517f70cf0030ba6ea1d6645e132337a7d5204a18d8d5636c02b", size = 14539393, upload-time = "2026-04-21T17:07:12.52Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d9/34a5efed8124f5a9234f55ac6a4ced4201e2c5b81e1109c49ad23190ec8c/mypy-1.20.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b6481b228d072315b053210b01ac320e1be243dc17f9e5887ef167f23f5fae4", size = 13361642, upload-time = "2026-04-21T17:06:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/14/eb377acf78c03c92d566a1510cda8137348215b5335085ef662ab82ecd3a/mypy-1.20.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34397cdced6b90b836e38182076049fdb41424322e0b0728c946b0939ebdf9f6", size = 13740347, upload-time = "2026-04-21T17:12:04.73Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/7e4634a32b641aa1c112422eed1bbece61ee16205f674190e8b536f884de/mypy-1.20.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5da6976f20cae27059ea8d0c86e7cef3de720e04c4bb9ee18e3690fdb792066", size = 14734042, upload-time = "2026-04-21T17:07:43.16Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f3/f7e62395cb7f434541b4491a01149a4439e28ace4c0c632bbf5431e92d1f/mypy-1.20.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56908d7e08318d39f85b1f0c6cfd47b0cac1a130da677630dac0de3e0623e102", size = 14964958, upload-time = "2026-04-21T17:11:00.665Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0d/47e3c3a0ec2a876e35aeac365df3cac7776c36bbd4ed18cc521e1b9d255b/mypy-1.20.2-cp312-cp312-win_amd64.whl", hash = "sha256:d52ad8d78522da1d308789df651ee5379088e77c76cb1994858d40a426b343b9", size = 10911340, upload-time = "2026-04-21T17:10:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/b2/6c852d72e0ea8b01f49da817fb52539993cde327e7d010e0103dc12d0dac/mypy-1.20.2-cp312-cp312-win_arm64.whl", hash = "sha256:785b08db19c9f214dc37d65f7c165d19a30fcecb48abfa30f31b01b5acaabb58", size = 9833947, upload-time = "2026-04-21T17:09:05.267Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c4/b93812d3a192c9bcf5df405bd2f30277cd0e48106a14d1023c7f6ed6e39b/mypy-1.20.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:edfbfca868cdd6bd8d974a60f8a3682f5565d3f5c99b327640cedd24c4264026", size = 14524670, upload-time = "2026-04-21T17:10:30.737Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/47/42c122501bff18eaf1e8f457f5c017933452d8acdc52918a9f59f6812955/mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943", size = 13336218, upload-time = "2026-04-21T17:08:44.069Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/75bbc92f41725fbd585fb17b440b1119b576105df1013622983e18640a93/mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517", size = 13724906, upload-time = "2026-04-21T17:08:01.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/32/4c49da27a606167391ff0c39aa955707a00edc500572e562f7c36c08a71f/mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15", size = 14726046, upload-time = "2026-04-21T17:11:22.354Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/fc/4e354a1bd70216359deb0c9c54847ee6b32ef78dfb09f5131ff99b494078/mypy-1.20.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d56a78b646f2e3daa865bc70cd5ec5a46c50045801ca8ff17a0c43abc97e3ee", size = 14955587, upload-time = "2026-04-21T17:12:16.033Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b2/c0f2056e9eb8f08c62cafd9715e4584b89132bdc832fcf85d27d07b5f3e5/mypy-1.20.2-cp313-cp313-win_amd64.whl", hash = "sha256:2a4102b03bb7481d9a91a6da8d174740c9c8c4401024684b9ca3b7cc5e49852f", size = 10922681, upload-time = "2026-04-21T17:06:35.842Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/14/065e333721f05de8ef683d0aa804c23026bcc287446b61cac657b902ccac/mypy-1.20.2-cp313-cp313-win_arm64.whl", hash = "sha256:a95a9248b0c6fd933a442c03c3b113c3b61320086b88e2c444676d3fd1ca3330", size = 9830560, upload-time = "2026-04-21T17:07:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30", size = 14524561, upload-time = "2026-04-21T17:06:27.325Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924", size = 13363883, upload-time = "2026-04-21T17:11:11.239Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/56/983916806bf4eddeaaa2c9230903c3669c6718552a921154e1c5182c701f/mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb", size = 13742945, upload-time = "2026-04-21T17:08:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc", size = 14706163, upload-time = "2026-04-21T17:05:15.51Z" },
+    { url = "https://files.pythonhosted.org/packages/94/97/48ff3b297cafcc94d185243a9190836fb1b01c1b0918fff64e941e973cc9/mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558", size = 14938677, upload-time = "2026-04-21T17:05:39.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8", size = 11089322, upload-time = "2026-04-21T17:06:44.29Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/ce7ee2ba36aeb954ba50f18fa25d9c1188578654b97d02a66a15b6f09531/mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3", size = 10017775, upload-time = "2026-04-21T17:07:20.732Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a1/9d93a7d0b5859af0ead82b4888b46df6c8797e1bc5e1e262a08518c6d48e/mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609", size = 15549002, upload-time = "2026-04-21T17:08:23.107Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d2/09a6a10ee1bf0008f6c144d9676f2ca6a12512151b4e0ad0ff6c4fac5337/mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2", size = 14401942, upload-time = "2026-04-21T17:07:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/57/da/9594b75c3c019e805250bed3583bdf4443ff9e6ef08f97e39ae308cb06f2/mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c", size = 15041649, upload-time = "2026-04-21T17:09:34.653Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/f75a65c278e6e8eba2071f7f5a90481891053ecc39878cc444634d892abe/mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744", size = 15864588, upload-time = "2026-04-21T17:11:44.936Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/46/1a4e1c66e96c1a3246ddf5403d122ac9b0a8d2b7e65730b9d6533ba7a6d3/mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6", size = 16093956, upload-time = "2026-04-21T17:10:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2c/78a8851264dec38cd736ca5b8bc9380674df0dd0be7792f538916157716c/mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec", size = 12568661, upload-time = "2026-04-21T17:11:54.473Z" },
+    { url = "https://files.pythonhosted.org/packages/83/01/cd7318aa03493322ce275a0e14f4f52b8896335e4e79d4fb8153a7ad2b77/mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382", size = 10389240, upload-time = "2026-04-21T17:09:42.719Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314, upload-time = "2026-04-21T17:05:54.5Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/cb/5b47425556ecc1f3fe18ed2a0083188aa46e1dd812b06e406475b3a5d536/pydantic_core-2.46.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b11b59b3eee90a80a36701ddb4576d9ae31f93f05cb9e277ceaa09e6bf074a67", size = 2101946, upload-time = "2026-04-20T14:40:52.581Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4f/2fb62c2267cae99b815bbf4a7b9283812c88ca3153ef29f7707200f1d4e5/pydantic_core-2.46.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af8653713055ea18a3abc1537fe2ebc42f5b0bbb768d1eb79fd74eb47c0ac089", size = 1951612, upload-time = "2026-04-20T14:42:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/b7348fd30d6556d132cddd5bd79f37f96f2601fe0608afac4f5fb01ec0b3/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75a519dab6d63c514f3a81053e5266c549679e4aa88f6ec57f2b7b854aceb1b0", size = 1977027, upload-time = "2026-04-20T14:42:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/82/11/31d60ee2b45540d3fb0b29302a393dbc01cd771c473f5b5147bcd353e593/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6cd87cb1575b1ad05ba98894c5b5c96411ef678fa2f6ed2576607095b8d9789", size = 2063008, upload-time = "2026-04-20T14:44:17.952Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/db/3a9d1957181b59258f44a2300ab0f0be9d1e12d662a4f57bb31250455c52/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f80a55484b8d843c8ada81ebf70a682f3f00a3d40e378c06cf17ecb44d280d7d", size = 2233082, upload-time = "2026-04-20T14:40:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e1/3277c38792aeb5cfb18c2f0c5785a221d9ff4e149abbe1184d53d5f72273/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3861f1731b90c50a3266316b9044f5c9b405eecb8e299b0a7120596334e4fe9c", size = 2304615, upload-time = "2026-04-20T14:42:12.584Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d5/e3d9717c9eba10855325650afd2a9cba8e607321697f18953af9d562da2f/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395", size = 2094380, upload-time = "2026-04-20T14:43:05.522Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/20/abac35dedcbfd66c6f0b03e4e3564511771d6c9b7ede10a362d03e110d9b/pydantic_core-2.46.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:367508faa4973b992b271ba1494acaab36eb7e8739d1e47be5035fb1ea225396", size = 2135429, upload-time = "2026-04-20T14:41:55.549Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a5/41bfd1df69afad71b5cf0535055bccc73022715ad362edbc124bc1e021d7/pydantic_core-2.46.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ad3c826fe523e4becf4fe39baa44286cff85ef137c729a2c5e269afbfd0905d", size = 2174582, upload-time = "2026-04-20T14:41:45.96Z" },
+    { url = "https://files.pythonhosted.org/packages/79/65/38d86ea056b29b2b10734eb23329b7a7672ca604df4f2b6e9c02d4ee22fe/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ec638c5d194ef8af27db69f16c954a09797c0dc25015ad6123eb2c73a4d271ca", size = 2187533, upload-time = "2026-04-20T14:40:55.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a1129141678a2026badc539ad1dee0a71d06f54c2f06a4bd68c030ac781b/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:28ed528c45446062ee66edb1d33df5d88828ae167de76e773a3c7f64bd14e976", size = 2332985, upload-time = "2026-04-20T14:44:13.05Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/60/cb26f4077719f709e54819f4e8e1d43f4091f94e285eb6bd21e1190a7b7c/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aed19d0c783886d5bd86d80ae5030006b45e28464218747dcf83dabfdd092c7b", size = 2373670, upload-time = "2026-04-20T14:41:53.421Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/7e/c3f21882bdf1d8d086876f81b5e296206c69c6082551d776895de7801fa0/pydantic_core-2.46.3-cp312-cp312-win32.whl", hash = "sha256:06d5d8820cbbdb4147578c1fe7ffcd5b83f34508cb9f9ab76e807be7db6ff0a4", size = 1966722, upload-time = "2026-04-20T14:44:30.588Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/6b5e757b859013ebfbd7adba02f23b428f37c86dcbf78b5bb0b4ffd36e99/pydantic_core-2.46.3-cp312-cp312-win_amd64.whl", hash = "sha256:c3212fda0ee959c1dd04c60b601ec31097aaa893573a3a1abd0a47bcac2968c1", size = 2072970, upload-time = "2026-04-20T14:42:54.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f8/a989b21cc75e9a32d24192ef700eea606521221a89faa40c919ce884f2b1/pydantic_core-2.46.3-cp312-cp312-win_arm64.whl", hash = "sha256:f1f8338dd7a7f31761f1f1a3c47503a9a3b34eea3c8b01fa6ee96408affb5e72", size = 2035963, upload-time = "2026-04-20T14:44:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/9b5e8eb9821936d065439c3b0fb1490ffa64163bfe7e1595985a47896073/pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37", size = 2102109, upload-time = "2026-04-20T14:41:24.219Z" },
+    { url = "https://files.pythonhosted.org/packages/91/97/1c41d1f5a19f241d8069f1e249853bcce378cdb76eec8ab636d7bc426280/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f", size = 1951820, upload-time = "2026-04-20T14:42:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b4/d03a7ae14571bc2b6b3c7b122441154720619afe9a336fa3a95434df5e2f/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8", size = 1977785, upload-time = "2026-04-20T14:42:31.648Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0c/4086f808834b59e3c8f1aa26df8f4b6d998cdcf354a143d18ef41529d1fe/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad", size = 2062761, upload-time = "2026-04-20T14:40:37.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/a649be5a5064c2df0db06e0a512c2281134ed2fcc981f52a657936a7527c/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c", size = 2232989, upload-time = "2026-04-20T14:42:59.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/7756e75763e810b3a710f4724441d1ecc5883b94aacb07ca71c5fb5cfb69/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f", size = 2303975, upload-time = "2026-04-20T14:41:32.287Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/35/68a762e0c1e31f35fa0dac733cbd9f5b118042853698de9509c8e5bf128b/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35", size = 2095325, upload-time = "2026-04-20T14:42:47.685Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bf/1bf8c9a8e91836c926eae5e3e51dce009bf495a60ca56060689d3df3f340/pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687", size = 2133368, upload-time = "2026-04-20T14:41:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/50/87d818d6bab915984995157ceb2380f5aac4e563dddbed6b56f0ed057aba/pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3", size = 2173908, upload-time = "2026-04-20T14:42:52.044Z" },
+    { url = "https://files.pythonhosted.org/packages/91/88/a311fb306d0bd6185db41fa14ae888fb81d0baf648a761ae760d30819d33/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022", size = 2186422, upload-time = "2026-04-20T14:43:29.55Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/79/28fd0d81508525ab2054fef7c77a638c8b5b0afcbbaeee493cf7c3fef7e1/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23", size = 2332709, upload-time = "2026-04-20T14:42:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/21/795bf5fe5c0f379308b8ef19c50dedab2e7711dbc8d0c2acf08f1c7daa05/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7", size = 2372428, upload-time = "2026-04-20T14:41:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b3/ed14c659cbe7605e3ef063077680a64680aec81eb1a04763a05190d49b7f/pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13", size = 1965601, upload-time = "2026-04-20T14:41:42.128Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/adb70d9a762ddd002d723fbf1bd492244d37da41e3af7b74ad212609027e/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0", size = 2071517, upload-time = "2026-04-20T14:43:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/52/eb/66faefabebfe68bd7788339c9c9127231e680b11906368c67ce112fdb47f/pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec", size = 2035802, upload-time = "2026-04-20T14:43:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/db/a7bcb4940183fda36022cd18ba8dd12f2dff40740ec7b58ce7457befa416/pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b", size = 2097614, upload-time = "2026-04-20T14:44:38.374Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/e4066358a22e3e99519db370494c7528f5a2aa1367370e80e27e20283543/pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018", size = 1951896, upload-time = "2026-04-20T14:40:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/87/92/37cf4049d1636996e4b888c05a501f40a43ff218983a551d57f9d5e14f0d/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34", size = 1979314, upload-time = "2026-04-20T14:41:49.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/9ff4d676dfbdfb2d591cf43f3d90ded01e15b1404fd101180ed2d62a2fd3/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7", size = 2056133, upload-time = "2026-04-20T14:42:23.574Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f0/405b442a4d7ba855b06eec8b2bf9c617d43b8432d099dfdc7bf999293495/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2", size = 2228726, upload-time = "2026-04-20T14:44:22.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f8/65cd92dd5a0bd89ba277a98ecbfaf6fc36bbd3300973c7a4b826d6ab1391/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba", size = 2301214, upload-time = "2026-04-20T14:44:48.792Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/86/ef96a4c6e79e7a2d0410826a68fbc0eccc0fd44aa733be199d5fcac3bb87/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f", size = 2099927, upload-time = "2026-04-20T14:41:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/53/269caf30e0096e0a8a8f929d1982a27b3879872cca2d917d17c2f9fdf4fe/pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22", size = 2128789, upload-time = "2026-04-20T14:41:15.868Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b0/1a6d9b6a587e118482910c244a1c5acf4d192604174132efd12bf0ac486f/pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f", size = 2173815, upload-time = "2026-04-20T14:44:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/87/56/e7e00d4041a7e62b5a40815590114db3b535bf3ca0bf4dca9f16cef25246/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127", size = 2181608, upload-time = "2026-04-20T14:41:28.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/22/4bd23c3d41f7c185d60808a1de83c76cf5aeabf792f6c636a55c3b1ec7f9/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c", size = 2326968, upload-time = "2026-04-20T14:42:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ac/66cd45129e3915e5ade3b292cb3bc7fd537f58f8f8dbdaba6170f7cabb74/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1", size = 2369842, upload-time = "2026-04-20T14:41:35.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/dd4248abb84113615473aa20d5545b7c4cd73c8644003b5259686f93996c/pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505", size = 1959661, upload-time = "2026-04-20T14:41:00.042Z" },
+    { url = "https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e", size = 2071686, upload-time = "2026-04-20T14:43:16.471Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/db/1cf77e5247047dfee34bc01fa9bca134854f528c8eb053e144298893d370/pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df", size = 2026907, upload-time = "2026-04-20T14:43:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c0/b3df9f6a543276eadba0a48487b082ca1f201745329d97dbfa287034a230/pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf", size = 2095047, upload-time = "2026-04-20T14:42:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/57/886a938073b97556c168fd99e1a7305bb363cd30a6d2c76086bf0587b32a/pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee", size = 1934329, upload-time = "2026-04-20T14:43:49.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7c/b42eaa5c34b13b07ecb51da21761297a9b8eb43044c864a035999998f328/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a", size = 1974847, upload-time = "2026-04-20T14:42:10.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9b/92b42db6543e7de4f99ae977101a2967b63122d4b6cf7773812da2d7d5b5/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c", size = 2041742, upload-time = "2026-04-20T14:40:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/19/46fbe1efabb5aa2834b43b9454e70f9a83ad9c338c1291e48bdc4fecf167/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1", size = 2236235, upload-time = "2026-04-20T14:41:27.307Z" },
+    { url = "https://files.pythonhosted.org/packages/77/da/b3f95bc009ad60ec53120f5d16c6faa8cabdbe8a20d83849a1f2b8728148/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64", size = 2282633, upload-time = "2026-04-20T14:44:33.271Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/401336117722e28f32fb8220df676769d28ebdf08f2f4469646d404c43a3/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb", size = 2109679, upload-time = "2026-04-20T14:44:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/53/b289f9bc8756a32fe718c46f55afaeaf8d489ee18d1a1e7be1db73f42cc4/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6", size = 2108342, upload-time = "2026-04-20T14:42:50.144Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5b/8292fc7c1f9111f1b2b7c1b0dcf1179edcd014fc3ea4517499f50b829d71/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c", size = 2157208, upload-time = "2026-04-20T14:42:08.133Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9e/f80044e9ec07580f057a89fc131f78dda7a58751ddf52bbe05eaf31db50f/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47", size = 2167237, upload-time = "2026-04-20T14:42:25.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/6781a1b037f3b96be9227edbd1101f6d3946746056231bf4ac48cdff1a8d/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab", size = 2312540, upload-time = "2026-04-20T14:40:40.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/db/19c0839feeb728e7df03255581f198dfdf1c2aeb1e174a8420b63c5252e5/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba", size = 2369556, upload-time = "2026-04-20T14:41:09.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756, upload-time = "2026-04-20T14:41:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305, upload-time = "2026-04-20T14:43:18.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310, upload-time = "2026-04-20T14:41:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/34/42/f426db557e8ab2791bc7562052299944a118655496fbff99914e564c0a94/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b12dd51f1187c2eb489af8e20f880362db98e954b54ab792fa5d92e8bcc6b803", size = 2091877, upload-time = "2026-04-20T14:43:27.091Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428, upload-time = "2026-04-20T14:40:45.781Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550, upload-time = "2026-04-20T14:44:02.425Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657, upload-time = "2026-04-20T14:42:45.149Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/9a/f35932a8c0eb6b2287b66fa65a0321df8c84e4e355a659c1841a37c39fdb/sse_starlette-3.4.1.tar.gz", hash = "sha256:f780bebcf6c8997fe514e3bd8e8c648d8284976b391c8bed0bcb1f611632b555", size = 35127, upload-time = "2026-04-26T13:32:32.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/07/45c21ed03d708c477367305726b89919b020a3a2a01f72aaf5ad941caf35/sse_starlette-3.4.1-py3-none-any.whl", hash = "sha256:6b43cf21f1d574d582a6e1b0cfbde1c94dc86a32a701a7168c99c4475c6bd1d0", size = 16487, upload-time = "2026-04-26T13:32:30.819Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "thanatos"
+version = "0.0.1"
+source = { editable = "." }
+dependencies = [
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "mcp", specifier = ">=1.2" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
+    { name = "pydantic", specifier = ">=2.9" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]


### PR DESCRIPTION
## Summary

M0 scaffold of the thanatos acceptance harness, per [`docs/thanatos.md`](../blob/feat/REQ-thanatos-m0-scaffold-v6-1777283112/docs/thanatos.md). This is the first of several milestones — the goal of M0 is to land the **shape** of the harness (module layout, MCP interface, Driver Protocol, helm chart topology) so subsequent milestones (M1 wires accept stage to MCP; M2 fills in real driver runtimes) have a stable substrate to build on.

### What's in (24 new files + 1 Makefile change)

- `docs/thanatos.md` — design doc (sole source of truth) is now in the repo so the spec_lint fixer can find it.
- `thanatos/` Python module:
  - `src/thanatos/server.py` — MCP stdio server registering `run_scenario`, `run_all`, `recall` (all M0 stubs).
  - `src/thanatos/scenario.py` — **real** parser for `#### Scenario:` blocks; supports gherkin-fenced and bullet formats; rejects mixed/empty/duplicate-id.
  - `src/thanatos/skill.py` — **real** pydantic-validated `.thanatos/skill.yaml` loader.
  - `src/thanatos/drivers/{base,playwright,adb,http}.py` — five-method async `Driver` Protocol + three driver classes that **all** raise `NotImplementedError(\"M0: scaffold only\")`.
  - `tests/test_scenario_parser.py` (11 cases) + `tests/test_skill_loader.py` (4 cases) — 15 unit tests, all pass locally.
  - `docs/semantic-contracts/{web,android,flutter}.md` — what product code needs in order to pass preflight when M1 lights up.
- `deploy/charts/thanatos/` helm chart with driver-conditional Pod topology:
  - `playwright` / `http` → 1 container.
  - `adb` → 2 containers (privileged redroid sidecar + thanatos with `ADB_SERVER_ADDR=localhost:5555`).
  - Invalid driver → `helm template` fails with a clear message.
- `openspec/changes/REQ-thanatos-m0-scaffold-v6-1777283112/` — proposal, design, tasks, contract.spec.yaml, spec.md (4 Requirements + 7 Scenarios `THAN-S1..THAN-S7`).
- `Makefile` (top-level) — `ci-lint` / `ci-unit-test` / `ci-integration-test` extended with one extra `cd thanatos && uv run …` line so thanatos rides the same `dev_cross_check` / `staging_test` paths as orchestrator.

### What's out (M1+)

- Real driver runtime (chromium spawn, adb shell, http client).
- preflight a11y/view-tree probing, screenshot fallback, kb_updates generation.
- Wiring `accept.md.j2` to call thanatos MCP, KB commit/push round-trip.
- Pushing the helm chart to OCI; modifying any business-repo `accept-env-up` Makefile.
- Any new sisyphus state / event / stage / mechanical checker / verifier prompt.

## Test plan

Already run locally on this branch (Coder workspace):

- [x] `openspec validate REQ-thanatos-m0-scaffold-v6-1777283112` — `Change … is valid`
- [x] `bash scripts/check-scenario-refs.sh` — `OK: 所有 scenario 引用都在 specs 中找到`
- [x] `make ci-lint` — `All checks passed!` (orchestrator + thanatos)
- [x] `make ci-unit-test` — `1443 passed` (orchestrator) + `15 passed` (thanatos)
- [x] `make ci-integration-test` — both subcomponents `exit 5 → pass`
- [x] `helm template deploy/charts/thanatos --set driver={playwright|adb|http}` — all 3 modes render; `--set driver=desktop` fails with `thanatos.driver must be one of playwright|adb|http, got \"desktop\"`
- [x] Container-shape verification: `driver=adb` → `[redroid, thanatos]` w/ `privileged: true` + `ADB_SERVER_ADDR=localhost:5555`; `driver=playwright` → `[thanatos]` w/ `command: [\"python\", \"-m\", \"thanatos.server\"]`

## Sisyphus pipeline next steps (mechanical, no agent)

1. spec_lint — `openspec validate` + `check-scenario-refs.sh`
2. dev_cross_check — `BASE_REV make ci-lint`
3. staging_test — `make ci-unit-test && make ci-integration-test`
4. pr_ci_watch — GitHub check-runs
5. accept stage is **noop for this REQ** by design (M0 doesn't wire accept.md.j2 to thanatos)
6. archive

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-thanatos-m0-scaffold-v6-1777283112\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/ig7k5r12)