### PR TITLE
feat(pr-ci-watch): active CI dispatch before polling [REQ-426]

### DIFF
--- a/docs/plan/PLAN-001.md
+++ b/docs/plan/PLAN-001.md
@@ -1,0 +1,135 @@
+# PLAN-001 Active CI dispatch before pr-ci-watch
+
+- **status**: implementing
+- **createdAt**: 2026-04-27 00:00
+- **approvedAt**: 2026-04-27
+- **relatedTask**: FEAT-001
+
+## Context
+
+### Problem
+
+`dispatch.yml` in ttpos business repos only triggers on `repository_dispatch`
+events — not on `pull_request` events. When analyze-agent opens a PR
+programmatically via `gh pr create` in a Coder workspace, no
+`repository_dispatch` event fires, so `ttpos-ci ci-go.yml` never starts. The
+pr-ci-watch checker then polls indefinitely and times out with `no-gha`.
+
+### Relevant files
+
+| File | Role |
+|------|------|
+| `orchestrator/src/orchestrator/actions/create_pr_ci_watch.py` | Action entry; owns `_run_checker()` path |
+| `orchestrator/src/orchestrator/checkers/pr_ci_watch.py` | Polling loop; reads check-runs only |
+| `orchestrator/src/orchestrator/config.py` | All feature flags |
+| `orchestrator/tests/test_actions_create_pr_ci_watch.py` | Existing unit tests for action layer |
+
+### Call chain (checker path)
+
+```
+create_pr_ci_watch()
+  └─ _capture_pr_urls()          ← best-effort PR URL discovery (already exists)
+  └─ _run_checker()
+       └─ _discover_repos_from_runner()
+       └─ checker.watch_pr_ci()  ← polls; currently no dispatch happens before this
+```
+
+### GitHub API
+
+`POST /repos/{owner}/{repo}/dispatches` with body:
+```json
+{"event_type": "<configurable>", "client_payload": {"branch": "feat/REQ-x", "req_id": "REQ-x"}}
+```
+Requires `github_token` with `repo` scope (classic) or `Actions: write`
+permission (fine-grained PAT). The orchestrator already has `github_token`
+available in `settings`.
+
+## Proposal
+
+### 1. `config.py` — two new flags
+
+```python
+# Active dispatch before pr-ci-watch polling
+pr_ci_dispatch_enabled: bool = False
+pr_ci_dispatch_event_type: str = "ci-trigger"
+```
+
+### 2. `create_pr_ci_watch.py` — add `_dispatch_ci_trigger()`
+
+```python
+async def _dispatch_ci_trigger(*, repos: list[str], branch: str, req_id: str) -> None:
+    """Best-effort: fire repository_dispatch on each repo to start CI.
+
+    Failure per repo → warning only; never raises. Blocked by
+    pr_ci_dispatch_enabled flag (caller must check).
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Authorization": f"Bearer {settings.github_token}",
+    }
+    payload = {
+        "event_type": settings.pr_ci_dispatch_event_type,
+        "client_payload": {"branch": branch, "req_id": req_id},
+    }
+    async with httpx.AsyncClient(base_url="https://api.github.com",
+                                  headers=headers, timeout=15.0) as client:
+        for repo in repos:
+            try:
+                r = await client.post(f"/repos/{repo}/dispatches", json=payload)
+                r.raise_for_status()
+                log.info("create_pr_ci_watch.dispatch_ok", repo=repo,
+                         event_type=settings.pr_ci_dispatch_event_type)
+            except Exception as e:
+                log.warning("create_pr_ci_watch.dispatch_failed",
+                            repo=repo, error=str(e))
+```
+
+### 3. `_run_checker()` — call dispatch after repo discovery, before polling
+
+```python
+async def _run_checker(*, req_id: str, ctx: dict) -> dict:
+    ...
+    repos = await _discover_repos_from_runner(req_id)
+    if not repos:
+        ...
+
+    if settings.pr_ci_dispatch_enabled and repos:
+        await _dispatch_ci_trigger(repos=repos, branch=branch, req_id=req_id)
+
+    result = await checker.watch_pr_ci(...)
+```
+
+### 4. Tests — new cases in `test_actions_create_pr_ci_watch.py`
+
+- `test_dispatch_ci_trigger_calls_gh_api` — happy path, two repos each get a POST
+- `test_dispatch_ci_trigger_tolerates_per_repo_error` — one repo 422, other succeeds
+- `test_run_checker_skips_dispatch_when_disabled` — flag off → no POST
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| github_token lacks `Actions: write` | Dispatch returns 422/403; failure is best-effort, polling continues; verifier catches `no-gha` |
+| Double-trigger if `dispatch.yml` also triggers on `pull_request` | Acceptable: duplicate GHA run, only one set of check-runs matters |
+| Wrong `event_type` (mismatch with dispatch.yml) | CI still won't start; same outcome as before; verifier handles `no-gha` |
+| No token configured (`github_token=""`) | `Authorization: Bearer ` header returns 401; per-repo warning, no crash |
+
+## Scope
+
+3 files:
+- `config.py` (+2 lines)
+- `create_pr_ci_watch.py` (+~25 lines: helper + call site)
+- `test_actions_create_pr_ci_watch.py` (+~50 lines: 3 new tests)
+
+## Alternatives
+
+**A. Trigger inside `watch_pr_ci` checker**: rejected — checker is a pure read-only
+poller; dispatch is an orchestrator write concern.
+
+**B. Always dispatch (no flag)**: rejected — rollout risk for deployments whose
+`dispatch.yml` uses a different `event_type` or doesn't exist.
+
+## Annotations
+
+(User annotations and responses.)

