### PR TITLE
feat(pr-ci-watch): proactively POST repository_dispatch to ttpos-ci before polling [REQ-447]

### DIFF
--- a/docs/integration-contracts.md
+++ b/docs/integration-contracts.md
@@ -358,6 +358,52 @@ gh pr list --head feat/REQ-29 --repo phona/ttpos-server-go --json number
 - 至少有一条 `check-run`（哪怕只是 lint）—— 没有 check-run 会 timeout（1800s 默认）
 - 失败的 check `conclusion` 用 `failure` / `cancelled` / `timed_out`（pr-ci-watch 认这些）
 
+### 6b. 主动 dispatch（可选，`ci_dispatch_enabled=True`）
+
+当 `SISYPHUS_CI_DISPATCH_ENABLED=true` 且 `SISYPHUS_CI_DISPATCH_REPO=phona/ttpos-ci` 时，
+sisyphus 在进入 pr-ci-watch 轮询**之前**主动发一次 `repository_dispatch`：
+
+```
+POST /repos/phona/ttpos-ci/dispatches
+{
+  "event_type": "<ci_dispatch_event_type>",   # 默认 "pr-ci-run"
+  "client_payload": {
+    "req_id":      "REQ-447",
+    "source_repo": "phona/ttpos-server-go",
+    "branch":      "feat/REQ-447",
+    "sha":         "<head SHA>",
+    "pr_number":   123
+  }
+}
+```
+
+每个 involved source repo 发一条（多仓 REQ → 多条）。语义是 **best-effort**：
+dispatch 失败只写 warning log，不阻塞后续轮询。
+
+**token 要求**：`SISYPHUS_GITHUB_TOKEN` 必须对 `ci_dispatch_repo` 有写权限
+（classic PAT 勾 `repo`，或 fine-grained PAT `phona/ttpos-ci` `Contents: Read-and-write`）。
+runner pod 只需读权限（§1c），orchestrator 进程用自己的 token 发 dispatch。
+
+**phona/ttpos-ci 侧**：需要配置监听 `repository_dispatch` 的 workflow：
+
+```yaml
+on:
+  repository_dispatch:
+    types: [pr-ci-run]
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.client_payload.source_repo }}
+          ref: ${{ github.event.client_payload.sha }}
+      # ... run ci-lint / ci-unit-test / ci-integration-test via make
+```
+
+check-runs 仍由 pr-ci-watch 在 source repo PR 上轮询（dispatch 后 GHA 会把 check-run
+附在 source repo 对应 PR 的 SHA 上）。
+
 ## 7. tag 契约（agent 报告结果）
 
 stage agent 完成时通过 BKD issue tag 报告结果。详见 [api-tag-management-spec.md](./api-tag-management-spec.md)。常用：

