### PR TITLE
refactor(runner_gc): split Pod vs PVC retention — reclaim escalated Pods immediately

### DIFF
--- a/openspec/changes/REQ-runner-gc-pod-pvc-split-1777283946/proposal.md
+++ b/openspec/changes/REQ-runner-gc-pod-pvc-split-1777283946/proposal.md
@@ -1,0 +1,147 @@
+# REQ-runner-gc-pod-pvc-split-1777283946: refactor(runner_gc): split Pod vs PVC retention so escalated Pods are reclaimed immediately while PVCs honor the human-debug retention window
+
+## 问题
+
+`runner_gc` 当前用**一个** keep set 同时管 Pod 和 PVC：
+
+```python
+# runner_gc.py 当前
+async def _active_req_ids(*, ignore_retention: bool = False) -> set[str]:
+    ...
+    if state == "escalated" and not ignore_retention:
+        if updated_at and (now - updated_at) < retention:
+            active.add(r["req_id"])    # ← Pod 跟 PVC 一起留
+    return active
+
+async def gc_once() -> dict:
+    ...
+    active = await _active_req_ids(ignore_retention=disk_pressure)
+    cleaned = await rc.gc_orphans(active)   # 列 PVC，扫到的同时删 Pod + PVC
+```
+
+- `gc_orphans(active)` 只迭代 PVC（label `sisyphus/role=workspace`）；ESCALATED 在
+  retention 内的 REQ 整段时间被当 active，PVC 在 keep set 里，**Pod 跟 PVC 一锅
+  端不动**
+- 进 ESCALATED 时引擎跑的 fire-and-forget `_cleanup_runner_on_terminal` 调
+  `cleanup_runner(retain_pvc=True)`，正常情况下 Pod 几秒内删
+- **如果那条 task 失败**（K8s API 抖动、orchestrator pod 重启把 task 吃了、
+  asyncio loop 在 task 跑完前关），Pod **整段 retention 都活着**，每个
+  pod request 512 Mi、limit 8 Gi —— 在 vm-node04（5991 Mi 总内存）小盘子上
+  直接吃掉别 REQ 的调度容量
+
+REQ-cleanup-runner-zombie-1777170378 修了 `force_escalate` 漏 schedule cleanup
+的问题；本 REQ 接力把 GC 兜底也补成"Pod 立即清"——任何路径漏的 Pod 一个
+GC tick 内补上。
+
+实证：vm-node04 5991Mi 总内存的小盘子，每个 runner pod request 512Mi，
+"塞 2-3 个并发 runner"已经卡死调度（k8s_runner.py L266-271 注释）。一个
+zombie ESCALATED Pod 整天占着，对调度容量来说就是少一个 in-flight REQ 的
+slot。
+
+## 方案
+
+把 `runner_gc` 的 keep set 拆成两个：
+
+| | Pod keep set | PVC keep set |
+|---|---|---|
+| non-terminal | 留 | 留 |
+| `done` | **清**（立即） | **清**（立即） |
+| `escalated`（retention 内） | **清**（立即） ← 本次新增 | 留 |
+| `escalated`（retention 过） | **清** | **清** |
+| disk pressure | 同上 | escalated 也清（紧急疏散） |
+
+对应 `RunnerController` 把单一 `gc_orphans(keep)` 拆成两个职责单一方法：
+
+- `gc_orphan_pods(pod_keep) -> list[str]`：列 Pod (`sisyphus/role=runner`)，
+  删 keep 之外的 **Pod，不动 PVC**
+- `gc_orphan_pvcs(pvc_keep) -> list[str]`：列 PVC (`sisyphus/role=workspace`)，
+  删 keep 之外的 **PVC，不动 Pod**（Pod GC 已独立扫；PVC 还有 Pod 依附时
+  K8s 把 PVC 标 Terminating 等 Pod 走，下轮 GC 重扫即生效）
+
+`gc_once()` 调两个新方法，返 dict 加 `cleaned_pods` + `cleaned_pvcs`。
+
+### 行为变化
+
+```
+之前：进 ESCALATED → fire-and-forget cleanup 删 Pod
+      若 cleanup task 失败 → Pod 整段 retention（默认 1d）当 zombie
+      retention 过期 → gc_orphans 一锅端 Pod + PVC
+
+之后：进 ESCALATED → fire-and-forget cleanup 删 Pod
+      若 cleanup task 失败 → 下个 GC tick（默认 15min）gc_orphan_pods 兜底
+      PVC 仍按 retention 留给人 debug
+      retention 过期 → gc_orphan_pvcs 单独扫 PVC
+```
+
+PVC retention 语义不变 —— 还是给人 follow-up 续 verifier issue 的窗口、
+跑 admin force_escalate 后 kubectl exec 进 PVC 看现场。
+
+### 实现要点
+
+1. **不删 `gc_orphans` 仅替换调用方**：`gc_orphans` 是 controller 唯一对外接口，
+   把它改成 `gc_orphan_pods` + `gc_orphan_pvcs` 两个方法（CLAUDE.md "避免
+   backwards-compatibility hacks"）。runner_gc / 测试同步更新。
+2. **Pod GC 按 Pod label 列**（不是 PVC label 推 Pod 名）：覆盖 PVC 已被删但
+   Pod 残留的边角（之前 gc_orphans 用 PVC iterate，PVC 没了找不到 Pod）。
+3. **PVC GC 不级联删 Pod**：拆成正交职责。Pod 还在时 PVC 删请求由 K8s 接受 +
+   标 Terminating 等 Pod 走 —— 下一轮 Pod GC 删完后 PVC 自动收。
+4. **`cleanup_runner` / `_cleanup_runner_on_terminal` 不动**：transition 路径
+   即时清理 + admin endpoint 的 fire-and-forget cleanup 仍走老路。GC 是兜底层。
+5. **disk-check / RBAC 降级路径不动**：`_DISK_CHECK_DISABLED` flag 行为同前；
+   ORCHN-S4..S8 contract 全过。
+
+### 与 runner-cleanup 调用图
+
+```
+transition → ESCALATED
+   ↓ fire-and-forget
+engine._cleanup_runner_on_terminal(req_id, ESCALATED)
+   ↓
+RunnerController.cleanup_runner(req_id, retain_pvc=True)   # 删 Pod 留 PVC
+   ↓ task 失败时漏网
+[zombie Pod 直到 retention 过期]                            # ← 之前
+
+[本 REQ 兜底]:
+runner_gc.gc_once() (每 15 min)
+   ↓
+RunnerController.gc_orphan_pods(pod_keep)                  # 删 zombie Pod
+RunnerController.gc_orphan_pvcs(pvc_keep)                  # 仍按 retention 留 PVC
+```
+
+## 取舍
+
+- **为什么不缩短 `runner_gc_interval_sec`** —— 间隔 15min 是 K8s API 配额
+  权衡，缩短到 1min 增 15× API 调用对治标。本 REQ 改的是"GC tick 真扫到时
+  扫不扫 ESCALATED Pod"——根因，不是频率。间隔保留作 ops 旋钮（settings）。
+- **为什么 `done` 也走 Pod GC（看似多余）** —— transition / admin.complete 已
+  fire-and-forget 清。GC 是兜底：fire-and-forget 失败时这里捞回来。两条路径
+  互补，跟 cleanup_runner 的 404 幂等性合作不冲突。
+- **为什么不在 GC 里继续按 PVC iterate 推断 Pod 名** —— 边角（PVC 删了 Pod
+  残留）覆盖不到；按 Pod label 列直接、对称。两个新方法是正交职责，跟资源
+  管理的语义对得上（Pod 内存、PVC 磁盘）。
+- **为什么 PVC GC 不也清 Pod** —— 把"PVC 用满删 Pod"耦合进 PVC sweep 让 GC
+  逻辑两栖，更难推。Pod GC 独立职责，由 keep set（Pod-only）决定；PVC GC
+  独立职责。K8s 自身的 Pod-PVC 依赖处理（Terminating 等 Pod 走）已经够用。
+- **为什么不也写一个 Pod-only 的 cleanup endpoint** —— GC 是周期性兜底层，
+  对单个 REQ 即刻 Pod 释放有 `/admin/req/{req_id}/runner-pause`（删 Pod 留
+  PVC，已经存在）—— 跟本 REQ 的 GC 拆分契约语义一致。
+
+## 影响面
+
+- 改 `orchestrator/src/orchestrator/runner_gc.py`：
+  - `_active_req_ids` 拆成 `_pod_keep_req_ids` + `_pvc_keep_req_ids`
+  - `gc_once` 调两个新方法，返 dict 加 `cleaned_pods` / `cleaned_pvcs` /
+    `pod_kept` / `pvc_kept` 字段（保留 `disk_pressure`）
+  - `run_loop` 日志字段调整为 pods/pvcs
+- 改 `orchestrator/src/orchestrator/k8s_runner.py`：
+  - 删 `gc_orphans`，新增 `gc_orphan_pods` + `gc_orphan_pvcs`
+- 测试：
+  - `orchestrator/tests/test_runner_gc.py` —— 现有 case 改 assert 两个 keep set；
+    加 `test_pod_keep_excludes_escalated_within_retention`
+  - `orchestrator/tests/test_k8s_runner.py` —— 替 `test_gc_orphans_removes_not_in_keep_set`
+    成 pods + pvcs 两个独立测试
+  - `orchestrator/tests/test_contract_orch_noise_cleanup.py` —— `_FakeController`
+    替 `gc_orphans` 成 `gc_orphan_pods` + `gc_orphan_pvcs`（5 处）
+- 不动 `engine.py` / `admin.py` / `state.py` / migrations / BKD 集成层 / settings。
+- 不动 `cleanup_runner` / `_cleanup_runner_on_terminal` 的契约（transition / admin
+  调用方无感）。

