### PR TITLE
feat(archive): PR merged → orch auto archive via GHA hook

### DIFF
--- a/.github/workflows/sisyphus-pr-merged-hook.yml
+++ b/.github/workflows/sisyphus-pr-merged-hook.yml
@@ -1,0 +1,54 @@
+name: sisyphus-pr-merged-hook
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  notify-orch:
+    # Only fire when PR is actually merged AND has the 'sisyphus' label.
+    # Closed-without-merge events are skipped.
+    if: >
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'sisyphus')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract REQ id from branch name
+        id: extract
+        run: |
+          branch="${{ github.event.pull_request.head.ref }}"
+          # Match first REQ-<slug> token (e.g. feat/REQ-foo-123 → REQ-foo-123)
+          req_id=$(echo "$branch" | grep -oP 'REQ-[A-Za-z0-9_-]+' | head -1)
+          echo "req_id=$req_id" | tee -a "$GITHUB_OUTPUT"
+          if [ -z "$req_id" ]; then
+            echo "No REQ id found in branch '$branch', skipping."
+          fi
+
+      - name: Notify orchestrator of PR merge
+        if: steps.extract.outputs.req_id != ''
+        env:
+          ORCH_ENDPOINT: ${{ secrets.ORCH_ENDPOINT }}
+          SISYPHUS_WEBHOOK_TOKEN: ${{ secrets.SISYPHUS_WEBHOOK_TOKEN }}
+        run: |
+          req_id="${{ steps.extract.outputs.req_id }}"
+          payload=$(jq -n \
+            --arg url "${{ github.event.pull_request.html_url }}" \
+            --arg sha "${{ github.event.pull_request.merge_commit_sha }}" \
+            --arg at  "${{ github.event.pull_request.merged_at }}" \
+            '{merged_pr_url: $url, merged_sha: $sha, merged_at: $at}')
+          echo "Notifying orch for $req_id …"
+          http_status=$(curl -sf -o /dev/null -w "%{http_code}" \
+            -X POST "$ORCH_ENDPOINT/admin/req/$req_id/pr-merged" \
+            -H "Authorization: Bearer $SISYPHUS_WEBHOOK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$payload")
+          echo "HTTP status: $http_status"
+          # 2xx = success; 409/noop states also acceptable (REQ already done).
+          # Fail loudly only on auth (401) or server error (5xx).
+          if [[ "$http_status" == 4* && "$http_status" != "404" && "$http_status" != "409" ]]; then
+            echo "Unexpected HTTP $http_status — failing workflow."
+            exit 1
+          fi
+          echo "Done."

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -43,7 +43,7 @@
 | **`done`** | REQ 完成 | **terminal** |
 | **`escalated`** | 熔断 / session-failed / 人工止损 | **terminal** |
 
-## 3. Event 枚举（32 个）
+## 3. Event 枚举（33 个）
 
 | event | 来源 | 触发什么 |
 |---|---|---|

--- a/openspec/changes/REQ-pr-merge-archive-hook-1777344443/proposal.md
+++ b/openspec/changes/REQ-pr-merge-archive-hook-1777344443/proposal.md
@@ -1,0 +1,36 @@
+# Proposal: PR Merged → Orchestrator Archive Closed Loop
+
+**REQ**: REQ-pr-merge-archive-hook-1777344443
+
+## Problem
+
+After `pr_ci_watch` passes, a REQ enters `PENDING_USER_REVIEW` waiting for a BKD
+`statusId=done` signal. When a human reviewer merges the PR on GitHub, sisyphus has
+no awareness — the REQ stays stuck in `pending-user-review` indefinitely.
+
+## Solution (Option A)
+
+1. **GHA workflow** (`.github/workflows/sisyphus-pr-merged-hook.yml`): fires on
+   `pull_request[closed]` where `merged==true` and label `sisyphus` is present.
+   Extracts `REQ-<id>` from the branch name, then POSTs to the orch admin endpoint.
+
+2. **New admin endpoint** `POST /admin/req/{req_id}/pr-merged`: authenticates with
+   the same Bearer token as other admin endpoints. Writes merge metadata to REQ
+   context, then emits `PR_MERGED` event through the state machine.
+
+3. **State machine extension**: new `Event.PR_MERGED` with transitions from
+   `PENDING_USER_REVIEW`, `REVIEW_RUNNING`, and `PR_CI_RUNNING` → `ARCHIVING`
+   via `done_archive` action. CAS guarantees concurrency safety.
+
+## Scope
+
+- New event + transitions in `state.py`
+- New endpoint in `admin.py`
+- New GHA workflow in `.github/workflows/`
+- Unit tests in `orchestrator/tests/test_admin_pr_merged.py`
+
+## Out of Scope
+
+- PR ready-for-review notification (separate REQ)
+- Human PR rollback reverse flow
+- Changes to `done_archive` action internals

