### PR TITLE
feat(staging_test): main HEAD baseline diff — PR failures ⊆ baseline → pass [REQ-staging-test-baseline-diff-1777343371]

### DIFF
--- a/openspec/changes/REQ-staging-test-baseline-diff-1777343371/proposal.md
+++ b/openspec/changes/REQ-staging-test-baseline-diff-1777343371/proposal.md
@@ -1,0 +1,25 @@
+# Proposal: staging_test Baseline Diff
+
+## Problem
+
+The `staging_test` checker runs `make ci-unit-test && make ci-integration-test` against
+the PR branch and treats any non-zero exit code as `STAGING_TEST_FAIL`. However, if
+`main` already has lint/test failures (e.g. a prior PR merged with broken tests), every
+subsequent REQ's staging_test will also fail — even though the PR itself introduced no
+new failures. This causes a dead-loop: verifier escalates → PR never merges → broken
+main never gets fixed.
+
+Observed: escalated:done ratio is 181:63 (25.8% done rate). 57 escalations (31%) are
+due to staging_test → verifier one-cut escalate, many on REQs whose PRs are clean.
+
+## Solution: Two-Phase Baseline Diff
+
+Before running tests on the PR branch, run the same tests on `origin/main` (baseline).
+The true failure set is `pr_failures - baseline_failures`:
+- Empty → `STAGING_TEST_PASS` (PR introduced no new failures; main itself is broken)
+- Non-empty → `STAGING_TEST_FAIL` with diff context for verifier
+
+Baseline results are cached 24h in a new `baseline_results` PG table to avoid
+re-running main tests for every REQ on the same main SHA.
+
+Baseline run failure/exception → graceful degradation to old single-phase exit-code logic.

--- a/openspec/changes/REQ-staging-test-baseline-diff-1777343371/specs/staging-test-baseline-diff/contract.spec.yaml
+++ b/openspec/changes/REQ-staging-test-baseline-diff-1777343371/specs/staging-test-baseline-diff/contract.spec.yaml
@@ -1,0 +1,49 @@
+version: "1.0"
+capability: staging-test-baseline-diff
+description: >
+  Two-phase baseline diff for staging_test checker.
+  Baseline (origin/main tests) cached 24h in baseline_results table.
+  True fail set = pr_failures - baseline_failures.
+
+scenarios:
+  - id: BD-1
+    description: baseline all pass + PR all pass → pass
+  - id: BD-2
+    description: baseline N fail + PR same N fail → diff empty → pass
+  - id: BD-3
+    description: baseline N fail + PR N+1 fail → fail with diff context in stderr
+  - id: BD-4
+    description: baseline phase exception → fallback to old exit-code logic
+
+db_objects:
+  - table: baseline_results
+    columns:
+      - name: cache_key
+        type: TEXT
+        unique: true
+        description: "baseline:staging_test:<main_head_sha>"
+      - name: main_sha
+        type: TEXT
+      - name: repo_results
+        type: JSONB
+        description: "{repo_basename: passed_bool}"
+      - name: created_at
+        type: TIMESTAMPTZ
+        default: NOW()
+    ttl_hours: 24
+
+checker_behavior:
+  phase1_baseline:
+    command: _build_baseline_cmd()
+    branch: origin/main
+    cache: true
+    cache_key_format: "baseline:staging_test:{main_sha}"
+    on_failure: degrade_to_old_logic
+  phase2_pr:
+    command: _build_cmd(req_id)
+    branch: "feat/{req_id}"
+    flake_retry: true
+  diff_logic:
+    pass_condition: "pr_introduced_failures == empty_set"
+    fail_condition: "pr_introduced_failures != empty_set"
+    context_in_stderr: SISYPHUS_BASELINE_DIFF_block

--- a/openspec/changes/REQ-staging-test-baseline-diff-1777343371/specs/staging-test-baseline-diff/spec.md
+++ b/openspec/changes/REQ-staging-test-baseline-diff-1777343371/specs/staging-test-baseline-diff/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: staging_test checker performs baseline diff before judging PR failures
+
+The `run_staging_test` checker SHALL execute a two-phase protocol before emitting
+`STAGING_TEST_PASS` or `STAGING_TEST_FAIL`. In Phase 1, the checker MUST checkout
+`origin/main` on each source repo and run the same `make ci-unit-test && make
+ci-integration-test` suite, collecting per-repo pass/fail results ("baseline_failures").
+Baseline results MUST be cached in the `baseline_results` PostgreSQL table keyed by
+`"baseline:staging_test:<main_head_sha>"` with a 24-hour TTL, so subsequent REQs
+running against the same main SHA reuse the cached results without re-running main tests.
+In Phase 2, the checker MUST run the same test suite on the `feat/<REQ>` branch and
+collect per-repo results ("pr_failures"). The checker MUST then compute
+`pr_introduced_failures = pr_failures − baseline_failures`; if this set is empty, the
+checker MUST return `passed=True` with `exit_code=0` and MUST NOT emit
+`STAGING_TEST_FAIL`, even if Phase 2 tests exited non-zero. If `pr_introduced_failures`
+is non-empty, the checker MUST return `passed=False` and MUST include a structured
+"SISYPHUS BASELINE DIFF" context block in `stderr_tail` listing `baseline_failures`,
+`pr_introduced_failures`, `all_pr_failures`, and `main_sha`. If Phase 1 fails or raises
+an exception, the checker MUST degrade gracefully to the old single-phase logic (using
+Phase 2 exit code directly) without propagating the baseline failure.
+
+#### Scenario: BD-1 baseline all pass and PR all pass yields pass
+
+- **GIVEN** baseline Phase 1 runs on origin/main and all repos pass (`baseline_failures = {}`)
+- **AND** Phase 2 runs on feat/<REQ> and all repos pass (`pr_failures = {}`)
+- **WHEN** `run_staging_test` completes
+- **THEN** the returned `CheckResult.passed` MUST be `True` and `exit_code` MUST be `0`
+
+#### Scenario: BD-2 baseline failures are identical to PR failures yields pass
+
+- **GIVEN** baseline Phase 1 reports `baseline_failures = {"repo-a"}` (repo-a fails on main)
+- **AND** Phase 2 reports `pr_failures = {"repo-a"}` (same set, PR introduced nothing new)
+- **WHEN** `run_staging_test` completes
+- **THEN** `CheckResult.passed` MUST be `True` and `exit_code` MUST be `0`
+- **AND** `stdout_tail` MUST contain the string `"SISYPHUS BASELINE DIFF"` to record the override
+- **AND** `stdout_tail` MUST contain `"pr_introduced_failures"` showing an empty list
+
+#### Scenario: BD-3 PR introduces new failures beyond baseline yields fail with diff context
+
+- **GIVEN** baseline Phase 1 reports `baseline_failures = {"repo-a"}` (repo-a fails on main)
+- **AND** Phase 2 reports `pr_failures = {"repo-a", "repo-b"}` (repo-b is new)
+- **WHEN** `run_staging_test` completes
+- **THEN** `CheckResult.passed` MUST be `False` and `exit_code` MUST be non-zero
+- **AND** `stderr_tail` MUST contain `"SISYPHUS BASELINE DIFF"` with the diff context
+- **AND** `stderr_tail` MUST contain `"repo-b"` in the `pr_introduced_failures` field
+
+#### Scenario: BD-4 baseline phase exception causes graceful degradation
+
+- **GIVEN** the SHA-get exec call raises a runtime exception (e.g. kubectl channel closed)
+- **AND** Phase 2 runs on feat/<REQ> and exits with code 1
+- **WHEN** `run_staging_test` completes
+- **THEN** `CheckResult.passed` MUST be `False` (old single-phase exit-code logic)
+- **AND** `stderr_tail` MUST NOT contain `"SISYPHUS BASELINE DIFF"` (no baseline context injected)

