### PR TITLE
feat(watchdog): reconcile BKD sessionStatus for CHALLENGER_RUNNING before stuck escalation (REQ-441)

### DIFF
--- a/openspec/changes/REQ-441/proposal.md
+++ b/openspec/changes/REQ-441/proposal.md
@@ -1,0 +1,37 @@
+# REQ-441: feat(watchdog): reconcile BKD sessionStatus before judging stuck — add CHALLENGER_RUNNING to issue map
+
+## 问题
+
+`watchdog._STATE_ISSUE_KEY` 表缺少 `ReqState.CHALLENGER_RUNNING` 条目。
+
+`_check_and_escalate` 在判断 stuck 前会先调 `bkd.get_issue()` 查
+`session_status`——但前提是 `_STATE_ISSUE_KEY[state]` 返回非 None 的 ctx key，
+watchdog 才能找到对应的 BKD issue ID。
+
+`CHALLENGER_RUNNING` 不在这张表里，导致：
+- `issue_key = _STATE_ISSUE_KEY.get(ReqState.CHALLENGER_RUNNING)` → Python 默认 `None`
+- `issue_id = None`
+- BKD **不被查询**，`still_running` 永远是 `False`
+- watchdog 对正在运行中的 challenger session 也套用 `ended_sec=300` 快车道阈值
+- 超 300s 未收到 webhook 就立即 escalate，杀掉真正在运行的 challenger-agent
+
+而 `start_challenger.py` 在创建 challenger issue 后已将 `challenger_issue_id`
+写入 req ctx（`return {"challenger_issue_id": issue.id, ...}`）——信息存在但
+watchdog 没读。
+
+## 方案
+
+在 `_STATE_ISSUE_KEY` 加一行：
+
+```python
+ReqState.CHALLENGER_RUNNING: "challenger_issue_id",
+```
+
+这样 `_check_and_escalate` 能正确取出 `ctx["challenger_issue_id"]`，查 BKD
+获取 `session_status`，若为 `"running"` 则 skip（保护长尾真运行），若已
+ended/failed 才走 `ended_sec` 快车道，与其他 autonomous-bounded stage 行为一致。
+
+## 影响范围
+
+- `orchestrator/src/orchestrator/watchdog.py` — `_STATE_ISSUE_KEY` 新增一行
+- `orchestrator/tests/test_watchdog.py` — 新增 3 个 CHALLENGER_RUNNING 相关 case

--- a/openspec/changes/REQ-441/specs/watchdog-stuck-double-check/contract.spec.yaml
+++ b/openspec/changes/REQ-441/specs/watchdog-stuck-double-check/contract.spec.yaml
@@ -1,0 +1,33 @@
+spec: watchdog-stuck-double-check
+version: 1
+description: >-
+  The orchestrator watchdog MUST reconcile BKD sessionStatus for ALL autonomous
+  agent stages before deciding they are stuck. CHALLENGER_RUNNING MUST be
+  tracked in _STATE_ISSUE_KEY so that a live challenger session is not
+  erroneously escalated when its session is still running.
+
+invariants:
+  - id: WSD-INV-1
+    statement: >-
+      Every state in _STAGE_POLICY with a non-None policy and a BKD agent issue
+      MUST appear in _STATE_ISSUE_KEY so the watchdog can call bkd.get_issue()
+      before escalating.
+  - id: WSD-INV-2
+    statement: >-
+      _STATE_ISSUE_KEY[ReqState.CHALLENGER_RUNNING] MUST equal the string
+      "challenger_issue_id", which is the key set by start_challenger.py in the
+      REQ context.
+  - id: WSD-INV-3
+    statement: >-
+      When CHALLENGER_RUNNING + BKD session_status="running", watchdog._tick()
+      MUST return escalated=0 for that row and MUST NOT call engine.step or
+      artifact_checks.insert_check.
+  - id: WSD-INV-4
+    statement: >-
+      When CHALLENGER_RUNNING + BKD session_status!="running" + stuck_sec >=
+      ended_sec, watchdog._tick() MUST call engine.step with event=SESSION_FAILED.
+
+scenarios_referenced:
+  - WSD-S1
+  - WSD-S2
+  - WSD-S3