--- a/openspec/changes/REQ-pr-merge-archive-hook-1777344443/specs/pr-merged-archive-hook/contract.spec.yaml
+++ b/openspec/changes/REQ-pr-merge-archive-hook-1777344443/specs/pr-merged-archive-hook/contract.spec.yaml
@@ -1,0 +1,40 @@
+id: pr-merged-archive-hook
+title: PR Merged Archive Hook
+description: >
+  POST /admin/req/{req_id}/pr-merged endpoint and PR_MERGED state machine event.
+  Closes the archive loop when a human reviewer merges a sisyphus PR on GitHub.
+
+scenarios:
+  - id: PMH-S1
+    description: state pending-user-review → emit PR_MERGED, call done_archive
+    spec_ref: PMH-S1
+  - id: PMH-S2
+    description: state review-running → emit PR_MERGED
+    spec_ref: PMH-S2
+  - id: PMH-S3
+    description: state pr-ci-running → emit PR_MERGED
+    spec_ref: PMH-S3
+  - id: PMH-S4
+    description: state done → 200 noop
+    spec_ref: PMH-S4
+  - id: PMH-S5
+    description: state escalated → 200 noop
+    spec_ref: PMH-S5
+  - id: PMH-S6
+    description: state analyzing → 409
+    spec_ref: PMH-S6
+  - id: PMH-S7
+    description: missing/bad token → 401
+    spec_ref: PMH-S7
+  - id: PMH-S8
+    description: unknown req_id → 404
+    spec_ref: PMH-S8
+  - id: PMH-S9
+    description: context patch contains all merge fields
+    spec_ref: PMH-S9
+  - id: PMH-S10
+    description: route registered at correct path
+    spec_ref: PMH-S10
+  - id: PMH-SM1
+    description: TRANSITIONS table has PR_MERGED for all three source states
+    spec_ref: PMH-SM1

--- a/openspec/changes/REQ-pr-merge-archive-hook-1777344443/specs/pr-merged-archive-hook/spec.md
+++ b/openspec/changes/REQ-pr-merge-archive-hook-1777344443/specs/pr-merged-archive-hook/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: PR merged hook triggers archive closed loop
+
+When a human reviewer merges a sisyphus-managed PR on GitHub, the orchestrator
+SHALL receive a notification via `POST /admin/req/{req_id}/pr-merged` and SHALL
+emit `Event.PR_MERGED` through the state machine to trigger the `done_archive`
+action. The endpoint MUST be authenticated with a Bearer token identical to other
+admin endpoints.
+
+The state machine MUST define `Event.PR_MERGED` with transitions from
+`PENDING_USER_REVIEW`, `REVIEW_RUNNING`, and `PR_CI_RUNNING` to `ARCHIVING`
+with action `done_archive`. For terminal states (`done`, `escalated`) the endpoint
+MUST return a 200 noop response without modifying state. For all other states the
+endpoint MUST return 409.
+
+#### Scenario: PMH-S1 state pending-user-review emits PR_MERGED and calls done_archive
+
+- **GIVEN** a REQ in state `pending-user-review`
+- **WHEN** `POST /admin/req/{req_id}/pr-merged` is called with valid Bearer token and merge metadata
+- **THEN** `update_context` is called with `merged_pr_url`, `merged_sha`, `merged_at`, `pr_merged_trigger=gha-hook`
+- **AND** `engine.step` is called with `event=Event.PR_MERGED` and `cur_state=pending-user-review`
+- **AND** response body has `action=pr_merged` and `from_state=pending-user-review`
+
+#### Scenario: PMH-S2 state review-running emits PR_MERGED
+
+- **GIVEN** a REQ in state `review-running`
+- **WHEN** `POST /admin/req/{req_id}/pr-merged` is called with valid token
+- **THEN** `engine.step` is called with `event=Event.PR_MERGED` and `cur_state=review-running`
+- **AND** response has `action=pr_merged`
+
+#### Scenario: PMH-S3 state pr-ci-running emits PR_MERGED
+
+- **GIVEN** a REQ in state `pr-ci-running`
+- **WHEN** `POST /admin/req/{req_id}/pr-merged` is called with valid token
+- **THEN** `engine.step` is called with `event=Event.PR_MERGED` and `cur_state=pr-ci-running`
+
+#### Scenario: PMH-S4 state done returns noop without DB write
+
+- **GIVEN** a REQ already in state `done`
+- **WHEN** `POST /admin/req/{req_id}/pr-merged` is called
+- **THEN** response is 200 with `action=noop`
+- **AND** `engine.step` MUST NOT be called
+- **AND** `update_context` MUST NOT be called
+
+#### Scenario: PMH-S5 state escalated returns noop without DB write
+
+- **GIVEN** a REQ in state `escalated`
+- **WHEN** `POST /admin/req/{req_id}/pr-merged` is called
+- **THEN** response is 200 with `action=noop`
+- **AND** no state mutation occurs
+
+#### Scenario: PMH-S6 unexpected state returns 409
+
+- **GIVEN** a REQ in state `analyzing`
+- **WHEN** `POST /admin/req/{req_id}/pr-merged` is called
+- **THEN** response is 409 with detail mentioning the current state
+- **AND** `engine.step` MUST NOT be called
+
+#### Scenario: PMH-S7 missing or bad token returns 401
+
+- **GIVEN** no Authorization header or invalid token
+- **WHEN** `POST /admin/req/{req_id}/pr-merged` is called
+- **THEN** response is 401
+- **AND** `req_state.get` MUST NOT be called
+
+#### Scenario: PMH-S8 unknown req id returns 404
+
+- **GIVEN** req_id not present in the database
+- **WHEN** `POST /admin/req/{req_id}/pr-merged` is called with valid token
+- **THEN** response is 404 with detail containing "not found"
+
+#### Scenario: PMH-S9 context patch includes all required merge fields
+
+- **GIVEN** a REQ in state `pending-user-review`
+- **WHEN** `POST /admin/req/{req_id}/pr-merged` is called with body `{merged_pr_url, merged_sha, merged_at}`
+- **THEN** `update_context` patch MUST include all four fields: `merged_pr_url`, `merged_sha`, `merged_at`, `pr_merged_trigger=gha-hook`
+
+#### Scenario: PMH-S10 route is registered at correct path
+
+- **GIVEN** the FastAPI admin router
+- **WHEN** POST routes are enumerated
+- **THEN** `/admin/req/{req_id}/pr-merged` MUST be present and bound to the `pr_merged` function
+
+### Requirement: PR_MERGED event wired in state machine for three source states
+
+The state machine SHALL contain `Event.PR_MERGED` with transitions from
+`PENDING_USER_REVIEW`, `REVIEW_RUNNING`, and `PR_CI_RUNNING`. Each transition
+MUST target `ReqState.ARCHIVING` with action `done_archive`.
+
+#### Scenario: PMH-SM1 TRANSITIONS table contains PR_MERGED for all three states
+
+- **GIVEN** the TRANSITIONS dict in state.py
+- **WHEN** keys are inspected
+- **THEN** `(PENDING_USER_REVIEW, PR_MERGED)`, `(REVIEW_RUNNING, PR_MERGED)`, and `(PR_CI_RUNNING, PR_MERGED)` MUST all be present with `next_state=ARCHIVING` and `action=done_archive`

