### PR TITLE
ci: add orchestrator-image build-and-push workflow

### DIFF
--- a/.github/workflows/orchestrator-image.yml
+++ b/.github/workflows/orchestrator-image.yml
@@ -1,0 +1,48 @@
+name: orchestrator-image
+
+on:
+  push:
+    branches: [main]
+    tags: ['orchestrator-v*']
+    paths:
+      - 'orchestrator/**'
+      - '.github/workflows/orchestrator-image.yml'
+
+env:
+  REGISTRY: ghcr
+  IMAGE_NAME: ${{ github.repository_owner }}/sisyphus-orchestrator
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract short SHA
+        id: vars
+        run: echo "sha_short=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./orchestrator
+          file: ./orchestrator/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ steps.vars.outputs.sha_short }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Auto-build orchestrator Docker image on push to main and push to GHCR with sha-<short> tag.

Uses `GITHUB_TOKEN` (no extra secrets needed).

**Triggered by:**
- push to main affecting `orchestrator/**` or this workflow
- tags matching `orchestrator-v*`

**Images pushed:**
- `ghcr.io/phona/sisyphus-orchestrator:sha-<short>`
- `ghcr.io/phona/sisyphus-orchestrator:latest`

**Why:** Previously orchestrator image was built manually/local-only. This automates the build so every merge to main produces a fresh image for `helm upgrade`.