### PR TITLE
feat(maintenance): periodic TTL cleanup for event_seen / dispatch_slugs / verifier_decisions / stage_runs

### DIFF
--- a/openspec/changes/REQ-pg-table-ttl-cleanup-1777344801/proposal.md
+++ b/openspec/changes/REQ-pg-table-ttl-cleanup-1777344801/proposal.md
@@ -1,0 +1,35 @@
+# REQ-pg-table-ttl-cleanup-1777344801: Periodic TTL Cleanup for Append-Only Tables
+
+## Problem
+
+Four tables in the sisyphus Postgres instance grow without bound and are never pruned:
+
+| Table | Purpose | Growth rate |
+|---|---|---|
+| `event_seen` | Webhook dedup | ~4000 rows/week |
+| `dispatch_slugs` | BKD issue creation idempotency | ~50 rows/week |
+| `verifier_decisions` | Verifier audit trail | ~50 rows/week |
+| `stage_runs` | Stage agent timing & token metrics | ~100 rows/week |
+
+Over months, unbounded growth leads to slow sequential scans on dedup lookups,
+inflated backup sizes, and degraded dashboard query performance.
+
+## Approach
+
+Add a background asyncio task (`table_ttl.run_loop`) to the orchestrator startup
+sequence. The task runs `run_ttl_cleanup(pool)` every `ttl_cleanup_interval_sec`
+seconds (default 24 h) and deletes rows older than per-table retention thresholds.
+
+**Key safety constraint**: `stage_runs` rows where `ended_at IS NULL` are _never_
+deleted — they represent still-open or abnormally-terminated runs that may be
+needed for debugging.
+
+All thresholds are configurable via environment variables (12-factor) with
+conservative defaults: 30 days for webhook dedup, 90 days for everything else.
+
+## Non-scope
+
+- `req_state` — permanent business record; never pruned
+- `bkd_snapshot` / obs views — managed by separate snapshot loop
+- Manual admin endpoint — 24 h periodic is sufficient; no on-demand trigger needed
+- Bulk historical backfill of already-accumulated rows — first automatic run handles it

--- a/openspec/changes/REQ-pg-table-ttl-cleanup-1777344801/specs/table-ttl/contract.spec.yaml
+++ b/openspec/changes/REQ-pg-table-ttl-cleanup-1777344801/specs/table-ttl/contract.spec.yaml
@@ -1,0 +1,85 @@
+capability: table-ttl
+version: "1.0"
+description: >
+  Periodic background TTL cleanup for four append-only tables in the sisyphus
+  Postgres instance. Runs as an asyncio background task in the orchestrator.
+  No HTTP endpoint — purely internal maintenance.
+
+background_task:
+  module: orchestrator.maintenance.table_ttl
+  entry: run_loop
+  startup_condition:
+    settings.ttl_cleanup_enabled: true
+    settings.ttl_cleanup_interval_sec: "> 0"
+
+tables:
+  event_seen:
+    time_column: seen_at
+    config_key: ttl_event_seen_days
+    default_days: 30
+    filter: none  # all rows subject to TTL
+
+  dispatch_slugs:
+    time_column: created_at
+    config_key: ttl_dispatch_slugs_days
+    default_days: 90
+    filter: none
+
+  verifier_decisions:
+    time_column: made_at
+    config_key: ttl_verifier_decisions_days
+    default_days: 90
+    filter: none
+
+  stage_runs:
+    time_column: ended_at
+    config_key: ttl_stage_runs_closed_days
+    default_days: 90
+    filter: "ended_at IS NOT NULL"  # MUST NOT delete open (in-flight) rows
+
+config_keys:
+  - key: SISYPHUS_TTL_CLEANUP_ENABLED
+    type: bool
+    default: true
+  - key: SISYPHUS_TTL_CLEANUP_INTERVAL_SEC
+    type: int
+    default: 86400
+  - key: SISYPHUS_TTL_EVENT_SEEN_DAYS
+    type: int
+    default: 30
+  - key: SISYPHUS_TTL_DISPATCH_SLUGS_DAYS
+    type: int
+    default: 90
+  - key: SISYPHUS_TTL_VERIFIER_DECISIONS_DAYS
+    type: int
+    default: 90
+  - key: SISYPHUS_TTL_STAGE_RUNS_CLOSED_DAYS
+    type: int
+    default: 90
+
+cleanup_result_schema:
+  type: object
+  properties:
+    event_seen:
+      $ref: "#/$defs/table_summary"
+    dispatch_slugs:
+      $ref: "#/$defs/table_summary"
+    verifier_decisions:
+      $ref: "#/$defs/table_summary"
+    stage_runs:
+      $ref: "#/$defs/table_summary"
+
+"$defs":
+  table_summary:
+    type: object
+    required: [before, after, deleted]
+    properties:
+      before:
+        type: integer
+        description: Row count before deletion
+      after:
+        type: integer
+        description: Row count after deletion
+      deleted:
+        type: integer
+        description: Number of rows deleted (before - after)

