### PR TITLE
fix(router): pre-set escalated_reason for session.completed → escalate paths

### DIFF
--- a/docs/task/TASK-router-session-completed-audit.md
+++ b/docs/task/TASK-router-session-completed-audit.md
@@ -1,0 +1,36 @@
+# TASK-router-session-completed-audit: fix escalated_reason="session-completed" fallback
+
+**REQ**: REQ-router-session-completed-audit
+**status**: in_progress
+**owner**: claude
+
+## Goal
+
+Fix 15 incidents where `context->>'escalated_reason' = 'session-completed'` appears in
+`req_state`, caused by `escalate.py` falling back to `body.event.replace(".", "-")` when
+`ctx.escalated_reason` is not pre-set and `body.event = "session.completed"`.
+
+## Root Cause
+
+`webhook.py` step 5.8 pre-sets `escalated_reason` only for `Event.VERIFY_ESCALATE`.
+Two other `session.completed` → escalate paths are unguarded:
+
+- `INTAKE_FAIL` (intake-agent session.completed + result:fail, or INTAKE_PASS downgrade
+  when no finalized intent JSON found)
+- `PR_CI_TIMEOUT` (pr-ci-watch session.completed with `pr-ci:timeout` tag)
+
+When escalate is called with `body.event = "session.completed"` and no `ctx.escalated_reason`,
+`escalate.py` priority-4 fallback yields `"session-completed"` — ambiguous and unhelpful.
+
+`router.derive_event` is already correct: stage tag without result → None → skipped silently.
+No router.py change needed.
+
+## Scope
+
+1. `orchestrator/src/orchestrator/webhook.py` — extend step 5.8 from VERIFY_ESCALATE-only
+   to a table covering VERIFY_ESCALATE + INTAKE_FAIL + PR_CI_TIMEOUT.
+2. `orchestrator/tests/test_router.py` — add 4 missing coverage cases:
+   - challenger without result → None
+   - fixer without result → FIXER_DONE
+   - no stage tag in session.completed → None
+   - known stage tag + result:weird → None

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -8,6 +8,7 @@ Last updated: 2026-04-27
 |---|---|---|---|---|
 | [-] | [TASK-001-verifier-infra-flake-auto-retry](TASK-001-verifier-infra-flake-auto-retry.md) | in_progress | claude | REQ-428 |
 | [-] | [TASK-001-ttpos-ci-direct-dispatch](TASK-001.md) | in_progress | claude | REQ-447 |
+| [-] | [TASK-router-session-completed-audit](TASK-router-session-completed-audit.md) | in_progress | claude | REQ-router-session-completed-audit |
 
 ## Completed
 

--- a/openspec/changes/REQ-router-session-completed-audit-1777344435/proposal.md
+++ b/openspec/changes/REQ-router-session-completed-audit-1777344435/proposal.md
@@ -1,0 +1,42 @@
+# REQ-router-session-completed-audit-1777344435: fix escalated_reason="session-completed"
+
+## Problem
+
+15 REQs in the last 7 days were escalated with `context->>'escalated_reason' = 'session-completed'`.
+This value is meaningless for triage: it only tells you the trigger event type, not _why_ the
+escalation happened.
+
+Root cause: `escalate.py` resolves its `reason` string via a 4-level priority chain. When called
+with `body.event = "session.completed"` and no `ctx.escalated_reason` pre-set, the priority-4
+fallback produces `"session-completed"` from `body.event.replace(".", "-")`.
+
+`webhook.py` step 5.8 pre-set `escalated_reason` only for `VERIFY_ESCALATE`. Two other
+session.completed → escalate paths were unguarded:
+
+- `INTAKE_FAIL` (intake-agent session + result:fail, or INTAKE_PASS downgraded when no
+  finalized intent JSON found in assistant messages)
+- `PR_CI_TIMEOUT` (pr-ci-watch session completed with pr-ci:timeout tag)
+
+Secondary audit found `router.derive_event` for `session.completed` is already correct:
+known stage tags without a result tag all return `None` (silently skipped). No router change
+needed for the "stage tag without result" path.
+
+## Proposal
+
+Extend webhook.py step 5.8 from a single VERIFY_ESCALATE guard to a table-driven lookup
+covering all three session.completed → escalate routes:
+
+| Event            | escalated_reason     |
+|------------------|----------------------|
+| VERIFY_ESCALATE  | "verifier-decision"  |
+| INTAKE_FAIL      | "intake-fail"        |
+| PR_CI_TIMEOUT    | "pr-ci-timeout"      |
+
+Add 5 missing `derive_event` test cases to confirm the "no result tag" paths return `None`
+rather than SESSION_FAILED.
+
+## Impact
+
+- Metabase Q* queries filtering `reason = 'session-completed'` will now see the correct value.
+- Historically escalated REQs keep their stored `session-completed` reason (no backfill).
+- No state machine change; no new escalation paths introduced.