--- a/openspec/changes/REQ-runner-gc-pod-pvc-split-1777283946/specs/runner-gc-pod-pvc-split/contract.spec.yaml
+++ b/openspec/changes/REQ-runner-gc-pod-pvc-split-1777283946/specs/runner-gc-pod-pvc-split/contract.spec.yaml
@@ -1,0 +1,123 @@
+capability: runner-gc-pod-pvc-split
+version: "1.0"
+description: |
+  runner_gc 拆 Pod vs PVC retention：Pod keep set 仅 non-terminal REQ
+  （escalated 不再绑 retention，立即可清释放内存），PVC keep set 保留
+  pvc_retain_on_escalate_days 天给人 debug。RunnerController 的
+  gc_orphans 拆成 gc_orphan_pods + gc_orphan_pvcs 两个正交方法：
+  Pod sweep 按 sisyphus/role=runner 列 Pod，PVC sweep 按
+  sisyphus/role=workspace 列 PVC，互不级联。
+
+  跟 REQ-cleanup-runner-zombie-1777170378 配对：那条修
+  force_escalate 漏 schedule cleanup（即时路径）；本 REQ 把
+  GC 兜底也补成 Pod-immediate（周期路径）。两个改动独立但互补。
+
+modules:
+  - orchestrator/src/orchestrator/runner_gc.py
+  - orchestrator/src/orchestrator/k8s_runner.py
+
+api:
+  RunnerController.gc_orphan_pods:
+    signature: "async def gc_orphan_pods(self, keep_req_ids: set[str]) -> list[str]"
+    behavior: |
+      列 self.namespace 下 label_selector="sisyphus/role=runner" 的 Pod。
+      对每个 metadata.labels["sisyphus/req-id"] 不在 keep_req_ids
+      （case-folded 比较）的 Pod，调 delete_namespaced_pod 删之。
+      404 视为 no-op。返已尝试删除的 req_id 列表。
+    side_effects:
+      - "list_namespaced_pod(namespace, label_selector='sisyphus/role=runner')"
+      - "delete_namespaced_pod(pod_name, namespace) for each non-keep Pod"
+    must_not:
+      - "delete or mutate any PVC"
+      - "call cleanup_runner (which would also delete PVC)"
+
+  RunnerController.gc_orphan_pvcs:
+    signature: "async def gc_orphan_pvcs(self, keep_req_ids: set[str]) -> list[str]"
+    behavior: |
+      列 self.namespace 下 label_selector="sisyphus/role=workspace" 的 PVC。
+      对每个 metadata.labels["sisyphus/req-id"] 不在 keep_req_ids
+      （case-folded 比较）的 PVC，调 delete_namespaced_persistent_volume_claim
+      删之。404 视为 no-op。返已尝试删除的 req_id 列表。
+    side_effects:
+      - "list_namespaced_persistent_volume_claim(namespace, label_selector='sisyphus/role=workspace')"
+      - "delete_namespaced_persistent_volume_claim(pvc_name, namespace) for each non-keep PVC"
+    must_not:
+      - "delete or mutate any Pod"
+
+  removed:
+    - "RunnerController.gc_orphans (replaced by the two methods above)"
+
+  runner_gc.gc_once:
+    signature: "async def gc_once() -> dict"
+    keep_set_logic:
+      pod_keep:
+        - "include req if state NOT in {done, escalated}"
+      pvc_keep:
+        - "include req if state NOT in {done, escalated}"
+        - "OR (state == 'escalated' AND not ignore_retention AND now - updated_at < retention)"
+        - "ignore_retention=True iff disk_pressure detected this tick"
+    dispatch_order:
+      - "1. disk-check (probe ratio if not _DISK_CHECK_DISABLED)"
+      - "2. compute pod_keep + pvc_keep from same req_state snapshot"
+      - "3. await rc.gc_orphan_pods(pod_keep)"
+      - "4. await rc.gc_orphan_pvcs(pvc_keep)"
+    return_dict:
+      cleaned_pods: "list[str] returned from gc_orphan_pods"
+      cleaned_pvcs: "list[str] returned from gc_orphan_pvcs"
+      pod_kept: "len(pod_keep)"
+      pvc_kept: "len(pvc_keep)"
+      disk_pressure: "bool (preserved from previous contract)"
+
+invariants:
+  pod_keep_excludes_terminal_states:
+    - "state == 'done' → not in pod_keep"
+    - "state == 'escalated' (any time, any disk pressure) → not in pod_keep"
+    - "rationale: Pod 占内存/调度容量，没有 'human debug' 用例需要保活 Pod"
+
+  pvc_keep_honors_retention:
+    - "state == 'escalated' AND within retention AND not disk_pressure → in pvc_keep"
+    - "state == 'escalated' AND past retention → not in pvc_keep"
+    - "state == 'escalated' AND disk_pressure → not in pvc_keep (紧急疏散)"
+    - "state == 'done' → not in pvc_keep (无 debug 价值)"
+
+  pod_pvc_orthogonality:
+    - "gc_orphan_pods MUST NOT touch PVCs"
+    - "gc_orphan_pvcs MUST NOT touch Pods"
+    - "rationale: K8s 自身处理 PVC-Pod 依赖（Pod 还在 → PVC 进 Terminating），下轮 GC 自然收"
+
+  disk_check_contract_unchanged:
+    - "ORCHN-S4..S8 全过：第一次 403 → INFO 'runner_gc.disk_check_rbac_denied' + flag=True"
+    - "_DISK_CHECK_DISABLED=True → 不再调 node_disk_usage_ratio"
+    - "non-403 → DEBUG 'runner_gc.disk_check_failed'"
+    - "ratio > threshold → WARNING 'runner_gc.disk_pressure' + disk_pressure=True"
+
+interaction_with_engine_cleanup:
+  description: |
+    engine._cleanup_runner_on_terminal 仍是 transition 路径的即时 cleanup
+    （fire-and-forget）。本 REQ 把周期 GC 也补成 Pod-immediate：fire-and-forget
+    失败 → 下个 GC tick 兜底 Pod。两条路径互补，cleanup_runner 本身 404
+    幂等不冲突。
+  redundancy: by design
+
+interaction_with_force_escalate:
+  description: |
+    REQ-cleanup-runner-zombie-1777170378 让 admin.force_escalate 在 SQL
+    UPDATE 后起 fire-and-forget cleanup task；本 REQ 给那条任务再加一道
+    周期兜底网。两个改动独立：force_escalate 走 transition-style 即时
+    cleanup（秒级），runner_gc 是 GC tick 间隔（默认 15min）的周期兜底。
+
+failure_modes:
+  pod_with_no_pvc:
+    cause: "PVC 已被 gc_orphan_pvcs 删，Pod 残留"
+    handler: "gc_orphan_pods 按 Pod label 列，独立扫到，删之"
+    note: "之前 gc_orphans 用 PVC iterate 推 Pod 名，PVC 没了找不到 Pod"
+
+  pvc_terminating_due_to_pod:
+    cause: "PVC 还有 Pod 依附（Pod GC 还没扫到），PVC delete 请求落地后 K8s 标 Terminating"
+    handler: "下一轮 GC tick：gc_orphan_pods 删 Pod → PVC 自动收"
+    note: "K8s 原生处理依赖序，sisyphus 不需要级联控制"
+
+  api_blip_during_pod_delete:
+    cause: "delete_namespaced_pod 抛非-404 ApiException"
+    handler: "传播给 caller（runner_gc.run_loop 的 except Exception 捕获 + log.exception）"
+    note: "下一轮 GC tick 重扫，幂等"