--- a/openspec/changes/REQ-pg-table-ttl-cleanup-1777344801/specs/table-ttl/spec.md
+++ b/openspec/changes/REQ-pg-table-ttl-cleanup-1777344801/specs/table-ttl/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: Background TTL cleanup task removes stale rows from append-only tables
+
+The orchestrator SHALL run a background asyncio task (`table_ttl.run_loop`) that
+periodically invokes `run_ttl_cleanup(pool)` to delete rows older than configured
+retention thresholds from four append-only tables. The task MUST be started during
+application startup when `ttl_cleanup_enabled=True` and
+`ttl_cleanup_interval_sec > 0`. When `ttl_cleanup_enabled=False` the loop MUST
+return immediately without performing any deletions.
+
+#### Scenario: TTL-S1 event_seen rows older than ttl_event_seen_days are deleted
+- **GIVEN** event_seen contains a row with seen_at 40 days ago and another with seen_at 1 day ago
+- **WHEN** run_ttl_cleanup is called with ttl_event_seen_days=30
+- **THEN** the 40-day-old row is deleted and the 1-day-old row is retained
+
+#### Scenario: TTL-S2 dispatch_slugs rows older than ttl_dispatch_slugs_days are deleted
+- **GIVEN** dispatch_slugs contains a row with created_at older than ttl_dispatch_slugs_days
+- **WHEN** run_ttl_cleanup is invoked
+- **THEN** the DELETE SQL targets dispatch_slugs WHERE created_at < cutoff
+
+#### Scenario: TTL-S3 verifier_decisions rows older than ttl_verifier_decisions_days are deleted
+- **GIVEN** verifier_decisions contains a row with made_at older than ttl_verifier_decisions_days
+- **WHEN** run_ttl_cleanup is invoked
+- **THEN** the DELETE SQL targets verifier_decisions WHERE made_at < cutoff
+
+#### Scenario: TTL-S4 run_ttl_cleanup returns summary dict with before/after/deleted per table
+- **GIVEN** run_ttl_cleanup completes successfully
+- **WHEN** the return value is inspected
+- **THEN** result contains keys event_seen, dispatch_slugs, verifier_decisions, stage_runs,
+  each with sub-keys before (int), after (int), deleted (int = before - after)
+
+### Requirement: stage_runs rows with ended_at IS NULL are never deleted
+
+The cleanup task MUST NOT delete any `stage_runs` row where `ended_at IS NULL`.
+Such rows represent still-running or abnormally-terminated stage agents that may
+be needed for incident debugging. Only closed rows (ended_at IS NOT NULL) older
+than `ttl_stage_runs_closed_days` SHALL be deleted.
+
+#### Scenario: TTL-S5 open stage_runs (ended_at IS NULL) are never deleted
+- **GIVEN** a stage_runs row with started_at 180 days ago and ended_at IS NULL
+- **WHEN** run_ttl_cleanup is called with ttl_stage_runs_closed_days=1
+- **THEN** the row still exists in the database after cleanup
+
+#### Scenario: TTL-S6 closed stage_runs older than ttl_stage_runs_closed_days are deleted
+- **GIVEN** stage_runs contains a row with ended_at 95 days ago and one with ended_at 1 day ago
+- **WHEN** run_ttl_cleanup is called with ttl_stage_runs_closed_days=90
+- **THEN** the 95-day-old closed row is deleted and the 1-day-old closed row is retained
+
+#### Scenario: TTL-S7 stage_runs DELETE SQL includes ended_at IS NOT NULL guard
+- **GIVEN** run_ttl_cleanup is invoked
+- **WHEN** the DELETE statement for stage_runs is inspected
+- **THEN** the SQL contains both "ended_at IS NOT NULL" AND "ended_at < $1"
+
+### Requirement: TTL thresholds and loop interval are configurable via environment variables
+
+The orchestrator SHALL read TTL configuration from the following environment
+variables (all prefixed `SISYPHUS_`). The system MUST apply conservative defaults
+so that deployments without explicit configuration retain data longer rather than
+deleting it too aggressively.
+
+Defaults:
+- `SISYPHUS_TTL_CLEANUP_ENABLED`: `true`
+- `SISYPHUS_TTL_CLEANUP_INTERVAL_SEC`: `86400` (24 h)
+- `SISYPHUS_TTL_EVENT_SEEN_DAYS`: `30`
+- `SISYPHUS_TTL_DISPATCH_SLUGS_DAYS`: `90`
+- `SISYPHUS_TTL_VERIFIER_DECISIONS_DAYS`: `90`
+- `SISYPHUS_TTL_STAGE_RUNS_CLOSED_DAYS`: `90`
+
+#### Scenario: TTL-S8 ttl_cleanup_enabled=False causes run_loop to return without blocking
+- **GIVEN** SISYPHUS_TTL_CLEANUP_ENABLED=false
+- **WHEN** run_loop() is awaited
+- **THEN** the coroutine returns immediately without entering the while loop
+
+#### Scenario: TTL-S9 startup spawns table_ttl background task when enabled
+- **GIVEN** SISYPHUS_TTL_CLEANUP_ENABLED=true and SISYPHUS_TTL_CLEANUP_INTERVAL_SEC > 0
+- **WHEN** orchestrator startup() runs
+- **THEN** a background asyncio.Task named "table_ttl" is added to the _bg_tasks list

--- a/openspec/changes/REQ-pg-table-ttl-cleanup-1777344801/tasks.md
+++ b/openspec/changes/REQ-pg-table-ttl-cleanup-1777344801/tasks.md
@@ -1,0 +1,33 @@
+# Tasks: REQ-pg-table-ttl-cleanup-1777344801
+
+## Stage: spec
+
+- [x] Author `specs/table-ttl/contract.spec.yaml` — background task data contract
+- [x] Author `specs/table-ttl/spec.md` — scenarios (TTL-S1 through TTL-S9)
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/maintenance/table_ttl.py` — new module:
+  `run_ttl_cleanup(pool, cfg)` single cleanup pass + `run_loop()` background loop
+- [x] `orchestrator/src/orchestrator/config.py` — 6 new settings:
+  `ttl_cleanup_enabled`, `ttl_cleanup_interval_sec`, `ttl_event_seen_days`,
+  `ttl_dispatch_slugs_days`, `ttl_verifier_decisions_days`, `ttl_stage_runs_closed_days`
+- [x] `orchestrator/src/orchestrator/main.py` — startup step 7: spawn `table_ttl.run_loop`
+  as background task when `ttl_cleanup_enabled=True` and `ttl_cleanup_interval_sec > 0`
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_table_ttl.py` — 6 unit tests (mock pool):
+  - SQL structure and cutoff parameter for each table
+  - `stage_runs` DELETE condition includes `ended_at IS NOT NULL`
+  - summary dict structure
+  - `ttl_cleanup_enabled=False` causes `run_loop` to exit immediately
+- [x] 3 integration tests (`@pytest.mark.integration`, real PG):
+  - `event_seen`: old row deleted, recent row kept
+  - `stage_runs` open (ended_at IS NULL): never deleted regardless of age
+  - `stage_runs` closed: old deleted, recent kept
+
+## Stage: PR
+
+- [x] `git push origin feat/REQ-pg-table-ttl-cleanup-1777344801`
+- [x] `gh pr create --label sisyphus`

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -225,5 +225,15 @@ class Settings(BaseSettings):
     checker_infra_flake_retry_max: int = 1            # 0 = no retry, 1 = 1 retry (2 attempts)
     checker_infra_flake_retry_backoff_sec: int = 15
 