--- a/openspec/changes/REQ-staging-test-baseline-diff-1777343371/tasks.md
+++ b/openspec/changes/REQ-staging-test-baseline-diff-1777343371/tasks.md
@@ -1,0 +1,48 @@
+# Tasks for REQ-staging-test-baseline-diff-1777343371
+
+## Stage: contract / spec
+
+- [x] author `specs/staging-test-baseline-diff/spec.md` ADDED delta:
+      two-phase baseline diff for staging_test checker
+- [x] 列 4 条 scenario（BD-1..BD-4）覆盖 pass/diff-empty/new-fail/baseline-exception
+
+## Stage: implementation
+
+- [x] `orchestrator/migrations/0011_baseline_results.sql` + rollback：
+      新增 `baseline_results` 表（cache_key UNIQUE, main_sha, repo_results JSONB, created_at）
+- [x] `orchestrator/src/orchestrator/store/baseline_results.py`：
+      `get_cached(pool, cache_key) -> dict[str, bool] | None` +
+      `put_cached(pool, cache_key, main_sha, repo_results)` 两函数
+- [x] `orchestrator/src/orchestrator/checkers/staging_test.py`：
+  - `_build_get_main_sha_cmd()` — 快速取 origin/main HEAD SHA
+  - `_build_baseline_cmd()` — checkout origin/main，跑同套 ci-*，
+    emit PASS/FAIL 标记 + MAIN_SHA；不要求 feat/<REQ> 分支
+  - `_parse_repo_results(stdout, stderr) -> dict[str, bool]` — 解析 PASS/FAIL 标记
+  - `_parse_main_sha(stdout) -> str | None`
+  - `_compute_diff(baseline, pr_repos) -> (baseline_failures, pr_failures, introduced)`
+  - `_format_diff_header(...)` — 生成 SISYPHUS BASELINE DIFF 上下文块
+  - `run_staging_test(req_id)` 改为三阶段：SHA get → baseline（24h 缓存）→ PR run → diff
+  - baseline 阶段异常 → 退化到老逻辑
+- [x] `orchestrator/src/orchestrator/actions/create_staging_test.py`：
+      fail 路径追加 `req_state.update_context(pool, req_id, {"staging_test_stderr_tail": result.stderr_tail})`
+- [x] `orchestrator/src/orchestrator/actions/_verifier.py`：
+      `invoke_verifier_for_staging_test_fail` 从 `ctx.staging_test_stderr_tail` 读
+      stderr_tail 并透传给 `invoke_verifier`
+- [x] `orchestrator/src/orchestrator/prompts/verifier/staging_test_fail.md.j2`：
+      加"Baseline 差量分析"指引节：SISYPHUS BASELINE DIFF 块存在时优先按差量判，
+      `pr_introduced_failures: []` → 判 pass
+
+## Stage: unit test
+
+- [x] `orchestrator/tests/test_checkers_staging_test.py`：
+  - BD-1: baseline 全 pass + PR 全 pass → staging-test.pass（老逻辑走）
+  - BD-2: baseline N fail + PR 同 N fail → diff 空 → staging-test.pass，stdout 含 BASELINE DIFF
+  - BD-3: baseline N fail + PR N+1 fail → staging-test.fail，stderr 含 pr_introduced_failures
+  - BD-4: baseline SHA get 异常 → 退化老逻辑，PR exit_code=1 → fail，无 BASELINE DIFF 块
+- [x] 已有测试（pass / fail / truncate / timeout / build_cmd / flake-retry）全部调整兼容：
+      `_make_seq_controller` 测试在序列头部追加 SHA-get 空结果（skip baseline）
+
+## Stage: PR
+
+- [x] git push feat/REQ-staging-test-baseline-diff-1777343371
+- [x] gh pr create --label sisyphus

--- a/orchestrator/migrations/0011_baseline_results.rollback.sql
+++ b/orchestrator/migrations/0011_baseline_results.rollback.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_baseline_results_cache_key;
+DROP TABLE IF EXISTS baseline_results;