--- a/openspec/changes/REQ-pr-merge-archive-hook-1777344443/tasks.md
+++ b/openspec/changes/REQ-pr-merge-archive-hook-1777344443/tasks.md
@@ -1,0 +1,16 @@
+# Tasks: REQ-pr-merge-archive-hook-1777344443
+
+## Stage: spec
+- [x] author specs/pr-merged-archive-hook/spec.md with scenarios PMH-S1 through PMH-S10
+- [x] author specs/pr-merged-archive-hook/contract.spec.yaml
+
+## Stage: implementation
+- [x] Add `Event.PR_MERGED = "pr.merged"` to `orchestrator/src/orchestrator/state.py`
+- [x] Add transitions: PENDING_USER_REVIEW/REVIEW_RUNNING/PR_CI_RUNNING + PR_MERGED → ARCHIVING (done_archive)
+- [x] Add `PrMergedBody` model and `pr_merged` endpoint to `orchestrator/src/orchestrator/admin.py`
+- [x] Add GHA workflow `.github/workflows/sisyphus-pr-merged-hook.yml`
+- [x] Write unit tests `orchestrator/tests/test_admin_pr_merged.py` (PMH-S1 to PMH-S10)
+
+## Stage: PR
+- [x] git push feat/REQ-pr-merge-archive-hook-1777344443
+- [x] gh pr create --label sisyphus

--- a/orchestrator/src/orchestrator/admin.py
+++ b/orchestrator/src/orchestrator/admin.py
@@ -9,6 +9,9 @@ State 操作：
   POST /admin/req/{req_id}/resume     body: {"action": "pass"|"fix-needed", "stage"?, "fixer"?, "reason"?}
                                        → state-level resume from ESCALATED
                                        （派 VERIFY_PASS / VERIFY_FIX_NEEDED 走合法 transition）
+  POST /admin/req/{req_id}/pr-merged  body: {"merged_pr_url": "...", "merged_sha": "...", "merged_at": "..."}
+                                       → GHA 钩：人手合 PR 后通知 orch，state 在 pending-user-review /
+                                          review-running / pr-ci-running 时发 PR_MERGED → done_archive
   GET  /admin/metrics
   GET  /admin/req/{req_id}
 
@@ -611,6 +614,96 @@ async def list_runners(
             }
             for r in runners
         ],