--- a/docs/plan/PLAN-001.md
+++ b/docs/plan/PLAN-001.md
@@ -1,0 +1,68 @@
+# PLAN-001: ttpos-ci-direct-dispatch
+
+**REQ**: REQ-447
+**status**: implementing
+
+## Context
+
+`create_pr_ci_watch` checker path currently only polls GitHub check-runs passively.
+When GitHub Actions are not triggered (webhook miss, branch not in workflow trigger list),
+sisyphus waits 1800s before timing out with `no-gha` or `timeout`.
+
+`phona/ttpos-ci` is the central CI repo that provides reusable GHA workflows.
+Business repos reference these via `workflow_call`. Sisyphus does not currently send
+any signal to this repo.
+
+## Proposal
+
+Before starting the check-run polling loop in `_run_checker`, optionally POST a
+`repository_dispatch` event to a configurable CI repo. The dispatch is best-effort:
+failure only logs a warning and does not block polling.
+
+## Design
+
+### New config fields (3)
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `ci_dispatch_enabled` | `bool` | `False` | Feature flag |
+| `ci_dispatch_repo` | `str` | `""` | Target repo, e.g. `phona/ttpos-ci` |
+| `ci_dispatch_event_type` | `str` | `"pr-ci-run"` | repository_dispatch event_type |
+
+### Dispatch flow
+
+1. `_run_checker` calls `_dispatch_to_ci_repo` before `checker.watch_pr_ci`
+2. `_dispatch_to_ci_repo`:
+   - skips if `ci_dispatch_enabled=False` or `ci_dispatch_repo=""`
+   - for each involved repo: calls `_get_pr_info` to get (pr_number, sha)
+   - POSTs `POST /repos/{ci_dispatch_repo}/dispatches` with payload:
+     ```json
+     {
+       "event_type": "<ci_dispatch_event_type>",
+       "client_payload": {
+         "req_id": "...", "source_repo": "...",
+         "branch": "...", "sha": "...", "pr_number": N
+       }
+     }
+     ```
+   - HTTP error → log warning, continue (best-effort)
+   - skips repos where PR lookup fails
+
+### Token
+
+Uses `settings.github_token` (same as polling path). For `repository_dispatch`,
+the token needs `repo` scope (classic PAT) or `Contents: Read-and-write` (fine-grained)
+on the target CI repo.
+
+## Files Changed
+
+1. `orchestrator/src/orchestrator/config.py`
+2. `orchestrator/src/orchestrator/actions/create_pr_ci_watch.py`
+3. `orchestrator/tests/test_actions_create_pr_ci_watch.py`
+4. `docs/integration-contracts.md`
+5. `openspec/changes/REQ-447/`
+
+## Risks
+
+- Token needs write scope on `phona/ttpos-ci`; mitigated by feature flag default=False
+- Dispatch payload format must match ttpos-ci expectation; `ci_dispatch_event_type` is configurable

--- a/docs/plan/index.md
+++ b/docs/plan/index.md
@@ -2,6 +2,13 @@
 
 Last updated: 2026-04-27
 
-| ID | Title | Status |
-|---|---|---|
-| [ ] | [PLAN-001](PLAN-001-verifier-infra-flake-auto-retry.md) | proposed |
+## Active
+
+| ID | Title | Status | REQ |
+|---|---|---|---|
+| [-] | [PLAN-001-verifier-infra-flake-auto-retry](PLAN-001-verifier-infra-flake-auto-retry.md) | proposed | REQ-428 |
+| [-] | [PLAN-001-ttpos-ci-direct-dispatch](PLAN-001.md) | implementing | REQ-447 |
+
+## Completed
+
+## Closed

--- a/docs/task/TASK-001.md
+++ b/docs/task/TASK-001.md
@@ -1,0 +1,19 @@
+# TASK-001: ttpos-ci-direct-dispatch
+
+**REQ**: REQ-447
+**status**: in_progress
+**owner**: analyze-agent (fld9vdxg)
+
+## Goal
+
+Add a feature-flagged capability for sisyphus orchestrator to proactively POST a
+`repository_dispatch` event to a configurable central CI repo (default: `phona/ttpos-ci`)
+before entering the pr-ci-watch polling loop.
+
+## Scope
+
+- `orchestrator/src/orchestrator/config.py`: 3 new settings
+- `orchestrator/src/orchestrator/actions/create_pr_ci_watch.py`: `_dispatch_to_ci_repo` helper
+- `orchestrator/tests/test_actions_create_pr_ci_watch.py`: unit tests for dispatch
+- `docs/integration-contracts.md`: §6 footnote on dispatch
+- `openspec/changes/REQ-447/`: spec, proposal, tasks

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -2,6 +2,13 @@
 
 Last updated: 2026-04-27
 
-| ID | Title | Status | Owner |
-|---|---|---|---|
-| [-] | [TASK-001](TASK-001-verifier-infra-flake-auto-retry.md) | in_progress | claude |
+## Active
+
+| ID | Title | Status | Owner | REQ |
+|---|---|---|---|---|
+| [-] | [TASK-001-verifier-infra-flake-auto-retry](TASK-001-verifier-infra-flake-auto-retry.md) | in_progress | claude | REQ-428 |
+| [-] | [TASK-001-ttpos-ci-direct-dispatch](TASK-001.md) | in_progress | claude | REQ-447 |
+
+## Completed
+
+## Closed