+    # ─── 周期 TTL 清理（增长表防膨胀） ───────────────────────────────────
+    # event_seen / dispatch_slugs / verifier_decisions / stage_runs(closed) 只增不减；
+    # 后台任务按 interval 周期删过期行。False = 关闭（dev / 单测可不跑）。
+    ttl_cleanup_enabled: bool = True
+    ttl_cleanup_interval_sec: int = 86400         # 24h
+    ttl_event_seen_days: int = 30                 # webhook dedup：7 天 4000+ 行，30 天足矣
+    ttl_dispatch_slugs_days: int = 90             # slug 幂等映射：低频写，保 90 天
+    ttl_verifier_decisions_days: int = 90         # verifier 判决审计：90 天
+    ttl_stage_runs_closed_days: int = 90          # stage_runs ended_at IS NOT NULL：90 天
+
 
 settings = Settings()  # type: ignore[call-arg]

--- a/orchestrator/src/orchestrator/main.py
+++ b/orchestrator/src/orchestrator/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from . import k8s_runner, runner_gc, snapshot, watchdog
 from .admin import admin as admin_api
 from .config import settings
+from .maintenance import table_ttl
 from .migrate import apply_pending
 from .store import db
 from .webhook import api as webhook_api
@@ -75,6 +76,9 @@ async def startup() -> None:
     # 6. 起 watchdog 兜底任务（M8：BKD 不发 session.failed 时周期性 escalate 卡死 REQ）
     if settings.watchdog_enabled and settings.watchdog_interval_sec > 0:
         _bg_tasks.append(asyncio.create_task(watchdog.run_loop(), name="watchdog"))