--- a/openspec/changes/REQ-router-session-completed-audit-1777344435/specs/router-session-completed-audit/spec.md
+++ b/openspec/changes/REQ-router-session-completed-audit-1777344435/specs/router-session-completed-audit/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: webhook pre-sets escalated_reason for all session.completed escalate paths
+
+The system SHALL pre-set `ctx.escalated_reason` before invoking the escalate action for
+every `session.completed` event that routes to the escalate action. The pre-set reason MUST
+be more specific than the generic fallback `"session-completed"`. Specifically, the system
+MUST map `VERIFY_ESCALATE` to `"verifier-decision"`, `INTAKE_FAIL` to `"intake-fail"`, and
+`PR_CI_TIMEOUT` to `"pr-ci-timeout"`.
+
+#### Scenario: RSCA-S1 INTAKE_FAIL from session.completed gets reason=intake-fail
+
+- **GIVEN** an intake-agent session.completed arrives with tags `["intake", "REQ-x", "result:fail"]`
+- **WHEN** derive_event returns INTAKE_FAIL and webhook step 5.8 runs
+- **THEN** ctx.escalated_reason is set to "intake-fail"
+- **AND** when escalate action fires, final_reason is "intake-fail" (not "session-completed")
+
+#### Scenario: RSCA-S2 PR_CI_TIMEOUT from session.completed gets reason=pr-ci-timeout
+
+- **GIVEN** a pr-ci-watch session.completed arrives with tags `["pr-ci", "REQ-x", "pr-ci:timeout"]`
+- **WHEN** derive_event returns PR_CI_TIMEOUT and webhook step 5.8 runs
+- **THEN** ctx.escalated_reason is set to "pr-ci-timeout"
+- **AND** when escalate action fires, final_reason is "pr-ci-timeout" (not "session-completed")
+
+#### Scenario: RSCA-S3 VERIFY_ESCALATE retains reason=verifier-decision
+
+- **GIVEN** a verifier session.completed arrives with a valid decision JSON action=escalate
+- **WHEN** derive_verifier_event returns VERIFY_ESCALATE and webhook step 5.8 runs
+- **THEN** ctx.escalated_reason remains "verifier-decision"
+
+### Requirement: derive_event returns None for session.completed without recognized result
+
+The system SHALL return `None` (silently skip) from `derive_event` when a
+`session.completed` event carries a known stage tag but no recognized result tag. This MUST
+NOT produce a `SESSION_FAILED` event. Known stage tags that require a result tag are:
+`challenger`, `staging-test`, `accept`, `pr-ci`, and `intake`. Tags that never require a
+result tag are: `fixer`, `analyze`, `done-archive`.
+
+#### Scenario: RSCA-S4 challenger without result returns None
+
+- **GIVEN** a session.completed event with tags `["challenger", "REQ-x"]`
+- **WHEN** derive_event is called
+- **THEN** result is None (not SESSION_FAILED, not CHALLENGER_FAIL)
+
+#### Scenario: RSCA-S5 session.completed with no stage tag returns None
+
+- **GIVEN** a session.completed event with tags `["REQ-x"]` (no stage tag)
+- **WHEN** derive_event is called
+- **THEN** result is None
+
+#### Scenario: RSCA-S6 session.completed with known stage and unrecognized result returns None
+
+- **GIVEN** a session.completed event with tags `["challenger", "REQ-x", "result:weird"]`
+- **WHEN** derive_event is called
+- **THEN** result is None (unknown result variant is silently skipped)
+
+#### Scenario: RSCA-S7 fixer without extra tags returns FIXER_DONE
+
+- **GIVEN** a session.completed event with tags `["fixer", "REQ-x"]` (no fixer:dev or result tag)
+- **WHEN** derive_event is called
+- **THEN** result is FIXER_DONE (fixer never requires a result tag)