--- a/openspec/changes/REQ-runner-gc-pod-pvc-split-1777283946/specs/runner-gc-pod-pvc-split/spec.md
+++ b/openspec/changes/REQ-runner-gc-pod-pvc-split-1777283946/specs/runner-gc-pod-pvc-split/spec.md
@@ -1,0 +1,142 @@
+# runner-gc-pod-pvc-split
+
+## ADDED Requirements
+
+### Requirement: runner_gc.gc_once SHALL compute Pod and PVC keep sets independently and dispatch each to its own controller sweep
+
+The orchestrator SHALL split the single `_active_req_ids` keep set into two
+keep sets that are computed independently from the same `req_state` snapshot:
+a Pod keep set containing only REQs whose `state` is non-terminal (i.e.
+NOT in `{done, escalated}`), and a PVC keep set containing non-terminal
+REQs PLUS `escalated` REQs whose `updated_at` is within
+`settings.pvc_retain_on_escalate_days`. `gc_once` MUST then dispatch the
+Pod keep set to `RunnerController.gc_orphan_pods(...)` and the PVC keep
+set to `RunnerController.gc_orphan_pvcs(...)`. The function MUST return a
+dict containing both `cleaned_pods` and `cleaned_pvcs` (lists of REQ ids
+that were swept), `pod_kept` and `pvc_kept` (cardinalities of the two
+keep sets), and the existing `disk_pressure` boolean. The Pod keep set
+MUST NOT honor any retention window for `escalated` REQs because the Pod
+holds 512Mi memory request / 8Gi limit and that capacity is needed by
+in-flight REQs; only the PVC retention window is for the human-debug
+workflow.
+
+#### Scenario: RGS-S1 escalated REQ within retention is in PVC keep set but NOT in Pod keep set
+
+- **GIVEN** a `req_state` row with `state='escalated'` and `updated_at` set to
+  2 hours ago (well within the default `pvc_retain_on_escalate_days=1` window)
+  and the K8s runner controller initialized with stub
+  `gc_orphan_pods` / `gc_orphan_pvcs` methods that return `[]`
+- **WHEN** `runner_gc.gc_once()` is awaited
+- **THEN** `RunnerController.gc_orphan_pods` MUST be invoked exactly once
+  with a keep set that does NOT contain that REQ id (so its zombie Pod
+  would be reaped)
+- **AND** `RunnerController.gc_orphan_pvcs` MUST be invoked exactly once
+  with a keep set that DOES contain that REQ id (so its PVC is preserved
+  for human debug)
+- **AND** the returned dict MUST contain both `cleaned_pods` and
+  `cleaned_pvcs` keys
+
+#### Scenario: RGS-S2 disk pressure forces escalated PVC out of keep set; Pod keep set still excludes terminal states
+
+- **GIVEN** a `req_state` row with `state='escalated'` and `updated_at` set
+  to 2 hours ago, AND `node_disk_usage_ratio()` returning 0.9 (above the
+  default 0.8 threshold)
+- **WHEN** `runner_gc.gc_once()` is awaited
+- **THEN** `RunnerController.gc_orphan_pvcs` MUST be invoked with an
+  empty keep set (escalated retention waived under disk pressure)
+- **AND** `RunnerController.gc_orphan_pods` MUST be invoked with an empty
+  keep set (Pod keep set never includes terminal states)
+- **AND** the returned dict MUST contain `disk_pressure == True`
+
+#### Scenario: RGS-S3 in-flight REQs are in both keep sets; done REQs are in neither
+
+- **GIVEN** three `req_state` rows: `REQ-A` state `analyzing`, `REQ-B`
+  state `staging-test-running`, `REQ-C` state `done` with recent
+  `updated_at`
+- **WHEN** `runner_gc.gc_once()` is awaited
+- **THEN** `RunnerController.gc_orphan_pods` MUST be invoked with a keep
+  set equal to `{"REQ-A", "REQ-B"}`
+- **AND** `RunnerController.gc_orphan_pvcs` MUST be invoked with a keep
+  set equal to `{"REQ-A", "REQ-B"}`
+- **AND** `REQ-C` MUST appear in neither keep set
+
+### Requirement: RunnerController.gc_orphan_pods SHALL list runner Pods by label and delete only Pods whose REQ is not in the keep set
+
+The orchestrator SHALL expose `RunnerController.gc_orphan_pods(keep_req_ids:
+set[str]) -> list[str]` that lists Pods in the runner namespace by label
+selector `sisyphus/role=runner`, extracts the REQ id from the
+`sisyphus/req-id` label, and deletes each Pod whose REQ id (case-folded)
+is NOT present in `keep_req_ids` (also case-folded). The method MUST NOT
+delete or otherwise mutate any PVC. The method MUST handle 404 from the
+delete call as a no-op (Pod already gone). The returned list MUST contain
+every REQ id that the method attempted to delete. This sweep covers Pods
+that survived `_cleanup_runner_on_terminal`'s fire-and-forget cleanup
+because of K8s API blips, orchestrator restart eating the task before
+completion, or manual `kubectl apply` re-creating the Pod after escalate.
+
+#### Scenario: RGS-S4 gc_orphan_pods deletes Pods not in keep set, leaves PVCs alone
+
+- **GIVEN** the K8s mock controller has three runner Pods labeled with
+  `sisyphus/req-id=req-1`, `req-2`, `req-3` and `sisyphus/role=runner`,
+  AND `delete_namespaced_pod` returns success for all three
+- **WHEN** `RunnerController.gc_orphan_pods({"REQ-1"})` is awaited
+- **THEN** `delete_namespaced_pod` MUST be invoked exactly twice (once
+  for `REQ-2`, once for `REQ-3`)
+- **AND** `delete_namespaced_persistent_volume_claim` MUST NOT be
+  invoked
+- **AND** the returned list MUST contain exactly `REQ-2` and `REQ-3`
+
+### Requirement: RunnerController.gc_orphan_pvcs SHALL list runner PVCs by label and delete only PVCs whose REQ is not in the keep set
+
+The orchestrator SHALL expose `RunnerController.gc_orphan_pvcs(keep_req_ids:
+set[str]) -> list[str]` that lists PVCs in the runner namespace by label
+selector `sisyphus/role=workspace`, extracts the REQ id from the
+`sisyphus/req-id` label, and deletes each PVC whose REQ id (case-folded)
+is NOT present in `keep_req_ids` (also case-folded). The method MUST NOT
+delete or otherwise mutate any Pod (Pod GC is a separate concern handled
+by `gc_orphan_pods`). The method MUST handle 404 from the delete call as
+a no-op (PVC already gone). The returned list MUST contain every REQ id
+that the method attempted to delete. If a PVC still has a Pod attached
+when the delete request is issued, K8s SHALL accept the delete and mark
+the PVC as `Terminating`; the actual deletion completes after the next
+`gc_orphan_pods` sweep removes the Pod.
+
+#### Scenario: RGS-S5 gc_orphan_pvcs deletes PVCs not in keep set, leaves Pods alone
+
+- **GIVEN** the K8s mock controller has three workspace PVCs labeled with
+  `sisyphus/req-id=req-1`, `req-2`, `req-3` and `sisyphus/role=workspace`,
+  AND `delete_namespaced_persistent_volume_claim` returns success for all
+- **WHEN** `RunnerController.gc_orphan_pvcs({"REQ-1"})` is awaited
+- **THEN** `delete_namespaced_persistent_volume_claim` MUST be invoked
+  exactly twice (once for `REQ-2`, once for `REQ-3`)
+- **AND** `delete_namespaced_pod` MUST NOT be invoked
+- **AND** the returned list MUST contain exactly `REQ-2` and `REQ-3`
+
+### Requirement: gc_once preserves the disk-check RBAC degradation contract from REQ-orch-noise-cleanup
+
+The split into Pod / PVC sweeps MUST NOT change any of the existing
+disk-check side effects exercised by ORCHN-S4..S8 contracts: the first
+`ApiException(status=403)` from `node_disk_usage_ratio()` MUST set the
+process-level `_DISK_CHECK_DISABLED` flag and emit exactly one INFO log
+`runner_gc.disk_check_rbac_denied`; subsequent ticks MUST short-circuit
+the disk probe; non-403 `ApiException` MUST log DEBUG
+`runner_gc.disk_check_failed` and leave the flag False; ratio above
+threshold MUST emit WARNING `runner_gc.disk_pressure` and set
+`disk_pressure=True` in the result. The sweep dispatch ordering (disk
+probe first, then keep-set computation, then Pod sweep, then PVC sweep)
+MUST be preserved so that a disk-pressure tick can still ignore the
+escalated PVC retention.
+
+#### Scenario: RGS-S6 gc_once with disk-check 403 sets flag and still computes both keep sets
+
+- **GIVEN** `_DISK_CHECK_DISABLED` is False AND `node_disk_usage_ratio()`
+  raises `ApiException(status=403)` AND a single `req_state` row with
+  `state='analyzing'`
+- **WHEN** `runner_gc.gc_once()` is awaited
+- **THEN** the result dict MUST contain `disk_pressure == False`
+- **AND** `_DISK_CHECK_DISABLED` MUST be True
+- **AND** exactly one INFO log `runner_gc.disk_check_rbac_denied` MUST be
+  emitted (no WARNING-level instance of that event)
+- **AND** both `RunnerController.gc_orphan_pods` and
+  `RunnerController.gc_orphan_pvcs` MUST be invoked exactly once with
+  keep sets containing the analyzing REQ id