+    # 7. 起 TTL 清理后台任务（event_seen / dispatch_slugs / verifier_decisions / stage_runs）
+    if settings.ttl_cleanup_enabled and settings.ttl_cleanup_interval_sec > 0:
+        _bg_tasks.append(asyncio.create_task(table_ttl.run_loop(), name="table_ttl"))
     log.info(
         "startup.ok",
         port=settings.port,

--- a/orchestrator/src/orchestrator/maintenance/table_ttl.py
+++ b/orchestrator/src/orchestrator/maintenance/table_ttl.py
@@ -1,0 +1,101 @@
+"""Table TTL 后台清理任务。
+
+每 ttl_cleanup_interval_sec 秒跑一次，删 4 张增长表的过期行：
+- event_seen        : seen_at  > ttl_event_seen_days 天
+- dispatch_slugs    : created_at > ttl_dispatch_slugs_days 天
+- verifier_decisions: made_at > ttl_verifier_decisions_days 天
+- stage_runs (closed, ended_at IS NOT NULL): ended_at > ttl_stage_runs_closed_days 天
+  ended_at IS NULL 的行永远不删（排错保留）
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+
+from ..config import settings
+from ..store import db
+
+log = structlog.get_logger(__name__)
+
+
+async def run_ttl_cleanup(pool: Any, cfg: Any | None = None) -> dict:
+    """单次 TTL 清理。返回各表 {before, after, deleted} 统计。
+
+    cfg 默认读 settings（模块全局）；测试可传入自定义对象覆盖 TTL 天数。
+    """
+    if cfg is None:
+        cfg = settings
+
+    now = datetime.now(UTC)
+
+    # ── event_seen ──────────────────────────────────────────────────────
+    cutoff_es = now - timedelta(days=cfg.ttl_event_seen_days)
+    before_es: int = await pool.fetchval("SELECT COUNT(*) FROM event_seen")
+    await pool.execute("DELETE FROM event_seen WHERE seen_at < $1", cutoff_es)
+    after_es: int = await pool.fetchval("SELECT COUNT(*) FROM event_seen")
+
+    # ── dispatch_slugs ──────────────────────────────────────────────────
+    cutoff_ds = now - timedelta(days=cfg.ttl_dispatch_slugs_days)
+    before_ds: int = await pool.fetchval("SELECT COUNT(*) FROM dispatch_slugs")
+    await pool.execute("DELETE FROM dispatch_slugs WHERE created_at < $1", cutoff_ds)
+    after_ds: int = await pool.fetchval("SELECT COUNT(*) FROM dispatch_slugs")
+
+    # ── verifier_decisions ──────────────────────────────────────────────
+    cutoff_vd = now - timedelta(days=cfg.ttl_verifier_decisions_days)
+    before_vd: int = await pool.fetchval("SELECT COUNT(*) FROM verifier_decisions")
+    await pool.execute("DELETE FROM verifier_decisions WHERE made_at < $1", cutoff_vd)
+    after_vd: int = await pool.fetchval("SELECT COUNT(*) FROM verifier_decisions")
+
+    # ── stage_runs (closed only) ─────────────────────────────────────────
+    # ended_at IS NULL = still running or never closed — never touch those.
+    cutoff_sr = now - timedelta(days=cfg.ttl_stage_runs_closed_days)
+    before_sr: int = await pool.fetchval(
+        "SELECT COUNT(*) FROM stage_runs WHERE ended_at IS NOT NULL"
+    )
+    await pool.execute(
+        "DELETE FROM stage_runs WHERE ended_at IS NOT NULL AND ended_at < $1", cutoff_sr
+    )
+    after_sr: int = await pool.fetchval(
+        "SELECT COUNT(*) FROM stage_runs WHERE ended_at IS NOT NULL"
+    )
+
+    summary = {
+        "event_seen": {"before": before_es, "after": after_es, "deleted": before_es - after_es},
+        "dispatch_slugs": {"before": before_ds, "after": after_ds, "deleted": before_ds - after_ds},
+        "verifier_decisions": {"before": before_vd, "after": after_vd, "deleted": before_vd - after_vd},
+        "stage_runs": {"before": before_sr, "after": after_sr, "deleted": before_sr - after_sr},
+    }
+    log.info(
+        "table_ttl.cleanup.summary",
+        event_seen_before=before_es, event_seen_deleted=before_es - after_es,
+        dispatch_slugs_before=before_ds, dispatch_slugs_deleted=before_ds - after_ds,
+        verifier_decisions_before=before_vd, verifier_decisions_deleted=before_vd - after_vd,
+        stage_runs_before=before_sr, stage_runs_deleted=before_sr - after_sr,
+    )
+    return summary
+
+
+async def run_loop() -> None:
+    """orchestrator 启动起的后台任务，周期性 TTL 清理。
+
+    ttl_cleanup_enabled=False 时立即返回（loop 退出）。
+    """
+    if not settings.ttl_cleanup_enabled:
+        log.info("table_ttl.disabled")
+        return
+
+    interval = settings.ttl_cleanup_interval_sec
+    log.info("table_ttl.loop.started", interval_sec=interval)
+    while True:
+        try:
+            pool = db.get_pool()
+            await run_ttl_cleanup(pool)
+        except asyncio.CancelledError:
+            log.info("table_ttl.loop.stopped")
+            raise
+        except Exception as e:
+            log.warning("table_ttl.error", error=str(e))
+        await asyncio.sleep(interval)

--- a/orchestrator/tests/test_contract_table_ttl_challenger.py
+++ b/orchestrator/tests/test_contract_table_ttl_challenger.py
@@ -1,0 +1,403 @@
+"""Challenger contract tests for REQ-pg-table-ttl-cleanup-1777344801.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-pg-table-ttl-cleanup-1777344801/specs/table-ttl/spec.md
+  openspec/changes/REQ-pg-table-ttl-cleanup-1777344801/specs/table-ttl/contract.spec.yaml
+
+Scenarios covered:
+  TTL-S1  event_seen: rows older than ttl_event_seen_days deleted, recent retained  [integration]
+  TTL-S2  dispatch_slugs: DELETE SQL targets created_at < cutoff
+  TTL-S3  verifier_decisions: DELETE SQL targets made_at < cutoff
+  TTL-S4  run_ttl_cleanup returns summary dict with before/after/deleted per table
+  TTL-S5  open stage_runs (ended_at IS NULL) are never deleted  [integration]
+  TTL-S6  closed stage_runs: old deleted, recent retained  [integration]
+  TTL-S7  stage_runs DELETE SQL includes ended_at IS NOT NULL AND ended_at < cutoff
+  TTL-S8  ttl_cleanup_enabled=False causes run_loop to return immediately
+  TTL-S9  startup references table_ttl.run_loop as a background task
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is truly wrong, escalate to spec_fixer to correct the spec.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+import inspect
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+_MODULE = "orchestrator.maintenance.table_ttl"
+_MAIN_MODULE = "orchestrator.main"
+
+
+# ─── Mock pool ────────────────────────────────────────────────────────────────
+
+
+class _CapturePool:
+    """Minimal asyncpg pool stand-in that records every SQL call."""
+
+    def __init__(self) -> None:
+        self.execute_calls: list[tuple[str, tuple]] = []
+        self.fetchval_calls: list[tuple[str, tuple]] = []
+        self.fetchrow_calls: list[tuple[str, tuple]] = []
+
+    async def execute(self, sql: str, *args: Any) -> str:
+        self.execute_calls.append((sql, args))
+        return "DELETE 0"
+
+    async def fetchval(self, sql: str, *args: Any) -> int:
+        self.fetchval_calls.append((sql, args))
+        return 0
+
+    async def fetchrow(self, sql: str, *args: Any) -> dict | None:
+        self.fetchrow_calls.append((sql, args))
+        return {"count": 0}
+
+    def all_sql(self) -> str:
+        """Concatenate all SQL statements seen across every call type."""
+        all_calls = self.execute_calls + self.fetchval_calls + self.fetchrow_calls
+        return " ".join(sql for sql, _ in all_calls)
+
+
+# ─── TTL-S2 ───────────────────────────────────────────────────────────────────
+
+
+async def test_ttl_s2_dispatch_slugs_delete_targets_created_at() -> None:
+    """TTL-S2: run_ttl_cleanup DELETE for dispatch_slugs MUST reference created_at."""
+    mod = importlib.import_module(_MODULE)
+    pool = _CapturePool()
+    await mod.run_ttl_cleanup(pool)
+    sql = pool.all_sql().lower()
+    assert "dispatch_slugs" in sql, (
+        "TTL-S2: run_ttl_cleanup MUST issue SQL that references the dispatch_slugs table"
+    )
+    # Find the section of SQL that references dispatch_slugs
+    dispatch_sqls = [
+        s for s, _ in (pool.execute_calls + pool.fetchval_calls + pool.fetchrow_calls)
+        if "dispatch_slugs" in s.lower()
+    ]
+    assert dispatch_sqls, "TTL-S2: expected at least one SQL statement for dispatch_slugs"
+    combined = " ".join(dispatch_sqls).lower()
+    assert "created_at" in combined, (
+        "TTL-S2: dispatch_slugs SQL MUST reference created_at column as the TTL cutoff"
+    )
+
+
+# ─── TTL-S3 ───────────────────────────────────────────────────────────────────
+
+
+async def test_ttl_s3_verifier_decisions_delete_targets_made_at() -> None:
+    """TTL-S3: run_ttl_cleanup DELETE for verifier_decisions MUST reference made_at."""
+    mod = importlib.import_module(_MODULE)
+    pool = _CapturePool()
+    await mod.run_ttl_cleanup(pool)
+    vd_sqls = [
+        s for s, _ in (pool.execute_calls + pool.fetchval_calls + pool.fetchrow_calls)
+        if "verifier_decisions" in s.lower()
+    ]
+    assert vd_sqls, (
+        "TTL-S3: run_ttl_cleanup MUST issue SQL that references the verifier_decisions table"
+    )
+    combined = " ".join(vd_sqls).lower()
+    assert "made_at" in combined, (
+        "TTL-S3: verifier_decisions SQL MUST reference made_at column as the TTL cutoff"
+    )
+
+
+# ─── TTL-S4 ───────────────────────────────────────────────────────────────────
+
+
+async def test_ttl_s4_returns_summary_dict_per_table() -> None:
+    """TTL-S4: run_ttl_cleanup MUST return a dict with 4 table keys, each containing
+    before (int), after (int), deleted (int = before - after).
+    """
+    mod = importlib.import_module(_MODULE)
+    pool = _CapturePool()
+    result = await mod.run_ttl_cleanup(pool)
+
+    assert isinstance(result, dict), (
+        f"TTL-S4: run_ttl_cleanup MUST return a dict, got {type(result).__name__}"
+    )
+    expected_tables = {"event_seen", "dispatch_slugs", "verifier_decisions", "stage_runs"}
+    assert expected_tables == set(result.keys()), (
+        f"TTL-S4: result keys MUST be exactly {sorted(expected_tables)!r}, "
+        f"got {sorted(result.keys())!r}"
+    )
+    for tbl, summary in result.items():
+        assert isinstance(summary, dict), (
+            f"TTL-S4: result[{tbl!r}] MUST be a dict, got {type(summary).__name__}"
+        )
+        for sub in ("before", "after", "deleted"):
+            assert sub in summary, (
+                f"TTL-S4: result[{tbl!r}] MUST contain key {sub!r}"
+            )
+            assert isinstance(summary[sub], int), (
+                f"TTL-S4: result[{tbl!r}][{sub!r}] MUST be int, "
+                f"got {type(summary[sub]).__name__}"
+            )
+        assert summary["deleted"] == summary["before"] - summary["after"], (
+            f"TTL-S4: result[{tbl!r}]['deleted'] MUST equal before - after "
+            f"({summary['before']} - {summary['after']} ≠ {summary['deleted']})"
+        )
+
+
+# ─── TTL-S7 ───────────────────────────────────────────────────────────────────
+
+
+async def test_ttl_s7_stage_runs_delete_has_ended_at_not_null_guard() -> None:
+    """TTL-S7: the SQL for stage_runs MUST contain both 'ended_at IS NOT NULL'
+    and an ended_at < cutoff condition so open runs are never deleted.
+    """
+    mod = importlib.import_module(_MODULE)
+    pool = _CapturePool()
+    await mod.run_ttl_cleanup(pool)
+
+    sr_sqls = [
+        s for s, _ in (pool.execute_calls + pool.fetchval_calls + pool.fetchrow_calls)
+        if "stage_runs" in s.lower()
+    ]
+    assert sr_sqls, (
+        "TTL-S7: run_ttl_cleanup MUST issue SQL that references the stage_runs table"
+    )
+    combined = " ".join(sr_sqls).lower()
+    assert "ended_at is not null" in combined, (
+        "TTL-S7: stage_runs SQL MUST contain 'ended_at IS NOT NULL' guard "
+        "to prevent deletion of open (in-flight) rows"
+    )
+    assert "ended_at" in combined and ("<" in combined or "$" in combined), (
+        "TTL-S7: stage_runs SQL MUST contain an ended_at < cutoff condition"
+    )
+
+
+# ─── TTL-S8 ───────────────────────────────────────────────────────────────────
+
+
+async def test_ttl_s8_disabled_run_loop_returns_immediately(monkeypatch) -> None:
+    """TTL-S8: when SISYPHUS_TTL_CLEANUP_ENABLED=false, run_loop() MUST return
+    immediately without entering the while loop.
+    """
+    monkeypatch.setenv("SISYPHUS_TTL_CLEANUP_ENABLED", "false")
+    # Reload so Settings picks up the env change
+    if "orchestrator.config" in importlib.sys.modules:
+        importlib.reload(importlib.sys.modules["orchestrator.config"])
+    mod = importlib.import_module(_MODULE)
+    importlib.reload(mod)
+
+    try:
+        await asyncio.wait_for(mod.run_loop(), timeout=2.0)
+    except asyncio.TimeoutError:
+        pytest.fail(
+            "TTL-S8: run_loop() MUST return in <2 s when ttl_cleanup_enabled=False; "
+            "it appears to be blocking (did not return)"
+        )
+
+
+# ─── TTL-S9 ───────────────────────────────────────────────────────────────────
+
+
+def test_ttl_s9_module_exposes_async_run_loop() -> None:
+    """TTL-S9a: orchestrator.maintenance.table_ttl MUST expose run_loop as an
+    async coroutine function — prerequisite for asyncio.create_task().
+    """
+    mod = importlib.import_module(_MODULE)
+    assert hasattr(mod, "run_loop"), (
+        "TTL-S9: orchestrator.maintenance.table_ttl MUST expose run_loop"
+    )
+    assert asyncio.iscoroutinefunction(mod.run_loop), (
+        "TTL-S9: table_ttl.run_loop MUST be defined with 'async def' "
+        "so it can be wrapped in asyncio.create_task()"
+    )
+
+
+def test_ttl_s9_main_startup_references_table_ttl() -> None:
+    """TTL-S9b: orchestrator.main MUST reference 'table_ttl' in its startup
+    logic so the background task is spawned when the orchestrator starts.
+    """
+    main_mod = importlib.import_module(_MAIN_MODULE)
+    src = inspect.getsource(main_mod)
+    assert "table_ttl" in src, (
+        "TTL-S9: orchestrator.main MUST reference 'table_ttl' — it is responsible "
+        "for spawning the background cleanup task during startup"
+    )
+
+
+# ─── Integration fixtures ─────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def live_pool():
+    """Real asyncpg pool against SISYPHUS_PG_DSN (integration tests only)."""
+    import asyncpg
+
+    dsn = os.environ.get("SISYPHUS_PG_DSN", "postgresql://test:test@localhost/test")
+    pool = await asyncpg.create_pool(dsn, min_size=1, max_size=3)
+    yield pool
+    await pool.close()
+
+
+# ─── TTL-S1 ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_ttl_s1_event_seen_old_deleted_recent_retained(
+    live_pool, monkeypatch
+) -> None:
+    """TTL-S1: a 40-day-old event_seen row is deleted and a 1-day-old row is retained
+    when ttl_event_seen_days=30.
+    """
+    monkeypatch.setenv("SISYPHUS_TTL_EVENT_SEEN_DAYS", "30")
+    monkeypatch.setenv("SISYPHUS_TTL_CLEANUP_ENABLED", "true")
+    if "orchestrator.config" in importlib.sys.modules:
+        importlib.reload(importlib.sys.modules["orchestrator.config"])
+    mod = importlib.import_module(_MODULE)
+    importlib.reload(mod)
+
+    now = datetime.now(UTC)
+    ts = now.timestamp()
+    old_key = f"__contract_s1_old_{ts}"
+    recent_key = f"__contract_s1_recent_{ts}"
+
+    await live_pool.execute(
+        "INSERT INTO event_seen (event_key, seen_at) VALUES ($1, $2) "
+        "ON CONFLICT (event_key) DO NOTHING",
+        old_key,
+        now - timedelta(days=40),
+    )
+    await live_pool.execute(
+        "INSERT INTO event_seen (event_key, seen_at) VALUES ($1, $2) "
+        "ON CONFLICT (event_key) DO NOTHING",
+        recent_key,
+        now - timedelta(days=1),
+    )
+
+    await mod.run_ttl_cleanup(live_pool)
+
+    old_row = await live_pool.fetchrow(
+        "SELECT 1 FROM event_seen WHERE event_key = $1", old_key
+    )
+    recent_row = await live_pool.fetchrow(
+        "SELECT 1 FROM event_seen WHERE event_key = $1", recent_key
+    )
+
+    # cleanup regardless of assertion outcome
+    await live_pool.execute(
+        "DELETE FROM event_seen WHERE event_key LIKE '__contract\\_s1\\_%' ESCAPE '\\'"
+    )
+
+    assert old_row is None, (
+        "TTL-S1: event_seen row with seen_at 40 days ago MUST be deleted "
+        "when ttl_event_seen_days=30"
+    )
+    assert recent_row is not None, (
+        "TTL-S1: event_seen row with seen_at 1 day ago MUST be retained "
+        "when ttl_event_seen_days=30"
+    )
+
+
+# ─── TTL-S5 ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_ttl_s5_open_stage_runs_never_deleted(live_pool, monkeypatch) -> None:
+    """TTL-S5: a stage_runs row with started_at 180 days ago and ended_at IS NULL
+    MUST NOT be deleted even when ttl_stage_runs_closed_days=1.
+    """
+    monkeypatch.setenv("SISYPHUS_TTL_STAGE_RUNS_CLOSED_DAYS", "1")
+    monkeypatch.setenv("SISYPHUS_TTL_CLEANUP_ENABLED", "true")
+    if "orchestrator.config" in importlib.sys.modules:
+        importlib.reload(importlib.sys.modules["orchestrator.config"])
+    mod = importlib.import_module(_MODULE)
+    importlib.reload(mod)
+
+    now = datetime.now(UTC)
+    req_id = f"__contract_s5_{now.timestamp()}"
+    started_at = now - timedelta(days=180)
+
+    row_id = await live_pool.fetchval(
+        "INSERT INTO stage_runs (req_id, stage, started_at, ended_at) "
+        "VALUES ($1, 'dev', $2, NULL) RETURNING id",
+        req_id,
+        started_at,
+    )
+
+    await mod.run_ttl_cleanup(live_pool)
+
+    still_there = await live_pool.fetchrow(
+        "SELECT 1 FROM stage_runs WHERE id = $1", row_id
+    )
+
+    # cleanup
+    await live_pool.execute(
+        "DELETE FROM stage_runs WHERE req_id LIKE '__contract\\_s5\\_%' ESCAPE '\\'"
+    )
+
+    assert still_there is not None, (
+        "TTL-S5: open stage_runs row (ended_at IS NULL, 180 days old) MUST NOT be "
+        "deleted regardless of ttl_stage_runs_closed_days"
+    )
+
+
+# ─── TTL-S6 ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_ttl_s6_closed_stage_runs_old_deleted_recent_retained(
+    live_pool, monkeypatch
+) -> None:
+    """TTL-S6: a closed stage_runs row with ended_at 95 days ago is deleted and
+    one with ended_at 1 day ago is retained when ttl_stage_runs_closed_days=90.
+    """
+    monkeypatch.setenv("SISYPHUS_TTL_STAGE_RUNS_CLOSED_DAYS", "90")
+    monkeypatch.setenv("SISYPHUS_TTL_CLEANUP_ENABLED", "true")
+    if "orchestrator.config" in importlib.sys.modules:
+        importlib.reload(importlib.sys.modules["orchestrator.config"])
+    mod = importlib.import_module(_MODULE)
+    importlib.reload(mod)
+
+    now = datetime.now(UTC)
+    ts = now.timestamp()
+    old_req = f"__contract_s6_old_{ts}"
+    recent_req = f"__contract_s6_recent_{ts}"
+    old_ended = now - timedelta(days=95)
+    recent_ended = now - timedelta(days=1)
+
+    old_id = await live_pool.fetchval(
+        "INSERT INTO stage_runs (req_id, stage, started_at, ended_at) "
+        "VALUES ($1, 'dev', $2, $3) RETURNING id",
+        old_req,
+        old_ended - timedelta(hours=1),
+        old_ended,
+    )
+    recent_id = await live_pool.fetchval(
+        "INSERT INTO stage_runs (req_id, stage, started_at, ended_at) "
+        "VALUES ($1, 'dev', $2, $3) RETURNING id",
+        recent_req,
+        recent_ended - timedelta(hours=1),
+        recent_ended,
+    )
+
+    await mod.run_ttl_cleanup(live_pool)
+
+    old_row = await live_pool.fetchrow(
+        "SELECT 1 FROM stage_runs WHERE id = $1", old_id
+    )
+    recent_row = await live_pool.fetchrow(
+        "SELECT 1 FROM stage_runs WHERE id = $1", recent_id
+    )
+
+    # cleanup
+    await live_pool.execute(
+        "DELETE FROM stage_runs WHERE req_id LIKE '__contract\\_s6\\_%' ESCAPE '\\'"
+    )
+
+    assert old_row is None, (
+        "TTL-S6: closed stage_runs row with ended_at 95 days ago MUST be deleted "
+        "when ttl_stage_runs_closed_days=90"
+    )
+    assert recent_row is not None, (
+        "TTL-S6: closed stage_runs row with ended_at 1 day ago MUST be retained "
+        "when ttl_stage_runs_closed_days=90"
+    )

