### PR TITLE
feat(ux): tag BKD intent issue pr-ready on REVIEW_RUNNING entry [REQ-pr-ready-for-review-notify-1777344793]

### DIFF
--- a/openspec/changes/REQ-pr-ready-for-review-notify-1777344793/proposal.md
+++ b/openspec/changes/REQ-pr-ready-for-review-notify-1777344793/proposal.md
@@ -1,0 +1,27 @@
+# REQ-pr-ready-for-review-notify-1777344793: PR ready for review 알림 (Phase 1)
+
+## 배경
+
+REQ가 pr_ci를 통과하여 REVIEW_RUNNING 진입 시 PR이 이미 열려있고 mergeable 상태임에도,
+사용자는 BKD intent issue가 여전히 `working` 상태로 보여 언제 심사해야 하는지 알 수 없다.
+이 "마지막 1km" UX 공백을 BKD intent issue 태그로 최소 가시 신호를 제공하는 방식으로 해소한다.
+
+## 해결 방법 (Phase 1)
+
+REQ가 어떤 stage에서든 REVIEW_RUNNING에 진입할 때:
+
+1. `ctx.pr_urls`(PR이 이미 발견된 경우 채워짐)가 비어있지 않으면
+2. BKD intent issue에 `pr-ready` 태그 + `pr:owner/repo#N` 태그(각 PR마다)를 추가
+3. statusId는 변경하지 않음 (sisyphus 상태 기계가 자체 관리)
+4. BKD PATCH 실패 시 warning 로그만 남기고 상태 전이 차단 안 함
+
+## 구현 위치
+
+- `orchestrator/src/orchestrator/engine.py`: `_tag_intent_pr_ready()` 헬퍼 + `step()`에서 호출
+- `orchestrator/src/orchestrator/intent_tags.py`: `pr-ready`를 sisyphus-managed 태그로 등록
+
+## 범위 외
+
+- Telegram/Slack/이메일 알림 (독립 REQ)
+- BKD comment 추가 (Phase 2, 선택 사항)
+- statusId를 review로 전환 (sisyphus 상태 기계 자체 관리 유지)

--- a/openspec/changes/REQ-pr-ready-for-review-notify-1777344793/specs/pr-ready-notify/contract.spec.yaml
+++ b/openspec/changes/REQ-pr-ready-for-review-notify-1777344793/specs/pr-ready-notify/contract.spec.yaml
@@ -1,0 +1,18 @@
+id: pr-ready-notify
+version: "1.0"
+description: >
+  REVIEW_RUNNING 진입 시 BKD intent issue pr-ready 태그 계약.
+  orchestrator engine이 REVIEW_RUNNING 전환 시 ctx.pr_urls 비어있지 않으면
+  BKD intent issue에 pr-ready 태그를 추가해야 한다.
+
+scenarios:
+  - id: PRN-S1
+    description: REVIEW_RUNNING + pr_urls 비어있지 않음 → pr-ready 태그 추가
+  - id: PRN-S2
+    description: pr_urls 빈 dict → BKD PATCH 없음
+  - id: PRN-S3
+    description: pr_urls 없음(None) → BKD PATCH 없음
+  - id: PRN-S4
+    description: BKD PATCH 5xx → warning 로그 + 상태 전이 불차단
+  - id: PRN-S5
+    description: intent_issue_id 없음 → no-op