--- a/openspec/changes/REQ-441/specs/watchdog-stuck-double-check/spec.md
+++ b/openspec/changes/REQ-441/specs/watchdog-stuck-double-check/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: watchdog SHALL reconcile BKD sessionStatus for CHALLENGER_RUNNING before escalating
+
+The watchdog MUST track the BKD issue associated with `CHALLENGER_RUNNING` state
+via `orchestrator.watchdog._STATE_ISSUE_KEY`. The entry for
+`ReqState.CHALLENGER_RUNNING` MUST map to the context key `"challenger_issue_id"`.
+Before deciding that a `CHALLENGER_RUNNING` REQ is stuck, the watchdog MUST call
+`bkd.get_issue()` to retrieve the live `session_status`. If `session_status` is
+`"running"`, the watchdog MUST skip escalation for that REQ (same long-tail
+protection semantics as other `autonomous-bounded` stages). Only when
+`session_status` is not `"running"` (ended / failed / cancelled / issue not found)
+SHALL the watchdog apply the `ended_sec` threshold and potentially escalate.
+
+#### Scenario: WSD-S1 CHALLENGER_RUNNING + session running → no escalation
+
+- **GIVEN** a REQ in state `CHALLENGER_RUNNING` whose `updated_at` exceeds
+  `watchdog_session_ended_threshold_sec` (300 s)
+- **AND** `ctx["challenger_issue_id"]` is set to a valid BKD issue ID
+- **AND** BKD reports `session_status="running"` for that issue
+- **WHEN** `watchdog._tick()` runs
+- **THEN** no `artifact_checks` insert, no `engine.step` call occur for this REQ
+- **AND** the result `escalated` count is 0 for this row
+
+#### Scenario: WSD-S2 CHALLENGER_RUNNING + session failed → escalate after ended_sec
+
+- **GIVEN** a REQ in state `CHALLENGER_RUNNING` whose `updated_at` exceeds
+  `watchdog_session_ended_threshold_sec` (300 s)
+- **AND** `ctx["challenger_issue_id"]` is set to a valid BKD issue ID
+- **AND** BKD reports `session_status="failed"` for that issue
+- **WHEN** `watchdog._tick()` runs
+- **THEN** `engine.step` is called once with `event=SESSION_FAILED`,
+  `cur_state=CHALLENGER_RUNNING`, and `body.issueId=challenger_issue_id`
+- **AND** the result `escalated` count is 1
+
+#### Scenario: WSD-S3 CHALLENGER_RUNNING entry present in _STATE_ISSUE_KEY
+
+- **GIVEN** the `orchestrator.watchdog` module is imported
+- **WHEN** `_STATE_ISSUE_KEY[ReqState.CHALLENGER_RUNNING]` is read
+- **THEN** the value MUST equal `"challenger_issue_id"`