--- a/docs/plan/index.md
+++ b/docs/plan/index.md
@@ -1,0 +1,32 @@
+# Sisyphus - Plan Index
+
+> Updated: 2026-04-27
+
+## Usage
+
+Each plan is a single line linking to its detail file. All detailed information lives in `docs/plan/PLAN-NNN.md`.
+
+### Format
+
+- [ ] [**PLAN-001 Short plan title**](PLAN-001.md) `YYYY-MM-DD`
+
+### Status Markers
+
+| Marker | Meaning |
+|--------|---------|
+| `[ ]`  | Draft / Pending review |
+| `[-]`  | Approved / Implementing |
+| `[x]`  | Completed |
+| `[~]`  | Rejected / Abandoned |
+
+### Rules
+
+- Only update the checkbox marker; never delete the line.
+- New plans append to the end.
+- See each `PLAN-NNN.md` for full details.
+
+---
+
+## Plans
+
+- [-] [**PLAN-001 Active CI dispatch before pr-ci-watch**](PLAN-001.md) `2026-04-27`

--- a/docs/task/FEAT-001.md
+++ b/docs/task/FEAT-001.md
@@ -1,0 +1,36 @@
+# FEAT-001 Add active CI dispatch before pr-ci-watch polling
+
+- **status**: in_progress
+- **priority**: P1
+- **owner**: sisyphus-bot
+- **createdAt**: 2026-04-27 00:00
+
+## Description
+
+Before sisyphus starts polling GitHub check-runs in the `pr-ci-watch` stage, it
+should actively fire a `repository_dispatch` event on each involved repo to
+trigger the business repo's `dispatch.yml` → `ttpos-ci ci-go.yml` pipeline.
+
+Currently the `dispatch.yml` in ttpos repos only triggers on `repository_dispatch`
+events (not on PR open), so CI may never start automatically when an analyze-agent
+opens a PR programmatically.
+
+Acceptance criteria:
+- `_dispatch_ci_trigger()` helper added to `create_pr_ci_watch.py`
+- Feature-gated by `pr_ci_dispatch_enabled` (default `False`)
+- `pr_ci_dispatch_event_type` config for the event type to fire (default `"ci-trigger"`)
+- Best-effort: dispatch failure logs a warning and does not block polling
+- Unit tests cover success, per-repo failure, and flag-disabled cases
+
+## ActiveForm
+
+Implementing active CI dispatch before pr-ci-watch polling.
+
+## Dependencies
+
+- **blocked by**: (none)
+- **blocks**: (none)
+
+## Notes
+
+Related plan: PLAN-001

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -1,0 +1,34 @@
+# Sisyphus - Task List
+
+> Updated: 2026-04-27
+
+## Usage
+
+Each task is a single line linking to its detail file. All detailed information lives in `docs/task/PREFIX-NNN.md`.
+
+### Format
+
+- [ ] [**PREFIX-001 Short imperative title**](PREFIX-001.md) `P1`
+
+### Status Markers
+
+| Marker | Meaning |
+|--------|---------|
+| `[ ]`  | Pending |
+| `[-]`  | In progress |
+| `[x]`  | Completed |
+| `[~]`  | Closed / Won't do |
+
+### Priority: P0 (blocking) > P1 (high) > P2 (medium) > P3 (low)
+
+### Rules
+
+- Only update the checkbox marker; never delete the line.
+- New tasks append to the end.
+- See each `PREFIX-NNN.md` for full details.
+
+---
+
+## Tasks
+
+- [-] [**FEAT-001 Add active CI dispatch before pr-ci-watch polling**](FEAT-001.md) `P1`

--- a/openspec/changes/REQ-426/proposal.md
+++ b/openspec/changes/REQ-426/proposal.md
@@ -1,0 +1,31 @@
+# REQ-426 — pr-ci-active-dispatch: sisyphus actively triggers ttpos-ci pipeline
+
+## Problem
+
+Business repos' `.github/workflows/dispatch.yml` only triggers on
+`repository_dispatch` events — not on `pull_request` events. When the
+analyze-agent opens a PR programmatically via `gh pr create` inside a Coder
+workspace, no `repository_dispatch` is fired, so `ttpos-ci ci-go.yml` never
+starts. The pr-ci-watch checker then polls indefinitely and eventually times
+out with `no-gha`, routing to the verifier unnecessarily.
+
+## Solution
+
+Add a best-effort `_dispatch_ci_trigger()` call inside `_run_checker()` in
+`create_pr_ci_watch.py`. After discovering the involved repos and before
+starting the `watch_pr_ci` polling loop, sisyphus fires
+`POST /repos/{owner}/{repo}/dispatches` with a configurable `event_type` for
+each repo. Failure per-repo is logged as a warning and does not block polling.
+
+Two new config flags gate and tune the behaviour:
+- `pr_ci_dispatch_enabled` (default `False`) — feature flag for safe rollout
+- `pr_ci_dispatch_event_type` (default `"ci-trigger"`) — must match the
+  `on.repository_dispatch.types` value in the business repo's `dispatch.yml`
+
+This change is purely an orchestrator operation (not a runner operation), using
+`settings.github_token` which is already injected for incident reporting.
+
+## Out of scope
+
+- Modifying `checkers/pr_ci_watch.py` — the checker stays a pure read-only poller
+- Any changes to runner pod or BKD agent paths