--- a/openspec/changes/REQ-pr-ready-for-review-notify-1777344793/specs/pr-ready-notify/spec.md
+++ b/openspec/changes/REQ-pr-ready-for-review-notify-1777344793/specs/pr-ready-notify/spec.md
@@ -1,0 +1,54 @@
+# pr-ready-notify
+
+## ADDED Requirements
+
+### Requirement: engine MUST tag BKD intent issue with pr-ready on REVIEW_RUNNING entry
+
+The orchestrator engine SHALL, upon a successful CAS transition into
+`ReqState.REVIEW_RUNNING`, check whether `ctx.pr_urls` is non-empty. When
+non-empty, it MUST schedule a fire-and-forget asyncio.Task that calls
+`BKDClient.merge_tags_and_update` on the BKD intent issue, adding the tag
+`pr-ready` plus one `pr:owner/repo#N` tag per `(repo, url)` entry in
+`ctx.pr_urls`. The statusId of the intent issue MUST NOT be changed. When
+`ctx.pr_urls` is absent or empty, the helper MUST skip the BKD call entirely.
+When `ctx.intent_issue_id` is absent, the helper MUST be a no-op. Any exception
+from the BKD call MUST be caught and logged at WARNING level; the state machine
+transition MUST NOT be blocked or rolled back.
+
+#### Scenario: PRN-S1 REVIEW_RUNNING with non-empty pr_urls adds pr-ready tag
+
+- **GIVEN** a REQ in state `PR_CI_RUNNING` with `ctx.intent_issue_id="intent-abc"`,
+  `ctx.pr_urls={"phona/sisyphus": "https://github.com/phona/sisyphus/pull/42"}`,
+  and `project_id="proj-x"`
+- **WHEN** `engine.step` processes `Event.PR_CI_FAIL` and the CAS to
+  `ReqState.REVIEW_RUNNING` succeeds
+- **THEN** a fire-and-forget asyncio.Task MUST be scheduled that calls
+  `BKDClient.merge_tags_and_update` with `add` containing `"pr-ready"` and
+  `"pr:phona/sisyphus#42"`
+
+#### Scenario: PRN-S2 empty pr_urls dict skips BKD PATCH
+
+- **GIVEN** a REQ transitioning into `REVIEW_RUNNING` with `ctx.pr_urls={}`
+- **WHEN** `engine.step` processes the transition and the pr-ready helper runs
+- **THEN** `BKDClient.merge_tags_and_update` MUST NOT be called
+
+#### Scenario: PRN-S3 absent pr_urls skips BKD PATCH
+
+- **GIVEN** a REQ in `SPEC_LINT_RUNNING` with no `pr_urls` key in ctx (PR not yet opened)
+- **WHEN** `engine.step` processes `Event.SPEC_LINT_FAIL` and transitions to `REVIEW_RUNNING`
+- **THEN** `BKDClient.merge_tags_and_update` MUST NOT be called
+
+#### Scenario: PRN-S4 BKD call failure logs warning and does not block transition
+
+- **GIVEN** a REQ transitioning into `REVIEW_RUNNING` with non-empty `pr_urls`
+  and BKD responding with HTTP 5xx
+- **WHEN** `merge_tags_and_update` raises an exception inside the async Task
+- **THEN** the helper MUST log a WARNING and MUST NOT re-raise
+- **AND** `req_state.state` MUST be `REVIEW_RUNNING` (no rollback)
+
+#### Scenario: PRN-S5 absent intent_issue_id is a no-op
+
+- **GIVEN** `_tag_intent_pr_ready` is called with `intent_issue_id=None`
+  and a non-empty `pr_urls` dict
+- **WHEN** the helper runs
+- **THEN** `BKDClient.merge_tags_and_update` MUST NOT be called

--- a/openspec/changes/REQ-pr-ready-for-review-notify-1777344793/tasks.md
+++ b/openspec/changes/REQ-pr-ready-for-review-notify-1777344793/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: REQ-pr-ready-for-review-notify-1777344793
+
+## Stage: spec
+- [x] author specs/pr-ready-notify/spec.md scenarios
+- [x] author specs/pr-ready-notify/contract.spec.yaml
+
+## Stage: implementation
+- [x] engine.py: `_tag_intent_pr_ready()` 헬퍼 추가
+- [x] engine.py: `step()`에서 REVIEW_RUNNING 진입 시 fire-and-forget 호출
+- [x] intent_tags.py: `pr-ready`를 SISYPHUS_MANAGED_EXACT에 추가
+
+## Stage: unit tests
+- [x] test_contract_pr_ready_notify.py: PRN-S1 ~ PRN-S5 (5개 테스트)
+  - [x] PRN-S1: REVIEW_RUNNING + pr_urls 비어있지 않음 → pr-ready + pr:repo#N 태그 추가
+  - [x] PRN-S2: pr_urls = {} (빈 dict) → BKD PATCH 없음
+  - [x] PRN-S3: pr_urls = None → BKD PATCH 없음
+  - [x] PRN-S4: BKD 5xx → warning 로그 + 상태 전이 불차단
+  - [x] PRN-S5: intent_issue_id 없음 → no-op
+
+## Stage: PR
+- [x] git push feat/REQ-pr-ready-for-review-notify-1777344793
+- [x] gh pr create --label sisyphus