--- a/openspec/changes/REQ-447/proposal.md
+++ b/openspec/changes/REQ-447/proposal.md
@@ -1,0 +1,31 @@
+# REQ-447: ttpos-ci-direct-dispatch
+
+## Problem
+
+`pr-ci-watch` currently relies on GitHub Actions being passively triggered by the `pull_request`
+webhook event in business repos. When that trigger is missed (webhook delivery failure, branch not
+in workflow trigger list, or `phona/ttpos-ci` workflow expecting an explicit dispatch), sisyphus
+waits up to 1800 seconds before timing out with a `no-gha` or `timeout` verdict.
+
+## Solution
+
+Add a feature-flagged "direct dispatch" step: when entering `pr-ci-watch`, sisyphus proactively
+POSTs a `repository_dispatch` event to a configurable central CI repo (defaulting to
+`phona/ttpos-ci`) for each involved source repo. This ensures CI runs even when webhook-based
+triggering is unreliable or the CI setup explicitly expects a dispatch from the orchestrator.
+
+## Key Design Decisions
+
+- **Best-effort**: dispatch failure never blocks the polling loop
+- **Feature flag `ci_dispatch_enabled` (default False)**: safe opt-in rollout
+- **One dispatch per source repo**: allows ttpos-ci to run repo-specific CI jobs
+- **Standard payload**: `{req_id, source_repo, branch, sha, pr_number}` — ttpos-ci can use
+  whichever fields it needs
+- **Token reuse**: uses the existing `settings.github_token`; no new secret needed; operator
+  must ensure token has write scope on `ci_dispatch_repo`
+
+## Out of Scope
+
+- Changes to how check-runs are polled (unchanged)
+- Any changes to `phona/ttpos-ci` itself
+- Retry logic for dispatch (best-effort semantics)

--- a/openspec/changes/REQ-447/specs/ttpos-ci-direct-dispatch/contract.spec.yaml
+++ b/openspec/changes/REQ-447/specs/ttpos-ci-direct-dispatch/contract.spec.yaml
@@ -1,0 +1,17 @@
+id: ttpos-ci-direct-dispatch
+version: "1.0"
+description: |
+  Contract for orchestrator proactively dispatching repository_dispatch to a central CI
+  repo before polling PR check-runs.
+
+scenarios:
+  - id: SIS-447-S1
+    description: dispatch is skipped when ci_dispatch_enabled is False
+  - id: SIS-447-S2
+    description: dispatch is skipped when ci_dispatch_repo is empty
+  - id: SIS-447-S3
+    description: one dispatch per source repo when enabled
+  - id: SIS-447-S4
+    description: dispatch HTTP error does not block polling
+  - id: SIS-447-S5
+    description: dispatch is skipped for repos with no open PR