--- a/openspec/changes/REQ-router-session-completed-audit-1777344435/tasks.md
+++ b/openspec/changes/REQ-router-session-completed-audit-1777344435/tasks.md
@@ -1,0 +1,20 @@
+# REQ-router-session-completed-audit-1777344435 Tasks
+
+## Stage: spec
+- [x] Write specs/router-session-completed-audit/spec.md with RSCA-S1 through RSCA-S7 scenarios
+
+## Stage: implementation
+- [x] webhook.py: replace step 5.8 single VERIFY_ESCALATE guard with table-driven
+      _SESSION_COMPLETED_ESCALATE_REASONS covering VERIFY_ESCALATE, INTAKE_FAIL, PR_CI_TIMEOUT
+
+## Stage: tests
+- [x] test_router.py: add 5 missing CASES entries:
+      - challenger without result → None
+      - fixer without extra tags → FIXER_DONE
+      - no stage tag in session.completed → None
+      - challenger + result:weird → None
+      - staging-test + result:weird → None
+
+## Stage: PR
+- [x] git push feat/REQ-router-session-completed-audit-1777344435
+- [x] gh pr create with sisyphus label

--- a/orchestrator/src/orchestrator/webhook.py
+++ b/orchestrator/src/orchestrator/webhook.py
@@ -420,12 +420,23 @@ async def webhook(request: Request) -> JSONResponse:
         await req_state.update_context(pool, req_id, patch)
         ctx = {**ctx, **patch}
 
-    # ─── 5.8 VERIFY_ESCALATE → 预置 escalated_reason ────────────────────────
-    # escalate action 从 ctx.escalated_reason 读 reason；没设则 fallback 到
-    # body.event.replace(".", "-") = "session-completed"，语义不明。
-    if event == Event.VERIFY_ESCALATE:
-        await req_state.update_context(pool, req_id, {"escalated_reason": "verifier-decision"})
-        ctx = {**ctx, "escalated_reason": "verifier-decision"}
+    # ─── 5.8 pre-set escalated_reason for session.completed → escalate paths ─────
+    # escalate action reads ctx.escalated_reason for its reason string; without it
+    # the priority-4 fallback yields body.event.replace(".", "-") = "session-completed"
+    # — ambiguous and unhelpful.  Cover all session.completed → escalate routes:
+    #   VERIFY_ESCALATE  → "verifier-decision"  (verifier explicit decision)
+    #   INTAKE_FAIL      → "intake-fail"         (intake-agent failed / no finalized intent)
+    #   PR_CI_TIMEOUT    → "pr-ci-timeout"       (pr-ci-watch timed out waiting for GHA)
+    _SESSION_COMPLETED_ESCALATE_REASONS: dict[Event, str] = {
+        Event.VERIFY_ESCALATE: "verifier-decision",
+        Event.INTAKE_FAIL:     "intake-fail",
+        Event.PR_CI_TIMEOUT:   "pr-ci-timeout",
+    }
+    if body.event == "session.completed":
+        _sc_reason = _SESSION_COMPLETED_ESCALATE_REASONS.get(event)
+        if _sc_reason is not None:
+            await req_state.update_context(pool, req_id, {"escalated_reason": _sc_reason})
+            ctx = {**ctx, "escalated_reason": _sc_reason}
 
     # ─── 5.9 stamp BKD session token onto 当前开着的 stage_run ───────────────
     # 必须放在 engine.step 之前：engine 在 transition 时会 close_latest_stage_run，

--- a/orchestrator/tests/test_contract_router_session_completed_audit_challenger.py
+++ b/orchestrator/tests/test_contract_router_session_completed_audit_challenger.py
@@ -15,8 +15,7 @@ Scenarios covered:
 from __future__ import annotations
 
 from typing import ClassVar