--- a/orchestrator/migrations/0011_baseline_results.sql
+++ b/orchestrator/migrations/0011_baseline_results.sql
@@ -1,0 +1,24 @@
+-- REQ-staging-test-baseline-diff-1777343371: baseline diff for staging_test
+--
+-- staging_test checker 现在两阶段跑：
+--   Phase 1: checkout main HEAD，跑同套 ci-unit-test + ci-integration-test，收集 "baseline_failures"
+--   Phase 2: checkout feat/<REQ>，跑同套，收集 "pr_failures"
+--   真 fail set = pr_failures - baseline_failures
+--     空 → staging-test.pass（PR 没引入新失败；main 自己坏了不是 agent 的锅）
+--     非空 → staging-test.fail（verifier 收到 baseline 差量上下文）
+--
+-- baseline_results 是缓存表：同 main HEAD SHA 24h 内复用，避免每个 REQ 都重跑 main 一遍。
+-- cache_key = "baseline:staging_test:<main_head_sha>"
+-- repo_results JSONB = {"repo-basename": true/false, ...}（true = passed）
+
+CREATE TABLE IF NOT EXISTS baseline_results (
+    id          BIGSERIAL PRIMARY KEY,
+    cache_key   TEXT NOT NULL,
+    main_sha    TEXT NOT NULL,
+    repo_results JSONB NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- 按 cache_key + created_at 查最新记录（TTL 窗口过滤）
+CREATE UNIQUE INDEX IF NOT EXISTS idx_baseline_results_cache_key
+    ON baseline_results(cache_key);

--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -429,9 +429,20 @@ async def invoke_verifier_for_staging_test_fail(*, body, req_id, tags, ctx):
     stage 来自 transition table，不从 tags 推。
     （机械 checker 没自己的 BKD issue，webhook tags 来自上游 dev issue，
     以前 sniff tag 会把 staging-test fail 误路成 dev。）
+
+    REQ-staging-test-baseline-diff-1777343371：ctx.staging_test_stderr_tail
+    由 create_staging_test._run_checker 写入，含 baseline diff 上下文；
+    透传给 verifier prompt 让 verifier 区分 "agent 引入的 fail" vs "main 上本来就坏"。
     """
-    return await _invoke_verifier_fail(
-        stage="staging_test", body=body, req_id=req_id, ctx=ctx,
+    ctx = ctx or {}
+    stderr_tail = ctx.get("staging_test_stderr_tail") or ""
+    return await invoke_verifier(
+        stage="staging_test",
+        trigger="fail",
+        req_id=req_id,
+        project_id=body.projectId,
+        stderr_tail=stderr_tail,
+        ctx=ctx,
     )
 
 

--- a/orchestrator/src/orchestrator/actions/create_staging_test.py
+++ b/orchestrator/src/orchestrator/actions/create_staging_test.py
@@ -81,6 +81,10 @@ async def _run_checker(*, req_id: str, ctx: dict) -> dict:
     log.info("create_staging_test.checker_done", req_id=req_id,
              passed=False, exit_code=result.exit_code,
              duration_sec=round(result.duration_sec, 1))
+    # 保存 stderr_tail（含 baseline diff 上下文）到 ctx，供 verifier prompt 渲染用。
+    await req_state.update_context(pool, req_id, {
+        "staging_test_stderr_tail": result.stderr_tail,
+    })
     return {
         "emit": Event.STAGING_TEST_FAIL.value,
         "passed": False,

--- a/orchestrator/src/orchestrator/checkers/staging_test.py
+++ b/orchestrator/src/orchestrator/checkers/staging_test.py
@@ -22,15 +22,26 @@ target 仍 [skip]（仓本身不可测，与 analyze-agent 无关）。
 
 每仓输出落 /tmp/staging-test-logs/<repo>-<kind>.log（kind ∈ unit/int），
 汇总阶段按仓 echo PASS/FAIL + tail 日志让 verifier 看清；任一失败整体红。
+
+REQ-staging-test-baseline-diff-1777343371：两阶段 baseline diff。
+Phase 1: checkout main HEAD，跑同套 ci-* 命令，收集 baseline_failures（24h PG 缓存）。
+Phase 2: checkout feat/<REQ>，跑同套命令，收集 pr_failures。
+真 fail set = pr_failures - baseline_failures：
+  - 空集 → staging-test.pass（PR 没引入新失败）
+  - 非空 → staging-test.fail，verifier 收到差量上下文
+baseline run 失败 → 退化到老逻辑（直接判 PR exit_code）。
 """
 from __future__ import annotations
 
 import asyncio
+import re
 
 import structlog
 
 from .. import k8s_runner
 from ..config import settings
+from ..store import baseline_results as _baseline_cache
+from ..store import db as _db
 from ._flake import run_with_flake_retry
 from ._types import CheckResult
 
@@ -41,6 +52,11 @@ log = structlog.get_logger(__name__)
 _TAIL = 2048
 _DEFAULT_TIMEOUT = 1800
 _STAGE = "staging_test"
+
+# 解析 === PASS/FAIL: <name> === 标记（PASS→stdout，FAIL→stderr）
+_PASS_RE = re.compile(r"=== PASS: (\S+) ===")
+_FAIL_RE = re.compile(r"=== FAIL: (\S+) ===")
+_SHA_RE = re.compile(r"MAIN_SHA:\s+([0-9a-f]{40})")
 
 
 def _build_cmd(req_id: str) -> str:
@@ -133,22 +149,214 @@ def _build_cmd(req_id: str) -> str:
     )
 
 