--- a/openspec/changes/REQ-447/specs/ttpos-ci-direct-dispatch/spec.md
+++ b/openspec/changes/REQ-447/specs/ttpos-ci-direct-dispatch/spec.md
@@ -1,0 +1,49 @@
+# ttpos-ci-direct-dispatch spec
+
+## ADDED Requirements
+
+### Requirement: orchestrator proactively dispatches repository_dispatch before polling
+
+When `ci_dispatch_enabled=True` and `ci_dispatch_repo` is non-empty, the orchestrator
+SHALL POST a `repository_dispatch` event to `ci_dispatch_repo` for each involved source
+repo before entering the pr-ci-watch polling loop. The dispatch MUST use the configured
+`ci_dispatch_event_type` and include a `client_payload` with `req_id`, `source_repo`,
+`branch`, `sha`, and `pr_number`. Dispatch failures MUST NOT block the polling loop
+(best-effort semantics): HTTP errors or missing PRs are logged as warnings only.
+
+#### Scenario: SIS-447-S1 dispatch is skipped when ci_dispatch_enabled is False
+
+- **GIVEN** `ci_dispatch_enabled=False`
+- **WHEN** `create_pr_ci_watch` enters the checker path
+- **THEN** no `POST /repos/{ci_dispatch_repo}/dispatches` is sent
+- **AND** watch_pr_ci proceeds normally
+
+#### Scenario: SIS-447-S2 dispatch is skipped when ci_dispatch_repo is empty
+
+- **GIVEN** `ci_dispatch_enabled=True` and `ci_dispatch_repo=""`
+- **WHEN** `create_pr_ci_watch` enters the checker path
+- **THEN** no HTTP request is made to any dispatch endpoint
+- **AND** watch_pr_ci proceeds normally
+
+#### Scenario: SIS-447-S3 one dispatch per source repo when enabled
+
+- **GIVEN** `ci_dispatch_enabled=True`, `ci_dispatch_repo="phona/ttpos-ci"`,
+  and two source repos `["phona/repo-a", "phona/repo-b"]`
+- **WHEN** both repos have open PRs and `create_pr_ci_watch` runs
+- **THEN** two `POST /repos/phona/ttpos-ci/dispatches` requests are sent, one per repo
+- **AND** each payload contains `source_repo`, `branch`, `sha`, `pr_number`, `req_id`
+
+#### Scenario: SIS-447-S4 dispatch HTTP error does not block polling
+
+- **GIVEN** `ci_dispatch_enabled=True` and the dispatch endpoint returns HTTP 422
+- **WHEN** `create_pr_ci_watch` runs
+- **THEN** the error is logged as a warning
+- **AND** `watch_pr_ci` still runs and returns its normal verdict
+
+#### Scenario: SIS-447-S5 dispatch is skipped for repos with no open PR
+
+- **GIVEN** `ci_dispatch_enabled=True` and one source repo has no open PR
+- **WHEN** `create_pr_ci_watch` runs
+- **THEN** no dispatch is sent for that repo
+- **AND** the warning is logged
+- **AND** watch_pr_ci runs normally

--- a/openspec/changes/REQ-447/tasks.md
+++ b/openspec/changes/REQ-447/tasks.md
@@ -1,0 +1,21 @@
+# Tasks for REQ-447
+
+## Stage: spec
+
+- [x] author specs/ttpos-ci-direct-dispatch/spec.md scenarios
+- [x] author specs/ttpos-ci-direct-dispatch/contract.spec.yaml
+
+## Stage: implementation
+
+- [x] config.py: add ci_dispatch_enabled / ci_dispatch_repo / ci_dispatch_event_type
+- [x] create_pr_ci_watch.py: add _dispatch_to_ci_repo helper + wire into _run_checker
+- [x] unit tests: test_actions_create_pr_ci_watch.py (dispatch scenarios)
+
+## Stage: docs
+
+- [x] docs/integration-contracts.md: §6 footnote on direct dispatch contract
+
+## Stage: PR
+
+- [x] git push feat/REQ-447
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
@@ -21,11 +21,13 @@ from __future__ import annotations
 
 import re
 
+import httpx
 import structlog
 
 from .. import k8s_runner, links, pr_links
 from ..bkd import BKDClient
 from ..checkers import pr_ci_watch as checker
+from ..checkers.pr_ci_watch import _get_pr_info
 from ..config import settings
 from ..prompts import render
 from ..state import Event
@@ -112,6 +114,57 @@ async def _discover_repos_from_runner(req_id: str) -> list[str]:
     return repos
 
 
