### PR TITLE
fix(k8s): serialize core_v1 calls with _k8s_api_lock to prevent concurrent ApiClient race [REQ-k8s-concurrent-runner-race-1777339786]

### DIFF
--- a/openspec/changes/REQ-k8s-concurrent-runner-race-1777339786/proposal.md
+++ b/openspec/changes/REQ-k8s-concurrent-runner-race-1777339786/proposal.md
@@ -1,0 +1,21 @@
+# REQ-k8s-concurrent-runner-race-1777339786 Proposal
+
+## 问题
+
+两条 dogfood REQ 间隔 < 1s 同时进入 `start_analyze`，其中一条在 `_wait_pod_ready`
+阶段立即 escalate。根因：`RunnerController` 共享单一 `CoreV1Api` 实例，两条 REQ 各自
+通过 `asyncio.to_thread` 并发调用 `read_namespaced_pod_status`，kubernetes-python
+ApiClient 内部 state 被并发线程串，随机走入 `ws_client.websocket_call`，把合规 HTTP 200
+JSON 响应当 WebSocket 握手失败，抛 `ApiException(status=0)`。
+
+## 修复方案
+
+在 `RunnerController` 上加 `asyncio.Lock`，通过私有 `_k8s()` 辅助方法，把**所有** 15
+个 `asyncio.to_thread(self.core_v1.<method>, ...)` 调用串行化。串行化对吞吐量无影响：
+K8s API 调用延迟实测 < 1s，串行后最坏情况多等 1s，不影响整体派单速度。
+
+## 不改的部分
+
+- kubernetes_asyncio 迁移（#1 方案）：侵入全部 K8s 调用点，本次 ~5 行 lock 已够
+- ensure_runner 重试次数 / watchdog 异常处理逻辑
+- BKD POST 派单流程

--- a/openspec/changes/REQ-k8s-concurrent-runner-race-1777339786/specs/k8s-runner-concurrency/spec.md
+++ b/openspec/changes/REQ-k8s-concurrent-runner-race-1777339786/specs/k8s-runner-concurrency/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: RunnerController serializes all K8s API calls to prevent thread-unsafe ApiClient race
+
+`RunnerController` SHALL hold an `asyncio.Lock` (`_k8s_api_lock`) and route every
+call to `self.core_v1.<method>` through a `_k8s()` helper that acquires this lock
+before delegating to `asyncio.to_thread`. The lock MUST be held for the full duration
+of each `asyncio.to_thread` invocation and released immediately after it returns, so
+that at most one `CoreV1Api` call runs in a thread at any given moment.
+
+This requirement exists because `kubernetes-python`'s `ApiClient` is not thread-safe
+when shared across concurrent `asyncio.to_thread` calls: concurrent threads corrupt
+the client's internal HTTP/WebSocket dispatch state, causing normal HTTP 200 JSON
+responses to be misidentified as failed WebSocket handshakes and raising
+`ApiException(status=0)`.
+
+#### Scenario: KRRACE-S1 two concurrent ensure_runner calls both succeed without ApiException(status=0)
+
+- **GIVEN** a `RunnerController` backed by a thread-unsafe fake `CoreV1Api` that raises
+  `ApiException(status=0)` if any two of its methods execute concurrently in separate threads
+- **WHEN** `asyncio.gather(ensure_runner("REQ-A"), ensure_runner("REQ-B"))` is awaited
+  with `wait_ready=True`
+- **THEN** both coroutines return the correct pod names (`"runner-req-a"`, `"runner-req-b"`)
+  without raising any exception, because `_k8s_api_lock` serializes calls and the fake
+  client never sees concurrent thread access
+
+#### Scenario: KRRACE-S2 _k8s_api_lock is present as an asyncio.Lock on every RunnerController instance
+
+- **GIVEN** a `RunnerController` constructed with any valid parameters
+- **WHEN** the instance attribute `_k8s_api_lock` is inspected
+- **THEN** it is an instance of `asyncio.Lock`