--- a/openspec/changes/REQ-runner-gc-pod-pvc-split-1777283946/tasks.md
+++ b/openspec/changes/REQ-runner-gc-pod-pvc-split-1777283946/tasks.md
@@ -1,0 +1,24 @@
+# Tasks — REQ-runner-gc-pod-pvc-split-1777283946
+
+owner: analyze-agent or sub-agent of analyze
+
+## Stage: spec
+- [x] author specs/runner-gc-pod-pvc-split/contract.spec.yaml
+- [x] author specs/runner-gc-pod-pvc-split/spec.md scenarios (RGS-S1..S6)
+
+## Stage: implementation
+- [x] `k8s_runner.py`: 删 `gc_orphans`，加 `gc_orphan_pods` + `gc_orphan_pvcs`
+- [x] `runner_gc.py`: `_active_req_ids` 拆 `_pod_keep_req_ids` + `_pvc_keep_req_ids`
+- [x] `runner_gc.py`: `gc_once` 调两个新 controller 方法，返 dict 加 `cleaned_pods` / `cleaned_pvcs`
+- [x] `runner_gc.py`: `run_loop` 日志字段调整为 pods/pvcs
+
+## Stage: unit tests
+- [x] `tests/test_runner_gc.py`: 改现有 case assert 两个 keep set
+- [x] `tests/test_runner_gc.py`: 加 `test_pod_keep_excludes_escalated_within_retention`
+- [x] `tests/test_k8s_runner.py`: 替 `test_gc_orphans_*` 成 `test_gc_orphan_pods_*` + `test_gc_orphan_pvcs_*`
+- [x] `tests/test_contract_orch_noise_cleanup.py`: `_FakeController` 替 `gc_orphans` 成 `gc_orphan_pods` + `gc_orphan_pvcs`
+
+## Stage: PR
+- [x] `make ci-lint` + `make ci-unit-test` 在 runner pod 内通过
+- [x] git push feat/REQ-runner-gc-pod-pvc-split-1777283946
+- [x] gh pr create --label sisyphus

--- a/orchestrator/src/orchestrator/k8s_runner.py
+++ b/orchestrator/src/orchestrator/k8s_runner.py
@@ -514,13 +514,52 @@ class RunnerController:
                     return max(0.0, min(1.0, used_ratio))
         raise RuntimeError("no node with ephemeral-storage info")
 
-    async def gc_orphans(self, keep_req_ids: set[str]) -> list[str]:
-        """删除 keep_req_ids 之外的所有 runner（pod + pvc）。
+    async def gc_orphan_pods(self, keep_req_ids: set[str]) -> list[str]:
+        """按 sisyphus/role=runner label 列 Pod，删 keep_req_ids 之外的 Pod。
 
-        调用方：orchestrator 启动时 + 周期性 task。
-        keep_req_ids = req_state 里 state not in (done, escalated 过期) 的 req_id 集合。
+        **不动 PVC** —— PVC 由 gc_orphan_pvcs 单独管。Pod 占内存/调度容量，
+        keep set（仅 non-terminal）跟 PVC keep set（含 escalated retention）
+        不同：escalated Pod 没"人 debug"用例，立即可清。
 
-        返回被清理的 req_id 列表。
+        覆盖 _cleanup_runner_on_terminal 漏网的 zombie Pod —— 那条 fire-and-
+        forget 任务在 K8s API blip / orchestrator restart 下可能没跑完。
+
+        404 视为 no-op（Pod 已被别处删）。返已尝试删除的 req_id 列表。
+        """
+        keep_lower = {r.lower() for r in keep_req_ids}
+        cleaned: list[str] = []
+
+        pods = await asyncio.to_thread(
+            self.core_v1.list_namespaced_pod,
+            self.namespace, label_selector="sisyphus/role=runner",
+        )
+        for pod in pods.items:
+            req_label = (pod.metadata.labels or {}).get("sisyphus/req-id", "")
+            if not req_label or req_label in keep_lower:
+                continue
+            req_id = req_label.upper() if req_label.lower().startswith("req-") else req_label
+            try:
+                await asyncio.to_thread(
+                    self.core_v1.delete_namespaced_pod,
+                    self.pod_name(req_id), self.namespace,
+                )
+            except ApiException as e:
+                if e.status != 404:
+                    raise
+            cleaned.append(req_id)
+
+        if cleaned:
+            log.info("runner.gc.pods_cleaned", count=len(cleaned), reqs=cleaned)
+        return cleaned
+
+    async def gc_orphan_pvcs(self, keep_req_ids: set[str]) -> list[str]:
+        """按 sisyphus/role=workspace label 列 PVC，删 keep_req_ids 之外的 PVC。
+
+        **不动 Pod** —— Pod 由 gc_orphan_pods 单独管。如果 PVC 还有 Pod 依附
+        （Pod GC 还没扫到），K8s 把 PVC 标 Terminating 等 Pod 走，下轮 GC
+        重扫即生效，不阻塞。
+
+        404 视为 no-op。返已尝试删除的 req_id 列表。
         """
         keep_lower = {r.lower() for r in keep_req_ids}
         cleaned: list[str] = []
@@ -534,12 +573,18 @@ class RunnerController:
             if not req_label or req_label in keep_lower:
                 continue
             req_id = req_label.upper() if req_label.lower().startswith("req-") else req_label
-            # 兜底 sweep：done 已立即清，escalated 过期才到这；都该硬删 PVC
-            await self.cleanup_runner(req_id, retain_pvc=False)
+            try:
+                await asyncio.to_thread(
+                    self.core_v1.delete_namespaced_persistent_volume_claim,
+                    self.pvc_name(req_id), self.namespace,
+                )
+            except ApiException as e:
+                if e.status != 404:
+                    raise
             cleaned.append(req_id)
 
         if cleaned:
-            log.info("runner.gc.cleaned", count=len(cleaned), reqs=cleaned)
+            log.info("runner.gc.pvcs_cleaned", count=len(cleaned), reqs=cleaned)
         return cleaned
 
     # ── exec ────────────────────────────────────────────────────────────

--- a/orchestrator/src/orchestrator/runner_gc.py
+++ b/orchestrator/src/orchestrator/runner_gc.py
@@ -1,8 +1,8 @@
 """Runner GC 后台任务（v0.2-S5）。
 
 每 N 秒扫一次：
-- state=done 的 REQ：其 Pod + PVC 立即销（释放磁盘）
-- state=escalated 且 escalated_at > retention 天的：也销
+- Pod GC：terminal REQ 的 Pod 立即清（escalated 不绑 retention，释放内存）
+- PVC GC：done 立即销 PVC；escalated PVC 保留 retention 给人 debug；磁盘压力时全清
 - 完全找不到 req_state 的 runner（孤儿：orchestrator 丢数据 / 手动清了 PG）：也销
 
 不会销正在跑的 REQ 资源（in-flight state）。
@@ -31,37 +31,53 @@ _TERMINAL_STATES = {"done", "escalated"}
 _DISK_CHECK_DISABLED = False
 
 
-async def _active_req_ids(*, ignore_retention: bool = False) -> set[str]:
-    """列出所有 non-terminal REQ 的 req_id；或 terminal 但仍在保留期内的也算 active。
+async def _pod_keep_req_ids() -> set[str]:
+    """Pod 保留集 = 仅 non-terminal REQ。
 
+    done / escalated 都是 terminal —— Pod 立即可清。escalated Pod 占 512Mi
+    内存 request、8Gi limit，retention 是 PVC 给人 debug 用的，不该绑 Pod
+    生命周期。zombie Pod 整段 retention 活着会挤掉别 REQ 的调度容量。
+    """
+    pool = db.get_pool()
+    rows = await pool.fetch("SELECT req_id, state FROM req_state")
+    return {r["req_id"] for r in rows if r["state"] not in _TERMINAL_STATES}
+
+
+async def _pvc_keep_req_ids(*, ignore_retention: bool = False) -> set[str]:
+    """PVC 保留集 = non-terminal + escalated 在 retention 内（除非磁盘压力）。
+
+    done 立即销 PVC（无 debug 价值，磁盘释放优先）。
     ignore_retention=True：磁盘压力下，escalated 也不留 retention，全清。
     """
     pool = db.get_pool()
     rows = await pool.fetch(
         "SELECT req_id, state, updated_at, context FROM req_state",
     )
-    active: set[str] = set()
+    keep: set[str] = set()
     now = datetime.now(UTC)
     retention = timedelta(days=settings.pvc_retain_on_escalate_days)
     for r in rows:
         state = r["state"]
         if state not in _TERMINAL_STATES:
-            active.add(r["req_id"])
+            keep.add(r["req_id"])
             continue
         if state == "done":
-            continue   # done 的 runner 立即销
-        # escalated：看是否还在保留期（磁盘压力时跳过 retention 直接清）
+            continue
         if state == "escalated" and not ignore_retention:
             updated_at = r["updated_at"]
             if updated_at and (now - updated_at) < retention:
-                active.add(r["req_id"])
-    return active
+                keep.add(r["req_id"])
+    return keep
 
 
 async def gc_once() -> dict:
-    """单次 GC pass。返回 {cleaned: [...]}。
+    """单次 GC pass。Pod 和 PVC 各扫一次（保留集不同）。
 
-    磁盘压力 (> threshold) 时：忽略 escalated retention，全清 non-active PVC（紧急疏散）。
+    Pod GC：terminal REQ 的 Pod 立即清（escalated 不再绑 retention，释放内存）。
+    PVC GC：escalated REQ 的 PVC 留 retention 给人 debug；磁盘压力时全清。
+
+    磁盘压力 (> threshold) 仅影响 PVC keep set —— Pod keep set 永远不含
+    terminal state，跟磁盘无关。
     """
     try:
         rc = k8s_runner.get_controller()