+async def _dispatch_to_ci_repo(*, req_id: str, branch: str, repos: list[str]) -> None:
+    """Best-effort POST repository_dispatch to ci_dispatch_repo for each source repo.
+
+    Skips silently when ci_dispatch_enabled=False or ci_dispatch_repo is empty.
+    HTTP errors and missing PRs are logged as warnings; never raises.
+    """
+    if not settings.ci_dispatch_enabled or not settings.ci_dispatch_repo:
+        return
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if settings.github_token:
+        headers["Authorization"] = f"Bearer {settings.github_token}"
+
+    async with httpx.AsyncClient(
+        base_url="https://api.github.com", headers=headers, timeout=15.0
+    ) as client:
+        for repo in repos:
+            try:
+                pr_number, sha, _ = await _get_pr_info(client, repo, branch)
+            except (httpx.HTTPError, ValueError) as e:
+                log.warning("create_pr_ci_watch.dispatch_pr_lookup_skipped",
+                            req_id=req_id, repo=repo, error=str(e))
+                continue
+
+            payload = {
+                "event_type": settings.ci_dispatch_event_type,
+                "client_payload": {
+                    "req_id": req_id,
+                    "source_repo": repo,
+                    "branch": branch,
+                    "sha": sha,
+                    "pr_number": pr_number,
+                },
+            }
+            try:
+                r = await client.post(
+                    f"/repos/{settings.ci_dispatch_repo}/dispatches", json=payload
+                )
+                r.raise_for_status()
+                log.info("create_pr_ci_watch.dispatch_sent",
+                         req_id=req_id, repo=repo, ci_repo=settings.ci_dispatch_repo,
+                         pr=pr_number, sha=sha[:8])
+            except httpx.HTTPError as e:
+                log.warning("create_pr_ci_watch.dispatch_failed",
+                            req_id=req_id, repo=repo, ci_repo=settings.ci_dispatch_repo,
+                            error=str(e))
+
+
 async def _run_checker(*, req_id: str, ctx: dict) -> dict:
     log.info("create_pr_ci_watch.checker_path", req_id=req_id)
     branch = ctx.get("branch") or f"feat/{req_id}"
@@ -122,6 +175,8 @@ async def _run_checker(*, req_id: str, ctx: dict) -> dict:
     if not repos:
         finalized = ctx.get("intake_finalized_intent") or {}
         repos = finalized.get("involved_repos") or ctx.get("involved_repos")