--- a/openspec/changes/REQ-426/specs/pr-ci-active-dispatch/spec.md
+++ b/openspec/changes/REQ-426/specs/pr-ci-active-dispatch/spec.md
@@ -2,14 +2,14 @@
 
 ### Requirement: sisyphus actively dispatches repository_dispatch before polling
 
-When the pr-ci-watch checker path is active (`checker_pr_ci_watch_enabled=True`)
-and the `pr_ci_dispatch_enabled` flag is `True`, sisyphus SHALL fire a
-`POST /repos/{owner}/{repo}/dispatches` request for each discovered repo before
-starting the check-run polling loop. The request body MUST contain
-`event_type` equal to `settings.pr_ci_dispatch_event_type` and a
-`client_payload` object with at least the fields `branch` (the `feat/REQ-x`
-branch name) and `req_id`. Dispatch MUST use `settings.github_token` for
-authorization via `Authorization: Bearer` header.
+Sisyphus SHALL fire a `POST /repos/{owner}/{repo}/dispatches` request for each
+discovered repo before starting the check-run polling loop when
+`checker_pr_ci_watch_enabled=True` and `pr_ci_dispatch_enabled=True`.
+The request body MUST contain `event_type` equal to
+`settings.pr_ci_dispatch_event_type` and a `client_payload` object with at
+least the fields `branch` (the `feat/REQ-x` branch name) and `req_id`.
+Dispatch MUST use `settings.github_token` for authorization via
+`Authorization: Bearer` header.
 
 When `pr_ci_dispatch_enabled` is `False` (default), sisyphus MUST NOT make
 any `POST /dispatches` call, and the polling loop MUST proceed as before.

--- a/openspec/changes/REQ-426/specs/pr-ci-active-dispatch/spec.md
+++ b/openspec/changes/REQ-426/specs/pr-ci-active-dispatch/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: sisyphus actively dispatches repository_dispatch before polling
+
+When the pr-ci-watch checker path is active (`checker_pr_ci_watch_enabled=True`)
+and the `pr_ci_dispatch_enabled` flag is `True`, sisyphus SHALL fire a
+`POST /repos/{owner}/{repo}/dispatches` request for each discovered repo before
+starting the check-run polling loop. The request body MUST contain
+`event_type` equal to `settings.pr_ci_dispatch_event_type` and a
+`client_payload` object with at least the fields `branch` (the `feat/REQ-x`
+branch name) and `req_id`. Dispatch MUST use `settings.github_token` for
+authorization via `Authorization: Bearer` header.
+
+When `pr_ci_dispatch_enabled` is `False` (default), sisyphus MUST NOT make
+any `POST /dispatches` call, and the polling loop MUST proceed as before.
+
+#### Scenario: PRCIAD-S1 dispatch fires for each repo before polling starts
+
+- **GIVEN** `pr_ci_dispatch_enabled=True` and two involved repos `owner/repo-a` and `owner/repo-b`
+- **WHEN** `_run_checker()` is called
+- **THEN** `POST /repos/owner/repo-a/dispatches` and `POST /repos/owner/repo-b/dispatches` are each called once with the configured `event_type` before `watch_pr_ci()` begins
+
+#### Scenario: PRCIAD-S2 dispatch flag disabled — no POST issued
+
+- **GIVEN** `pr_ci_dispatch_enabled=False`
+- **WHEN** `_run_checker()` is called with two repos
+- **THEN** no `POST /dispatches` request is issued; `watch_pr_ci()` is called directly
+
+### Requirement: dispatch failure is best-effort and does not abort polling
+
+The dispatch step MUST NOT raise an exception or return a failure result when
+the `POST /dispatches` call fails for any individual repo. Any HTTP error or
+network exception per repo SHALL be logged at WARNING level and the system MUST
+continue to the next repo and then proceed to the polling loop. The system MUST
+NOT skip polling even if all repos' dispatch calls fail.
+
+#### Scenario: PRCIAD-S3 one repo dispatch fails — other repos unaffected, polling continues
+
+- **GIVEN** `pr_ci_dispatch_enabled=True` and two repos; repo-a returns HTTP 422, repo-b returns HTTP 204
+- **WHEN** `_dispatch_ci_trigger()` is called
+- **THEN** a warning is logged for repo-a; repo-b dispatch succeeds; no exception is raised; `watch_pr_ci()` is called normally
+
+#### Scenario: PRCIAD-S4 no github_token — dispatch returns 401 warning only
+
+- **GIVEN** `pr_ci_dispatch_enabled=True` and `github_token=""` (empty)
+- **WHEN** `_dispatch_ci_trigger()` is called
+- **THEN** the request is sent (with `Authorization: Bearer ` empty header); any resulting HTTP error is logged as a warning only; no exception propagates