--- a/orchestrator/src/orchestrator/engine.py
+++ b/orchestrator/src/orchestrator/engine.py
@@ -180,6 +180,47 @@ async def _sync_intent_status_on_terminal(
         )
 
 
+async def _tag_intent_pr_ready(
+    project_id: str,
+    intent_issue_id: str | None,
+    pr_urls: dict | None,
+    *,
+    req_id: str | None = None,
+) -> None:
+    """REQ-pr-ready-for-review-notify: REVIEW_RUNNING 进入时给 BKD intent issue 打 pr-ready tag.
+
+    pr_urls 空或缺失 → no-op（PR 还没开，跳过标记）。
+    intent_issue_id 缺失 → no-op。
+    BKD 不可达 → log warning，不阻塞状态机。
+    """
+    if not intent_issue_id or not pr_urls:
+        return
+    add_tags = ["pr-ready"]
+    for repo, url in pr_urls.items():
+        # url 形如 https://github.com/owner/repo/pull/123 → tag pr:owner/repo#123
+        try:
+            pr_num = url.rstrip("/").split("/")[-1]
+            tag = f"pr:{repo}#{pr_num}"
+            if tag not in add_tags:
+                add_tags.append(tag)
+        except (AttributeError, IndexError):
+            log.warning("engine.pr_ready.url_parse_failed", url=url, req_id=req_id)
+    try:
+        async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+            await bkd.merge_tags_and_update(
+                project_id=project_id,
+                issue_id=intent_issue_id,
+                add=add_tags,
+            )
+    except Exception as e:
+        log.warning(
+            "engine.pr_ready_tag_failed",
+            req_id=req_id,
+            intent_issue_id=intent_issue_id,
+            error=str(e),
+        )
+
+
 async def _cleanup_runner_on_terminal(req_id: str, terminal_state: ReqState) -> None:
     try:
         rc = k8s_runner.get_controller()
@@ -271,6 +312,19 @@ async def step(
         )
         _cleanup_tasks.add(sync_task)
         sync_task.add_done_callback(_cleanup_tasks.discard)