-from unittest.mock import AsyncMock, call
-
+from unittest.mock import AsyncMock
 
 # ─── Shared helpers ───────────────────────────────────────────────────────────
 

--- a/orchestrator/tests/test_contract_router_session_completed_audit_challenger.py
+++ b/orchestrator/tests/test_contract_router_session_completed_audit_challenger.py
@@ -1,0 +1,297 @@
+"""Contract tests for webhook session.completed escalated_reason audit.
+
+Black-box behavioral contracts derived from:
+  openspec/changes/REQ-router-session-completed-audit-1777344435/specs/router-session-completed-audit/spec.md
+
+Scenarios covered:
+  RSCA-S1  INTAKE_FAIL session.completed → ctx.escalated_reason = "intake-fail"
+  RSCA-S2  PR_CI_TIMEOUT session.completed → ctx.escalated_reason = "pr-ci-timeout"
+  RSCA-S3  VERIFY_ESCALATE → ctx.escalated_reason must NOT be overwritten to "session-completed"
+  RSCA-S4  challenger without result tag → derive_event returns None (not SESSION_FAILED)
+  RSCA-S5  session.completed with no stage tag → derive_event returns None
+  RSCA-S6  session.completed with known stage + unrecognized result → derive_event returns None
+  RSCA-S7  fixer without result tag → derive_event returns FIXER_DONE
+"""
+from __future__ import annotations
+
+from typing import ClassVar
+from unittest.mock import AsyncMock, call
+
+
+# ─── Shared helpers ───────────────────────────────────────────────────────────
+
+
+class _FakePool:
+    def __init__(self):
+        self.execute_calls: list = []
+
+    async def fetchrow(self, sql, *args):
+        return None
+
+    async def execute(self, sql, *args):
+        self.execute_calls.append((sql, args))
+
+
+def _make_session_completed_request(tags: list[str], issue_id: str = "issue-rsca") -> object:
+    class _Req:
+        headers: ClassVar = {"authorization": "Bearer test-webhook-token"}
+
+        async def json(self_inner):
+            return {
+                "event": "session.completed",
+                "issueId": issue_id,
+                "issueNumber": None,
+                "projectId": "proj-rsca",
+                "executionId": "exec-rsca",
+                "tags": tags,
+            }
+
+    return _Req()
+
+
+def _mock_bkd(monkeypatch, webhook_mod, tags: list[str]) -> None:
+    class _BKD:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get_issue(self, *a, **kw):
+            class _R:
+                pass
+
+            _R.tags = tags
+            return _R()
+
+        async def update_issue(self, *a, **kw):
+            pass
+
+    monkeypatch.setattr(webhook_mod, "BKDClient", _BKD)
+
+
+def _setup_webhook_for_escalation(monkeypatch, *, req_id: str, derive_event_val):
+    """
+    Set up webhook mocks for session.completed escalation path tests.
+    Returns a tracking dict with update_ctx_calls and step_calls.
+    """
+    import orchestrator.observability as obs
+    from orchestrator import engine, webhook
+    from orchestrator import router as router_lib
+    from orchestrator.state import ReqState
+    from orchestrator.store import db, dedup
+    from orchestrator.store import req_state as rs_mod
+
+    update_ctx_calls: list = []
+    step_calls: list = []
+
+    monkeypatch.setattr(dedup, "check_and_record", AsyncMock(return_value="new"))
+    monkeypatch.setattr(dedup, "mark_processed", AsyncMock())
+    monkeypatch.setattr(db, "get_pool", lambda: _FakePool())
+    monkeypatch.setattr(obs, "record_event", AsyncMock())
+    monkeypatch.setattr(router_lib, "extract_req_id", lambda tags, num=None: req_id)
+    monkeypatch.setattr(router_lib, "derive_event", lambda evt, tags: derive_event_val)
+
+    class _Row:
+        state = ReqState.REVIEW_RUNNING
+        context: ClassVar = {}
+
+    monkeypatch.setattr(rs_mod, "get", AsyncMock(return_value=_Row()))
+    monkeypatch.setattr(rs_mod, "insert_init", AsyncMock())
+    monkeypatch.setattr(
+        rs_mod,
+        "update_context",
+        AsyncMock(side_effect=lambda *a, **kw: update_ctx_calls.append((list(a), kw))),
+    )
+    monkeypatch.setattr(
+        engine,
+        "step",
+        AsyncMock(side_effect=lambda *a, **kw: step_calls.append((list(a), kw)) or {"action": "noop"}),
+    )
+    _mock_bkd(monkeypatch, webhook, [])
+
+    return {
+        "update_ctx_calls": update_ctx_calls,
+        "step_calls": step_calls,
+        "webhook": webhook,
+    }
+
+
+def _find_escalated_reason(update_ctx_calls: list) -> str | None:
+    """
+    Inspect all update_context call args for any dict containing "escalated_reason".
+    Returns the first value found, or None.
+    """
+    for args, kwargs in update_ctx_calls:
+        # check positional args
+        for a in args:
+            if isinstance(a, dict) and "escalated_reason" in a:
+                return a["escalated_reason"]
+        # check keyword args
+        for v in kwargs.values():
+            if isinstance(v, dict) and "escalated_reason" in v:
+                return v["escalated_reason"]
+    return None
+
+
+# ─── RSCA-S1: INTAKE_FAIL → escalated_reason = "intake-fail" ────────────────
+
+
+async def test_rsca_s1_intake_fail_sets_escalated_reason(monkeypatch):
+    """
+    RSCA-S1: session.completed with tags ["intake", "REQ-x", "result:fail"] routes to
+    INTAKE_FAIL; webhook step 5.8 must pre-set ctx.escalated_reason = "intake-fail"
+    before the escalate action fires.
+    """
+    from orchestrator.state import Event
+
+    tracking = _setup_webhook_for_escalation(
+        monkeypatch,
+        req_id="REQ-rsca-s1",
+        derive_event_val=Event.INTAKE_FAIL,
+    )
+
+    req = _make_session_completed_request(["intake", "REQ-rsca-s1", "result:fail"])
+    await tracking["webhook"].webhook(req)
+
+    reason = _find_escalated_reason(tracking["update_ctx_calls"])
+    assert reason == "intake-fail", (
+        f"RSCA-S1: ctx.escalated_reason must be 'intake-fail' for INTAKE_FAIL event; "
+        f"got {reason!r}. update_context call args: {tracking['update_ctx_calls']!r}"
+    )
+
+
+# ─── RSCA-S2: PR_CI_TIMEOUT → escalated_reason = "pr-ci-timeout" ────────────
+
+
+async def test_rsca_s2_pr_ci_timeout_sets_escalated_reason(monkeypatch):
+    """
+    RSCA-S2: session.completed with tags ["pr-ci", "REQ-x", "pr-ci:timeout"] routes to
+    PR_CI_TIMEOUT; webhook step 5.8 must pre-set ctx.escalated_reason = "pr-ci-timeout".
+    """
+    from orchestrator.state import Event
+
+    tracking = _setup_webhook_for_escalation(
+        monkeypatch,
+        req_id="REQ-rsca-s2",
+        derive_event_val=Event.PR_CI_TIMEOUT,
+    )
+
+    req = _make_session_completed_request(["pr-ci", "REQ-rsca-s2", "pr-ci:timeout"])
+    await tracking["webhook"].webhook(req)
+
+    reason = _find_escalated_reason(tracking["update_ctx_calls"])
+    assert reason == "pr-ci-timeout", (
+        f"RSCA-S2: ctx.escalated_reason must be 'pr-ci-timeout' for PR_CI_TIMEOUT event; "
+        f"got {reason!r}. update_context call args: {tracking['update_ctx_calls']!r}"
+    )
+
+
+# ─── RSCA-S3: VERIFY_ESCALATE → must NOT overwrite with "session-completed" ──
+
+
+async def test_rsca_s3_verify_escalate_does_not_produce_session_completed(monkeypatch):
+    """
+    RSCA-S3: session.completed routed to VERIFY_ESCALATE must retain
+    ctx.escalated_reason = "verifier-decision" (or leave it unset).
+    It must NOT write "session-completed" as the reason.
+    """
+    from orchestrator.state import Event
+
+    tracking = _setup_webhook_for_escalation(
+        monkeypatch,
+        req_id="REQ-rsca-s3",
+        derive_event_val=Event.VERIFY_ESCALATE,
+    )
+
+    req = _make_session_completed_request(["verifier", "REQ-rsca-s3", "result:pass"])
+    await tracking["webhook"].webhook(req)
+
+    # Verify that "session-completed" was never stored as escalated_reason
+    for args, kwargs in tracking["update_ctx_calls"]:
+        all_dicts = [a for a in args if isinstance(a, dict)]
+        all_dicts += [v for v in kwargs.values() if isinstance(v, dict)]
+        for d in all_dicts:
+            actual = d.get("escalated_reason")
+            assert actual != "session-completed", (
+                "RSCA-S3: ctx.escalated_reason must NOT be set to 'session-completed' "
+                f"for VERIFY_ESCALATE; found {actual!r} in update_context call"
+            )
+
+    # engine.step must have been invoked (event was not silently dropped)
+    assert len(tracking["step_calls"]) >= 1, (
+        "RSCA-S3: engine.step must be called for VERIFY_ESCALATE event; "
+        "webhook must not silently drop this event path"
+    )
+
+
+# ─── RSCA-S4: challenger without result → None ───────────────────────────────
+
+
+def test_rsca_s4_challenger_without_result_returns_none():
+    """
+    RSCA-S4: derive_event("session.completed", ["challenger", "REQ-x"]) must return
+    None, not SESSION_FAILED or any other event.
+    """
+    from orchestrator.router import derive_event
+
+    result = derive_event("session.completed", ["challenger", "REQ-rsca-s4"])
+    assert result is None, (
+        "RSCA-S4: derive_event must return None for session.completed with challenger tag "
+        f"and no result tag (prevents spurious SESSION_FAILED); got {result!r}"
+    )
+
+
+# ─── RSCA-S5: no stage tag → None ────────────────────────────────────────────
+
+
+def test_rsca_s5_no_stage_tag_returns_none():
+    """
+    RSCA-S5: derive_event("session.completed", ["REQ-x"]) — no stage tag at all —
+    must return None (silently skip).
+    """
+    from orchestrator.router import derive_event
+
+    result = derive_event("session.completed", ["REQ-rsca-s5"])
+    assert result is None, (
+        "RSCA-S5: derive_event must return None for session.completed with no stage tag; "
+        f"got {result!r}"
+    )
+
+
+# ─── RSCA-S6: known stage + unrecognized result → None ───────────────────────
+
+
+def test_rsca_s6_known_stage_unrecognized_result_returns_none():
+    """
+    RSCA-S6: derive_event("session.completed", ["challenger", "REQ-x", "result:weird"])
+    must return None — unknown result variants are silently skipped.
+    """
+    from orchestrator.router import derive_event
+
+    result = derive_event("session.completed", ["challenger", "REQ-rsca-s6", "result:weird"])
+    assert result is None, (
+        "RSCA-S6: derive_event must return None for session.completed with known stage tag "
+        f"but unrecognized result tag; got {result!r}"
+    )
+
+
+# ─── RSCA-S7: fixer without result → FIXER_DONE ─────────────────────────────
+
+
+def test_rsca_s7_fixer_without_result_returns_fixer_done():
+    """
+    RSCA-S7: derive_event("session.completed", ["fixer", "REQ-x"]) must return
+    FIXER_DONE — fixer never requires a result tag.
+    """
+    from orchestrator.router import derive_event
+    from orchestrator.state import Event
+
+    result = derive_event("session.completed", ["fixer", "REQ-rsca-s7"])
+    assert result == Event.FIXER_DONE, (
+        "RSCA-S7: derive_event must return FIXER_DONE for session.completed + fixer tag "
+        f"(fixer never needs a result tag); got {result!r}"
+    )