+    }
+
+
+class PrMergedBody(BaseModel):
+    """PR merge hook body from GHA workflow."""
+    merged_pr_url: str
+    merged_sha: str
+    merged_at: str
+
+
+# Terminal states where PR_MERGED is a noop (already done or escalated).
+_PR_MERGED_NOOP_STATES = frozenset({ReqState.DONE, ReqState.ESCALATED})
+
+# States that accept PR_MERGED → done_archive transition (via state.py TRANSITIONS).
+_PR_MERGED_VALID_STATES = frozenset({
+    ReqState.PENDING_USER_REVIEW,
+    ReqState.REVIEW_RUNNING,
+    ReqState.PR_CI_RUNNING,
+})
+
+
+@admin.post("/req/{req_id}/pr-merged")
+async def pr_merged(
+    req_id: str,
+    body: PrMergedBody,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    """GHA 钩：人手合 PR 后通知 orch 闭环归档（REQ-pr-merge-archive-hook-1777344443）。
+
+    - state ∈ {done, escalated} → 200 noop（幂等，防双触发）
+    - state ∈ {pending-user-review, review-running, pr-ci-running} → 写 merge ctx + emit PR_MERGED
+    - 其他 state → 409（不在预期窗口，需人工 triage）
+    """
+    _verify_token(authorization)
+
+    pool = db.get_pool()
+    row = await req_state.get(pool, req_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"req {req_id} not found")
+
+    if row.state in _PR_MERGED_NOOP_STATES:
+        log.info("admin.pr_merged.noop", req_id=req_id, state=row.state.value)
+        return {"action": "noop", "state": row.state.value}
+
+    if row.state not in _PR_MERGED_VALID_STATES:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"req {req_id} is in state {row.state.value!r}; "
+                f"pr-merged hook only applies to "
+                f"{[s.value for s in _PR_MERGED_VALID_STATES]}"
+            ),
+        )
+
+    # 写 merge 元数据入 ctx，让 done_archive action 可读到
+    ctx_patch = {
+        "merged_pr_url": body.merged_pr_url,
+        "merged_sha": body.merged_sha,
+        "merged_at": body.merged_at,
+        "pr_merged_trigger": "gha-hook",
+    }
+    await req_state.update_context(pool, req_id, ctx_patch)
+
+    # 重读 ctx（update_context 后 row.context 未刷新）
+    row = await req_state.get(pool, req_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"req {req_id} not found")
+
+    log.warning(
+        "admin.pr_merged",
+        req_id=req_id,
+        from_state=row.state.value,
+        merged_pr_url=body.merged_pr_url,
+        merged_sha=body.merged_sha,
+    )
+    fake = _FakeBody(req_id, row.project_id)
+    result = await engine.step(
+        pool,
+        body=fake,
+        req_id=req_id,
+        project_id=row.project_id,
+        tags=[],
+        cur_state=row.state,
+        ctx=row.context,
+        event=Event.PR_MERGED,
+    )
+    return {
+        "action": "pr_merged",
+        "from_state": row.state.value,
+        "result": result,
     }
 
 

--- a/orchestrator/src/orchestrator/state.py
+++ b/orchestrator/src/orchestrator/state.py
@@ -69,6 +69,8 @@ class Event(StrEnum):
     TEARDOWN_DONE_PASS = "teardown-done.pass"       # env-down 完（上一个是 accept.pass）
     TEARDOWN_DONE_FAIL = "teardown-done.fail"       # env-down 完（上一个是 accept.fail）→ verifier
     ARCHIVE_DONE = "archive.done"
+    # REQ-pr-merge-archive-hook-1777344443：人手合 PR 后 GHA 触发，跳过剩余 gate 直接归档
+    PR_MERGED = "pr.merged"
     SESSION_FAILED = "session.failed"
     # REQ-bkd-acceptance-feedback-loop-1777278984: BKD-native 用户验收 gate（Case 2, 0 黑话纯原语）
     # 信号通道 = BKD intent issue statusId（webhook 在 PENDING_USER_REVIEW state 收 issue.updated 时派事件）
@@ -213,6 +215,23 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
     (ReqState.PENDING_USER_REVIEW, Event.USER_REVIEW_FIX):
         Transition(ReqState.ESCALATED, "escalate",
                    "用户把 BKD intent statusId 改 review/blocked → 标 user-requested-fix 入 escalated"),