-async def run_staging_test(req_id: str) -> CheckResult:
-    """在 runner pod 并行对每个 source repo 跑 ci-unit-test && ci-integration-test，收退出码决定 pass/fail。
-
-    REQ-checker-infra-flake-retry-1777247423：用 run_with_flake_retry 包 exec，
-    DNS / kubectl-channel / registry-rate-limit / go-mod 等 infra 抖动自动重跑，
-    bounded by settings。retry 时同 cmd 全量重跑（业务仓 ci-* 必须幂等，详见
-    docs/integration-contracts.md）。
+def _build_get_main_sha_cmd() -> str:
+    """从第一个可访问的 source repo 快速取 origin/main HEAD SHA。
+    成功输出 "MAIN_SHA: <40-char-sha>"，失败 exit 1。
     """
-    cmd = _build_cmd(req_id)
-    timeout_sec = _DEFAULT_TIMEOUT
-
-    rc = k8s_runner.get_controller()
-    log.info(
-        "checker.staging_test.start",
-        req_id=req_id, timeout=timeout_sec,
+    return (
+        "sha=''; "
+        "for repo in /workspace/source/*/; do "
+        "  if [ -d \"$repo\" ]; then "
+        "    cd \"$repo\" && git fetch origin main 2>/dev/null; "
+        "    sha=$(git rev-parse origin/main 2>/dev/null || true); "
+        "    if [ -n \"$sha\" ]; then break; fi; "
+        "  fi; "
+        "done; "
+        "[ -n \"$sha\" ] && echo \"MAIN_SHA: $sha\" || exit 1"
     )
+
+
+def _build_baseline_cmd() -> str:
+    """Checkout origin/main 对每个 source repo 并行跑 ci-* 测试，收集 baseline_failures。
+
+    结构与 _build_cmd 一致（相同 PASS/FAIL 标记，相同 ci-setup/unit/integration 流），
+    但不要求 feat/<REQ> 分支（baseline 跑 main，不是 agent 的 PR 分支）。
+    最后输出 "MAIN_SHA: <sha>" 给调用方缓存用。
+
+    失败仓 → 整体 exit 1，但已发出的 PASS/FAIL 标记仍可解析（partial 也有用）。
+    baseline run 异常（exit 1 + 0 标记解析到）→ 调用方退化到老逻辑。
+    """
+    return (
+        "set -o pipefail; "
+        "if [ ! -d /workspace/source ]; then "
+        '  echo "=== FAIL baseline: /workspace/source missing ===" >&2; '
+        "  exit 1; "
+        "fi; "
+        "repo_count=$(find /workspace/source -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l); "
+        'if [ "$repo_count" -eq 0 ]; then '
+        '  echo "=== FAIL baseline: /workspace/source empty ===" >&2; '
+        "  exit 1; "
+        "fi; "
+        "fail=0; ran=0; main_sha=''; "
+        "mkdir -p /tmp/baseline-logs; "
+        'pids=""; '
+        "for repo in /workspace/source/*/; do "
+        '  name=$(basename "$repo"); '
+        '  if ! (cd "$repo" && git fetch origin main 2>/dev/null && '
+        "         git checkout -B _sisyphus_baseline origin/main >/dev/null 2>&1); then "
+        '    echo "[baseline-skip] $name: failed to checkout origin/main" >&2; '
+        "    continue; "
+        "  fi; "
+        '  if [ -z "$main_sha" ]; then '
+        '    main_sha=$(cd "$repo" && git rev-parse HEAD 2>/dev/null || true); '
+        "  fi; "
+        '  if [ -f "$repo/Makefile" ] '
+        '       && (cd "$repo" && (make -p -n 2>/dev/null || true) | grep -qE \'^ci-unit-test:\') '
+        '       && (cd "$repo" && (make -p -n 2>/dev/null || true) | grep -qE \'^ci-integration-test:\'); then '
+        '    echo "=== baseline (ci-setup): $name ==="; '
+        '    (cd "$repo" && make ci-setup) || true; '
+        "    ( "
+        '      cd "$repo" '
+        '      && make ci-unit-test > "/tmp/baseline-logs/$name-unit.log" 2>&1 '
+        '      && make ci-integration-test > "/tmp/baseline-logs/$name-int.log" 2>&1 '
+        "    ) & "
+        '    pids="$pids $!:$name"; '
+        "    ran=$((ran+1)); "
+        "  else "
+        '    echo "[baseline-skip] $name: missing ci targets"; '
+        "  fi; "
+        "done; "
+        'if [ "$ran" -eq 0 ]; then '
+        '  echo "=== FAIL baseline: 0 repos eligible ===" >&2; '
+        "  exit 1; "
+        "fi; "
+        "for pid_name in $pids; do "
+        "  pid=${pid_name%%:*}; "
+        "  name=${pid_name##*:}; "
+        "  if ! wait $pid; then "
+        '    echo "=== FAIL: $name ===" >&2; '
+        "    fail=1; "
+        "  else "
+        '    echo "=== PASS: $name ==="; '
+        "  fi; "
+        "done; "
+        '[ -n "$main_sha" ] && echo "MAIN_SHA: $main_sha"; '
+        "[ $fail -eq 0 ]"
+    )
+
+
+def _parse_repo_results(stdout: str, stderr: str) -> dict[str, bool]:
+    """解析 === PASS/FAIL: <name> === 标记。返回 {repo_basename: passed}。
+
+    PASS 标记在 stdout，FAIL 标记在 stderr（与 _build_cmd 输出方向一致）。
+    解析失败返空 dict；调用方按空 dict 退化处理。
+    """
+    results: dict[str, bool] = {}
+    for m in _PASS_RE.finditer(stdout):
+        results[m.group(1)] = True
+    for m in _FAIL_RE.finditer(stderr):
+        results[m.group(1)] = False
+    return results
+
+
+def _parse_main_sha(stdout: str) -> str | None:
+    """从命令输出提取 MAIN_SHA: <sha>。"""
+    m = _SHA_RE.search(stdout)
+    return m.group(1) if m else None
+
+
+def _compute_diff(
+    baseline: dict[str, bool],
+    pr_repos: dict[str, bool],
+) -> tuple[set[str], set[str], set[str]]:
+    """返回 (baseline_failures, pr_failures, pr_introduced)。
+
+    pr_introduced = pr_failures - baseline_failures（PR 新引入的失败）。
+    """
+    baseline_failures = {r for r, p in baseline.items() if not p}
+    pr_failures = {r for r, p in pr_repos.items() if not p}
+    return baseline_failures, pr_failures, pr_failures - baseline_failures
+
+
+def _format_diff_header(
+    main_sha: str | None,
+    baseline_failures: set[str],
+    pr_failures: set[str],
+    introduced: set[str],
+) -> str:
+    verdict = "PASS (no new failures)" if not introduced else "FAIL (new failures introduced)"
+    return (
+        f"=== SISYPHUS BASELINE DIFF: {verdict} ===\n"
+        f"main_sha: {main_sha or 'unknown'}\n"
+        f"baseline_failures: {sorted(baseline_failures) or '[]'}\n"
+        f"pr_introduced_failures: {sorted(introduced) or '[]'}\n"
+        f"all_pr_failures: {sorted(pr_failures) or '[]'}\n"
+        "=========================================\n\n"
+    )
+
+
+async def run_staging_test(req_id: str) -> CheckResult:
+    """两阶段 baseline diff staging test。
+
+    Phase 1: baseline（main HEAD，24h PG 缓存）
+    Phase 2: PR 测试（feat/<REQ>，infra-flake retry）
+    Phase 3: 差量判定
+
+    baseline run 失败/异常 → 退化到老逻辑（直接判 PR exit_code），不拖死 stage。
+
+    REQ-checker-infra-flake-retry-1777247423：PR 阶段用 run_with_flake_retry 包 exec，
+    DNS / kubectl-channel / registry-rate-limit / go-mod 等 infra 抖动自动重跑。
+    baseline 阶段不做 flake retry（失败直接退化，不阻塞）。
+    """
+    rc = k8s_runner.get_controller()
+    obs_pool = _db.get_obs_pool()  # 可能为 None（obs dsn 未配置时）
+
+    log.info("checker.staging_test.start", req_id=req_id, timeout=_DEFAULT_TIMEOUT)
+
+    # ── Phase 1: Baseline（带 24h 缓存）────────────────────────────────────
+    baseline_repos: dict[str, bool] | None = None
+    main_sha: str | None = None
+
+    try:
+        sha_result = await asyncio.wait_for(
+            rc.exec_in_runner(req_id, _build_get_main_sha_cmd(), timeout_sec=60),
+            timeout=70,
+        )
+        main_sha = _parse_main_sha(sha_result.stdout)
+
+        if main_sha:
+            cache_key = f"baseline:staging_test:{main_sha}"
+
+            if obs_pool is not None:
+                baseline_repos = await _baseline_cache.get_cached(obs_pool, cache_key)
+                if baseline_repos is not None:
+                    log.info(
+                        "checker.staging_test.baseline_cache_hit",
+                        req_id=req_id, main_sha=main_sha[:8], repos=baseline_repos,
+                    )
+
+            if baseline_repos is None:
+                log.info(
+                    "checker.staging_test.baseline_run_start",
+                    req_id=req_id, main_sha=main_sha[:8],
+                )
+                bl_raw = await asyncio.wait_for(
+                    rc.exec_in_runner(req_id, _build_baseline_cmd(), timeout_sec=_DEFAULT_TIMEOUT),
+                    timeout=_DEFAULT_TIMEOUT + 10,
+                )
+                baseline_repos = _parse_repo_results(bl_raw.stdout, bl_raw.stderr)
+                # 从 baseline 命令输出中也可以拿到 sha（更精确，是 HEAD 而非 origin/main）
+                sha_from_bl = _parse_main_sha(bl_raw.stdout)
+                if sha_from_bl:
+                    main_sha = sha_from_bl
+                    cache_key = f"baseline:staging_test:{main_sha}"
+                log.info(
+                    "checker.staging_test.baseline_run_done",
+                    req_id=req_id, results=baseline_repos, main_sha=main_sha[:8],
+                )
+                # 只在有解析到结果时才缓存（避免缓存 infra crash 的空结果）
+                if baseline_repos and obs_pool is not None:
+                    await _baseline_cache.put_cached(obs_pool, cache_key, main_sha, baseline_repos)
+
+    except Exception as exc:
+        log.warning(
+            "checker.staging_test.baseline_phase_failed",
+            req_id=req_id, error=str(exc)[:200],
+        )
+        # 退化到老逻辑：baseline_repos 保持 None
+
+    # ── Phase 2: PR 测试（含 infra-flake retry）────────────────────────────
+    cmd = _build_cmd(req_id)
 
     max_retries = (
         settings.checker_infra_flake_retry_max
@@ -158,8 +366,8 @@ async def run_staging_test(req_id: str) -> CheckResult:
 
     async def _run_once():
         return await asyncio.wait_for(
-            rc.exec_in_runner(req_id, cmd, timeout_sec=timeout_sec),
-            timeout=timeout_sec + 10,
+            rc.exec_in_runner(req_id, cmd, timeout_sec=_DEFAULT_TIMEOUT),
+            timeout=_DEFAULT_TIMEOUT + 10,
         )
 
     result, attempts, flake_reason = await run_with_flake_retry(
@@ -170,6 +378,51 @@ async def run_staging_test(req_id: str) -> CheckResult:
         backoff_sec=settings.checker_infra_flake_retry_backoff_sec,
     )
 
+    # ── Phase 3: Diff ────────────────────────────────────────────────────
+    pr_repos = _parse_repo_results(result.stdout, result.stderr)
+
+    # baseline_repos 非空（至少解析到 1 个 repo 结果）且 PR 有失败时才做差量判定。
+    # baseline_repos 空 dict 视为"baseline 无可用数据"，退化到老逻辑。
+    if baseline_repos and result.exit_code != 0:
+        baseline_failures, pr_failures, introduced = _compute_diff(baseline_repos, pr_repos)
+        diff_header = _format_diff_header(main_sha, baseline_failures, pr_failures, introduced)
+
+        if not introduced:
+            # PR 没引入新失败：main 自己就坏了，override 到 pass
+            log.info(
+                "checker.staging_test.baseline_diff_override_pass",
+                req_id=req_id, baseline_failures=sorted(baseline_failures),
+                pr_failures=sorted(pr_failures),
+            )
+            return CheckResult(
+                passed=True,
+                exit_code=0,
+                stdout_tail=(diff_header + result.stdout)[-_TAIL:],
+                stderr_tail=result.stderr[-_TAIL:],
+                duration_sec=result.duration_sec,
+                cmd=cmd,
+                reason=flake_reason or "baseline-diff-pass",
+                attempts=attempts,
+            )
+
+        # 有新失败：fail，stderr 前置 diff 上下文供 verifier 判断
+        log.info(
+            "checker.staging_test.baseline_diff_new_failures",
+            req_id=req_id, baseline_failures=sorted(baseline_failures),
+            introduced=sorted(introduced),
+        )
+        return CheckResult(
+            passed=False,
+            exit_code=result.exit_code,
+            stdout_tail=result.stdout[-_TAIL:],
+            stderr_tail=(diff_header + result.stderr)[-_TAIL:],
+            duration_sec=result.duration_sec,
+            cmd=cmd,
+            reason=flake_reason,
+            attempts=attempts,
+        )
+
+    # ── 老逻辑 fallback（baseline 不可用 or PR 已经 pass）───────────────
     passed = result.exit_code == 0
     log.info(
         "checker.staging_test.done",

--- a/orchestrator/src/orchestrator/prompts/verifier/staging_test_fail.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/staging_test_fail.md.j2
@@ -14,6 +14,18 @@ stderr 里每仓挂了会带 `=== FAIL: <repo> ===` + unit / integration 各自 
 ```
 {% endif %}
 
+### Baseline 差量分析（重要——先看这里）
+
+如果 stderr 开头含 `=== SISYPHUS BASELINE DIFF: ===` 块，说明 sisyphus 已经跑了
+main HEAD baseline，并对比了 PR 引入了哪些新失败。**优先按差量分析判断**：
+
+- `pr_introduced_failures: []`（空列表）→ **PR 没有引入新失败**，main 自己就坏了。
+  这种情况 checker 理应已经 override 到 pass，若仍到达 verifier 则一律判 `pass`。
+- `pr_introduced_failures: [repo-a, ...]`（非空）→ **PR 确实引入了这些仓的新失败**。
+  按下方"关注点"判 fix / escalate。
+- 没有 baseline diff 块 → baseline 无可用数据（infra 异常/obs pool 未配置），
+  按原始 stderr 内容正常判断。
+
 你要判：这失败是 **code bug / spec bug / env bug / flaky** 哪一类，以及能不能修。
 
 ### 关注点

--- a/orchestrator/src/orchestrator/store/baseline_results.py
+++ b/orchestrator/src/orchestrator/store/baseline_results.py
@@ -1,0 +1,55 @@
+"""baseline_results 表：staging_test baseline 缓存读写。
+
+cache_key = "baseline:staging_test:<main_head_sha>"
+TTL = 24h（查询时过滤 created_at > NOW() - 24h）
+repo_results JSONB = {"repo-basename": true/false}
+
+obs pool 是可选的（dsn 留空则 None），调用方负责 if obs_pool: 判断。
+"""
+from __future__ import annotations
+
+import json
+
+import asyncpg
+
+_TTL_SQL = "INTERVAL '24 hours'"
+
+
+async def get_cached(
+    pool: asyncpg.Pool,
+    cache_key: str,
+) -> dict[str, bool] | None:
+    """读 24h 内的 baseline 缓存。不命中返 None。"""
+    row = await pool.fetchrow(
+        f"""
+        SELECT repo_results FROM baseline_results
+        WHERE cache_key = $1
+          AND created_at > NOW() - {_TTL_SQL}
+        """,
+        cache_key,
+    )
+    if row is None:
+        return None
+    return {k: bool(v) for k, v in row["repo_results"].items()}
+
+
+async def put_cached(
+    pool: asyncpg.Pool,
+    cache_key: str,
+    main_sha: str,
+    repo_results: dict[str, bool],
+) -> None:
+    """写（或覆盖）baseline 缓存。UPSERT by cache_key。"""
+    await pool.execute(
+        """
+        INSERT INTO baseline_results (cache_key, main_sha, repo_results)
+        VALUES ($1, $2, $3::jsonb)
+        ON CONFLICT (cache_key) DO UPDATE SET
+            main_sha     = EXCLUDED.main_sha,
+            repo_results = EXCLUDED.repo_results,
+            created_at   = NOW()
+        """,
+        cache_key,
+        main_sha,
+        json.dumps(repo_results),
+    )

--- a/orchestrator/tests/test_checkers_staging_test.py
+++ b/orchestrator/tests/test_checkers_staging_test.py
@@ -3,6 +3,8 @@
 多仓重构后 + ttpos-ci 契约统一：cmd 遍历 /workspace/source/*，**repo 之间并行**
 对每个含 `ci-unit-test` + `ci-integration-test` target 的仓跑
 `make ci-unit-test && make ci-integration-test`（**单 repo 内串行**）。
+
+REQ-staging-test-baseline-diff-1777343371：两阶段 baseline diff 测试（BD-1~BD-4）。
 """
 from __future__ import annotations
 