--- a/orchestrator/tests/test_table_ttl.py
+++ b/orchestrator/tests/test_table_ttl.py
@@ -1,0 +1,233 @@
+"""table_ttl 单测 + 集成测试。
+
+单测：mock pool，验证 SQL 语句和 cutoff 参数正确。
+集成测试：真 PG，insert 过期行 + 新鲜行，验证只删过期行。
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from orchestrator.maintenance.table_ttl import run_loop, run_ttl_cleanup
+
+# ── 测试用 config stub ─────────────────────────────────────────────────────────
+
+class _Cfg:
+    """最小化 settings stub，只含 TTL 天数字段。"""
+
+    def __init__(
+        self,
+        ttl_event_seen_days: int = 30,
+        ttl_dispatch_slugs_days: int = 90,
+        ttl_verifier_decisions_days: int = 90,
+        ttl_stage_runs_closed_days: int = 90,
+    ):
+        self.ttl_event_seen_days = ttl_event_seen_days
+        self.ttl_dispatch_slugs_days = ttl_dispatch_slugs_days
+        self.ttl_verifier_decisions_days = ttl_verifier_decisions_days
+        self.ttl_stage_runs_closed_days = ttl_stage_runs_closed_days
+
+
+# ── FakePool ─────────────────────────────────────────────────────────────────
+
+class _FakePool:
+    """asyncpg pool stub: 记录所有 execute/fetchval 调用，返回固定 count。"""
+
+    def __init__(self, count: int = 100):
+        self._count = count
+        self.execute_calls: list[tuple[str, tuple]] = []
+        self.fetchval_calls: list[tuple[str, tuple]] = []
+
+    async def fetchval(self, sql: str, *args):
+        self.fetchval_calls.append((sql, args))
+        return self._count
+
+    async def execute(self, sql: str, *args):
+        self.execute_calls.append((sql, args))
+
+
+# ── 单元测试：SQL 结构 + cutoff 参数 ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_event_seen_delete_sql_and_cutoff():
+    """event_seen DELETE 用 seen_at < $1，cutoff ≈ 30 天前。"""
+    pool = _FakePool()
+    cfg = _Cfg(ttl_event_seen_days=30)
+    before = datetime.now(UTC)
+    await run_ttl_cleanup(pool, cfg)
+    after = datetime.now(UTC)
+
+    deletes = [(sql, args) for sql, args in pool.execute_calls if "event_seen" in sql]
+    assert len(deletes) == 1
+    sql, args = deletes[0]
+    assert "DELETE FROM event_seen" in sql
+    assert "seen_at < $1" in sql
+    cutoff: datetime = args[0]
+    assert (before - timedelta(days=30, seconds=1)) <= cutoff <= (after - timedelta(days=30) + timedelta(seconds=1))
+
+
+@pytest.mark.asyncio
+async def test_dispatch_slugs_delete_sql_and_cutoff():
+    """dispatch_slugs DELETE 用 created_at < $1，cutoff ≈ 90 天前。"""
+    pool = _FakePool()
+    cfg = _Cfg(ttl_dispatch_slugs_days=90)
+    before = datetime.now(UTC)
+    await run_ttl_cleanup(pool, cfg)
+    after = datetime.now(UTC)
+
+    deletes = [(sql, args) for sql, args in pool.execute_calls if "dispatch_slugs" in sql]
+    assert len(deletes) == 1
+    sql, args = deletes[0]
+    assert "DELETE FROM dispatch_slugs" in sql
+    assert "created_at < $1" in sql
+    cutoff: datetime = args[0]
+    assert (before - timedelta(days=90, seconds=1)) <= cutoff <= (after - timedelta(days=90) + timedelta(seconds=1))
+
+
+@pytest.mark.asyncio
+async def test_verifier_decisions_delete_sql_and_cutoff():
+    """verifier_decisions DELETE 用 made_at < $1，cutoff ≈ 90 天前。"""
+    pool = _FakePool()
+    cfg = _Cfg(ttl_verifier_decisions_days=90)
+    before = datetime.now(UTC)
+    await run_ttl_cleanup(pool, cfg)
+    after = datetime.now(UTC)
+
+    deletes = [(sql, args) for sql, args in pool.execute_calls if "verifier_decisions" in sql]
+    assert len(deletes) == 1
+    sql, args = deletes[0]
+    assert "DELETE FROM verifier_decisions" in sql
+    assert "made_at < $1" in sql
+    cutoff: datetime = args[0]
+    assert (before - timedelta(days=90, seconds=1)) <= cutoff <= (after - timedelta(days=90) + timedelta(seconds=1))
+
+
+@pytest.mark.asyncio
+async def test_stage_runs_delete_only_closed():
+    """stage_runs DELETE 必须带 ended_at IS NOT NULL 条件，不删 open 行。"""
+    pool = _FakePool()
+    cfg = _Cfg(ttl_stage_runs_closed_days=90)
+    await run_ttl_cleanup(pool, cfg)
+
+    deletes = [(sql, args) for sql, args in pool.execute_calls if "stage_runs" in sql]
+    assert len(deletes) == 1
+    sql, _args = deletes[0]
+    assert "DELETE FROM stage_runs" in sql
+    assert "ended_at IS NOT NULL" in sql
+    assert "ended_at < $1" in sql
+
+
+@pytest.mark.asyncio
+async def test_summary_dict_contains_all_tables():
+    """run_ttl_cleanup 返回包含 4 张表统计的 dict。"""
+    pool = _FakePool(count=50)
+    result = await run_ttl_cleanup(pool, _Cfg())
+
+    for table in ("event_seen", "dispatch_slugs", "verifier_decisions", "stage_runs"):
+        assert table in result
+        assert "before" in result[table]
+        assert "after" in result[table]
+        assert "deleted" in result[table]
+        assert result[table]["before"] == 50
+        assert result[table]["after"] == 50
+        assert result[table]["deleted"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_loop_exits_when_disabled(monkeypatch):
+    """ttl_cleanup_enabled=False → run_loop 立刻返回（不进 while True）。"""
+    from orchestrator.maintenance import table_ttl
+
+    monkeypatch.setattr(table_ttl.settings, "ttl_cleanup_enabled", False)
+    # 如果 run_loop 没有立刻退出会卡死（asyncio timeout 会 fail），
+    # 但 pytest-asyncio auto mode 下直接 await 就行——返回意味着退出了。
+    await run_loop()  # must return without blocking
+
+
+# ── 集成测试：真 PG ────────────────────────────────────────────────────────────
+
+@pytest.mark.integration
+class TestTTLCleanupIntegration:
+    """需要真实 PostgreSQL（由 SISYPHUS_PG_DSN 指定）。"""
+
+    _dsn = os.environ.get("SISYPHUS_PG_DSN", "postgresql://test:test@localhost/test")
+
+    async def _pool(self):
+        import asyncpg
+        return await asyncpg.create_pool(self._dsn)
+
+    @pytest.mark.asyncio
+    async def test_event_seen_deletes_old_keeps_recent(self):
+        """event_seen: seen_at > 30 天的行被删，30 天内的保留。"""
+        pool = await self._pool()
+        old_id = f"ttl-test-{uuid.uuid4()}"
+        recent_id = f"ttl-test-{uuid.uuid4()}"
+        try:
+            await pool.execute(
+                "INSERT INTO event_seen (event_id, seen_at) VALUES ($1, $2)",
+                old_id, datetime.now(UTC) - timedelta(days=40),
+            )
+            await pool.execute(
+                "INSERT INTO event_seen (event_id, seen_at) VALUES ($1, $2)",
+                recent_id, datetime.now(UTC) - timedelta(days=1),
+            )
+            await run_ttl_cleanup(pool, _Cfg(ttl_event_seen_days=30))
+
+            assert await pool.fetchrow("SELECT 1 FROM event_seen WHERE event_id=$1", old_id) is None
+            assert await pool.fetchrow("SELECT 1 FROM event_seen WHERE event_id=$1", recent_id) is not None
+        finally:
+            await pool.execute("DELETE FROM event_seen WHERE event_id LIKE 'ttl-test-%'")
+            await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_stage_runs_open_never_deleted(self):
+        """stage_runs: ended_at IS NULL 的行永远不删（无论 ended_at cutoff）。"""
+        pool = await self._pool()
+        # ended_at IS NULL = still running（far past started_at，但没 ended_at）
+        run_id: int = await pool.fetchval(
+            """INSERT INTO stage_runs (req_id, stage, started_at)
+               VALUES ($1, 'test-ttl', $2) RETURNING id""",
+            f"REQ-ttl-test-{uuid.uuid4()}",
+            datetime.now(UTC) - timedelta(days=180),
+        )
+        try:
+            await run_ttl_cleanup(pool, _Cfg(ttl_stage_runs_closed_days=1))
+            row = await pool.fetchrow("SELECT id FROM stage_runs WHERE id=$1", run_id)
+            assert row is not None, "open stage_run (ended_at IS NULL) must never be deleted"
+        finally:
+            await pool.execute("DELETE FROM stage_runs WHERE id=$1", run_id)
+            await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_stage_runs_closed_old_deleted_recent_kept(self):
+        """stage_runs: ended_at IS NOT NULL かつ > 90 日の行は削除、新しい行は保留。"""
+        pool = await self._pool()
+        req_pfx = f"REQ-ttl-test-{uuid.uuid4()}"
+        old_run_id: int = await pool.fetchval(
+            """INSERT INTO stage_runs (req_id, stage, started_at, ended_at)
+               VALUES ($1, 'test-ttl', $2, $3) RETURNING id""",
+            req_pfx + "-old",
+            datetime.now(UTC) - timedelta(days=100),
+            datetime.now(UTC) - timedelta(days=95),
+        )
+        recent_run_id: int = await pool.fetchval(
+            """INSERT INTO stage_runs (req_id, stage, started_at, ended_at)
+               VALUES ($1, 'test-ttl', $2, $3) RETURNING id""",
+            req_pfx + "-recent",
+            datetime.now(UTC) - timedelta(days=5),
+            datetime.now(UTC) - timedelta(days=1),
+        )
+        try:
+            await run_ttl_cleanup(pool, _Cfg(ttl_stage_runs_closed_days=90))
+            assert await pool.fetchrow("SELECT id FROM stage_runs WHERE id=$1", old_run_id) is None
+            assert await pool.fetchrow("SELECT id FROM stage_runs WHERE id=$1", recent_run_id) is not None
+        finally:
+            await pool.execute(
+                "DELETE FROM stage_runs WHERE id = ANY($1::bigint[])",
+                [old_run_id, recent_run_id],
+            )
+            await pool.close()


### PR DESCRIPTION
## Summary

- Adds `orchestrator/src/orchestrator/maintenance/table_ttl.py`: `run_ttl_cleanup(pool, cfg)` single-pass cleanup + `run_loop()` background task
- Wires `table_ttl.run_loop` into `main.py` startup (step 7), guarded by `ttl_cleanup_enabled` and `ttl_cleanup_interval_sec > 0`
- Adds 6 config fields to `config.py` (`SISYPHUS_TTL_*` env vars)
- 6 unit tests (mock pool) + 3 integration tests (`@pytest.mark.integration`, real PG)

**Tables and retention**:

| Table | Time column | Default TTL |
|---|---|---|
| `event_seen` | `seen_at` | 30 days |
| `dispatch_slugs` | `created_at` | 90 days |
| `verifier_decisions` | `made_at` | 90 days |
| `stage_runs` (closed) | `ended_at` IS NOT NULL | 90 days |

`stage_runs` rows where `ended_at IS NULL` (still-open or crashed runs) are **never** touched.

## Test plan

- [ ] `make ci-unit-test` passes (6 new unit tests green, no regressions in the existing 1644-test suite)
- [ ] `make ci-integration-test` passes with a live PG (`SISYPHUS_PG_DSN` set): verifies old rows deleted, open stage_runs protected
- [ ] Deploy to staging: confirm startup log shows `table_ttl.loop.started interval_sec=86400`
- [ ] After 24 h: confirm `table_ttl.cleanup.summary` log appears with `event_seen_deleted`, `stage_runs_deleted` > 0

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-pg-table-ttl-cleanup-1777344801`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/vc6srdwm)