+
+    # ─── PR_MERGED：人手合 PR 后 GHA 钩 → admin endpoint 注入，跳 gate 直归档 ───────────
+    # REQ-pr-merge-archive-hook-1777344443
+    # 主场景：PENDING_USER_REVIEW（最常见的卡死态：accept 全过但 sisyphus 不知道 PR 被人合了）。
+    # 兜底：REVIEW_RUNNING / PR_CI_RUNNING（极少：verifier 或 CI 还在跑时人已合 PR）。
+    # CAS 保证并发安全：如果 verifier/CI 也在尝试 transition，两者竞争，输的一方 CAS_LOST。
+    (ReqState.PENDING_USER_REVIEW, Event.PR_MERGED):
+        Transition(ReqState.ARCHIVING, "done_archive",
+                   "PR merged by reviewer → skip user-review gate → archive"),
+
+    (ReqState.REVIEW_RUNNING, Event.PR_MERGED):
+        Transition(ReqState.ARCHIVING, "done_archive",
+                   "PR merged while verifier running → archive (CAS races verifier; one wins)"),
+
+    (ReqState.PR_CI_RUNNING, Event.PR_MERGED):
+        Transition(ReqState.ARCHIVING, "done_archive",
+                   "PR merged while CI running → archive (CAS races ci-watch; one wins)"),
 
     # ─── verifier 子链 ─────────────────────────────────────────────────
     # verifier-agent 完成 → webhook 解 decision JSON → emit 对应事件。

--- a/orchestrator/tests/test_admin_pr_merged.py
+++ b/orchestrator/tests/test_admin_pr_merged.py
@@ -22,9 +22,8 @@ from datetime import UTC, datetime
 import pytest
 from fastapi import HTTPException
 
-from orchestrator.admin import PrMergedBody, _FakeBody, pr_merged
+from orchestrator.admin import PrMergedBody, pr_merged
 from orchestrator.state import Event, ReqState
-
 
 # ─── shared fixtures ──────────────────────────────────────────────────────────
 
@@ -105,7 +104,7 @@ def _setup(monkeypatch, *, state: ReqState, rows: list[_Row] | None = None):
 ])
 async def test_pmh_valid_state_emits_pr_merged(monkeypatch, valid_state):
     """PMH-S1/S2/S3: state ∈ valid set → update_context called + engine.step with PR_MERGED."""
-    pool, update_calls, step_calls = _setup(monkeypatch, state=valid_state)
+    _pool, update_calls, step_calls = _setup(monkeypatch, state=valid_state)
 
     result = await pr_merged("REQ-X", body=_GOOD_BODY, authorization="Bearer tok")
 
@@ -137,7 +136,7 @@ async def test_pmh_valid_state_emits_pr_merged(monkeypatch, valid_state):
 @pytest.mark.parametrize("noop_state", [ReqState.DONE, ReqState.ESCALATED])
 async def test_pmh_noop_for_terminal_states(monkeypatch, noop_state):
     """PMH-S4/S5: state ∈ {done, escalated} → 200 noop, no DB write, no engine.step."""
-    pool, update_calls, step_calls = _setup(monkeypatch, state=noop_state)
+    _pool, update_calls, step_calls = _setup(monkeypatch, state=noop_state)
 
     result = await pr_merged("REQ-X", body=_GOOD_BODY, authorization="Bearer tok")
 
@@ -153,7 +152,7 @@ async def test_pmh_noop_for_terminal_states(monkeypatch, noop_state):
 @pytest.mark.asyncio
 async def test_pmh_409_for_unexpected_state(monkeypatch):
     """PMH-S6: state=analyzing → 409 with valid-states hint."""
-    pool, update_calls, step_calls = _setup(monkeypatch, state=ReqState.ANALYZING)
+    _pool, update_calls, step_calls = _setup(monkeypatch, state=ReqState.ANALYZING)
 
     with pytest.raises(HTTPException) as ei:
         await pr_merged("REQ-X", body=_GOOD_BODY, authorization="Bearer tok")
@@ -221,7 +220,7 @@ async def test_pmh_404_when_req_not_found(monkeypatch):
 @pytest.mark.asyncio
 async def test_pmh_ctx_contains_all_merge_fields(monkeypatch):
     """PMH-S9: context patch contains merged_pr_url, merged_sha, merged_at, pr_merged_trigger."""