@@ -96,11 +112,15 @@ async def gc_once() -> dict:
             # 取不到磁盘指标 → 退回正常 retention 模式
             log.debug("runner_gc.disk_check_failed", error=str(e))
 
-    active = await _active_req_ids(ignore_retention=disk_pressure)
-    cleaned = await rc.gc_orphans(active)
+    pod_keep = await _pod_keep_req_ids()
+    pvc_keep = await _pvc_keep_req_ids(ignore_retention=disk_pressure)
+    cleaned_pods = await rc.gc_orphan_pods(pod_keep)
+    cleaned_pvcs = await rc.gc_orphan_pvcs(pvc_keep)
     return {
-        "cleaned": cleaned,
-        "active_kept": len(active),
+        "cleaned_pods": cleaned_pods,
+        "cleaned_pvcs": cleaned_pvcs,
+        "pod_kept": len(pod_keep),
+        "pvc_kept": len(pvc_keep),
         "disk_pressure": disk_pressure,
     }
 
@@ -112,8 +132,12 @@ async def run_loop() -> None:
     while True:
         try:
             result = await gc_once()
-            if result.get("cleaned"):
-                log.warning("runner_gc.swept", cleaned=result["cleaned"])
+            if result.get("cleaned_pods") or result.get("cleaned_pvcs"):
+                log.warning(
+                    "runner_gc.swept",
+                    pods=result.get("cleaned_pods", []),
+                    pvcs=result.get("cleaned_pvcs", []),
+                )
             else:
                 log.debug("runner_gc.tick", result=result)
         except asyncio.CancelledError:

--- a/orchestrator/tests/test_contract_orch_noise_cleanup.py
+++ b/orchestrator/tests/test_contract_orch_noise_cleanup.py
@@ -197,7 +197,9 @@ async def test_orchn_s4_first_403_logs_info_and_disables(monkeypatch):
     class _FakeController:
         async def node_disk_usage_ratio(self):
             raise ApiException(status=403)
-        async def gc_orphans(self, keep):
+        async def gc_orphan_pods(self, keep):
+            return []
+        async def gc_orphan_pvcs(self, keep):
             return []
 
     monkeypatch.setattr(gc_mod.k8s_runner, "get_controller", lambda: _FakeController())
@@ -261,7 +263,9 @@ async def test_orchn_s5_disabled_skips_node_api(monkeypatch):
         async def node_disk_usage_ratio(self):
             ratio_calls.append(True)
             return 0.0
-        async def gc_orphans(self, keep):
+        async def gc_orphan_pods(self, keep):
+            return []
+        async def gc_orphan_pvcs(self, keep):
             return []
 
     monkeypatch.setattr(gc_mod.k8s_runner, "get_controller", lambda: _FakeController())
@@ -309,7 +313,9 @@ async def test_orchn_s6_non_403_debug_no_disable(monkeypatch):
     class _FakeController:
         async def node_disk_usage_ratio(self):
             raise ApiException(status=500)
-        async def gc_orphans(self, keep):
+        async def gc_orphan_pods(self, keep):
+            return []
+        async def gc_orphan_pvcs(self, keep):
             return []
 
     monkeypatch.setattr(gc_mod.k8s_runner, "get_controller", lambda: _FakeController())
@@ -354,7 +360,9 @@ async def test_orchn_s7_high_ratio_triggers_disk_pressure(monkeypatch):
     class _FakeController:
         async def node_disk_usage_ratio(self):
             return 0.9
-        async def gc_orphans(self, keep):
+        async def gc_orphan_pods(self, keep):
+            return []
+        async def gc_orphan_pvcs(self, keep):
             return []
 
     monkeypatch.setattr(gc_mod.k8s_runner, "get_controller", lambda: _FakeController())
@@ -398,7 +406,9 @@ async def test_orchn_s8_warning_filter_excludes_rbac_denied(monkeypatch):
     class _FakeController:
         async def node_disk_usage_ratio(self):
             raise ApiException(status=403)
-        async def gc_orphans(self, keep):
+        async def gc_orphan_pods(self, keep):
+            return []
+        async def gc_orphan_pvcs(self, keep):
             return []
 
     monkeypatch.setattr(gc_mod.k8s_runner, "get_controller", lambda: _FakeController())