+
+    # REQ-pr-ready-for-review-notify: REVIEW_RUNNING 进入时给 BKD intent issue 打 pr-ready tag
+    if transition.next_state == ReqState.REVIEW_RUNNING:
+        intent_issue_id = (ctx or {}).get("intent_issue_id")
+        pr_urls = (ctx or {}).get("pr_urls")
+        pr_ready_task = asyncio.create_task(
+            _tag_intent_pr_ready(
+                project_id, intent_issue_id, pr_urls,
+                req_id=req_id,
+            )
+        )
+        _cleanup_tasks.add(pr_ready_task)
+        pr_ready_task.add_done_callback(_cleanup_tasks.discard)
 
     await obs.record_event(
         "router.decision",

--- a/orchestrator/src/orchestrator/intent_tags.py
+++ b/orchestrator/src/orchestrator/intent_tags.py
@@ -31,6 +31,7 @@ SISYPHUS_MANAGED_EXACT: frozenset[str] = frozenset({
     "staging-test",
     "pr-ci",
     "done-archive",
+    "pr-ready",
 })
 
 # Sisyphus 自己管的 tag 前缀。覆盖 §1 入口 / §4 结果 / §5 verifier / §6 fixer /

--- a/orchestrator/tests/test_contract_pr_ready_notify.py
+++ b/orchestrator/tests/test_contract_pr_ready_notify.py
@@ -1,0 +1,314 @@
+"""Contract tests for REQ-pr-ready-for-review-notify.
+
+When a REQ transitions into REVIEW_RUNNING and ctx.pr_urls is non-empty,
+the BKD intent issue MUST receive a `pr-ready` tag (+ `pr:owner/repo#N`
+for each PR URL) via merge_tags_and_update. If pr_urls is empty or
+intent_issue_id is missing, no PATCH is made. BKD failures log a warning
+but do not block the transition.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from orchestrator import engine, k8s_runner
+from orchestrator.actions import ACTION_META, REGISTRY
+from orchestrator.state import Event, ReqState
+
+# ─── Fake pool (same minimal pattern as test_intent_status_sync.py) ───────────
+
+@dataclass
+class _FakeReq:
+    state: str
+    history: list[dict] = field(default_factory=list)
+    context: dict = field(default_factory=dict)
+
+
+class _FakePool:
+    def __init__(self, initial: dict[str, _FakeReq]):
+        self.rows = initial
+        self._next_id = 1
+
+    async def fetchrow(self, sql: str, *args):
+        s = sql.strip()
+        if s.startswith("SELECT"):
+            rid = args[0]
+            r = self.rows.get(rid)
+            if r is None:
+                return None
+            return {
+                "req_id": rid, "project_id": "proj-x", "state": r.state,
+                "history": json.dumps(r.history),
+                "context": json.dumps(r.context),
+                "created_at": None, "updated_at": None,
+            }
+        if s.startswith("UPDATE req_state"):
+            rid, expected, target, history_json, *rest = args
+            r = self.rows.get(rid)
+            if r is None or r.state != expected:
+                return None
+            r.state = target
+            r.history.extend(json.loads(history_json))
+            if rest:
+                try:
+                    patch_d = json.loads(rest[0])
+                    if isinstance(patch_d, dict):
+                        r.context.update(patch_d)
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            return {"req_id": rid}
+        if s.startswith("INSERT INTO stage_runs") or s.startswith("UPDATE stage_runs"):
+            rid = self._next_id
+            self._next_id += 1
+            return {"id": rid}
+        raise NotImplementedError(s[:60])
+
+    async def execute(self, sql: str, *args):
+        s = sql.strip()
+        if s.startswith("UPDATE req_state SET context"):
+            rid, patch_json = args
+            try:
+                p = json.loads(patch_json)
+            except (json.JSONDecodeError, TypeError):
+                return
+            r = self.rows.get(rid)
+            if r and isinstance(p, dict):
+                r.context.update(p)
+            return
+        if s.startswith("UPDATE stage_runs"):
+            return
+        raise NotImplementedError(s[:60])
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def _isolated_actions(monkeypatch):
+    saved_reg = dict(REGISTRY)
+    saved_meta = dict(ACTION_META)
+    REGISTRY.clear()
+    ACTION_META.clear()
+    yield REGISTRY
+    REGISTRY.clear()
+    ACTION_META.clear()
+    REGISTRY.update(saved_reg)
+    ACTION_META.update(saved_meta)
+
+
+@pytest.fixture
+def _mock_runner_controller():
+    fake = MagicMock()
+    fake.cleanup_runner = AsyncMock(return_value=None)
+    k8s_runner.set_controller(fake)
+    yield fake
+    k8s_runner.set_controller(None)
+
+
+def _make_bkd_mock(merge_tags_and_update: AsyncMock | None = None):
+    m = merge_tags_and_update or AsyncMock(return_value=None)
+    inst = MagicMock()
+    inst.merge_tags_and_update = m
+    inst.__aenter__ = AsyncMock(return_value=inst)
+    inst.__aexit__ = AsyncMock(return_value=None)
+    return inst, m
+
+
+async def _drain_tasks() -> None:
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PRN-S1: REVIEW_RUNNING + pr_urls 非空 → pr-ready + pr:owner/repo#N tag 추가
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_prn_s1_review_running_with_pr_urls_adds_pr_ready_tag(
+    _isolated_actions, _mock_runner_controller,
+):
+    inst, merge_mock = _make_bkd_mock()
+
+    async def _stub_invoke_verifier(*, body, req_id, tags, ctx):
+        return {"verifier_issue_id": "ver-1"}
+
+    REGISTRY["invoke_verifier_for_pr_ci_fail"] = _stub_invoke_verifier
+
+    pr_urls = {"phona/sisyphus": "https://github.com/phona/sisyphus/pull/42"}
+    pool = _FakePool({
+        "REQ-1": _FakeReq(
+            state=ReqState.PR_CI_RUNNING.value,
+            context={
+                "intent_issue_id": "intent-abc",
+                "pr_urls": pr_urls,
+            },
+        ),
+    })
+    body = type("B", (), {
+        "issueId": "pr-ci-1", "projectId": "proj-x",
+        "event": "check.failed",
+    })()
+
+    with patch("orchestrator.engine.BKDClient", return_value=inst):
+        await engine.step(
+            pool, body=body, req_id="REQ-1", project_id="proj-x", tags=[],
+            cur_state=ReqState.PR_CI_RUNNING,
+            ctx={"intent_issue_id": "intent-abc", "pr_urls": pr_urls},
+            event=Event.PR_CI_FAIL,
+        )
+        await _drain_tasks()
+
+    assert pool.rows["REQ-1"].state == ReqState.REVIEW_RUNNING.value
+    merge_mock.assert_awaited_once()
+    added = merge_mock.await_args.kwargs.get("add") or []
+    assert "pr-ready" in added
+    assert "pr:phona/sisyphus#42" in added
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PRN-S2: pr_urls 빈 dict → BKD PATCH 안함
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_prn_s2_empty_pr_urls_no_patch(
+    _isolated_actions, _mock_runner_controller,
+):
+    inst, merge_mock = _make_bkd_mock()
+
+    async def _stub_invoke_verifier(*, body, req_id, tags, ctx):
+        return {"verifier_issue_id": "ver-1"}
+
+    REGISTRY["invoke_verifier_for_staging_test_fail"] = _stub_invoke_verifier
+
+    pool = _FakePool({
+        "REQ-1": _FakeReq(
+            state=ReqState.STAGING_TEST_RUNNING.value,
+            context={
+                "intent_issue_id": "intent-abc",
+                "pr_urls": {},
+            },
+        ),
+    })
+    body = type("B", (), {
+        "issueId": "staging-1", "projectId": "proj-x",
+        "event": "test.failed",
+    })()
+
+    with patch("orchestrator.engine.BKDClient", return_value=inst):
+        await engine.step(
+            pool, body=body, req_id="REQ-1", project_id="proj-x", tags=[],
+            cur_state=ReqState.STAGING_TEST_RUNNING,
+            ctx={"intent_issue_id": "intent-abc", "pr_urls": {}},
+            event=Event.STAGING_TEST_FAIL,
+        )
+        await _drain_tasks()
+
+    assert pool.rows["REQ-1"].state == ReqState.REVIEW_RUNNING.value
+    merge_mock.assert_not_awaited()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PRN-S3: pr_urls 없음(None) → BKD PATCH 안함
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_prn_s3_no_pr_urls_no_patch(
+    _isolated_actions, _mock_runner_controller,
+):
+    inst, merge_mock = _make_bkd_mock()
+
+    async def _stub_invoke_verifier(*, body, req_id, tags, ctx):
+        return {"verifier_issue_id": "ver-1"}
+
+    REGISTRY["invoke_verifier_for_spec_lint_fail"] = _stub_invoke_verifier
+
+    pool = _FakePool({
+        "REQ-1": _FakeReq(
+            state=ReqState.SPEC_LINT_RUNNING.value,
+            context={"intent_issue_id": "intent-abc"},
+        ),
+    })
+    body = type("B", (), {
+        "issueId": "lint-1", "projectId": "proj-x",
+        "event": "lint.failed",
+    })()
+
+    with patch("orchestrator.engine.BKDClient", return_value=inst):
+        await engine.step(
+            pool, body=body, req_id="REQ-1", project_id="proj-x", tags=[],
+            cur_state=ReqState.SPEC_LINT_RUNNING,
+            ctx={"intent_issue_id": "intent-abc"},
+            event=Event.SPEC_LINT_FAIL,
+        )
+        await _drain_tasks()
+
+    assert pool.rows["REQ-1"].state == ReqState.REVIEW_RUNNING.value
+    merge_mock.assert_not_awaited()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PRN-S4: BKD PATCH 5xx → log warning + transition 不阻塞
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_prn_s4_bkd_patch_failure_logs_warning_no_rollback(
+    _isolated_actions, _mock_runner_controller,
+):
+    merge_mock = AsyncMock(side_effect=RuntimeError("bkd 503"))
+    inst, _ = _make_bkd_mock(merge_tags_and_update=merge_mock)
+
+    async def _stub_invoke_verifier(*, body, req_id, tags, ctx):
+        return {"verifier_issue_id": "ver-1"}
+
+    REGISTRY["invoke_verifier_for_pr_ci_fail"] = _stub_invoke_verifier
+
+    pr_urls = {"phona/sisyphus": "https://github.com/phona/sisyphus/pull/7"}
+    pool = _FakePool({
+        "REQ-1": _FakeReq(
+            state=ReqState.PR_CI_RUNNING.value,
+            context={"intent_issue_id": "intent-abc", "pr_urls": pr_urls},
+        ),
+    })
+    body = type("B", (), {
+        "issueId": "pr-ci-1", "projectId": "proj-x",
+        "event": "check.failed",
+    })()
+
+    with patch("orchestrator.engine.BKDClient", return_value=inst):
+        result = await engine.step(
+            pool, body=body, req_id="REQ-1", project_id="proj-x", tags=[],
+            cur_state=ReqState.PR_CI_RUNNING,
+            ctx={"intent_issue_id": "intent-abc", "pr_urls": pr_urls},
+            event=Event.PR_CI_FAIL,
+        )
+        await _drain_tasks()
+
+    # 상태 전이는 성공해야 함
+    assert pool.rows["REQ-1"].state == ReqState.REVIEW_RUNNING.value
+    assert result["next_state"] == ReqState.REVIEW_RUNNING.value
+    # PATCH는 시도됐어야 함 (BKD 실패가 전이를 막으면 안됨)
+    merge_mock.assert_awaited_once()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PRN-S5: 헬퍼 직접 호출 — intent_issue_id 없으면 no-op
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_prn_s5_helper_no_op_missing_intent_issue_id():
+    inst, merge_mock = _make_bkd_mock()
+    pr_urls = {"phona/sisyphus": "https://github.com/phona/sisyphus/pull/1"}
+
+    with patch("orchestrator.engine.BKDClient", return_value=inst):
+        await engine._tag_intent_pr_ready(
+            project_id="proj-x",
+            intent_issue_id=None,
+            pr_urls=pr_urls,
+            req_id="REQ-1",
+        )
+
+    merge_mock.assert_not_awaited()


### PR DESCRIPTION
## Summary

- When a REQ enters `REVIEW_RUNNING` and `ctx.pr_urls` is non-empty, orchestrator now fires a non-blocking `asyncio.Task` that adds `pr-ready` + `pr:owner/repo#N` tags to the BKD intent issue via `merge_tags_and_update`
- `pr_urls` empty / absent → no PATCH (guard: PR not yet opened)
- `intent_issue_id` absent → no-op
- BKD 5xx → warning log only, state transition proceeds normally
- `pr-ready` added to `SISYPHUS_MANAGED_EXACT` so it's not propagated as a user hint

## Test plan

- [x] PRN-S1: REVIEW_RUNNING + non-empty pr_urls → `pr-ready` + `pr:owner/repo#N` tags added
- [x] PRN-S2: `pr_urls={}` → no BKD PATCH
- [x] PRN-S3: `pr_urls` absent → no BKD PATCH
- [x] PRN-S4: BKD 5xx → warning log + transition not blocked
- [x] PRN-S5: `intent_issue_id=None` → no-op
- [x] All 5 new tests pass; 1634 pre-existing tests unaffected

## Files changed

| File | Change |
|---|---|
| `orchestrator/src/orchestrator/engine.py` | `_tag_intent_pr_ready()` helper + `step()` fire-and-forget call on REVIEW_RUNNING entry |
| `orchestrator/src/orchestrator/intent_tags.py` | `"pr-ready"` added to `SISYPHUS_MANAGED_EXACT` |
| `orchestrator/tests/test_contract_pr_ready_notify.py` | 5 unit tests (PRN-S1..S5) |
| `openspec/changes/REQ-pr-ready-for-review-notify-1777344793/` | proposal, spec, contract, tasks |

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-pr-ready-for-review-notify-1777344793`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/2gornyft)