@@ -268,3 +270,138 @@ async def test_run_staging_test_retry_disabled_when_setting_off(monkeypatch):
     assert result.attempts == 1
     assert result.reason is None
     assert FakeRC.calls == 1
+
+
+# ── BD-1~BD-4: baseline diff（REQ-staging-test-baseline-diff-1777343371）────────
+
+
+def _patch_baseline_disabled(monkeypatch):
+    """obs_pool = None → 跳过缓存（baseline 每次都跑）。"""
+    monkeypatch.setattr("orchestrator.checkers.staging_test._db.get_obs_pool", lambda: None)
+    # 禁 infra-flake retry，让 PR run 只跑一次
+    monkeypatch.setattr("orchestrator.checkers.staging_test.settings.checker_infra_flake_retry_enabled", False)
+    monkeypatch.setattr("orchestrator.checkers.staging_test.settings.checker_infra_flake_retry_backoff_sec", 0)
+
+
+def _sha_result(sha: str = "a" * 40) -> ExecResult:
+    return ExecResult(exit_code=0, stdout=f"MAIN_SHA: {sha}\n", stderr="", duration_sec=0.1)
+
+
+def _baseline_result(pass_repos: list[str], fail_repos: list[str], sha: str = "a" * 40) -> ExecResult:
+    stdout = "".join(f"=== PASS: {r} ===\n" for r in pass_repos)
+    stdout += f"MAIN_SHA: {sha}\n"
+    stderr = "".join(f"=== FAIL: {r} ===\n" for r in fail_repos)
+    exit_code = 1 if fail_repos else 0
+    return ExecResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration_sec=2.0)
+
+
+def _pr_result(pass_repos: list[str], fail_repos: list[str]) -> ExecResult:
+    stdout = "".join(f"=== PASS: {r} ===\n" for r in pass_repos)
+    stderr = "".join(f"=== FAIL: {r} ===\n" for r in fail_repos)
+    exit_code = 1 if fail_repos else 0
+    return ExecResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration_sec=5.0)
+
+
+def _make_phase_controller(*phase_results: ExecResult):
+    """按顺序依次返回 phase_results（sha get → baseline → PR …）。"""
+    seq = list(phase_results)
+
+    class FakeRC:
+        calls = 0
+
+        async def exec_in_runner(self, req_id, command, **kw):
+            FakeRC.calls += 1
+            return seq.pop(0)
+
+    FakeRC.calls = 0
+    return FakeRC
+
+
+@pytest.mark.asyncio
+async def test_bd1_baseline_all_pass_pr_all_pass(monkeypatch):
+    """BD-1: baseline 全 pass + PR 全 pass → staging-test.pass（老逻辑走，exit_code=0）。"""
+    _patch_baseline_disabled(monkeypatch)
+    FakeRC = _make_phase_controller(
+        _sha_result(),
+        _baseline_result(pass_repos=["repo-a"], fail_repos=[]),
+        _pr_result(pass_repos=["repo-a"], fail_repos=[]),
+    )
+    monkeypatch.setattr("orchestrator.checkers.staging_test.k8s_runner.get_controller", lambda: FakeRC())
+
+    result = await run_staging_test("REQ-X")
+
+    assert result.passed is True
+    assert result.exit_code == 0
+    # 3 exec calls: sha + baseline + PR
+    assert FakeRC.calls == 3
+
+
+@pytest.mark.asyncio
+async def test_bd2_baseline_n_fail_pr_same_n_fail_pass(monkeypatch):
+    """BD-2: baseline N 个 fail + PR 同 N 个 fail（相同 set）→ staging-test.pass（差量为空）。"""
+    _patch_baseline_disabled(monkeypatch)
+    FakeRC = _make_phase_controller(
+        _sha_result(),
+        _baseline_result(pass_repos=["repo-b"], fail_repos=["repo-a"]),
+        _pr_result(pass_repos=["repo-b"], fail_repos=["repo-a"]),
+    )
+    monkeypatch.setattr("orchestrator.checkers.staging_test.k8s_runner.get_controller", lambda: FakeRC())
+
+    result = await run_staging_test("REQ-X")
+
+    assert result.passed is True
+    assert result.exit_code == 0
+    # stdout 应含 baseline diff 上下文
+    assert "SISYPHUS BASELINE DIFF" in result.stdout_tail
+    assert "pr_introduced_failures" in result.stdout_tail
+    assert "[]" in result.stdout_tail
+
+
+@pytest.mark.asyncio
+async def test_bd3_baseline_n_fail_pr_more_fail_staging_fail(monkeypatch):
+    """BD-3: baseline N 个 fail + PR N+1 个 fail（多了 1 个 PR-introduced）→ staging-test.fail，
+    verifier ctx（stderr）里 pr_introduced_failures 含新增的那 1 个。
+    """
+    _patch_baseline_disabled(monkeypatch)
+    FakeRC = _make_phase_controller(
+        _sha_result(),
+        _baseline_result(pass_repos=["repo-b"], fail_repos=["repo-a"]),
+        _pr_result(pass_repos=[], fail_repos=["repo-a", "repo-b"]),
+    )
+    monkeypatch.setattr("orchestrator.checkers.staging_test.k8s_runner.get_controller", lambda: FakeRC())
+
+    result = await run_staging_test("REQ-X")
+
+    assert result.passed is False
+    assert result.exit_code != 0
+    # stderr 应含 diff 上下文，pr_introduced 含 repo-b
+    assert "SISYPHUS BASELINE DIFF" in result.stderr_tail
+    assert "repo-b" in result.stderr_tail
+    assert "pr_introduced_failures" in result.stderr_tail
+
+
+@pytest.mark.asyncio
+async def test_bd4_baseline_phase_exception_fallback_old_logic(monkeypatch):
+    """BD-4: baseline SHA 取失败（exception）→ 退化到老逻辑，PR exit_code=1 → staging-test.fail。"""
+    _patch_baseline_disabled(monkeypatch)
+
+    class ErrorRC:
+        calls = 0
+
+        async def exec_in_runner(self, req_id, command, **kw):
+            ErrorRC.calls += 1
+            if ErrorRC.calls == 1:
+                # SHA 获取阶段 raise（模拟 kubectl channel 断开）
+                raise RuntimeError("kubectl exec channel closed")
+            # PR 阶段正常返回（exit_code=1 → fail）
+            return _pr_result(pass_repos=[], fail_repos=["repo-a"])
+
+    ErrorRC.calls = 0
+    monkeypatch.setattr("orchestrator.checkers.staging_test.k8s_runner.get_controller", lambda: ErrorRC())
+
+    result = await run_staging_test("REQ-X")
+
+    # 退化到老逻辑：PR exit_code=1 → fail
+    assert result.passed is False
+    # 无 baseline diff 块（退化路径不注入）
+    assert "SISYPHUS BASELINE DIFF" not in result.stderr_tail