--- a/orchestrator/tests/test_contract_runner_gc_pod_pvc_split.py
+++ b/orchestrator/tests/test_contract_runner_gc_pod_pvc_split.py
@@ -1,0 +1,320 @@
+"""Contract tests for runner-gc-pod-pvc-split (REQ-runner-gc-pod-pvc-split-1777283946).
+
+Black-box challenger. Does NOT read implementation code (runner_gc.py / k8s_runner.py).
+Derived from:
+  openspec/changes/REQ-runner-gc-pod-pvc-split-1777283946/specs/runner-gc-pod-pvc-split/spec.md
+
+Scenarios:
+  RGS-S1  escalated REQ within retention → in PVC keep set but NOT in Pod keep set
+  RGS-S2  disk pressure forces escalated PVC out of keep set; Pod keep set still excludes terminal
+  RGS-S3  in-flight REQs in both keep sets; done REQs in neither
+  RGS-S4  gc_orphan_pods deletes Pods not in keep set, leaves PVCs alone
+  RGS-S5  gc_orphan_pvcs deletes PVCs not in keep set, leaves Pods alone
+  RGS-S6  gc_once with disk-check 403 sets flag and both sweeps still run
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is wrong, escalate to spec_fixer to correct the spec.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+from kubernetes.client import ApiException
+
+from orchestrator import k8s_runner, runner_gc
+from orchestrator.k8s_runner import RunnerController
+
+
+# ─── Shared helpers ───────────────────────────────────────────────────────────
+
+
+def _row(req_id: str, state: str, updated_at=None) -> dict:
+    return {"req_id": req_id, "state": state, "updated_at": updated_at, "context": {}}
+
+
+class _FakePool:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def fetch(self, sql, *args):
+        return self._rows
+
+
+def _make_pod_item(req_id: str) -> MagicMock:
+    item = MagicMock()
+    item.metadata.name = f"runner-{req_id.lower()}"
+    item.metadata.labels = {"sisyphus/req-id": req_id.lower(), "sisyphus/role": "runner"}
+    return item
+
+
+def _make_pvc_item(req_id: str) -> MagicMock:
+    item = MagicMock()
+    item.metadata.name = f"workspace-{req_id.lower()}"
+    item.metadata.labels = {"sisyphus/req-id": req_id.lower(), "sisyphus/role": "workspace"}
+    return item
+
+
+def _make_controller(core_v1: MagicMock | None = None) -> RunnerController:
+    return RunnerController(
+        namespace="sisyphus-runners",
+        runner_image="ghcr.io/test/runner:latest",
+        runner_sa="sisyphus-runner-sa",
+        storage_class="local-path",
+        workspace_size="10Gi",
+        runner_secret_name="sisyphus-runner-secrets",
+        image_pull_secrets=[],
+        ready_timeout_sec=5,
+        core_v1=core_v1 or MagicMock(),
+    )
+
+
+import pytest
+
+
+@pytest.fixture
+def mock_controller(monkeypatch):
+    fake = MagicMock()
+    fake.gc_orphan_pods = AsyncMock(return_value=[])
+    fake.gc_orphan_pvcs = AsyncMock(return_value=[])
+    k8s_runner.set_controller(fake)
+    yield fake
+    k8s_runner.set_controller(None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_disk_flag():
+    runner_gc._DISK_CHECK_DISABLED = False
+    yield
+    runner_gc._DISK_CHECK_DISABLED = False
+
+
+# ─── RGS-S1 ──────────────────────────────────────────────────────────────────
+
+
+async def test_rgs_s1_escalated_within_retention_in_pvc_keep_not_in_pod_keep(
+    monkeypatch, mock_controller
+):
+    """RGS-S1: escalated REQ within retention window → excluded from Pod keep set,
+    included in PVC keep set, and result dict has both cleaned_pods/cleaned_pvcs keys.
+    """
+    recent = datetime.now(UTC) - timedelta(hours=2)  # well within default 1-day window
+    pool = _FakePool([_row("REQ-GC-1", "escalated", updated_at=recent)])
+    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
+
+    result = await runner_gc.gc_once()
+
+    pod_keep = mock_controller.gc_orphan_pods.await_args.args[0]
+    pvc_keep = mock_controller.gc_orphan_pvcs.await_args.args[0]
+
+    assert "REQ-GC-1" not in pod_keep, (
+        "escalated REQ within retention MUST NOT be in Pod keep set — "
+        "Pod holds 512Mi memory and must be reclaimed immediately to free scheduling capacity"
+    )
+    assert "REQ-GC-1" in pvc_keep, (
+        "escalated REQ within retention MUST be in PVC keep set — "
+        "PVC is needed for human-debug workflow during retention window"
+    )
+    assert "cleaned_pods" in result, "result dict MUST contain 'cleaned_pods' key"
+    assert "cleaned_pvcs" in result, "result dict MUST contain 'cleaned_pvcs' key"
+
+
+# ─── RGS-S2 ──────────────────────────────────────────────────────────────────
+
+
+async def test_rgs_s2_disk_pressure_evicts_escalated_pvc_pod_keep_still_empty(
+    monkeypatch, mock_controller
+):
+    """RGS-S2: disk pressure (ratio=0.9) → escalated-within-retention PVC also evicted;
+    Pod keep set is empty regardless (terminal states never kept); disk_pressure=True.
+    """
+    recent = datetime.now(UTC) - timedelta(hours=2)
+    pool = _FakePool([_row("REQ-GC-1", "escalated", updated_at=recent)])
+    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
+    mock_controller.node_disk_usage_ratio = AsyncMock(return_value=0.9)
+
+    result = await runner_gc.gc_once()
+
+    pod_keep = mock_controller.gc_orphan_pods.await_args.args[0]
+    pvc_keep = mock_controller.gc_orphan_pvcs.await_args.args[0]
+
+    assert pod_keep == set(), (
+        "Pod keep set MUST be empty — terminal states (escalated) are NEVER kept "
+        "in Pod keep set, regardless of disk pressure"
+    )
+    assert pvc_keep == set(), (
+        "disk pressure MUST evict escalated PVC retention — emergency evacuation "
+        "waives the human-debug retention window"
+    )
+    assert result.get("disk_pressure") is True, (
+        "result MUST contain disk_pressure=True when disk ratio exceeds threshold"
+    )
+
+
+# ─── RGS-S3 ──────────────────────────────────────────────────────────────────
+
+
+async def test_rgs_s3_inflight_in_both_keep_sets_done_in_neither(
+    monkeypatch, mock_controller
+):
+    """RGS-S3: in-flight REQs → both keep sets; done REQ → neither keep set."""
+    pool = _FakePool([
+        _row("REQ-A", "analyzing"),
+        _row("REQ-B", "staging-test-running"),
+        _row("REQ-C", "done", updated_at=datetime.now(UTC)),
+    ])
+    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
+
+    await runner_gc.gc_once()
+
+    pod_keep = mock_controller.gc_orphan_pods.await_args.args[0]
+    pvc_keep = mock_controller.gc_orphan_pvcs.await_args.args[0]
+
+    assert pod_keep == {"REQ-A", "REQ-B"}, (
+        f"Pod keep set MUST be exactly {{REQ-A, REQ-B}}, got {pod_keep!r}"
+    )
+    assert pvc_keep == {"REQ-A", "REQ-B"}, (
+        f"PVC keep set MUST be exactly {{REQ-A, REQ-B}}, got {pvc_keep!r}"
+    )
+    assert "REQ-C" not in pod_keep, "done REQ MUST NOT appear in Pod keep set"
+    assert "REQ-C" not in pvc_keep, "done REQ MUST NOT appear in PVC keep set"
+
+
+# ─── RGS-S4 ──────────────────────────────────────────────────────────────────
+
+
+async def test_rgs_s4_gc_orphan_pods_deletes_non_keep_leaves_pvcs_untouched():
+    """RGS-S4: gc_orphan_pods(keep={REQ-1}) with 3 Pods → deletes REQ-2 and REQ-3 Pods,
+    MUST NOT call delete_namespaced_persistent_volume_claim.
+    """
+    core_v1 = MagicMock()
+
+    pod_list = MagicMock()
+    pod_list.items = [
+        _make_pod_item("req-1"),
+        _make_pod_item("req-2"),
+        _make_pod_item("req-3"),
+    ]
+    core_v1.list_namespaced_pod.return_value = pod_list
+    core_v1.delete_namespaced_pod.return_value = MagicMock()
+
+    rc = _make_controller(core_v1)
+    deleted = await rc.gc_orphan_pods({"REQ-1"})
+
+    # MUST list Pods by sisyphus/role=runner label selector
+    core_v1.list_namespaced_pod.assert_called_once()
+    list_call = str(core_v1.list_namespaced_pod.call_args)
+    assert "sisyphus/role=runner" in list_call, (
+        f"gc_orphan_pods MUST list Pods with label_selector='sisyphus/role=runner'; "
+        f"got call_args={list_call}"
+    )
+
+    # MUST delete exactly 2 Pods (req-2 and req-3)
+    assert core_v1.delete_namespaced_pod.call_count == 2, (
+        f"delete_namespaced_pod MUST be called exactly 2 times; "
+        f"got {core_v1.delete_namespaced_pod.call_count}"
+    )
+
+    # MUST NOT touch PVCs
+    core_v1.delete_namespaced_persistent_volume_claim.assert_not_called()
+
+    # returned list MUST contain the deleted REQ ids
+    deleted_lower = {r.lower() for r in deleted}
+    assert deleted_lower == {"req-2", "req-3"}, (
+        f"returned list MUST contain exactly req-2 and req-3; got {deleted!r}"
+    )
+
+
+# ─── RGS-S5 ──────────────────────────────────────────────────────────────────
+
+
+async def test_rgs_s5_gc_orphan_pvcs_deletes_non_keep_leaves_pods_untouched():
+    """RGS-S5: gc_orphan_pvcs(keep={REQ-1}) with 3 PVCs → deletes REQ-2 and REQ-3 PVCs,
+    MUST NOT call delete_namespaced_pod.
+    """
+    core_v1 = MagicMock()
+
+    pvc_list = MagicMock()
+    pvc_list.items = [
+        _make_pvc_item("req-1"),
+        _make_pvc_item("req-2"),
+        _make_pvc_item("req-3"),
+    ]
+    core_v1.list_namespaced_persistent_volume_claim.return_value = pvc_list
+    core_v1.delete_namespaced_persistent_volume_claim.return_value = MagicMock()
+
+    rc = _make_controller(core_v1)
+    deleted = await rc.gc_orphan_pvcs({"REQ-1"})
+
+    # MUST list PVCs by sisyphus/role=workspace label selector
+    core_v1.list_namespaced_persistent_volume_claim.assert_called_once()
+    list_call = str(core_v1.list_namespaced_persistent_volume_claim.call_args)
+    assert "sisyphus/role=workspace" in list_call, (
+        f"gc_orphan_pvcs MUST list PVCs with label_selector='sisyphus/role=workspace'; "
+        f"got call_args={list_call}"
+    )
+
+    # MUST delete exactly 2 PVCs (req-2 and req-3)
+    assert core_v1.delete_namespaced_persistent_volume_claim.call_count == 2, (
+        f"delete_namespaced_persistent_volume_claim MUST be called exactly 2 times; "
+        f"got {core_v1.delete_namespaced_persistent_volume_claim.call_count}"
+    )
+
+    # MUST NOT touch Pods
+    core_v1.delete_namespaced_pod.assert_not_called()
+
+    # returned list MUST contain the deleted REQ ids
+    deleted_lower = {r.lower() for r in deleted}
+    assert deleted_lower == {"req-2", "req-3"}, (
+        f"returned list MUST contain exactly req-2 and req-3; got {deleted!r}"
+    )
+
+
+# ─── RGS-S6 ──────────────────────────────────────────────────────────────────
+
+
+async def test_rgs_s6_disk_check_403_sets_flag_emits_info_log_both_sweeps_run(
+    monkeypatch, mock_controller, capsys
+):
+    """RGS-S6: ApiException(status=403) from node_disk_usage_ratio → _DISK_CHECK_DISABLED
+    set to True, exactly one INFO log 'runner_gc.disk_check_rbac_denied' emitted,
+    disk_pressure=False, and both gc_orphan_pods/gc_orphan_pvcs still invoked with
+    the analyzing REQ in their keep sets.
+    """
+    pool = _FakePool([_row("REQ-Z", "analyzing")])
+    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
+    mock_controller.node_disk_usage_ratio = AsyncMock(
+        side_effect=ApiException(status=403, reason="Forbidden")
+    )
+
+    assert runner_gc._DISK_CHECK_DISABLED is False, "precondition: flag must start False"
+
+    result = await runner_gc.gc_once()
+
+    assert result.get("disk_pressure") is False, (
+        "403 RBAC denial MUST result in disk_pressure=False — it is NOT treated as disk pressure"
+    )
+    assert runner_gc._DISK_CHECK_DISABLED is True, (
+        "first ApiException(status=403) MUST set process-level _DISK_CHECK_DISABLED=True "
+        "so subsequent ticks short-circuit the disk probe"
+    )
+
+    out = capsys.readouterr().out
+    assert "disk_check_rbac_denied" in out, (
+        "MUST emit exactly one INFO log with event 'runner_gc.disk_check_rbac_denied'; "
+        f"stdout was: {out!r}"
+    )
+
+    # Both sweeps MUST still run after disk-check 403
+    mock_controller.gc_orphan_pods.assert_awaited_once()
+    mock_controller.gc_orphan_pvcs.assert_awaited_once()
+
+    pod_keep = mock_controller.gc_orphan_pods.await_args.args[0]
+    pvc_keep = mock_controller.gc_orphan_pvcs.await_args.args[0]
+
+    assert "REQ-Z" in pod_keep, (
+        "analyzing REQ MUST be in Pod keep set even after disk-check 403"
+    )
+    assert "REQ-Z" in pvc_keep, (
+        "analyzing REQ MUST be in PVC keep set even after disk-check 403"
+    )

--- a/orchestrator/tests/test_contract_runner_gc_pod_pvc_split.py
+++ b/orchestrator/tests/test_contract_runner_gc_pod_pvc_split.py
@@ -20,11 +20,11 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from kubernetes.client import ApiException
 
 from orchestrator import k8s_runner, runner_gc
 from orchestrator.k8s_runner import RunnerController
-
 
 # ─── Shared helpers ───────────────────────────────────────────────────────────
 
@@ -67,9 +67,6 @@ def _make_controller(core_v1: MagicMock | None = None) -> RunnerController:
         ready_timeout_sec=5,
         core_v1=core_v1 or MagicMock(),
     )
-
-
-import pytest
 
 
 @pytest.fixture

--- a/orchestrator/tests/test_k8s_runner.py
+++ b/orchestrator/tests/test_k8s_runner.py
@@ -446,11 +446,63 @@ async def test_cleanup_runner_raises_on_other_api_error():
         await rc.cleanup_runner("REQ-1")
 
 
-# ─── gc_orphans ────────────────────────────────────────────────────────
+# ─── gc_orphan_pods / gc_orphan_pvcs ───────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_gc_orphans_removes_not_in_keep_set():
+async def test_gc_orphan_pods_removes_pods_not_in_keep_set_without_touching_pvcs():
+    """RGS-S4: Pod-only sweep 删 keep 之外的 Pod，不动 PVC。"""
+    core = MagicMock()
+
+    def _pod(req_label):
+        return MagicMock(metadata=MagicMock(labels={
+            "sisyphus/req-id": req_label, "sisyphus/role": "runner",
+        }))
+
+    core.list_namespaced_pod = MagicMock(return_value=MagicMock(
+        items=[_pod("req-1"), _pod("req-2"), _pod("req-3")],
+    ))
+    core.delete_namespaced_pod = MagicMock(return_value=None)
+    core.delete_namespaced_persistent_volume_claim = MagicMock(return_value=None)
+    rc = _make_controller(core)
+
+    # keep REQ-1 only；REQ-2 + REQ-3 的 Pod 应被清
+    cleaned = await rc.gc_orphan_pods({"REQ-1"})
+    assert sorted(cleaned) == ["REQ-2", "REQ-3"]
+    assert core.delete_namespaced_pod.call_count == 2
+    # PVC 完全没碰
+    assert core.delete_namespaced_persistent_volume_claim.call_count == 0
+    # list 走的是 Pod label 而非 PVC label
+    core.list_namespaced_pod.assert_called_once()
+    call_kwargs = core.list_namespaced_pod.call_args.kwargs
+    assert call_kwargs.get("label_selector") == "sisyphus/role=runner"
+
+
+@pytest.mark.asyncio
+async def test_gc_orphan_pods_handles_404_idempotent():
+    """delete_namespaced_pod 返 404（Pod 已被别处删）→ 视为成功，不抛。"""
+    core = MagicMock()
+
+    def _pod(req_label):
+        return MagicMock(metadata=MagicMock(labels={
+            "sisyphus/req-id": req_label, "sisyphus/role": "runner",
+        }))
+
+    core.list_namespaced_pod = MagicMock(return_value=MagicMock(
+        items=[_pod("req-2")],
+    ))
+    core.delete_namespaced_pod = MagicMock(
+        side_effect=ApiException(status=404, reason="Not Found"),
+    )
+    rc = _make_controller(core)
+
+    cleaned = await rc.gc_orphan_pods({"REQ-1"})
+    assert cleaned == ["REQ-2"]   # 仍记入 cleaned 列表
+
+
+@pytest.mark.asyncio
+async def test_gc_orphan_pvcs_removes_pvcs_not_in_keep_set_without_touching_pods():
+    """RGS-S5: PVC-only sweep 删 keep 之外的 PVC，不动 Pod。"""
     core = MagicMock()
 
     def _pvc(req_label):
@@ -465,12 +517,37 @@ async def test_gc_orphans_removes_not_in_keep_set():
     core.delete_namespaced_persistent_volume_claim = MagicMock(return_value=None)
     rc = _make_controller(core)
 
-    # keep REQ-1 only；REQ-2 + REQ-3 应被清
-    cleaned = await rc.gc_orphans({"REQ-1"})
+    cleaned = await rc.gc_orphan_pvcs({"REQ-1"})
     assert sorted(cleaned) == ["REQ-2", "REQ-3"]
-    # 两次 destroy = 两次 pod delete + 两次 pvc delete
-    assert core.delete_namespaced_pod.call_count == 2
     assert core.delete_namespaced_persistent_volume_claim.call_count == 2
+    # Pod 完全没碰（gc_orphan_pvcs 拆开后不级联）
+    assert core.delete_namespaced_pod.call_count == 0
+    # list 走的是 PVC label
+    core.list_namespaced_persistent_volume_claim.assert_called_once()
+    call_kwargs = core.list_namespaced_persistent_volume_claim.call_args.kwargs
+    assert call_kwargs.get("label_selector") == "sisyphus/role=workspace"
+
+
+@pytest.mark.asyncio
+async def test_gc_orphan_pvcs_handles_404_idempotent():
+    """delete_namespaced_persistent_volume_claim 404 → 不抛。"""
+    core = MagicMock()
+
+    def _pvc(req_label):
+        return MagicMock(metadata=MagicMock(labels={
+            "sisyphus/req-id": req_label, "sisyphus/role": "workspace",
+        }))
+
+    core.list_namespaced_persistent_volume_claim = MagicMock(return_value=MagicMock(
+        items=[_pvc("req-2")],
+    ))
+    core.delete_namespaced_persistent_volume_claim = MagicMock(
+        side_effect=ApiException(status=404, reason="Not Found"),
+    )
+    rc = _make_controller(core)
+
+    cleaned = await rc.gc_orphan_pvcs({"REQ-1"})
+    assert cleaned == ["REQ-2"]
 
 
 # ─── exec marker parsing ───────────────────────────────────────────────

--- a/orchestrator/tests/test_runner_gc.py
+++ b/orchestrator/tests/test_runner_gc.py
@@ -27,9 +27,10 @@ def _row(req_id, state, updated_at=None):
 
 @pytest.fixture
 def mock_controller(monkeypatch):
-    """注入 fake controller + 记录 gc_orphans 被调用的 keep_set。"""
+    """注入 fake controller + 记录两个 sweep 的 keep_set。"""
     fake = MagicMock()
-    fake.gc_orphans = AsyncMock(return_value=[])
+    fake.gc_orphan_pods = AsyncMock(return_value=[])
+    fake.gc_orphan_pvcs = AsyncMock(return_value=[])
     k8s_runner.set_controller(fake)
     yield fake
     k8s_runner.set_controller(None)
@@ -45,7 +46,7 @@ def _reset_disk_check_flag():
 
 @pytest.mark.asyncio
 async def test_active_includes_inflight(monkeypatch, mock_controller):
-    """in-flight 状态（非 done/escalated）全部算 active，runner 保留。"""
+    """in-flight 状态（非 done/escalated）全部算 active，runner 保留（pod + pvc）。"""
     pool = _FakePool([
         _row("REQ-1", "analyzing"),
         _row("REQ-2", "staging-test-running"),
@@ -55,13 +56,15 @@ async def test_active_includes_inflight(monkeypatch, mock_controller):
 
     await runner_gc.gc_once()
 
-    called_with = mock_controller.gc_orphans.await_args.args[0]
-    assert called_with == {"REQ-1", "REQ-2", "REQ-3"}
+    pod_keep = mock_controller.gc_orphan_pods.await_args.args[0]
+    pvc_keep = mock_controller.gc_orphan_pvcs.await_args.args[0]
+    assert pod_keep == {"REQ-1", "REQ-2", "REQ-3"}
+    assert pvc_keep == {"REQ-1", "REQ-2", "REQ-3"}
 
 
 @pytest.mark.asyncio
 async def test_done_state_not_active(monkeypatch, mock_controller):
-    """done 的 REQ 立即移出 active（runner 会被清）。"""
+    """done 的 REQ 立即移出 pod + pvc keep（runner 会被两个 sweep 都清）。"""
     pool = _FakePool([
         _row("REQ-1", "done", updated_at=datetime.now(UTC)),
         _row("REQ-2", "analyzing"),
@@ -69,14 +72,35 @@ async def test_done_state_not_active(monkeypatch, mock_controller):
     monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
 
     await runner_gc.gc_once()
-    called_with = mock_controller.gc_orphans.await_args.args[0]
-    assert called_with == {"REQ-2"}   # done 不在 keep 集合
+    pod_keep = mock_controller.gc_orphan_pods.await_args.args[0]
+    pvc_keep = mock_controller.gc_orphan_pvcs.await_args.args[0]
+    assert pod_keep == {"REQ-2"}
+    assert pvc_keep == {"REQ-2"}
+
+
+@pytest.mark.asyncio
+async def test_pod_keep_excludes_escalated_within_retention(monkeypatch, mock_controller):
+    """escalated REQ 在 retention 内：PVC 保留给人 debug，但 Pod 立即可清。
+
+    REQ-runner-gc-pod-pvc-split 的核心：拆开 pod / pvc 的保留语义。
+    Pod 占 512Mi 内存白白吃调度容量；PVC 才是给人 kubectl exec 看现场的。
+    """
+    recent = datetime.now(UTC) - timedelta(hours=2)  # < 1 day default retention
+    pool = _FakePool([
+        _row("REQ-1", "escalated", updated_at=recent),
+    ])
+    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
+
+    await runner_gc.gc_once()
+    pod_keep = mock_controller.gc_orphan_pods.await_args.args[0]
+    pvc_keep = mock_controller.gc_orphan_pvcs.await_args.args[0]
+    assert pod_keep == set()        # Pod 立即可清（哪怕 retention 内）
+    assert pvc_keep == {"REQ-1"}    # PVC 留 retention 给人 debug
 
 
 @pytest.mark.asyncio
 async def test_escalated_within_retention_purged_on_disk_pressure(monkeypatch, mock_controller):
-    """disk > threshold → escalated 也强清（不留 retention）。"""
-    from unittest.mock import AsyncMock
+    """disk > threshold → escalated PVC 也强清（不留 retention）。Pod 永远不留。"""
     recent = datetime.now(UTC) - timedelta(hours=2)
     pool = _FakePool([
         _row("REQ-1", "escalated", updated_at=recent),
@@ -87,27 +111,15 @@ async def test_escalated_within_retention_purged_on_disk_pressure(monkeypatch, m
 
     result = await runner_gc.gc_once()
     assert result["disk_pressure"] is True
-    called_with = mock_controller.gc_orphans.await_args.args[0]
-    assert called_with == set()  # 紧急模式，escalated 不再 keep
-
-
-@pytest.mark.asyncio
-async def test_escalated_within_retention_kept(monkeypatch, mock_controller):
-    """escalated 但还在保留期内（默认 1 天）→ 仍 active（PVC 留给人 PR #48 resume）。"""
-    recent = datetime.now(UTC) - timedelta(hours=2)  # < 1 day default retention
-    pool = _FakePool([
-        _row("REQ-1", "escalated", updated_at=recent),
-    ])
-    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
-
-    await runner_gc.gc_once()
-    called_with = mock_controller.gc_orphans.await_args.args[0]
-    assert called_with == {"REQ-1"}
+    pod_keep = mock_controller.gc_orphan_pods.await_args.args[0]
+    pvc_keep = mock_controller.gc_orphan_pvcs.await_args.args[0]
+    assert pod_keep == set()  # 跟 disk pressure 无关：Pod keep 永远不含 terminal
+    assert pvc_keep == set()  # 紧急模式：escalated PVC 也不再 keep
 
 
 @pytest.mark.asyncio
 async def test_escalated_past_retention_cleaned(monkeypatch, mock_controller):