--- a/openspec/changes/REQ-426/tasks.md
+++ b/openspec/changes/REQ-426/tasks.md
@@ -1,0 +1,23 @@
+# REQ-426 tasks — pr-ci-active-dispatch
+
+## Stage: spec
+
+- [x] author openspec/changes/REQ-426/proposal.md
+- [x] author openspec/changes/REQ-426/specs/pr-ci-active-dispatch/spec.md with scenarios
+
+## Stage: implementation
+
+- [x] config.py: add pr_ci_dispatch_enabled and pr_ci_dispatch_event_type flags
+- [x] create_pr_ci_watch.py: add _dispatch_ci_trigger() helper
+- [x] create_pr_ci_watch.py: call _dispatch_ci_trigger() in _run_checker() before watch_pr_ci
+
+## Stage: unit tests
+
+- [x] test_actions_create_pr_ci_watch.py: test_dispatch_ci_trigger_calls_gh_api
+- [x] test_actions_create_pr_ci_watch.py: test_dispatch_ci_trigger_tolerates_per_repo_error
+- [x] test_actions_create_pr_ci_watch.py: test_run_checker_skips_dispatch_when_disabled
+
+## Stage: PR
+
+- [x] git push feat/REQ-426
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import re
 
+import httpx
 import structlog
 
 from .. import k8s_runner, links, pr_links
@@ -112,6 +113,35 @@ async def _discover_repos_from_runner(req_id: str) -> list[str]:
     return repos
 
 
+async def _dispatch_ci_trigger(*, repos: list[str], branch: str, req_id: str) -> None:
+    """Best-effort: fire repository_dispatch on each repo to start CI.
+
+    Uses settings.pr_ci_dispatch_event_type as the event_type. Any per-repo
+    HTTP or network failure is logged as a warning — never raises.
+    Caller must check pr_ci_dispatch_enabled before calling.
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Authorization": f"Bearer {settings.github_token}",
+    }
+    payload = {
+        "event_type": settings.pr_ci_dispatch_event_type,
+        "client_payload": {"branch": branch, "req_id": req_id},
+    }
+    async with httpx.AsyncClient(base_url="https://api.github.com",
+                                  headers=headers, timeout=15.0) as client:
+        for repo in repos:
+            try:
+                r = await client.post(f"/repos/{repo}/dispatches", json=payload)
+                r.raise_for_status()
+                log.info("create_pr_ci_watch.dispatch_ok", req_id=req_id, repo=repo,
+                         event_type=settings.pr_ci_dispatch_event_type)
+            except Exception as e:
+                log.warning("create_pr_ci_watch.dispatch_failed",
+                            req_id=req_id, repo=repo, error=str(e))
+
+
 async def _run_checker(*, req_id: str, ctx: dict) -> dict:
     log.info("create_pr_ci_watch.checker_path", req_id=req_id)
     branch = ctx.get("branch") or f"feat/{req_id}"
@@ -122,6 +152,9 @@ async def _run_checker(*, req_id: str, ctx: dict) -> dict:
     if not repos:
         finalized = ctx.get("intake_finalized_intent") or {}
         repos = finalized.get("involved_repos") or ctx.get("involved_repos")
+
+    if settings.pr_ci_dispatch_enabled and repos:
+        await _dispatch_ci_trigger(repos=repos, branch=branch, req_id=req_id)
 
     try:
         result = await checker.watch_pr_ci(

--- a/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
@@ -118,8 +118,9 @@ async def _dispatch_ci_trigger(*, repos: list[str], branch: str, req_id: str) ->
 
     Uses settings.pr_ci_dispatch_event_type as the event_type. Any per-repo
     HTTP or network failure is logged as a warning — never raises.
-    Caller must check pr_ci_dispatch_enabled before calling.
     """
+    if not settings.pr_ci_dispatch_enabled:
+        return
     headers = {
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
@@ -129,11 +130,12 @@ async def _dispatch_ci_trigger(*, repos: list[str], branch: str, req_id: str) ->
         "event_type": settings.pr_ci_dispatch_event_type,
         "client_payload": {"branch": branch, "req_id": req_id},
     }
-    async with httpx.AsyncClient(base_url="https://api.github.com",
-                                  headers=headers, timeout=15.0) as client:
+    async with httpx.AsyncClient(base_url="https://api.github.com", timeout=15.0) as client:
         for repo in repos:
             try:
-                r = await client.post(f"/repos/{repo}/dispatches", json=payload)
+                r = await client.post(
+                    f"/repos/{repo}/dispatches", json=payload, headers=headers
+                )
                 r.raise_for_status()
                 log.info("create_pr_ci_watch.dispatch_ok", req_id=req_id, repo=repo,
                          event_type=settings.pr_ci_dispatch_event_type)

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -140,6 +140,13 @@ class Settings(BaseSettings):
     pr_ci_watch_poll_interval_sec: int = 30
     pr_ci_watch_timeout_sec: int = 1800   # 30 min
 