--- a/openspec/changes/REQ-441/tasks.md
+++ b/openspec/changes/REQ-441/tasks.md
@@ -1,0 +1,20 @@
+# REQ-441 Tasks
+
+## Stage: contract / spec
+
+- [x] author specs/watchdog-stuck-double-check/spec.md with CHALLENGER_RUNNING reconcile scenarios
+
+## Stage: implementation
+
+- [x] Add `ReqState.CHALLENGER_RUNNING: "challenger_issue_id"` to `_STATE_ISSUE_KEY` in watchdog.py
+
+## Stage: tests
+
+- [x] test_challenger_running_session_skips_when_still_running — session=running → skip
+- [x] test_challenger_running_session_failed_escalates — session=failed + elapsed > ended_sec → escalate
+- [x] test_challenger_running_in_state_issue_key — structural contract test
+
+## Stage: PR
+
+- [x] git push feat/REQ-441
+- [x] gh pr create --label sisyphus

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -53,6 +53,7 @@ _STATE_ISSUE_KEY: dict[ReqState, str | None] = {
     ReqState.ANALYZE_ARTIFACT_CHECKING: None,    # 客观 checker，由 orchestrator 下发不绑 issue
     ReqState.SPEC_LINT_RUNNING: None,            # M15: 客观 checker，由 orchestrator 下发不绑 issue
     ReqState.DEV_CROSS_CHECK_RUNNING: None,      # M15: 客观 checker，由 orchestrator 下发不绑 issue
+    ReqState.CHALLENGER_RUNNING: "challenger_issue_id",
     ReqState.STAGING_TEST_RUNNING: "staging_test_issue_id",
     ReqState.PR_CI_RUNNING: "pr_ci_watch_issue_id",
     ReqState.ACCEPT_RUNNING: "accept_issue_id",

--- a/orchestrator/tests/test_contract_watchdog_stuck_double_check_challenger.py
+++ b/orchestrator/tests/test_contract_watchdog_stuck_double_check_challenger.py
@@ -1,0 +1,217 @@
+"""Challenger contract tests: watchdog reconciles BKD sessionStatus for CHALLENGER_RUNNING.
+
+REQ-441 — watchdog 判 stuck 前 reconcile BKD sessionStatus
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-441/specs/watchdog-stuck-double-check/spec.md
+  openspec/changes/REQ-441/specs/watchdog-stuck-double-check/contract.spec.yaml
+
+Scenarios covered:
+  WSD-S1  CHALLENGER_RUNNING + session=running + stuck > ended_sec → no escalation
+  WSD-S2  CHALLENGER_RUNNING + session=failed  + stuck > ended_sec → escalate (SESSION_FAILED)
+  WSD-S3  _STATE_ISSUE_KEY[ReqState.CHALLENGER_RUNNING] == "challenger_issue_id"
+
+Invariants checked:
+  WSD-INV-2  _STATE_ISSUE_KEY[ReqState.CHALLENGER_RUNNING] == "challenger_issue_id"
+  WSD-INV-3  session=running → escalated=0, no engine.step, no artifact_checks call
+  WSD-INV-4  session=failed + stuck >= ended_sec → engine.step(event=SESSION_FAILED)
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is truly wrong, escalate to spec_fixer to correct the spec, not the test.
+"""
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock
+
+import pytest
+
+from orchestrator import watchdog
+from orchestrator.state import Event, ReqState
+
+# ─── shared fakes ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakePool:
+    rows: list = field(default_factory=list)
+    executed: list = field(default_factory=list)
+
+    async def fetch(self, sql, *args):
+        return self.rows
+
+    async def execute(self, sql, *args):
+        self.executed.append((sql, args))
+
+
+@dataclass
+class _FakeIssue:
+    session_status: str | None = "failed"
+    id: str = "ch-issue-1"
+    project_id: str = "proj-1"
+    issue_number: int = 0
+    title: str = ""
+    status_id: str = "todo"
+    tags: list = field(default_factory=list)
+
+
+def _make_row(state: str, *, req_id: str = "REQ-441", project_id: str = "proj-1",
+              ctx: dict | None = None, stuck_sec: int = 400) -> dict:
+    return {
+        "req_id": req_id,
+        "project_id": project_id,
+        "state": state,
+        "context": json.dumps(ctx or {}),
+        "stuck_sec": stuck_sec,
+    }
+
+
+def _patch_pool(monkeypatch, pool: _FakePool) -> None:
+    monkeypatch.setattr("orchestrator.watchdog.db.get_pool", lambda: pool)
+
+
+def _patch_bkd(monkeypatch, issue: _FakeIssue | None) -> AsyncMock:
+    fake = AsyncMock()
+    fake.get_issue = AsyncMock(return_value=issue)
+
+    @asynccontextmanager
+    async def _ctx(*a, **kw):
+        yield fake
+
+    monkeypatch.setattr("orchestrator.watchdog.BKDClient", _ctx)
+    return fake
+
+
+def _patch_engine(monkeypatch) -> list:
+    calls: list = []
+
+    async def fake_step(pool, *, body, req_id, project_id, tags, cur_state,
+                        ctx, event, depth=0):
+        calls.append({
+            "req_id": req_id,
+            "cur_state": cur_state,
+            "event": event,
+            "body_issue": getattr(body, "issueId", None),
+        })
+        return {}
+
+    monkeypatch.setattr("orchestrator.watchdog.engine.step", fake_step)
+    return calls
+
+
+def _patch_artifact(monkeypatch) -> list:
+    calls: list = []
+
+    async def fake_insert(pool, req_id, stage, result):
+        calls.append({"req_id": req_id, "stage": stage, "result": result})
+
+    monkeypatch.setattr("orchestrator.watchdog.artifact_checks.insert_check", fake_insert)
+    return calls
+
+
+# ─── WSD-S3 / WSD-INV-2: static key-table check ──────────────────────────────
+
+
+def test_wsd_s3_challenger_running_in_state_issue_key():
+    """WSD-S3 / WSD-INV-2: _STATE_ISSUE_KEY MUST contain CHALLENGER_RUNNING → "challenger_issue_id".
+
+    The spec requires that the watchdog can locate the BKD issue for a
+    CHALLENGER_RUNNING REQ via ctx["challenger_issue_id"]. This is only possible
+    if _STATE_ISSUE_KEY maps that state to the correct context key.
+    """
+    assert ReqState.CHALLENGER_RUNNING in watchdog._STATE_ISSUE_KEY, (
+        "WSD-INV-2: _STATE_ISSUE_KEY MUST contain ReqState.CHALLENGER_RUNNING"
+    )
+    assert watchdog._STATE_ISSUE_KEY[ReqState.CHALLENGER_RUNNING] == "challenger_issue_id", (
+        "WSD-INV-2: _STATE_ISSUE_KEY[CHALLENGER_RUNNING] MUST equal 'challenger_issue_id', "
+        f"got {watchdog._STATE_ISSUE_KEY[ReqState.CHALLENGER_RUNNING]!r}"
+    )
+
+
+# ─── WSD-S1 / WSD-INV-3: running session → no escalation ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wsd_s1_challenger_running_session_running_no_escalation(monkeypatch):
+    """WSD-S1 / WSD-INV-3: CHALLENGER_RUNNING + session_status=running → escalated=0.
+
+    Even when stuck_sec exceeds watchdog_session_ended_threshold_sec, if BKD
+    reports the challenger session as still running, the watchdog MUST skip
+    escalation for that REQ (long-tail protection).
+    """
+    pool = _FakePool(rows=[
+        _make_row(
+            ReqState.CHALLENGER_RUNNING.value,
+            req_id="REQ-441",
+            ctx={"challenger_issue_id": "ch-live", "intent_issue_id": "intent-1"},
+            stuck_sec=400,
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, _FakeIssue(session_status="running", id="ch-live"))
+    step_calls = _patch_engine(monkeypatch)
+    art_calls = _patch_artifact(monkeypatch)
+    monkeypatch.setattr(
+        "orchestrator.watchdog.settings.watchdog_session_ended_threshold_sec", 300,
+    )
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 0}, (
+        f"WSD-S1: expected escalated=0 for running session, got {result}"
+    )
+    assert step_calls == [], (
+        "WSD-INV-3: engine.step MUST NOT be called when session_status='running'"
+    )
+    assert art_calls == [], (
+        "WSD-INV-3: artifact_checks.insert_check MUST NOT be called when session_status='running'"
+    )
+
+
+# ─── WSD-S2 / WSD-INV-4: failed session → escalate ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wsd_s2_challenger_running_session_failed_escalates(monkeypatch):
+    """WSD-S2 / WSD-INV-4: CHALLENGER_RUNNING + session_status=failed + stuck > ended_sec → escalate.
+
+    When BKD reports the challenger session as failed/ended and the REQ has been
+    stuck longer than watchdog_session_ended_threshold_sec, the watchdog MUST
+    call engine.step with event=SESSION_FAILED for that REQ.
+    """
+    pool = _FakePool(rows=[
+        _make_row(
+            ReqState.CHALLENGER_RUNNING.value,
+            req_id="REQ-441",
+            ctx={"challenger_issue_id": "ch-dead", "intent_issue_id": "intent-2"},
+            stuck_sec=400,
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, _FakeIssue(session_status="failed", id="ch-dead"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+    monkeypatch.setattr(
+        "orchestrator.watchdog.settings.watchdog_session_ended_threshold_sec", 300,
+    )
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}, (
+        f"WSD-S2: expected escalated=1 for failed session, got {result}"
+    )
+    assert len(step_calls) == 1, (
+        f"WSD-INV-4: engine.step MUST be called exactly once, got {len(step_calls)} calls"
+    )
+    assert step_calls[0]["event"] == Event.SESSION_FAILED, (
+        f"WSD-INV-4: engine.step event MUST be SESSION_FAILED, got {step_calls[0]['event']!r}"
+    )
+    assert step_calls[0]["cur_state"] == ReqState.CHALLENGER_RUNNING, (
+        f"WSD-INV-4: cur_state MUST be CHALLENGER_RUNNING, got {step_calls[0]['cur_state']!r}"
+    )
+    assert step_calls[0]["body_issue"] == "ch-dead", (
+        f"WSD-INV-4: body.issueId MUST be the challenger issue id 'ch-dead', "
+        f"got {step_calls[0]['body_issue']!r}"
+    )

--- a/orchestrator/tests/test_watchdog.py
+++ b/orchestrator/tests/test_watchdog.py
@@ -659,3 +659,51 @@ def test_settings_session_ended_threshold_env_override(monkeypatch):
         bkd_token="x", webhook_token="x", pg_dsn="postgresql://x:x@x/x",  # type: ignore[call-arg]
     )
     assert s.watchdog_session_ended_threshold_sec == 120
+
+
+# ─── CHALLENGER_RUNNING: reconcile BKD sessionStatus ──────────────────────────
+
+@pytest.mark.asyncio
+async def test_challenger_running_session_skips_when_still_running(monkeypatch):
+    """CHALLENGER_RUNNING + session_status=running → skip（不杀长尾 challenger）。"""
+    pool = FakePool(rows=[
+        _row("REQ-CH", ReqState.CHALLENGER_RUNNING.value,
+             ctx={"challenger_issue_id": "ch-1", "intent_issue_id": "intent-1"},
+             stuck_sec=400),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, FakeIssue(session_status="running", id="ch-1"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 0}
+    assert step_calls == []
+
+
+@pytest.mark.asyncio
+async def test_challenger_running_session_failed_escalates(monkeypatch):
+    """CHALLENGER_RUNNING + session_status=failed + stuck > ended_sec → escalate。"""
+    pool = FakePool(rows=[
+        _row("REQ-CH2", ReqState.CHALLENGER_RUNNING.value,
+             ctx={"challenger_issue_id": "ch-2", "intent_issue_id": "intent-2"},
+             stuck_sec=400),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, FakeIssue(session_status="failed", id="ch-2"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    assert step_calls[0]["event"] == Event.SESSION_FAILED
+    assert step_calls[0]["cur_state"] == ReqState.CHALLENGER_RUNNING
+    assert step_calls[0]["body_issue"] == "ch-2"
+
+
+def test_challenger_running_in_state_issue_key():
+    """CHALLENGER_RUNNING 必须在 _STATE_ISSUE_KEY 中以便 watchdog 能 reconcile BKD session。"""
+    assert ReqState.CHALLENGER_RUNNING in watchdog._STATE_ISSUE_KEY
+    assert watchdog._STATE_ISSUE_KEY[ReqState.CHALLENGER_RUNNING] == "challenger_issue_id"

--- a/thanatos/pyproject.toml
+++ b/thanatos/pyproject.toml
@@ -24,6 +24,14 @@ dev = [
     "mypy>=1.13",
 ]
 
+[dependency-groups]
+dev = [
+    "pytest>=8.3",
+    "pytest-asyncio>=0.24",
+    "ruff>=0.7",
+    "mypy>=1.13",
+]
+
 [project.scripts]
 thanatos-server = "thanatos.server:main"
 

--- a/thanatos/uv.lock
+++ b/thanatos/uv.lock
@@ -841,6 +841,14 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "mcp", specifier = ">=1.2" },
@@ -852,6 +860,14 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.13" },
+    { name = "pytest", specifier = ">=8.3" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "ruff", specifier = ">=0.7" },
+]
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
## 问题

`watchdog._STATE_ISSUE_KEY` 缺少 `ReqState.CHALLENGER_RUNNING` 条目。

`_check_and_escalate` 判断 stuck 前会先查 `bkd.get_issue()` 获取 `session_status`，
但前提是能从 `_STATE_ISSUE_KEY[state]` 拿到 ctx key，进而取出 BKD issue ID。

`CHALLENGER_RUNNING` 不在表里，导致：
- `issue_key = _STATE_ISSUE_KEY.get(ReqState.CHALLENGER_RUNNING)` → Python 默认 `None`
- `issue_id = None`，BKD 不查，`still_running` 永远 `False`
- 正在运行的 challenger session 也套用 `ended_sec=300` 快车道
- 超 300 s 未收 webhook 就 escalate，误杀真正运行中的 challenger-agent

`start_challenger.py` 已将 `challenger_issue_id` 写入 req ctx，信息存在但 watchdog 没读。

## 修复

`_STATE_ISSUE_KEY` 加一行：

```python
ReqState.CHALLENGER_RUNNING: "challenger_issue_id",
```

watchdog 现在能正确取出 `ctx["challenger_issue_id"]`，查 BKD 获取 `session_status`：
- `session_status == "running"` → skip（保护长尾真运行）
- `session_status != "running"` → 走 `ended_sec` 快车道（与其他 autonomous-bounded stage 一致）

## 测试

新增 3 个 unit test：
- `test_challenger_running_session_skips_when_still_running` — session=running → 不 escalate
- `test_challenger_running_session_failed_escalates` — session=failed + elapsed > ended_sec → escalate
- `test_challenger_running_in_state_issue_key` — structural contract：key 存在且值为 `"challenger_issue_id"`

全部 28 个 watchdog tests 通过（`uv run pytest tests/test_watchdog.py`）。

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-441`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/xj26sfil)