-    pool, update_calls, step_calls = _setup(
+    _pool, update_calls, _step_calls = _setup(
         monkeypatch, state=ReqState.PENDING_USER_REVIEW
     )
 
@@ -245,7 +244,8 @@ async def test_pmh_ctx_contains_all_merge_fields(monkeypatch):
 
 def test_pmh_route_registered():
     """PMH-S10: /admin/req/{req_id}/pr-merged POST route is registered."""
-    from orchestrator.admin import admin as admin_router, pr_merged as endpoint_fn
+    from orchestrator.admin import admin as admin_router
+    from orchestrator.admin import pr_merged as endpoint_fn
 
     paths_to_endpoint = {
         r.path: r.endpoint

--- a/orchestrator/tests/test_admin_pr_merged.py
+++ b/orchestrator/tests/test_admin_pr_merged.py
@@ -1,0 +1,283 @@
+"""Unit tests: POST /admin/req/{req_id}/pr-merged endpoint.
+
+REQ-pr-merge-archive-hook-1777344443
+
+Scenarios:
+  PMH-S1  state=pending-user-review → update_context + engine.step(PR_MERGED) called
+  PMH-S2  state=review-running      → update_context + engine.step(PR_MERGED) called
+  PMH-S3  state=pr-ci-running       → update_context + engine.step(PR_MERGED) called
+  PMH-S4  state=done                → 200 noop, no DB write, no engine.step
+  PMH-S5  state=escalated           → 200 noop, no DB write, no engine.step
+  PMH-S6  state=analyzing           → 409 with valid-states hint
+  PMH-S7  no/bad Bearer token       → 401
+  PMH-S8  REQ not found             → 404
+  PMH-S9  ctx written: merged_pr_url / merged_sha / merged_at / pr_merged_trigger
+  PMH-S10 result shape: action=pr_merged, from_state, result
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import pytest
+from fastapi import HTTPException
+
+from orchestrator.admin import PrMergedBody, _FakeBody, pr_merged
+from orchestrator.state import Event, ReqState
+
+
+# ─── shared fixtures ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class _Row:
+    req_id: str
+    project_id: str
+    state: ReqState
+    context: dict = field(default_factory=dict)
+    history: list = field(default_factory=list)
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+class _FakePool:
+    def __init__(self):
+        self.executed: list = []
+
+    async def execute(self, sql, *args):
+        self.executed.append((sql, args))
+        return "UPDATE 1"
+
+
+_GOOD_BODY = PrMergedBody(
+    merged_pr_url="https://github.com/phona/sisyphus/pull/99",
+    merged_sha="abc1234",
+    merged_at="2026-04-28T10:00:00Z",
+)
+
+
+def _setup(monkeypatch, *, state: ReqState, rows: list[_Row] | None = None):
+    """Wire monkeypatch: bypass auth, fake pool, cycling req_state.get, capture update_context."""
+    from orchestrator import admin as admin_mod
+
+    monkeypatch.setattr(admin_mod, "_verify_token", lambda x: None)
+
+    pool = _FakePool()
+    monkeypatch.setattr("orchestrator.admin.db.get_pool", lambda: pool)
+
+    base_row = _Row(req_id="REQ-X", project_id="proj", state=state)
+    _rows = rows if rows is not None else [base_row, base_row]
+    call_count = {"n": 0}
+
+    async def _get(_pool, _req_id):
+        idx = min(call_count["n"], len(_rows) - 1)
+        call_count["n"] += 1
+        return _rows[idx]
+
+    monkeypatch.setattr("orchestrator.admin.req_state.get", _get)
+
+    update_calls: list[dict] = []
+
+    async def _update(_pool, _req_id, patch):
+        update_calls.append(dict(patch))
+
+    monkeypatch.setattr("orchestrator.admin.req_state.update_context", _update)
+
+    step_calls: list[dict] = []
+
+    async def _step(*a, **kw):
+        step_calls.append(kw)
+        return {"action": "done_archive", "next_state": "archiving"}
+
+    monkeypatch.setattr("orchestrator.admin.engine.step", _step)
+
+    return pool, update_calls, step_calls
+
+
+# ─── PMH-S1/S2/S3: valid states trigger PR_MERGED ────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("valid_state", [
+    ReqState.PENDING_USER_REVIEW,
+    ReqState.REVIEW_RUNNING,
+    ReqState.PR_CI_RUNNING,
+])
+async def test_pmh_valid_state_emits_pr_merged(monkeypatch, valid_state):
+    """PMH-S1/S2/S3: state ∈ valid set → update_context called + engine.step with PR_MERGED."""
+    pool, update_calls, step_calls = _setup(monkeypatch, state=valid_state)
+
+    result = await pr_merged("REQ-X", body=_GOOD_BODY, authorization="Bearer tok")
+
+    # engine.step called exactly once with PR_MERGED event
+    assert len(step_calls) == 1, f"PMH: engine.step MUST be called once, got {step_calls}"
+    assert step_calls[0]["event"] == Event.PR_MERGED, (
+        f"PMH: event MUST be PR_MERGED, got {step_calls[0]['event']}"
+    )
+    assert step_calls[0]["cur_state"] == valid_state
+
+    # update_context called with merge metadata
+    assert len(update_calls) == 1
+    patch = update_calls[0]
+    assert patch["merged_pr_url"] == _GOOD_BODY.merged_pr_url
+    assert patch["merged_sha"] == _GOOD_BODY.merged_sha
+    assert patch["merged_at"] == _GOOD_BODY.merged_at
+    assert patch["pr_merged_trigger"] == "gha-hook"
+
+    # result shape
+    assert result["action"] == "pr_merged"
+    assert result["from_state"] == valid_state.value
+    assert "result" in result
+
+
+# ─── PMH-S4/S5: noop states ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("noop_state", [ReqState.DONE, ReqState.ESCALATED])
+async def test_pmh_noop_for_terminal_states(monkeypatch, noop_state):
+    """PMH-S4/S5: state ∈ {done, escalated} → 200 noop, no DB write, no engine.step."""
+    pool, update_calls, step_calls = _setup(monkeypatch, state=noop_state)
+
+    result = await pr_merged("REQ-X", body=_GOOD_BODY, authorization="Bearer tok")
+
+    assert result["action"] == "noop"
+    assert result["state"] == noop_state.value
+    assert step_calls == [], "PMH-S4/5: engine.step MUST NOT be called on noop"
+    assert update_calls == [], "PMH-S4/5: update_context MUST NOT be called on noop"
+
+
+# ─── PMH-S6: invalid state → 409 ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pmh_409_for_unexpected_state(monkeypatch):
+    """PMH-S6: state=analyzing → 409 with valid-states hint."""
+    pool, update_calls, step_calls = _setup(monkeypatch, state=ReqState.ANALYZING)
+
+    with pytest.raises(HTTPException) as ei:
+        await pr_merged("REQ-X", body=_GOOD_BODY, authorization="Bearer tok")
+
+    assert ei.value.status_code == 409
+    assert "analyzing" in ei.value.detail
+    assert step_calls == []
+    assert update_calls == []
+
+
+# ─── PMH-S7: auth ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pmh_401_bad_token(monkeypatch):
+    """PMH-S7: bad/missing token → 401, no DB access."""
+    from orchestrator import admin as admin_mod
+
+    def _bad(_):
+        raise HTTPException(status_code=401, detail="bad token")
+
+    monkeypatch.setattr(admin_mod, "_verify_token", _bad)
+
+    get_calls: list = []
+
+    async def _get(*a, **kw):
+        get_calls.append(1)
+
+    monkeypatch.setattr("orchestrator.admin.req_state.get", _get)
+    monkeypatch.setattr("orchestrator.admin.db.get_pool", lambda: _FakePool())
+
+    with pytest.raises(HTTPException) as ei:
+        await pr_merged("REQ-X", body=_GOOD_BODY, authorization=None)
+
+    assert ei.value.status_code == 401
+    assert get_calls == [], "PMH-S7: req_state.get MUST NOT be called on auth failure"
+
+
+# ─── PMH-S8: 404 ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pmh_404_when_req_not_found(monkeypatch):
+    """PMH-S8: REQ not found → 404."""
+    from orchestrator import admin as admin_mod
+
+    monkeypatch.setattr(admin_mod, "_verify_token", lambda x: None)
+    monkeypatch.setattr("orchestrator.admin.db.get_pool", lambda: _FakePool())
+
+    async def _get(_pool, _req_id):
+        return None
+
+    monkeypatch.setattr("orchestrator.admin.req_state.get", _get)
+
+    with pytest.raises(HTTPException) as ei:
+        await pr_merged("REQ-MISSING", body=_GOOD_BODY, authorization="Bearer tok")
+
+    assert ei.value.status_code == 404
+    assert "not found" in ei.value.detail
+
+
+# ─── PMH-S9: ctx fields ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pmh_ctx_contains_all_merge_fields(monkeypatch):
+    """PMH-S9: context patch contains merged_pr_url, merged_sha, merged_at, pr_merged_trigger."""
+    pool, update_calls, step_calls = _setup(
+        monkeypatch, state=ReqState.PENDING_USER_REVIEW
+    )
+
+    body = PrMergedBody(
+        merged_pr_url="https://github.com/org/repo/pull/42",
+        merged_sha="deadbeef",
+        merged_at="2026-04-28T12:34:56Z",
+    )
+    await pr_merged("REQ-X", body=body, authorization="Bearer tok")
+
+    assert len(update_calls) == 1
+    patch = update_calls[0]
+    assert patch["merged_pr_url"] == "https://github.com/org/repo/pull/42"
+    assert patch["merged_sha"] == "deadbeef"
+    assert patch["merged_at"] == "2026-04-28T12:34:56Z"
+    assert patch["pr_merged_trigger"] == "gha-hook"
+
+
+# ─── PMH-S10: route registered ────────────────────────────────────────────────
+
+
+def test_pmh_route_registered():
+    """PMH-S10: /admin/req/{req_id}/pr-merged POST route is registered."""
+    from orchestrator.admin import admin as admin_router, pr_merged as endpoint_fn
+
+    paths_to_endpoint = {
+        r.path: r.endpoint
+        for r in admin_router.routes
+        if hasattr(r, "path") and "POST" in (getattr(r, "methods", set()) or set())
+    }
+    assert "/admin/req/{req_id}/pr-merged" in paths_to_endpoint, (
+        "PMH-S10: route /admin/req/{req_id}/pr-merged MUST be registered"
+    )
+    assert paths_to_endpoint["/admin/req/{req_id}/pr-merged"] is endpoint_fn
+
+
+# ─── PMH state machine: PR_MERGED event registered ───────────────────────────
+
+
+def test_pr_merged_event_in_state_machine():
+    """PR_MERGED event MUST have transitions for all three valid states."""
+    from orchestrator.state import TRANSITIONS, Event, ReqState
+
+    expected = [
+        (ReqState.PENDING_USER_REVIEW, Event.PR_MERGED),
+        (ReqState.REVIEW_RUNNING, Event.PR_MERGED),
+        (ReqState.PR_CI_RUNNING, Event.PR_MERGED),
+    ]
+    for key in expected:
+        assert key in TRANSITIONS, (
+            f"TRANSITIONS must contain {key}; PR_MERGED event not wired"
+        )
+        t = TRANSITIONS[key]
+        assert t.next_state == ReqState.ARCHIVING, (
+            f"{key}: next_state MUST be ARCHIVING, got {t.next_state}"
+        )
+        assert t.action == "done_archive", (
+            f"{key}: action MUST be 'done_archive', got {t.action}"
+        )

--- a/orchestrator/tests/test_engine_escalated_resume.py
+++ b/orchestrator/tests/test_engine_escalated_resume.py
@@ -442,15 +442,15 @@ async def test_ert_s9_full_transition_sweep(
     )
 
 
-def test_ert_s9_sweep_covers_exactly_50():
+def test_ert_s9_sweep_covers_exactly_53():
     """Sanity: TRANSITIONS 必须正好 50 条 —— 加 / 减 transition 时这条 fail 提醒
     review 是否同步加 spec scenario / 文档（state-machine.md / dump_transitions）。
 
     REQ-bkd-acceptance-feedback-loop-1777278984 起新增 PENDING_USER_REVIEW 入/出
     transitions（pr.opened 入站 + acceptance approve/request_changes 出站），从 47
     增至 49；后续 REQ 再增 1 条至 50。"""
-    assert len(state_mod.TRANSITIONS) == 50, (
-        f"expected 50 transitions, got {len(state_mod.TRANSITIONS)}; "
+    assert len(state_mod.TRANSITIONS) == 53, (
+        f"expected 53 transitions, got {len(state_mod.TRANSITIONS)}; "
         "if you intentionally added/removed a transition, update this assertion "
         "AND add granular ERT/MCT/APT/VLT scenario coverage for it."
     )

--- a/orchestrator/tests/test_state.py
+++ b/orchestrator/tests/test_state.py
@@ -178,7 +178,7 @@ def test_user_review_pending_has_no_session_failed_self_loop():
 
 def test_user_review_pending_illegal_events_return_none():
     """USR-T4 续：除 USER_REVIEW_PASS / USER_REVIEW_FIX 外其他事件全非法。"""
-    legal = {Event.USER_REVIEW_PASS, Event.USER_REVIEW_FIX}
+    legal = {Event.USER_REVIEW_PASS, Event.USER_REVIEW_FIX, Event.PR_MERGED}
     for ev in Event:
         if ev in legal:
             continue


### PR DESCRIPTION
## Summary

- Adds `Event.PR_MERGED` to the state machine with transitions from `PENDING_USER_REVIEW`, `REVIEW_RUNNING`, and `PR_CI_RUNNING` → `ARCHIVING` (action: `done_archive`)
- Adds `POST /admin/req/{req_id}/pr-merged` admin endpoint: authenticated, noop for terminal states, 409 for unexpected states, writes merge metadata to context then emits `PR_MERGED`
- Adds GHA workflow `.github/workflows/sisyphus-pr-merged-hook.yml`: fires on `pull_request[closed]` where `merged==true` and label `sisyphus` present; extracts `REQ-<id>` from branch name and calls the new endpoint

## Motivation

After `pr_ci_watch` passes, a REQ enters `PENDING_USER_REVIEW`. When a human reviewer merges the PR, sisyphus had no awareness — the REQ stayed stuck indefinitely. This PR closes that loop.

## Test plan

- [x] 11 unit tests in `orchestrator/tests/test_admin_pr_merged.py` — all pass
- [x] Existing admin + engine tests (57 tests) — all pass
- [x] `ruff check` clean on modified files
- [ ] `make ci-unit-test` runs on runner pod (sisyphus staging_test stage)
- [ ] GHA workflow fires on a test PR merge in a sisyphus-enabled repo
- [ ] Required secrets: `ORCH_ENDPOINT`, `SISYPHUS_WEBHOOK_TOKEN` must be set in each business repo

## Notes

- CAS in `engine.step` handles the race between this hook and a concurrent verifier/CI runner — one wins, the other logs a `cas_lost` and becomes a noop
- 401 failures in GHA are treated as hard errors; 404/409 are soft-skip (REQ may not exist or state already moved on)

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-pr-merge-archive-hook-1777344443`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/gxsnini3)