+    # ─── REQ-426 pr-ci-active-dispatch：主动触发 CI ───────────────────
+    # True = 在轮询开始前对每个 repo 发 repository_dispatch 事件，触发 dispatch.yml
+    # False（默认）= 不发，行为与之前一致（dispatch.yml 不依赖 repository_dispatch 的仓不需要开）
+    pr_ci_dispatch_enabled: bool = False
+    # event_type 必须与业务 repo dispatch.yml 的 on.repository_dispatch.types 对齐
+    pr_ci_dispatch_event_type: str = "ci-trigger"
+
     # ─── runner ready 重试 ─────────────────────────────────────────────
     # ensure_runner 等 Pod Ready 的外层 attempts：N × runner_ready_timeout_sec
     # 总等待；最后一次抛 TimeoutError 让 engine 走 escalate。

--- a/orchestrator/tests/test_actions_create_pr_ci_watch.py
+++ b/orchestrator/tests/test_actions_create_pr_ci_watch.py
@@ -1,10 +1,12 @@
-"""actions/create_pr_ci_watch.py：runner discovery 单测。
+"""actions/create_pr_ci_watch.py：runner discovery + CI dispatch 单测。
 
-不测 watch_pr_ci 主体（在 test_checkers_pr_ci_watch.py），只测 _discover_repos_from_runner
-对 runner stdout 的解析 + 失败兜底。
+不测 watch_pr_ci 主体（在 test_checkers_pr_ci_watch.py），只测：
+- _discover_repos_from_runner 对 runner stdout 的解析 + 失败兜底
+- _dispatch_ci_trigger 的 GH API 调用、容错、flag 开关
 """
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from unittest.mock import AsyncMock
 
@@ -80,3 +82,101 @@ async def test_discover_repos_empty_stdout(monkeypatch):
 
     repos = await action._discover_repos_from_runner("REQ-x")
     assert repos == []
+
+
+# ── _dispatch_ci_trigger tests ────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_dispatch_ci_trigger_calls_gh_api(httpx_mock, monkeypatch):
+    """PRCIAD-S1: dispatch fires POST /dispatches for each repo before polling."""
+    monkeypatch.setattr(action.settings, "github_token", "tok-test")
+    monkeypatch.setattr(action.settings, "pr_ci_dispatch_event_type", "ci-trigger")
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/owner/repo-a/dispatches",
+        status_code=204,
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/owner/repo-b/dispatches",
+        status_code=204,
+    )
+
+    await action._dispatch_ci_trigger(
+        repos=["owner/repo-a", "owner/repo-b"],
+        branch="feat/REQ-426",
+        req_id="REQ-426",
+    )
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+    urls = {str(r.url) for r in requests}
+    assert "https://api.github.com/repos/owner/repo-a/dispatches" in urls
+    assert "https://api.github.com/repos/owner/repo-b/dispatches" in urls
+
+    body = json.loads(requests[0].content)
+    assert body["event_type"] == "ci-trigger"
+    assert body["client_payload"]["branch"] == "feat/REQ-426"
+    assert body["client_payload"]["req_id"] == "REQ-426"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_ci_trigger_tolerates_per_repo_error(httpx_mock, monkeypatch):
+    """PRCIAD-S3: one repo 422 does not abort; other repo succeeds; no exception."""
+    monkeypatch.setattr(action.settings, "github_token", "tok-test")
+    monkeypatch.setattr(action.settings, "pr_ci_dispatch_event_type", "ci-trigger")
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/owner/repo-a/dispatches",
+        status_code=422,
+        json={"message": "Unprocessable"},
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/owner/repo-b/dispatches",
+        status_code=204,
+    )
+
+    # Must not raise even though repo-a returns 422
+    await action._dispatch_ci_trigger(
+        repos=["owner/repo-a", "owner/repo-b"],
+        branch="feat/REQ-426",
+        req_id="REQ-426",
+    )
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_run_checker_skips_dispatch_when_disabled(monkeypatch):
+    """PRCIAD-S2: pr_ci_dispatch_enabled=False — no _dispatch_ci_trigger call issued."""
+    monkeypatch.setattr(action.settings, "pr_ci_dispatch_enabled", False)
+
+    dispatch_called = []
+
+    async def fake_dispatch(**kwargs):
+        dispatch_called.append(kwargs)
+
+    monkeypatch.setattr(action, "_dispatch_ci_trigger", fake_dispatch)
+
+    # Stub out watch_pr_ci and discover_repos so _run_checker exits cleanly
+    from orchestrator.checkers._types import CheckResult
+    monkeypatch.setattr(
+        action.checker, "watch_pr_ci",
+        AsyncMock(return_value=CheckResult(
+            passed=True, exit_code=0, stdout_tail="ok", stderr_tail="",
+            duration_sec=0.1, cmd="test",
+        )),
+    )
+    exec_fn = AsyncMock(return_value=FakeExec(
+        stdout="git@github.com:owner/repo-a.git"
+    ))
+    _patch_controller(monkeypatch, exec_fn)
+
+    # Stub DB pool so artifact_checks.insert_check doesn't fail
+    pool_mock = AsyncMock()
+    monkeypatch.setattr(action.db, "get_pool", lambda: pool_mock)
+    monkeypatch.setattr(action.artifact_checks, "insert_check", AsyncMock())
+
+    await action._run_checker(req_id="REQ-426", ctx={"branch": "feat/REQ-426"})
+
+    assert dispatch_called == [], "dispatch should not be called when flag is False"

--- a/orchestrator/tests/test_contract_pr_ci_active_dispatch.py
+++ b/orchestrator/tests/test_contract_pr_ci_active_dispatch.py
@@ -1,0 +1,316 @@
+"""Contract tests: sisyphus actively dispatches repository_dispatch before polling.
+REQ-426
+
+Black-box challenger. Derived from:
+  openspec/changes/REQ-426/specs/pr-ci-active-dispatch/spec.md
+
+Scenarios covered: PRCIAD-S1 through PRCIAD-S4.
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is truly wrong, escalate to spec_fixer to correct the spec.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ─── Shared helpers ──────────────────────────────────────────────────────────
+
+def _make_response(status_code: int = 204, text: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text or f"HTTP {status_code}"
+    return resp
+
+
+def _make_httpx_mock(per_repo_responses: dict[str, MagicMock] | None = None):
+    """Returns (mock_AsyncClient_class, post_calls_list).
+
+    per_repo_responses: {partial_url_fragment: mock_response}
+    All unmatched POSTs return HTTP 204 by default.
+    """
+    post_calls: list[dict] = []
+    per_repo_responses = per_repo_responses or {}
+
+    async def _post(url: str, **kwargs):
+        call_record = {"url": url, **kwargs}
+        post_calls.append(call_record)
+        for fragment, resp in per_repo_responses.items():
+            if fragment in url:
+                return resp
+        return _make_response(204)
+
+    mock_client = AsyncMock()
+    mock_client.post = _post
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_cls = MagicMock(return_value=mock_cm)
+    return mock_cls, post_calls
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PRCIAD-S1: dispatch fires for each repo before polling starts
+# ═══════════════════════════════════════════════════════════════════════════════
+
+async def test_prciad_s1_dispatch_fires_for_each_repo_when_enabled(monkeypatch):
+    """PRCIAD-S1: pr_ci_dispatch_enabled=True + 2 repos → POST to each repo dispatches endpoint."""
+    from orchestrator.actions.create_pr_ci_watch import _dispatch_ci_trigger
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "pr_ci_dispatch_enabled", True)
+    monkeypatch.setattr(cfg, "pr_ci_dispatch_event_type", "ci-trigger")
+    monkeypatch.setattr(cfg, "github_token", "gh-test-token")
+
+    mock_cls, post_calls = _make_httpx_mock()
+
+    with patch("orchestrator.actions.create_pr_ci_watch.httpx.AsyncClient", mock_cls):
+        await _dispatch_ci_trigger(
+            repos=["owner/repo-a", "owner/repo-b"],
+            branch="feat/REQ-426",
+            req_id="REQ-426",
+        )
+
+    # Contract 1: exactly 2 POSTs (one per repo)
+    assert len(post_calls) == 2, (
+        f"PRCIAD-S1: MUST POST exactly twice (once per repo). Got {len(post_calls)}"
+    )
+
+    # Contract 2: each POST targets the /dispatches endpoint of the correct repo
+    posted_urls = [c["url"] for c in post_calls]
+    assert any("owner/repo-a" in u and "/dispatches" in u for u in posted_urls), (
+        f"PRCIAD-S1: MUST POST to .../repos/owner/repo-a/dispatches. Got URLs: {posted_urls}"
+    )
+    assert any("owner/repo-b" in u and "/dispatches" in u for u in posted_urls), (
+        f"PRCIAD-S1: MUST POST to .../repos/owner/repo-b/dispatches. Got URLs: {posted_urls}"
+    )
+
+    # Contract 3: payload has event_type + client_payload with branch and req_id
+    for call_data in post_calls:
+        payload = call_data.get("json") or {}
+        assert payload.get("event_type") == "ci-trigger", (
+            f"PRCIAD-S1: event_type MUST be 'ci-trigger'. Got payload keys={list(payload.keys())}, "
+            f"event_type={payload.get('event_type')!r}"
+        )
+        cp = payload.get("client_payload", {})
+        assert "branch" in cp, (
+            f"PRCIAD-S1: client_payload MUST contain 'branch'. Got client_payload={cp!r}"
+        )
+        assert "req_id" in cp, (
+            f"PRCIAD-S1: client_payload MUST contain 'req_id'. Got client_payload={cp!r}"
+        )
+        assert cp["branch"] == "feat/REQ-426", (
+            f"PRCIAD-S1: client_payload.branch MUST be 'feat/REQ-426'. Got {cp['branch']!r}"
+        )
+        assert cp["req_id"] == "REQ-426", (
+            f"PRCIAD-S1: client_payload.req_id MUST be 'REQ-426'. Got {cp['req_id']!r}"
+        )
+
+    # Contract 4: Authorization: Bearer header present
+    for call_data in post_calls:
+        headers = call_data.get("headers", {})
+        auth_vals = list(headers.values()) if headers else []
+        assert any("Bearer" in str(v) for v in auth_vals), (
+            f"PRCIAD-S1: Authorization: Bearer header MUST be present. Got headers={headers!r}"
+        )
+        assert any("gh-test-token" in str(v) for v in auth_vals), (
+            f"PRCIAD-S1: Bearer token MUST use settings.github_token. Got headers={headers!r}"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PRCIAD-S2: dispatch flag disabled — no POST issued
+# ═══════════════════════════════════════════════════════════════════════════════
+
+async def test_prciad_s2_dispatch_disabled_no_post_issued(monkeypatch):
+    """PRCIAD-S2: pr_ci_dispatch_enabled=False → no POST /dispatches issued at all."""
+    from orchestrator.actions.create_pr_ci_watch import _dispatch_ci_trigger
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "pr_ci_dispatch_enabled", False)
+    monkeypatch.setattr(cfg, "pr_ci_dispatch_event_type", "ci-trigger")
+    monkeypatch.setattr(cfg, "github_token", "gh-test-token")
+
+    mock_cls, post_calls = _make_httpx_mock()
+
+    with patch("orchestrator.actions.create_pr_ci_watch.httpx.AsyncClient", mock_cls):
+        await _dispatch_ci_trigger(
+            repos=["owner/repo-a", "owner/repo-b"],
+            branch="feat/REQ-426",
+            req_id="REQ-426",
+        )
+
+    # Contract: absolutely no POST calls when flag is False
+    dispatch_posts = [c for c in post_calls if "/dispatches" in c.get("url", "")]
+    assert not dispatch_posts, (
+        f"PRCIAD-S2: NO POST /dispatches MUST be issued when pr_ci_dispatch_enabled=False. "
+        f"Got dispatch POSTs: {[c['url'] for c in dispatch_posts]}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PRCIAD-S3: one repo dispatch fails — other repos unaffected, polling continues
+# ═══════════════════════════════════════════════════════════════════════════════
+
+async def test_prciad_s3_one_repo_fails_others_unaffected(monkeypatch):
+    """PRCIAD-S3: repo-a returns 422, repo-b returns 204 → no exception raised, repo-b succeeds."""
+    from orchestrator.actions.create_pr_ci_watch import _dispatch_ci_trigger
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "pr_ci_dispatch_enabled", True)
+    monkeypatch.setattr(cfg, "pr_ci_dispatch_event_type", "ci-trigger")
+    monkeypatch.setattr(cfg, "github_token", "gh-test-token")
+
+    mock_cls, post_calls = _make_httpx_mock({
+        "owner/repo-a": _make_response(422, "Unprocessable Entity"),
+        "owner/repo-b": _make_response(204),
+    })
+
+    raised: Exception | None = None
+    with patch("orchestrator.actions.create_pr_ci_watch.httpx.AsyncClient", mock_cls):
+        try:
+            await _dispatch_ci_trigger(
+                repos=["owner/repo-a", "owner/repo-b"],
+                branch="feat/REQ-426",
+                req_id="REQ-426",
+            )
+        except Exception as e:
+            raised = e
+
+    # Contract 1: no exception raised (best-effort, never propagates)
+    assert raised is None, (
+        f"PRCIAD-S3: _dispatch_ci_trigger MUST NOT raise when repo-a returns 422. "
+        f"Got {type(raised).__name__}: {raised}"
+    )
+
+    # Contract 2: both repos were attempted (failure doesn't skip remaining repos)
+    posted_urls = [c["url"] for c in post_calls]
+    assert any("owner/repo-a" in u for u in posted_urls), (
+        f"PRCIAD-S3: repo-a MUST still be attempted. Got URLs: {posted_urls}"
+    )
+    assert any("owner/repo-b" in u for u in posted_urls), (
+        f"PRCIAD-S3: repo-b MUST be attempted even after repo-a fails. Got URLs: {posted_urls}"
+    )
+    assert len(post_calls) == 2, (
+        f"PRCIAD-S3: MUST attempt POST for each repo regardless of failures. "
+        f"Got {len(post_calls)} POSTs"
+    )
+
+
+async def test_prciad_s3_all_repos_fail_no_exception(monkeypatch):
+    """PRCIAD-S3 extension: ALL repos fail → still no exception raised."""
+    from orchestrator.actions.create_pr_ci_watch import _dispatch_ci_trigger
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "pr_ci_dispatch_enabled", True)
+    monkeypatch.setattr(cfg, "pr_ci_dispatch_event_type", "ci-trigger")
+    monkeypatch.setattr(cfg, "github_token", "gh-test-token")
+
+    mock_cls, post_calls = _make_httpx_mock({
+        "owner/repo-a": _make_response(422, "Unprocessable Entity"),
+        "owner/repo-b": _make_response(500, "Internal Server Error"),
+    })
+
+    raised: Exception | None = None
+    with patch("orchestrator.actions.create_pr_ci_watch.httpx.AsyncClient", mock_cls):
+        try:
+            await _dispatch_ci_trigger(
+                repos=["owner/repo-a", "owner/repo-b"],
+                branch="feat/REQ-426",
+                req_id="REQ-426",
+            )
+        except Exception as e:
+            raised = e
+
+    assert raised is None, (
+        f"PRCIAD-S3: _dispatch_ci_trigger MUST NOT raise even when all repos fail. "
+        f"Got {type(raised).__name__}: {raised}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PRCIAD-S4: no github_token — dispatch returns 401 warning only
+# ═══════════════════════════════════════════════════════════════════════════════
+
+async def test_prciad_s4_empty_token_request_sent_no_exception(monkeypatch):
+    """PRCIAD-S4: github_token="" → request sent with empty Bearer; any error logged as warning only."""
+    from orchestrator.actions.create_pr_ci_watch import _dispatch_ci_trigger
+    from orchestrator.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "pr_ci_dispatch_enabled", True)
+    monkeypatch.setattr(cfg, "pr_ci_dispatch_event_type", "ci-trigger")
+    monkeypatch.setattr(cfg, "github_token", "")
+
+    mock_cls, post_calls = _make_httpx_mock({
+        "owner/repo-a": _make_response(401, "Unauthorized"),
+    })
+
+    raised: Exception | None = None
+    with patch("orchestrator.actions.create_pr_ci_watch.httpx.AsyncClient", mock_cls):
+        try:
+            await _dispatch_ci_trigger(
+                repos=["owner/repo-a"],
+                branch="feat/REQ-426",
+                req_id="REQ-426",
+            )
+        except Exception as e:
+            raised = e
+
+    # Contract 1: no exception propagated
+    assert raised is None, (
+        f"PRCIAD-S4: _dispatch_ci_trigger MUST NOT raise when token is empty and API returns 401. "
+        f"Got {type(raised).__name__}: {raised}"
+    )
+
+    # Contract 2: request was still sent (best-effort, does not skip on empty token)
+    assert len(post_calls) >= 1, (
+        f"PRCIAD-S4: request MUST still be sent even with empty token (spec says it IS sent). "
+        f"Got post_calls={post_calls}"
+    )
+
+    # Contract 3: Authorization: Bearer header present (with empty value)
+    call_data = post_calls[0]
+    headers = call_data.get("headers", {})
+    has_auth = any("Authorization" in k or "Bearer" in str(v) for k, v in headers.items())
+    assert has_auth, (
+        f"PRCIAD-S4: Authorization header MUST be present even with empty token. "
+        f"Got headers={headers!r}"
+    )
+
+
+async def test_prciad_s4_network_exception_does_not_propagate(monkeypatch):
+    """PRCIAD-S4 extension: network exception on dispatch → still no exception propagated."""
+    from orchestrator.actions.create_pr_ci_watch import _dispatch_ci_trigger
+    from orchestrator.config import settings as cfg
+    import httpx
+
+    monkeypatch.setattr(cfg, "pr_ci_dispatch_enabled", True)
+    monkeypatch.setattr(cfg, "pr_ci_dispatch_event_type", "ci-trigger")
+    monkeypatch.setattr(cfg, "github_token", "gh-test-token")
+
+    async def _raise_network(url, **kwargs):
+        raise httpx.ConnectError("Connection refused")
+
+    mock_client = AsyncMock()
+    mock_client.post = _raise_network
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+    mock_cls = MagicMock(return_value=mock_cm)
+
+    raised: Exception | None = None
+    with patch("orchestrator.actions.create_pr_ci_watch.httpx.AsyncClient", mock_cls):
+        try:
+            await _dispatch_ci_trigger(
+                repos=["owner/repo-a"],
+                branch="feat/REQ-426",
+                req_id="REQ-426",
+            )
+        except Exception as e:
+            raised = e
+
+    assert raised is None, (
+        f"PRCIAD-S4: network exception MUST be caught and not propagated. "
+        f"Got {type(raised).__name__}: {raised}"
+    )