--- a/orchestrator/tests/test_engine_escalated_resume.py
+++ b/orchestrator/tests/test_engine_escalated_resume.py
@@ -443,12 +443,12 @@ async def test_ert_s9_full_transition_sweep(
 
 
 def test_ert_s9_sweep_covers_exactly_50():
-    """Sanity: TRANSITIONS 必须正好 49 条 —— 加 / 减 transition 时这条 fail 提醒
+    """Sanity: TRANSITIONS 必须正好 50 条 —— 加 / 减 transition 时这条 fail 提醒
     review 是否同步加 spec scenario / 文档（state-machine.md / dump_transitions）。
 
     REQ-bkd-acceptance-feedback-loop-1777278984 起新增 PENDING_USER_REVIEW 入/出
     transitions（pr.opened 入站 + acceptance approve/request_changes 出站），从 47
-    增至 49。"""
+    增至 49；后续 REQ 再增 1 条至 50。"""
     assert len(state_mod.TRANSITIONS) == 50, (
         f"expected 50 transitions, got {len(state_mod.TRANSITIONS)}; "
         "if you intentionally added/removed a transition, update this assertion "

--- a/orchestrator/tests/test_router.py
+++ b/orchestrator/tests/test_router.py
@@ -58,6 +58,17 @@ CASES: list[tuple[str, list[str], Event | None]] = [
     ("session.completed", ["pr-ci", "REQ-1"],                                None),
     ("session.completed", ["accept", "REQ-1"],                               None),
 
+    # REQ-router-session-completed-audit: session.completed without result coverage
+    # challenger without result → None (intermediate round, not SESSION_FAILED)
+    ("session.completed", ["challenger", "REQ-1"],                           None),
+    # fixer without extra tags → FIXER_DONE (fixer never uses result:* tags)
+    ("session.completed", ["fixer", "REQ-1"],                                Event.FIXER_DONE),
+    # no stage tag at all → None (orphan / unclassified session, skip silently)
+    ("session.completed", ["REQ-1"],                                         None),
+    # known stage tag + unrecognized result variant → None (not SESSION_FAILED)
+    ("session.completed", ["challenger", "REQ-1", "result:weird"],           None),
+    ("session.completed", ["staging-test", "REQ-1", "result:weird"],         None),
+
     # 未知 event_type
     ("session.unknown",   ["dev", "REQ-1"],                                  None),
 ]


### PR DESCRIPTION
## Problem

15 REQs escalated with `escalated_reason = 'session-completed'` — the raw BKD event slug
instead of the actual cause. This value is meaningless for triage in Metabase Q* queries.

## Root cause

`escalate.py` resolves its reason via a 4-level priority chain. Priority 4 fallback:
```python
reason = ctx_reason or body.event.replace(".", "-")[:40]
```
When `body.event = "session.completed"` and `ctx.escalated_reason` is not pre-set,
this yields `"session-completed"`.

`webhook.py` step 5.8 only pre-set `ctx.escalated_reason` for `VERIFY_ESCALATE`. Two other
`session.completed → escalate` paths were unguarded:

- **`INTAKE_FAIL`** — intake-agent session + result:fail, or INTAKE_PASS downgraded when
  no finalized intent JSON found in assistant messages
- **`PR_CI_TIMEOUT`** — pr-ci-watch session completed with `pr-ci:timeout` tag

## Changes

**`orchestrator/src/orchestrator/webhook.py`** — step 5.8:

Replace single `if event == VERIFY_ESCALATE` guard with a table-driven lookup:
```python
_SESSION_COMPLETED_ESCALATE_REASONS = {
    Event.VERIFY_ESCALATE: "verifier-decision",
    Event.INTAKE_FAIL:     "intake-fail",
    Event.PR_CI_TIMEOUT:   "pr-ci-timeout",
}
```

**`orchestrator/tests/test_router.py`** — add 5 missing coverage cases:
- `challenger` without result → `None` (not SESSION_FAILED)
- `fixer` without extra tags → `FIXER_DONE`
- no stage tag in `session.completed` → `None`
- `challenger + result:weird` → `None`
- `staging-test + result:weird` → `None`

## Test plan

- [x] `uv run pytest tests/test_router.py` — 36 passed (31 existing + 5 new)
- [x] Full suite: 1643 passed; 7 pre-existing failures unrelated to this change
  (ruff issues in other test files, PG-dependent tests, transition-count assertion)
- [x] `openspec validate REQ-router-session-completed-audit-1777344435` — valid

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-router-session-completed-audit-1777344435`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/sy8bnd7q)