-    """escalated 超过保留期 → 移出 active，runner 会被清。"""
+    """escalated 超过保留期 → 移出 pvc keep（runner 会被清）。"""
     old = datetime.now(UTC) - timedelta(days=30)
     pool = _FakePool([
         _row("REQ-1", "escalated", updated_at=old),
@@ -115,8 +127,10 @@ async def test_escalated_past_retention_cleaned(monkeypatch, mock_controller):
     monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
 
     await runner_gc.gc_once()
-    called_with = mock_controller.gc_orphans.await_args.args[0]
-    assert called_with == set()   # 空 keep = REQ-1 被 gc_orphans 清
+    pod_keep = mock_controller.gc_orphan_pods.await_args.args[0]
+    pvc_keep = mock_controller.gc_orphan_pvcs.await_args.args[0]
+    assert pod_keep == set()
+    assert pvc_keep == set()
 
 
 @pytest.mark.asyncio
@@ -172,3 +186,19 @@ async def test_disk_check_non_403_keeps_probe_alive(monkeypatch, mock_controller
 
     assert result["disk_pressure"] is False
     assert runner_gc._DISK_CHECK_DISABLED is False  # 没禁用
+
+
+@pytest.mark.asyncio
+async def test_gc_once_returns_split_cleaned_lists(monkeypatch, mock_controller):
+    """gc_once 返 dict 必须含 cleaned_pods + cleaned_pvcs（分开记录）。"""
+    pool = _FakePool([_row("REQ-1", "analyzing")])
+    monkeypatch.setattr("orchestrator.runner_gc.db.get_pool", lambda: pool)
+    mock_controller.gc_orphan_pods = AsyncMock(return_value=["REQ-zombie-pod"])
+    mock_controller.gc_orphan_pvcs = AsyncMock(return_value=["REQ-zombie-pvc"])
+
+    result = await runner_gc.gc_once()
+
+    assert result["cleaned_pods"] == ["REQ-zombie-pod"]
+    assert result["cleaned_pvcs"] == ["REQ-zombie-pvc"]
+    assert result["pod_kept"] == 1
+    assert result["pvc_kept"] == 1


### PR DESCRIPTION
## Summary

`runner_gc` 之前用单一 keep set 同时管 Pod + PVC，escalated REQ 在
`pvc_retain_on_escalate_days` 内 Pod 也被当 active —— 当
`engine._cleanup_runner_on_terminal` fire-and-forget cleanup 失败时
（K8s API blip / orchestrator restart 把 task 吃了）Pod 整段 retention
都当 zombie，512Mi memory request 一直占着 vm-node04 的小盘子。

本 PR 拆 Pod / PVC 两个独立 keep set：

| | Pod keep set | PVC keep set |
|---|---|---|
| non-terminal | 留 | 留 |
| `done` | **清** | **清** |
| `escalated`（retention 内） | **清**（本 PR 新增） | 留 |
| `escalated`（retention 过） | **清** | **清** |
| disk pressure | 同上 | escalated 也清（紧急疏散） |

`RunnerController.gc_orphans` 拆成 `gc_orphan_pods` + `gc_orphan_pvcs`
两个正交方法（按各自 label 列资源、互不级联，K8s 自身处理 Pod-PVC 依赖）。
`gc_once` 返 dict 加 `cleaned_pods` / `cleaned_pvcs` / `pod_kept` /
`pvc_kept`。disk-check / RBAC 降级路径不动 —— ORCHN-S4..S8 全过。

跟 REQ-cleanup-runner-zombie-1777170378 配对：那条修 `force_escalate`
漏 schedule cleanup（即时路径）；本 PR 把 GC 兜底也补成 Pod-immediate
（周期路径）。

## Test plan

- [x] `openspec validate REQ-runner-gc-pod-pvc-split-1777283946` 通过
- [x] `bash scripts/check-scenario-refs.sh` 全 477 个 scenario 引用 OK
- [x] `make ci-lint` 全过
- [x] `make ci-unit-test` 1447 passed（含新 case：
  `test_pod_keep_excludes_escalated_within_retention`,
  `test_gc_once_returns_split_cleaned_lists`,
  `test_gc_orphan_pods_*` × 2, `test_gc_orphan_pvcs_*` × 2）
- [x] 现有 ORCHN-S4..S8（disk-check / RBAC 降级 contract）全过

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-runner-gc-pod-pvc-split-1777283946\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/cjq902o8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)