--- a/orchestrator/tests/test_checkers_staging_test.py
+++ b/orchestrator/tests/test_checkers_staging_test.py
@@ -193,7 +193,10 @@ async def test_run_staging_test_recovers_from_dns_flake(monkeypatch):
     monkeypatch.setattr(
         "orchestrator.checkers.staging_test.settings.checker_infra_flake_retry_backoff_sec", 0,
     )
+    # 第 1 次 exec = SHA get（空 stdout → main_sha=None → 跳过 baseline，退化到老逻辑）
+    # 第 2 次 exec = PR run #1（DNS flake），第 3 次 = PR run #2（pass）
     FakeRC = _make_seq_controller(
+        ExecResult(exit_code=0, stdout="", stderr="", duration_sec=0.1),  # SHA get → no sha → skip baseline
         ExecResult(
             exit_code=128, stdout="",
             stderr="fatal: Could not resolve host github.com", duration_sec=1.0,
@@ -210,7 +213,7 @@ async def test_run_staging_test_recovers_from_dns_flake(monkeypatch):
     assert result.attempts == 2
     assert result.reason is not None
     assert "flake-retry-recovered" in result.reason
-    assert FakeRC.calls == 2
+    assert FakeRC.calls == 3  # SHA get + 2 PR runs
 
 
 @pytest.mark.asyncio
@@ -225,7 +228,9 @@ async def test_run_staging_test_does_not_retry_real_test_failure(monkeypatch):
     monkeypatch.setattr(
         "orchestrator.checkers.staging_test.settings.checker_infra_flake_retry_backoff_sec", 0,
     )
+    # 第 1 次 exec = SHA get（空 stdout → skip baseline）；第 2 次 = PR run（real fail，不重试）
     FakeRC = _make_seq_controller(
+        ExecResult(exit_code=0, stdout="", stderr="", duration_sec=0.1),  # SHA get
         ExecResult(
             exit_code=2, stdout="--- FAIL: TestFoo (0.10s)\n",
             stderr="make: *** [Makefile:42] Error 1", duration_sec=10.0,
@@ -240,7 +245,7 @@ async def test_run_staging_test_does_not_retry_real_test_failure(monkeypatch):
     assert result.exit_code == 2
     assert result.attempts == 1
     assert result.reason is None
-    assert FakeRC.calls == 1
+    assert FakeRC.calls == 2  # SHA get + 1 PR run
 
 
 @pytest.mark.asyncio
@@ -255,7 +260,9 @@ async def test_run_staging_test_retry_disabled_when_setting_off(monkeypatch):
     monkeypatch.setattr(
         "orchestrator.checkers.staging_test.settings.checker_infra_flake_retry_backoff_sec", 0,
     )
+    # 第 1 次 exec = SHA get（空 stdout → skip baseline）；第 2 次 = PR run（DNS flake，不重试）
     FakeRC = _make_seq_controller(
+        ExecResult(exit_code=0, stdout="", stderr="", duration_sec=0.1),  # SHA get
         ExecResult(
             exit_code=128, stdout="",
             stderr="fatal: Could not resolve host github.com", duration_sec=1.0,
@@ -269,7 +276,7 @@ async def test_run_staging_test_retry_disabled_when_setting_off(monkeypatch):
     assert result.passed is False
     assert result.attempts == 1
     assert result.reason is None
-    assert FakeRC.calls == 1
+    assert FakeRC.calls == 2  # SHA get + 1 PR run
 
 
 # ── BD-1~BD-4: baseline diff（REQ-staging-test-baseline-diff-1777343371）────────

--- a/orchestrator/tests/test_contract_docs_drift_audit.py
+++ b/orchestrator/tests/test_contract_docs_drift_audit.py
@@ -269,12 +269,12 @@ def test_docs_s6_tag_spec_not_apifox_content():
 # DOCS-S7: migration count 0001–0007 reflected in docs
 # ──────────────────────────────────────────────────────────────────────────
 
-def test_docs_s7_forward_migration_count_is_9():
+def test_docs_s7_forward_migration_count_is_11():
     """DOCS-S7: orchestrator/migrations/ has exactly 10 forward migration files
     (0001..0010 contiguous; 0009 = artifact_checks_flake, 0010 = dispatch_slugs)."""
     forward = [f for f in MIGRATIONS_DIR.glob("*.sql") if ".rollback." not in f.name]
-    assert len(forward) == 10, (
-        f"orchestrator/migrations/ has {len(forward)} forward migration(s), expected 10: "
+    assert len(forward) == 11, (
+        f"orchestrator/migrations/ has {len(forward)} forward migration(s), expected 11: "
         f"{sorted(f.name for f in forward)}"
     )
 


### PR DESCRIPTION
## Summary

- **Problem**: `staging_test` checker treated any non-zero exit code as fail, even when
  `main` itself was broken. This caused a dead-loop: broken main → every PR's staging_test fails
  → verifier escalates → PR never merges. Observed: 57/181 escalations (31%) from staging_test.

- **Fix**: Two-phase baseline diff. Phase 1 runs same tests on `origin/main` (cached 24h in
  new `baseline_results` PG table). Phase 2 runs on `feat/<REQ>`. True fail set =
  `pr_failures − baseline_failures`. Empty diff → `STAGING_TEST_PASS` even if Phase 2 exited 1.

- **Graceful degradation**: baseline phase exception → old single-phase exit-code logic,
  no blocking.

## Changes

| File | Change |
|---|---|
| `orchestrator/migrations/0011_baseline_results.sql` | New `baseline_results` table (cache_key UNIQUE, 24h TTL) |
| `orchestrator/store/baseline_results.py` | `get_cached` / `put_cached` functions |
| `orchestrator/checkers/staging_test.py` | Two-phase `run_staging_test`: SHA get → baseline (cached) → PR run → diff |
| `orchestrator/actions/create_staging_test.py` | Store `stderr_tail` in ctx on fail |
| `orchestrator/actions/_verifier.py` | `invoke_verifier_for_staging_test_fail` passes `stderr_tail` from ctx |
| `orchestrator/prompts/verifier/staging_test_fail.md.j2` | Baseline diff guidance for verifier |
| `orchestrator/tests/test_checkers_staging_test.py` | 4 new BD-1..BD-4 tests; fix 3 existing flake-retry tests |

## Test plan

- [x] `uv run pytest tests/test_checkers_staging_test.py -v` → 14 passed (was 10)
- [x] BD-1: baseline all pass + PR all pass → pass (old logic)
- [x] BD-2: baseline N fail + PR same N fail → diff empty → override to pass
- [x] BD-3: baseline N fail + PR N+1 fail → fail with `SISYPHUS BASELINE DIFF` context in stderr
- [x] BD-4: baseline SHA-get exception → fallback, PR exit_code=1 → fail, no diff block
- [x] `openspec validate REQ-staging-test-baseline-diff-1777343371` → valid

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-staging-test-baseline-diff-1777343371`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/7ph4dslq)