+
+    await _dispatch_to_ci_repo(req_id=req_id, branch=branch, repos=repos or [])
 
     try:
         result = await checker.watch_pr_ci(

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -140,6 +140,15 @@ class Settings(BaseSettings):
     pr_ci_watch_poll_interval_sec: int = 30
     pr_ci_watch_timeout_sec: int = 1800   # 30 min
 
+    # ─── ttpos-ci-direct-dispatch（REQ-447）──────────────────────────────
+    # True = checker 路径进入轮询前主动 POST repository_dispatch 给 ci_dispatch_repo
+    # False（默认）= 不主动 dispatch，依赖 PR webhook 被动触发 GHA
+    ci_dispatch_enabled: bool = False
+    # dispatch 目标仓，如 "phona/ttpos-ci"；空 = 关闭（即使 ci_dispatch_enabled=True）
+    ci_dispatch_repo: str = ""
+    # repository_dispatch event_type；ttpos-ci workflow 监听这个事件名
+    ci_dispatch_event_type: str = "pr-ci-run"
+
     # ─── runner ready 重试 ─────────────────────────────────────────────
     # ensure_runner 等 Pod Ready 的外层 attempts：N × runner_ready_timeout_sec
     # 总等待；最后一次抛 TimeoutError 让 engine 走 escalate。

--- a/orchestrator/tests/test_actions_create_pr_ci_watch.py
+++ b/orchestrator/tests/test_actions_create_pr_ci_watch.py
@@ -1,12 +1,14 @@
-"""actions/create_pr_ci_watch.py：runner discovery 单测。
+"""actions/create_pr_ci_watch.py：runner discovery + direct dispatch 单测。
 
-不测 watch_pr_ci 主体（在 test_checkers_pr_ci_watch.py），只测 _discover_repos_from_runner
-对 runner stdout 的解析 + 失败兜底。
+不测 watch_pr_ci 主体（在 test_checkers_pr_ci_watch.py），只测：
+- _discover_repos_from_runner 对 runner stdout 的解析 + 失败兜底
+- _dispatch_to_ci_repo 的 flag / skip / payload / error 行为（SIS-447-S1～S5）
 """
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -80,3 +82,118 @@ async def test_discover_repos_empty_stdout(monkeypatch):
 
     repos = await action._discover_repos_from_runner("REQ-x")
     assert repos == []
+
+
+# ── _dispatch_to_ci_repo ──────────────────────────────────────────────────
+
+def _patch_settings(monkeypatch, *, enabled: bool, repo: str, event_type: str = "pr-ci-run"):
+    fake = MagicMock()
+    fake.ci_dispatch_enabled = enabled
+    fake.ci_dispatch_repo = repo
+    fake.ci_dispatch_event_type = event_type
+    fake.github_token = "ghp_test"
+    monkeypatch.setattr("orchestrator.actions.create_pr_ci_watch.settings", fake)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skipped_when_disabled(monkeypatch):
+    """SIS-447-S1: ci_dispatch_enabled=False → _get_pr_info never called, no HTTP."""
+    _patch_settings(monkeypatch, enabled=False, repo="phona/ttpos-ci")
+    fake_pr_info = AsyncMock()
+    monkeypatch.setattr("orchestrator.actions.create_pr_ci_watch._get_pr_info", fake_pr_info)
+
+    await action._dispatch_to_ci_repo(
+        req_id="REQ-447", branch="feat/REQ-447", repos=["phona/repo-a"]
+    )
+    fake_pr_info.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skipped_when_repo_empty(monkeypatch):
+    """SIS-447-S2: ci_dispatch_repo="" → _get_pr_info never called even if enabled."""
+    _patch_settings(monkeypatch, enabled=True, repo="")
+    fake_pr_info = AsyncMock()
+    monkeypatch.setattr("orchestrator.actions.create_pr_ci_watch._get_pr_info", fake_pr_info)
+
+    await action._dispatch_to_ci_repo(
+        req_id="REQ-447", branch="feat/REQ-447", repos=["phona/repo-a"]
+    )
+    fake_pr_info.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sends_one_per_repo(httpx_mock, monkeypatch):
+    """SIS-447-S3: two source repos → two dispatches with correct payload fields."""
+    _patch_settings(monkeypatch, enabled=True, repo="phona/ttpos-ci")
+
+    fake_pr_info = AsyncMock(side_effect=[
+        (11, "aaa111", "open"),
+        (22, "bbb222", "open"),
+    ])
+    monkeypatch.setattr("orchestrator.actions.create_pr_ci_watch._get_pr_info", fake_pr_info)
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ttpos-ci/dispatches",
+        status_code=204,
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ttpos-ci/dispatches",
+        status_code=204,
+    )
+
+    await action._dispatch_to_ci_repo(
+        req_id="REQ-447",
+        branch="feat/REQ-447",
+        repos=["phona/repo-a", "phona/repo-b"],
+    )
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+
+    body0 = json.loads(requests[0].content)
+    assert body0["event_type"] == "pr-ci-run"
+    assert body0["client_payload"]["source_repo"] == "phona/repo-a"
+    assert body0["client_payload"]["sha"] == "aaa111"
+    assert body0["client_payload"]["pr_number"] == 11
+    assert body0["client_payload"]["req_id"] == "REQ-447"
+
+    body1 = json.loads(requests[1].content)
+    assert body1["client_payload"]["source_repo"] == "phona/repo-b"
+    assert body1["client_payload"]["pr_number"] == 22
+
+
+@pytest.mark.asyncio
+async def test_dispatch_http_error_does_not_raise(httpx_mock, monkeypatch):
+    """SIS-447-S4: HTTP 422 from dispatch endpoint → warning logged, no exception."""
+    _patch_settings(monkeypatch, enabled=True, repo="phona/ttpos-ci")
+
+    fake_pr_info = AsyncMock(return_value=(99, "ccc333", "open"))
+    monkeypatch.setattr("orchestrator.actions.create_pr_ci_watch._get_pr_info", fake_pr_info)
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ttpos-ci/dispatches",
+        status_code=422,
+        json={"message": "Unprocessable Entity"},
+    )
+
+    # Must not raise
+    await action._dispatch_to_ci_repo(
+        req_id="REQ-447", branch="feat/REQ-447", repos=["phona/repo-a"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_repo_with_no_pr(monkeypatch):
+    """SIS-447-S5: PR not found → skip dispatch for that repo, no HTTP, no exception."""
+    _patch_settings(monkeypatch, enabled=True, repo="phona/ttpos-ci")
+
+    fake_pr_info = AsyncMock(
+        side_effect=ValueError("No PR found for branch feat/REQ-447 in phona/repo-a")
+    )
+    monkeypatch.setattr("orchestrator.actions.create_pr_ci_watch._get_pr_info", fake_pr_info)
+
+    # _get_pr_info raises ValueError → dispatch loop skips this repo
+    # httpx_mock not needed (no HTTP call expected)
+    await action._dispatch_to_ci_repo(
+        req_id="REQ-447", branch="feat/REQ-447", repos=["phona/repo-a"]
+    )


### PR DESCRIPTION
## Motivation

`pr-ci-watch` currently relies on GitHub Actions being passively triggered by the
`pull_request` webhook in business repos. When that trigger is missed (webhook delivery
failure, branch not in workflow trigger list, or `phona/ttpos-ci` expecting an explicit
dispatch), sisyphus waits up to 1800 s before timing out with `no-gha` or `timeout`.

## Changes

Add a feature-flagged "direct dispatch" step in `_run_checker`: before entering the
check-run polling loop, sisyphus can now proactively POST a `repository_dispatch` event
to a configurable central CI repo.

### New config fields (all default-off)

| Env var | Default | Description |
|---|---|---|
| `SISYPHUS_CI_DISPATCH_ENABLED` | `false` | Enable direct dispatch |
| `SISYPHUS_CI_DISPATCH_REPO` | `""` | Target repo, e.g. `phona/ttpos-ci` |
| `SISYPHUS_CI_DISPATCH_EVENT_TYPE` | `"pr-ci-run"` | `repository_dispatch` event_type |

### Dispatch payload (one per source repo)

```json
{
  "event_type": "pr-ci-run",
  "client_payload": {
    "req_id": "REQ-447",
    "source_repo": "phona/ttpos-server-go",
    "branch": "feat/REQ-447",
    "sha": "<head SHA>",
    "pr_number": 123
  }
}
```

### Semantics

- **Best-effort**: HTTP errors and missing PRs are logged as warnings; polling always proceeds
- **Feature flag default=False**: safe opt-in rollout; existing deployments unaffected
- **Token**: reuses existing `SISYPHUS_GITHUB_TOKEN`; operator must grant write access on `ci_dispatch_repo`

## Test plan

- [x] 5 new unit tests in `test_actions_create_pr_ci_watch.py` (9 total, all pass)
  - SIS-447-S1: dispatch skipped when `ci_dispatch_enabled=False`
  - SIS-447-S2: dispatch skipped when `ci_dispatch_repo=""`
  - SIS-447-S3: two repos → two dispatches with correct payload fields
  - SIS-447-S4: HTTP 422 does not raise, does not block polling
  - SIS-447-S5: missing PR → skip that repo, no exception
- [x] `ruff check` passes on all changed files
- [x] Full unit-test suite: 586 passed (pre-existing `test_MFCT_S6` failure unrelated to this change — thanatos module import error)

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-447`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/fld9vdxg)