### PR TITLE
fix(ruff): fix I001 import sort and F841 unused vars in dispatch idempotency test

### DIFF
--- a/orchestrator/tests/test_contract_dispatch_idempotency_challenger.py
+++ b/orchestrator/tests/test_contract_dispatch_idempotency_challenger.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
 # ─── Minimal fake pool ────────────────────────────────────────────────────────
 
 
@@ -267,7 +266,7 @@ async def test_DISP_S2_no_slug_hit_calls_create_issue_and_stores_slug():
     )
 
     with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-        result = await invoke_verifier(
+        await invoke_verifier(
             stage="spec_lint",
             trigger="fail",
             req_id="REQ-1",
@@ -339,7 +338,7 @@ async def test_DISP_S5_round_aware_slug_distinguishes_fixer_rounds():
     ]
 
     with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-        result = await invoke_verifier(
+        await invoke_verifier(
             stage="spec_lint",
             trigger="success",
             req_id="REQ-1",


### PR DESCRIPTION
## Summary

- Fix I001: remove extra blank line between import groups so ruff isort passes
- Fix F841 (×2): drop `result =` assignment for two `await invoke_verifier(...)` calls whose return value is never used

File: `orchestrator/tests/test_contract_dispatch_idempotency_challenger.py`

These lint errors were left by PR #176 and are currently blocking PRs #184 / #183 / #179.

## Test plan

- [x] `uv run ruff check tests/test_contract_dispatch_idempotency_challenger.py` → All checks passed!
- [x] `make ci-unit-test` passes (1643 tests, no regressions)
- [ ] CI lint (BASE_REV diff-only scan) should pass on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)