### PR DESCRIPTION
## Summary

- Add `_dispatch_ci_trigger()` helper to `create_pr_ci_watch.py` that fires `POST /repos/{owner}/{repo}/dispatches` for each involved repo before the check-run polling loop.
- Business repos' `dispatch.yml` only triggers on `repository_dispatch` (not `pull_request`), so programmatic PR creation by the analyze-agent never started `ttpos-ci ci-go.yml`. This caused `pr-ci-watch` to time out with `no-gha`.
- Feature is gated by `pr_ci_dispatch_enabled` (default `False`). Set `pr_ci_dispatch_event_type` to match the business repo's `dispatch.yml` trigger.
- Best-effort: per-repo failure is logged as a warning; polling continues regardless.

## Changed files

| File | Change |
|------|--------|
| `orchestrator/src/orchestrator/config.py` | Add `pr_ci_dispatch_enabled` + `pr_ci_dispatch_event_type` flags |
| `orchestrator/src/orchestrator/actions/create_pr_ci_watch.py` | Add `_dispatch_ci_trigger()` helper; call from `_run_checker()` |
| `orchestrator/tests/test_actions_create_pr_ci_watch.py` | Add 3 new tests (happy path / 422 tolerance / flag disabled) |

## Test plan

- [x] `test_dispatch_ci_trigger_calls_gh_api` — verifies POST fires for each repo with correct body (PRCIAD-S1)
- [x] `test_dispatch_ci_trigger_tolerates_per_repo_error` — one repo 422, other succeeds, no exception (PRCIAD-S3)
- [x] `test_run_checker_skips_dispatch_when_disabled` — flag False → `_dispatch_ci_trigger` not called (PRCIAD-S2)
- [x] All 1582 existing unit tests pass

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-426`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/ax1ez94m)