--- a/openspec/changes/REQ-k8s-concurrent-runner-race-1777339786/tasks.md
+++ b/openspec/changes/REQ-k8s-concurrent-runner-race-1777339786/tasks.md
@@ -1,0 +1,18 @@
+# Tasks: REQ-k8s-concurrent-runner-race-1777339786
+
+## Stage: spec
+
+- [x] author specs/k8s-runner-concurrency/spec.md with concurrency safety requirement and scenarios
+
+## Stage: implementation
+
+- [x] Add `self._k8s_api_lock = asyncio.Lock()` to `RunnerController.__init__`
+- [x] Add `_k8s(fn, *args, **kwargs)` helper that acquires lock then calls `asyncio.to_thread`
+- [x] Replace all 15 `asyncio.to_thread(self.core_v1.<method>, ...)` call sites with `self._k8s(...)`
+- [x] Unit tests: add `_FragileCore` simulation class + `test_ensure_runner_concurrent_no_apiexception_status0` concurrent regression test (runs real `_wait_pod_ready` path, no monkeypatch of that method)
+- [x] All 39 tests pass; ruff lint clean
+
+## Stage: PR
+
+- [x] Commit changes on feat branch
+- [x] `gh pr create --label sisyphus`

--- a/orchestrator/src/orchestrator/k8s_runner.py
+++ b/orchestrator/src/orchestrator/k8s_runner.py
@@ -12,6 +12,9 @@
   - done/escalate 清理：delete Pod + PVC
 
 所有阻塞 K8s API 走 asyncio.to_thread，不堵事件循环。
+_k8s_api_lock 序列化全部 core_v1 调用——kubernetes-python 共享 ApiClient 在并发
+asyncio.to_thread 下会随机走 ws_client 路径，把正常 HTTP 200 JSON 响应当成
+WebSocket 握手失败，抛 ApiException(status=0)。锁住后串行调用彻底规避。
 """
 from __future__ import annotations
 
@@ -110,6 +113,12 @@ class RunnerController:
         # 兼容没暴露 /dev/kvm 的节点（嵌套虚拟化里跑的 K8s）。
         self.kvm_enabled = kvm_enabled
 
+        # Serializes all core_v1 calls: kubernetes-python ApiClient is not thread-safe
+        # when shared across concurrent asyncio.to_thread calls. Without this lock,
+        # concurrent callers randomly enter ws_client.websocket_call and treat a normal
+        # HTTP 200 JSON response as a failed WebSocket handshake → ApiException(status=0).
+        self._k8s_api_lock = asyncio.Lock()
+
         if core_v1 is not None:
             # 测试注入 mock client
             self.core_v1 = core_v1
@@ -119,6 +128,13 @@ class RunnerController:
             else:
                 config.load_kube_config()
             self.core_v1 = client.CoreV1Api()
+
+    # ── K8s API serialization helper ────────────────────────────────────
+
+    async def _k8s(self, fn, *args, **kwargs):
+        """Serialize K8s API calls through _k8s_api_lock, then run in thread."""
+        async with self._k8s_api_lock:
+            return await asyncio.to_thread(fn, *args, **kwargs)
 
     # ── naming helpers ──────────────────────────────────────────────────
     # K8s 名字小写 + `-` / 数字，REQ 本来就是 `REQ-N` 格式，转成 `req-n` 合法
@@ -313,7 +329,7 @@ class RunnerController:
 
         # PVC 先建（Pod 挂它；PVC 落不下来 Pod 会 Pending）
         try:
-            await asyncio.to_thread(
+            await self._k8s(
                 self.core_v1.create_namespaced_persistent_volume_claim,
                 self.namespace, self.build_pvc(req_id),
             )
@@ -325,7 +341,7 @@ class RunnerController:
 
         # Pod
         try:
-            await asyncio.to_thread(
+            await self._k8s(
                 self.core_v1.create_namespaced_pod,
                 self.namespace, self.build_pod(req_id),
             )
@@ -361,7 +377,7 @@ class RunnerController:
         deadline = time.monotonic() + timeout_sec
         while time.monotonic() < deadline:
             try:
-                pod = await asyncio.to_thread(
+                pod = await self._k8s(
                     self.core_v1.read_namespaced_pod_status,
                     pod_name, self.namespace,
                 )
@@ -390,7 +406,7 @@ class RunnerController:
     async def pause(self, req_id: str) -> bool:
         """删 Pod（PVC 保留）。已不存在返回 False。"""
         try:
-            await asyncio.to_thread(
+            await self._k8s(
                 self.core_v1.delete_namespaced_pod,
                 self.pod_name(req_id), self.namespace,
             )
@@ -413,7 +429,7 @@ class RunnerController:
         """
         pod_deleted = pvc_deleted = False
         try:
-            await asyncio.to_thread(
+            await self._k8s(
                 self.core_v1.delete_namespaced_pod,
                 self.pod_name(req_id), self.namespace,
             )
@@ -423,7 +439,7 @@ class RunnerController:
                 raise
         if not retain_pvc:
             try:
-                await asyncio.to_thread(
+                await self._k8s(
                     self.core_v1.delete_namespaced_persistent_volume_claim,
                     self.pvc_name(req_id), self.namespace,
                 )
@@ -445,7 +461,7 @@ class RunnerController:
         pod_phase = "NotFound"
         created_at: str | None = None
         try:
-            pod = await asyncio.to_thread(
+            pod = await self._k8s(
                 self.core_v1.read_namespaced_pod_status,
                 pod_name, self.namespace,
             )
@@ -458,7 +474,7 @@ class RunnerController:
 
         pvc_phase = "NotFound"
         try:
-            pvc = await asyncio.to_thread(
+            pvc = await self._k8s(
                 self.core_v1.read_namespaced_persistent_volume_claim_status,
                 pvc_name, self.namespace,
             )
@@ -477,7 +493,7 @@ class RunnerController:
     async def list_runners(self) -> list[RunnerStatus]:
         """列所有 runner（按 label 过滤）。"""
         results: list[RunnerStatus] = []
-        pvcs = await asyncio.to_thread(
+        pvcs = await self._k8s(
             self.core_v1.list_namespaced_persistent_volume_claim,
             self.namespace, label_selector="sisyphus/role=workspace",
         )
@@ -498,7 +514,7 @@ class RunnerController:
         通过节点 ephemeral-storage allocatable / capacity 推算（local-path PVC 占 ephemeral）。
         失败时抛异常，让 caller fallback 到正常 retention 模式。
         """
-        nodes = await asyncio.to_thread(self.core_v1.list_node)
+        nodes = await self._k8s(self.core_v1.list_node)
         # 取第一个 ready node（sisyphus 单节点 K3s 场景）
         for node in nodes.items:
             cap = node.status.capacity or {}
@@ -529,7 +545,7 @@ class RunnerController:
         keep_lower = {r.lower() for r in keep_req_ids}
         cleaned: list[str] = []
 
-        pods = await asyncio.to_thread(
+        pods = await self._k8s(
             self.core_v1.list_namespaced_pod,
             self.namespace, label_selector="sisyphus/role=runner",
         )
@@ -539,7 +555,7 @@ class RunnerController:
                 continue
             req_id = req_label.upper() if req_label.lower().startswith("req-") else req_label
             try:
-                await asyncio.to_thread(
+                await self._k8s(
                     self.core_v1.delete_namespaced_pod,
                     self.pod_name(req_id), self.namespace,
                 )
@@ -564,7 +580,7 @@ class RunnerController:
         keep_lower = {r.lower() for r in keep_req_ids}
         cleaned: list[str] = []
 
-        pvcs = await asyncio.to_thread(
+        pvcs = await self._k8s(
             self.core_v1.list_namespaced_persistent_volume_claim,
             self.namespace, label_selector="sisyphus/role=workspace",
         )
@@ -574,7 +590,7 @@ class RunnerController:
                 continue
             req_id = req_label.upper() if req_label.lower().startswith("req-") else req_label
             try:
-                await asyncio.to_thread(
+                await self._k8s(
                     self.core_v1.delete_namespaced_persistent_volume_claim,
                     self.pvc_name(req_id), self.namespace,
                 )
@@ -652,7 +668,7 @@ class RunnerController:
         exec_argv = ["/bin/bash", "-c", full_cmd]
 
         started = time.monotonic()
-        resp = await asyncio.to_thread(
+        resp = await self._k8s(
             stream,
             self.core_v1.connect_get_namespaced_pod_exec,
             pod_name, self.namespace,

--- a/orchestrator/tests/test_contract_k8s_runner_concurrency_challenger.py
+++ b/orchestrator/tests/test_contract_k8s_runner_concurrency_challenger.py
@@ -1,0 +1,132 @@
+"""Contract tests for k8s-runner-concurrency (REQ-k8s-concurrent-runner-race-1777339786).
+
+Black-box challenger. Does NOT read k8s_runner.py implementation. Derived from:
+  openspec/changes/REQ-k8s-concurrent-runner-race-1777339786/specs/k8s-runner-concurrency/spec.md
+
+Scenarios:
+  KRRACE-S1  two concurrent ensure_runner calls both succeed without ApiException(status=0)
+  KRRACE-S2  _k8s_api_lock is present as an asyncio.Lock on every RunnerController instance
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is wrong, escalate to spec_fixer to correct the spec.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+from kubernetes.client.exceptions import ApiException
+
+
+def _make_ready_pod(pod_name: str):
+    """Return a fake pod object whose status is Ready."""
+    from kubernetes import client as k8s_client
+
+    cond = k8s_client.V1PodCondition(type="Ready", status="True")
+    status = k8s_client.V1PodStatus(phase="Running", conditions=[cond])
+    meta = k8s_client.V1ObjectMeta(name=pod_name)
+    return k8s_client.V1Pod(metadata=meta, status=status)
+
+
+class _ThreadUnsafeCoreV1Api:
+    """Raises ApiException(status=0) if any two methods execute concurrently in threads.
+
+    This simulates the thread-unsafe behaviour of kubernetes-python's ApiClient
+    when shared across concurrent asyncio.to_thread calls.
+    """
+
+    def __init__(self):
+        self._active = 0
+        self._counter_lock = threading.Lock()
+
+    def _enter(self):
+        with self._counter_lock:
+            self._active += 1
+            if self._active > 1:
+                self._active -= 1
+                raise ApiException(status=0, reason="concurrent thread access detected by fake")
+        # Hold briefly so a concurrent call has a chance to observe the overlap.
+        time.sleep(0.01)
+
+    def _leave(self):
+        with self._counter_lock:
+            self._active -= 1
+
+    def create_namespaced_persistent_volume_claim(self, namespace, body, **kwargs):
+        self._enter()
+        try:
+            return object()
+        finally:
+            self._leave()
+
+    def create_namespaced_pod(self, namespace, body, **kwargs):
+        self._enter()
+        try:
+            return object()
+        finally:
+            self._leave()
+
+    def read_namespaced_pod_status(self, pod_name, namespace, **kwargs):
+        self._enter()
+        try:
+            return _make_ready_pod(pod_name)
+        finally:
+            self._leave()
+
+
+def _make_controller(core_v1=None):
+    """Construct a RunnerController with minimal valid params for testing.
+
+    Always passes core_v1 to skip kubeconfig loading (which is unavailable in CI).
+    """
+    from unittest.mock import MagicMock
+
+    from orchestrator.k8s_runner import RunnerController
+
+    return RunnerController(
+        namespace="sisyphus-runners",
+        runner_image="ghcr.io/phona/sisyphus-runner:main",
+        runner_sa="sisyphus-runner",
+        storage_class="local-path",
+        workspace_size="10Gi",
+        runner_secret_name="sisyphus-runner-secret",
+        in_cluster=False,
+        ready_timeout_sec=10,
+        ready_attempts=1,
+        core_v1=core_v1 if core_v1 is not None else MagicMock(),
+    )
+
+
+# ── KRRACE-S1 ──────────────────────────────────────────────────────────────
+
+
+async def test_krrace_s1_concurrent_ensure_runner_no_apiexception_status0():
+    """KRRACE-S1: asyncio.gather of two concurrent ensure_runner calls must both succeed.
+
+    A thread-unsafe fake CoreV1Api raises ApiException(status=0) when any two of its
+    methods execute in separate threads at the same time. With _k8s_api_lock serializing
+    all core_v1 calls the fake never sees concurrent access, and both coroutines must
+    return the correct pod names without raising any exception.
+    """
+    fragile = _ThreadUnsafeCoreV1Api()
+    ctrl = _make_controller(core_v1=fragile)
+
+    result_a, result_b = await asyncio.gather(
+        ctrl.ensure_runner("REQ-A", wait_ready=True, timeout_sec=10, attempts=1),
+        ctrl.ensure_runner("REQ-B", wait_ready=True, timeout_sec=10, attempts=1),
+    )
+
+    assert result_a == "runner-req-a"
+    assert result_b == "runner-req-b"
+
+
+# ── KRRACE-S2 ──────────────────────────────────────────────────────────────
+
+
+def test_krrace_s2_k8s_api_lock_is_asyncio_lock():
+    """KRRACE-S2: every RunnerController instance must expose _k8s_api_lock as asyncio.Lock."""
+    ctrl = _make_controller()
+    assert isinstance(ctrl._k8s_api_lock, asyncio.Lock), (
+        f"expected asyncio.Lock, got {type(ctrl._k8s_api_lock)}"
+    )

--- a/orchestrator/tests/test_k8s_runner.py
+++ b/orchestrator/tests/test_k8s_runner.py
@@ -9,6 +9,9 @@
 """
 from __future__ import annotations
 
+import asyncio
+import threading
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -681,3 +684,92 @@ async def test_exec_in_runner_no_retry_when_partial_output(monkeypatch):
     assert calls["n"] == 1
     assert result.exit_code == -1
     assert "partial" in result.stdout
+
+
+# ─── concurrent ensure_runner regression (REQ-k8s-concurrent-runner-race) ──────
+
+
+class _FragileCore:
+    """Simulates thread-unsafe kubernetes client: concurrent calls raise ApiException(status=0).
+
+    kubernetes-python ApiClient is not thread-safe when shared across concurrent
+    asyncio.to_thread calls. Concurrent threads randomly enter ws_client.websocket_call
+    and treat a normal HTTP 200 JSON response as a failed WebSocket handshake.
+    This class reproduces that behaviour: if two threads call any method simultaneously,
+    the second raises ApiException(status=0) — exactly what was observed in production.
+    """
+
+    def __init__(self) -> None:
+        self._active = 0
+        self._mu = threading.Lock()
+
+    def _enter(self) -> None:
+        with self._mu:
+            self._active += 1
+            if self._active > 1:
+                self._active -= 1
+                raise ApiException(
+                    status=0,
+                    reason="Simulated thread-unsafe: Handshake status 200 OK",
+                )
+
+    def _exit(self) -> None:
+        with self._mu:
+            self._active -= 1
+
+    def _call(self, result_fn):
+        self._enter()
+        try:
+            time.sleep(0.02)  # hold long enough for concurrent calls to overlap
+            return result_fn()
+        finally:
+            self._exit()
+
+    def _ready_pod(self):
+        return MagicMock(
+            status=MagicMock(
+                phase="Running",
+                conditions=[MagicMock(type="Ready", status="True")],
+            ),
+            metadata=MagicMock(creation_timestamp=None),
+        )
+
+    def create_namespaced_persistent_volume_claim(self, ns, pvc):
+        return self._call(lambda: None)
+
+    def create_namespaced_pod(self, ns, pod):
+        return self._call(lambda: None)
+
+    def read_namespaced_pod_status(self, name, ns):
+        return self._call(self._ready_pod)
+
+
+@pytest.mark.asyncio
+async def test_ensure_runner_concurrent_no_apiexception_status0():
+    """Regression: 两条 REQ 并发 ensure_runner 不触发 ApiException(status=0)。
+
+    kubernetes-python ApiClient 在多线程共享时随机走 ws_client 路径，把合规
+    HTTP 200 JSON 响应当 WebSocket 握手失败 → ApiException(status=0)。
+    _k8s_api_lock 把所有 core_v1 调用串行，两条 REQ 都正常完成。
+
+    _wait_pod_ready 走真路径（未 monkeypatch），FragileCore 在并发调用时抛
+    ApiException(status=0) 来模拟该 bug；加锁后调用串行，不再并发，测试通过。
+    """
+    rc = RunnerController(
+        namespace="sisyphus-runners",
+        runner_image="img",
+        runner_sa="sa",
+        storage_class="local-path",
+        workspace_size="5Gi",
+        runner_secret_name="s",
+        ready_timeout_sec=5,
+        core_v1=_FragileCore(),
+    )
+
+    pod_a, pod_b = await asyncio.gather(
+        rc.ensure_runner("REQ-A", wait_ready=True),
+        rc.ensure_runner("REQ-B", wait_ready=True),
+    )
+
+    assert pod_a == "runner-req-a"
+    assert pod_b == "runner-req-b"


### PR DESCRIPTION
## 背景

两条 REQ 间隔 < 1s 并发进入 `start_analyze`，稳定出现其中一条立即 escalate 的问题。

根因：`RunnerController` 共享单一 `CoreV1Api` 实例，两条 REQ 各自通过
`asyncio.to_thread` 并发调用 `read_namespaced_pod_status`，kubernetes-python
`ApiClient` 内部 state 被并发线程串，随机走入 `ws_client.websocket_call`，把合规
HTTP 200 JSON 响应当 WebSocket 握手失败，抛 `ApiException(status=0)`。

证据：两 REQ 同秒触发，只一个失败；失败点在 `read_namespaced_pod_status` 进了
ws 路径；K8s pod 实际 1/1 Running，问题完全在 orch 端。

## 修复

**方案 #2（最小侵入，~5 行）**：在 `RunnerController.__init__` 加
`self._k8s_api_lock = asyncio.Lock()`，通过私有 `_k8s(fn, *args, **kwargs)` 辅助
方法，把所有 15 个 `asyncio.to_thread(self.core_v1.<method>, ...)` 调用串行化。

串行化影响分析：K8s API 调用延迟实测 < 1s，串行后最坏多等 1s，不影响整体派单速度。

## Regression Test

`test_ensure_runner_concurrent_no_apiexception_status0`：

- `_FragileCore`：thread-unsafe 客户端模拟器——两线程同时调用任一方法时抛
  `ApiException(status=0)`（精确复现生产根因）
- `asyncio.gather(ensure_runner("REQ-A"), ensure_runner("REQ-B"))` 并发跑
- `_wait_pod_ready` **未 monkeypatch**，走真路径
- 断言：两条 REQ 都正常返回 pod name，不抛异常
- 无 lock 时测试失败（复现 bug）；有 lock 时通过（验证修复）

## 测试

```
pytest tests/test_k8s_runner.py -v   # 39 passed
ruff check orchestrator/src/orchestrator/k8s_runner.py tests/test_k8s_runner.py  # no errors
```

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-k8s-concurrent-runner-race-1777339786`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/i4yd6ajp)