### PR TITLE
fix(watchdog+start_challenger): persist challenger_issue_id to ctx + watchdog defensive guard [REQ-start-actions-ctx-persist-1777345119]

### DIFF
--- a/openspec/changes/REQ-start-actions-ctx-persist-1777345119/proposal.md
+++ b/openspec/changes/REQ-start-actions-ctx-persist-1777345119/proposal.md
@@ -1,0 +1,66 @@
+# REQ-start-actions-ctx-persist-1777345119: fix(watchdog+start_challenger): persist challenger_issue_id to ctx + watchdog defensive guard
+
+## 问题
+
+`start_challenger.py` 在创建 challenger BKD issue 后，没有调用 `req_state.update_context()` 把 `challenger_issue_id` 写入 REQ context。
+
+结果：`watchdog.py` 的 `_check_and_escalate` 在 `_STATE_ISSUE_KEY[CHALLENGER_RUNNING]` 查 ctx key 时，得到 `issue_id=None`；因为 `issue_id is None` 时跳过 BKD session 查询，直接走 escalate 路径，**即使 challenger agent 仍在运行**。
+
+实证：issues #474 / #467 — challenger 刚起约 5 min（`watchdog_session_ended_threshold_sec` 阈值）被 watchdog 误判为 stuck 并 escalate，challenger agent 仍 session_status=running。
+
+根因拆解：
+1. **ctx-write 缺失**：`start_challenger.py` 无 `db` / `req_state` import，issue.id 从未落 ctx。
+2. **`_STATE_ISSUE_KEY` 缺失 CHALLENGER_RUNNING**：watchdog 不知道 challenger 有对应 ctx key，无法查 BKD session status。
+3. **无防守性跳过**：`issue_id=None` 时 watchdog 直接 escalate，而正确行为应是"跳过，等 ctx key 落地"。
+
+## 方案
+
+### 修复 1：start_challenger.py 写 ctx（主链修复）
+
+`start_challenger` 在 `bkd.update_issue` 之后调用：
+
+```python
+pool = db.get_pool()
+await req_state.update_context(pool, req_id, {"challenger_issue_id": issue.id})
+```
+
+这确保 CHALLENGER_RUNNING 进 watchdog 扫描窗口之前，ctx 里已有 `challenger_issue_id`。
+
+### 修复 2：watchdog `_STATE_ISSUE_KEY` 补 CHALLENGER_RUNNING
+
+```python
+_STATE_ISSUE_KEY: dict[ReqState, str | None] = {
+    ...
+    ReqState.CHALLENGER_RUNNING: "challenger_issue_id",
+    ...
+}
+```
+
+watchdog 能用 `challenger_issue_id` 查 BKD session 状态，再决定是否 escalate。
+
+### 修复 3：watchdog CHALLENGER_RUNNING 防守性 skip（defense-in-depth）
+
+在 `_check_and_escalate` 里，`issue_id` 解析之后、BKD 查询之前：
+
+```python
+if state == ReqState.CHALLENGER_RUNNING and issue_id is None:
+    log.warning("watchdog.missing_issue_id", ...)
+    return False
+```
+
+作用域**只限 CHALLENGER_RUNNING**：
+- FIXER_RUNNING 等有 fixer-round-cap 安全上限，必须无条件 escalate，不受影响。
+- STAGING_TEST / ACCEPT 等无硬性 issue_id 依赖，按原路径走。
+
+## 取舍
+
+- **只改 CHALLENGER_RUNNING**：audit 发现其他 state 的 ctx-write 均已有对应实现，或属于无 BKD issue 的客观 checker（ctx key=None 是设计）。如后续发现其他 action 漏 ctx-write，应单独修。
+- **守卫作用域最小化**：broad guard（所有 issue_key≠None 且 issue_id=None 都跳过）会破坏 FIXER_RUNNING 的 fixer-round-cap 安全机制——fixer 可以没有 fixer_issue_id 但仍必须被 watchdog cap 兜底。因此守卫显式 scoped to CHALLENGER_RUNNING。
+- **不加 stuck_sec fallback**：不引入"超过 N 分钟就算卡死"的二次 cap。理由：正确 ctx-write 修复后 issue_id 总会在 5 min 内落地；二次 cap 是复杂度换轻微防御增益，不值。
+- **不修改 `_SKIP_STATES`**：CHALLENGER_RUNNING 不是终态，应被 watchdog 扫描，修复的是 issue_id 缺失的处理逻辑，不是扫描条件。
+
+## 兼容性
+
+- **既有 CHALLENGER_RUNNING REQ**（ctx 无 `challenger_issue_id`）：watchdog 防守性跳过，不误 escalate，等待下一次 deploy 后新 start_challenger 调用写入正确 ctx key。
+- **其他 state**：`_STATE_ISSUE_KEY` 新增一行，其余行不变，行为无影响。
+- **测试**：4 个既有 start_challenger 单测 + 1 新测；watchdog 既有单测 + 4 新测。

--- a/openspec/changes/REQ-start-actions-ctx-persist-1777345119/specs/start-actions-ctx-persist/contract.spec.yaml
+++ b/openspec/changes/REQ-start-actions-ctx-persist-1777345119/specs/start-actions-ctx-persist/contract.spec.yaml
@@ -1,0 +1,61 @@
+capability: start-actions-ctx-persist
+version: "1.0"
+description: |
+  start_challenger action must persist challenger_issue_id to REQ context so
+  that watchdog can query the BKD session status when the REQ is in
+  CHALLENGER_RUNNING state.
+
+  watchdog must include CHALLENGER_RUNNING in _STATE_ISSUE_KEY with the ctx key
+  "challenger_issue_id", and must skip escalation (not falsely escalate) when
+  challenger_issue_id is absent from ctx — a defense-in-depth guard against
+  races where the ctx write has not yet completed.
+
+context_fields:
+  challenger_issue_id:
+    type: string
+    written_by:
+      - "start_challenger action via req_state.update_context AFTER bkd.update_issue"
+    consumed_by:
+      - "watchdog._check_and_escalate: _STATE_ISSUE_KEY[CHALLENGER_RUNNING]"
+    semantics: |
+      BKD issue ID of the challenger agent issue for this REQ.
+      Used by watchdog to query session_status and decide whether to escalate.
+
+state_issue_key_changes:
+  added:
+    - state: CHALLENGER_RUNNING
+      ctx_key: challenger_issue_id
+      reason: |
+        challenger_issue_id now persisted by start_challenger; watchdog can
+        fetch the BKD issue and skip escalation when session is still running.
+
+watchdog_guard:
+  condition: "state == CHALLENGER_RUNNING and issue_id is None"
+  action: "log warning + return False (skip escalation)"
+  scope: CHALLENGER_RUNNING only
+  rationale: |
+    Absence of challenger_issue_id in ctx should be treated as a transient
+    race (ctx write in flight) rather than an ended session. Other states
+    (e.g. FIXER_RUNNING) have hard safety caps that must fire even without
+    an issue_id in ctx, so the guard is NOT applied broadly.
+
+actions:
+  start_challenger:
+    module: orchestrator.actions.start_challenger
+    ctx_write_semantics: |
+      AFTER bkd.update_issue(status_id="working") completes:
+        pool = db.get_pool()
+        await req_state.update_context(pool, req_id, {"challenger_issue_id": issue.id})
+      The write MUST occur before the function returns so that CHALLENGER_RUNNING
+      state in watchdog has a non-None issue_id to query.
+
+  watchdog._check_and_escalate:
+    module: orchestrator.watchdog
+    challenger_guard_semantics: |
+      After resolving issue_id from ctx via _STATE_ISSUE_KEY, BEFORE calling
+      BKDClient.get_issue:
+        IF state == CHALLENGER_RUNNING AND issue_id is None:
+          log.warning("watchdog.missing_issue_id", ...)
+          return False
+      This prevents false escalation when ctx write is delayed or on pre-fix
+      deployments where challenger_issue_id was never written.

--- a/openspec/changes/REQ-start-actions-ctx-persist-1777345119/specs/start-actions-ctx-persist/spec.md
+++ b/openspec/changes/REQ-start-actions-ctx-persist-1777345119/specs/start-actions-ctx-persist/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: start_challenger 必须在创建 BKD issue 后把 challenger_issue_id 写入 REQ context
+
+The `start_challenger` action MUST call `req_state.update_context(pool, req_id, {"challenger_issue_id": issue.id})` after `bkd.update_issue(status_id="working")` completes and before the function returns. The call MUST use a connection pool obtained from `db.get_pool()`. This ensures that when the REQ transitions to `CHALLENGER_RUNNING` and the watchdog begins scanning, the `challenger_issue_id` key is already present in the REQ context so watchdog can query the BKD session status.
+
+#### Scenario: SACP-S1 start_challenger 写 challenger_issue_id 到 ctx
+
+- **GIVEN** REQ 进入 start_challenger，body.issueId="spec-lint-1"，req_id="REQ-CH"
+- **WHEN** BKD create_issue 成功返回 issue.id="ch-new-1"，start_challenger 完成
+- **THEN** `req_state.update_context` 被调用一次，参数 `(pool, "REQ-CH", {"challenger_issue_id": "ch-new-1"})`
+
+#### Scenario: SACP-S2 start_challenger 返回值含 challenger_issue_id
+
+- **GIVEN** REQ 进入 start_challenger，BKD 返回 issue.id="ch-42"
+- **WHEN** start_challenger 完成
+- **THEN** 返回 dict 包含 `{"challenger_issue_id": "ch-42", "req_id": ...}`
+
+### Requirement: watchdog 必须在 _STATE_ISSUE_KEY 中包含 CHALLENGER_RUNNING
+
+The `watchdog._STATE_ISSUE_KEY` dict MUST contain the entry `ReqState.CHALLENGER_RUNNING: "challenger_issue_id"`. This enables watchdog to look up the correct ctx key for the challenger stage and query BKD session status before deciding to escalate.
+
+#### Scenario: SACP-S3 _STATE_ISSUE_KEY 包含 CHALLENGER_RUNNING 映射
+
+- **GIVEN** orchestrator 启动
+- **WHEN** 读取 `watchdog._STATE_ISSUE_KEY`
+- **THEN** `_STATE_ISSUE_KEY[ReqState.CHALLENGER_RUNNING] == "challenger_issue_id"`
+
+### Requirement: watchdog 必须在 CHALLENGER_RUNNING + issue_id 缺失时跳过而非 escalate
+
+The `watchdog._check_and_escalate` function MUST, when `state == ReqState.CHALLENGER_RUNNING` and `issue_id is None`, log a warning and return `False` (skip escalation) rather than proceeding to the escalate path. This is a defense-in-depth guard: a missing `challenger_issue_id` in ctx should be treated as a transient condition (ctx write in flight or pre-fix deployment), not as evidence that the challenger session has ended. This guard MUST be scoped only to `CHALLENGER_RUNNING`; it MUST NOT apply to other states such as `FIXER_RUNNING` that have hard safety caps which must fire regardless of issue_id presence.
+
+#### Scenario: SACP-S4 CHALLENGER_RUNNING + ctx 无 challenger_issue_id → 跳过
+
+- **GIVEN** REQ row state=CHALLENGER_RUNNING，ctx 不含 `challenger_issue_id`（issue_id=None），卡死时间超阈值
+- **WHEN** watchdog._check_and_escalate 跑
+- **THEN** 返回 False；`engine.step` 不被调；log `watchdog.missing_issue_id` warning 被发出
+
+#### Scenario: SACP-S5 CHALLENGER_RUNNING + issue_id in ctx + session running → 跳过
+
+- **GIVEN** REQ row state=CHALLENGER_RUNNING，ctx.challenger_issue_id="ch-99"，BKD session_status="running"，卡死时间超阈值
+- **WHEN** watchdog._check_and_escalate 跑
+- **THEN** 返回 False；`engine.step` 不被调（agent 仍在运行，不误 escalate）
+
+#### Scenario: SACP-S6 CHALLENGER_RUNNING + issue_id in ctx + session failed → escalate
+
+- **GIVEN** REQ row state=CHALLENGER_RUNNING，ctx.challenger_issue_id="ch-99"，BKD session_status="failed"，卡死时间超阈值
+- **WHEN** watchdog._check_and_escalate 跑
+- **THEN** 返回 True；`engine.step` 被调，event=SESSION_FAILED
+
+#### Scenario: SACP-S7 其他 state（如 STAGING_TEST_RUNNING）+ issue_id 缺失 → 照常 escalate
+
+- **GIVEN** REQ row state=STAGING_TEST_RUNNING，ctx 不含 staging_test_issue_id（issue_id=None），卡死时间超阈值
+- **WHEN** watchdog._check_and_escalate 跑
+- **THEN** CHALLENGER_RUNNING 守卫不触发；engine.step 被调，照常 escalate（现有行为不变）

--- a/openspec/changes/REQ-start-actions-ctx-persist-1777345119/tasks.md
+++ b/openspec/changes/REQ-start-actions-ctx-persist-1777345119/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: REQ-start-actions-ctx-persist-1777345119
+
+## Stage: implementation (start_challenger)
+
+- [x] `orchestrator/src/orchestrator/actions/start_challenger.py`：
+  - 新增 `from ..store import db, req_state` import
+  - 在 `bkd.update_issue` 调用后写 ctx：`await req_state.update_context(pool, req_id, {"challenger_issue_id": issue.id})`
+  - return dict 补 `challenger_issue_id`
+
+## Stage: implementation (watchdog)
+
+- [x] `orchestrator/src/orchestrator/watchdog.py`：
+  - `_STATE_ISSUE_KEY` 新增 `ReqState.CHALLENGER_RUNNING: "challenger_issue_id"` 条目（在 DEV_CROSS_CHECK_RUNNING 之后）
+  - `_check_and_escalate`：issue_id 解析后、BKD get_issue 调用前，加 CHALLENGER_RUNNING 防守性跳过：
+    `if state == ReqState.CHALLENGER_RUNNING and issue_id is None: log.warning(...); return False`
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_actions_start_challenger.py`：
+  - 新增 autouse fixture `_mock_db_and_req_state`：monkeypatch `start_challenger.db.get_pool` + `start_challenger.req_state.update_context`（防止真 DB 调用）
+  - 新增 `test_start_challenger_writes_challenger_issue_id_to_ctx`：验证 `req_state.update_context` 被调且 `call_args[2] == {"challenger_issue_id": "ch-new-1"}`
+- [x] `orchestrator/tests/test_watchdog.py`：
+  - 复原 `test_missing_issue_id_in_ctx_escalates` 为 STAGING_TEST_RUNNING（新守卫不影响该 state）
+  - 新增 `test_challenger_running_in_state_issue_key`：验证 `_STATE_ISSUE_KEY[CHALLENGER_RUNNING] == "challenger_issue_id"`
+  - 新增 `test_challenger_running_missing_issue_id_skips`：CHALLENGER_RUNNING + ctx={} → `_check_and_escalate` 返 False，engine.step 不被调
+  - 新增 `test_challenger_running_session_skips_when_still_running`：CHALLENGER_RUNNING + issue_id in ctx + session_status="running" → 跳过
+  - 新增 `test_challenger_running_session_failed_escalates`：CHALLENGER_RUNNING + issue_id in ctx + session_status="failed" → escalate（engine.step 被调）
+
+## Stage: spec
+
+- [x] `openspec/changes/REQ-start-actions-ctx-persist-1777345119/proposal.md`
+- [x] `openspec/changes/REQ-start-actions-ctx-persist-1777345119/tasks.md`
+- [x] `openspec/changes/REQ-start-actions-ctx-persist-1777345119/specs/start-actions-ctx-persist/contract.spec.yaml`
+- [x] `openspec/changes/REQ-start-actions-ctx-persist-1777345119/specs/start-actions-ctx-persist/spec.md`
+
+## Stage: PR
+
+- [x] git push feat/REQ-start-actions-ctx-persist-1777345119
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/actions/start_challenger.py
+++ b/orchestrator/src/orchestrator/actions/start_challenger.py
@@ -29,6 +29,7 @@ from ..config import settings
 from ..intent_tags import filter_propagatable_intent_tags
 from ..prompts import render
 from ..state import Event
+from ..store import db, req_state
 from . import register, short_title
 from ._skip import skip_if_enabled
 
@@ -76,5 +77,7 @@ async def start_challenger(*, body, req_id, tags, ctx):
         await bkd.follow_up_issue(project_id=proj, issue_id=issue.id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue.id, status_id="working")
 
+    pool = db.get_pool()
+    await req_state.update_context(pool, req_id, {"challenger_issue_id": issue.id})
     log.info("start_challenger.done", req_id=req_id, issue_id=issue.id)
     return {"challenger_issue_id": issue.id, "req_id": req_id}

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -53,6 +53,7 @@ _STATE_ISSUE_KEY: dict[ReqState, str | None] = {
     ReqState.ANALYZE_ARTIFACT_CHECKING: None,    # 客观 checker，由 orchestrator 下发不绑 issue
     ReqState.SPEC_LINT_RUNNING: None,            # M15: 客观 checker，由 orchestrator 下发不绑 issue
     ReqState.DEV_CROSS_CHECK_RUNNING: None,      # M15: 客观 checker，由 orchestrator 下发不绑 issue
+    ReqState.CHALLENGER_RUNNING: "challenger_issue_id",
     ReqState.STAGING_TEST_RUNNING: "staging_test_issue_id",
     ReqState.PR_CI_RUNNING: "pr_ci_watch_issue_id",
     ReqState.ACCEPT_RUNNING: "accept_issue_id",
@@ -152,6 +153,18 @@ async def _check_and_escalate(row) -> bool:
     issue_id: str | None = None
     if issue_key:
         issue_id = ctx.get(issue_key)
+
+    # Defense-in-depth for CHALLENGER_RUNNING: if challenger_issue_id was not
+    # persisted to ctx (start_challenger action bug), skip rather than falsely
+    # treating as an ended session and killing a live agent.
+    # Scoped to CHALLENGER_RUNNING only; other states (e.g. FIXER_RUNNING) have
+    # safety caps that must still fire even without an issue_id in ctx.
+    if state == ReqState.CHALLENGER_RUNNING and issue_id is None:
+        log.warning(
+            "watchdog.missing_issue_id",
+            req_id=req_id, state=state_str, issue_key=issue_key,
+        )
+        return False
 
     # 1. 查 BKD session 状态（有 issue_id 才查）
     issue = None

--- a/orchestrator/tests/test_actions_start_challenger.py
+++ b/orchestrator/tests/test_actions_start_challenger.py
@@ -9,11 +9,18 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from orchestrator.actions import start_challenger
+
+
+@pytest.fixture(autouse=True)
+def _mock_db_and_req_state(monkeypatch):
+    """Prevent real DB calls introduced by REQ-start-actions-ctx-persist."""
+    monkeypatch.setattr(start_challenger.db, "get_pool", MagicMock(return_value=object()))
+    monkeypatch.setattr(start_challenger.req_state, "update_context", AsyncMock())
 
 
 @dataclass
@@ -159,3 +166,27 @@ async def test_start_challenger_no_hint_keeps_base_tags(monkeypatch):
     )
     _, kwargs = fake.create_issue.await_args
     assert kwargs["tags"] == ["challenger", "REQ-X", "parent-id:analyze-1"]
+
+
+# ─── REQ-start-actions-ctx-persist: challenger_issue_id written to ctx ────────
+
+
+@pytest.mark.asyncio
+async def test_start_challenger_writes_challenger_issue_id_to_ctx(monkeypatch):
+    """start_challenger must persist challenger_issue_id to ctx via req_state.update_context
+    so that watchdog can reconcile the BKD session status for CHALLENGER_RUNNING state."""
+    _patch_bkd(monkeypatch)
+    _patch_pr_links_empty(monkeypatch)
+
+    await start_challenger.start_challenger(
+        body=_make_body(issue_id="spec-lint-1"),
+        req_id="REQ-CH",
+        tags=["REQ-CH"],
+        ctx={},
+    )
+
+    start_challenger.req_state.update_context.assert_awaited_once()
+    call_args, _ = start_challenger.req_state.update_context.await_args
+    # positional: (pool, req_id, patch_dict)
+    assert call_args[1] == "REQ-CH"
+    assert call_args[2] == {"challenger_issue_id": "ch-new-1"}

--- a/orchestrator/tests/test_contract_start_actions_ctx_persist_challenger.py
+++ b/orchestrator/tests/test_contract_start_actions_ctx_persist_challenger.py
@@ -23,8 +23,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 _PRODUCTION_SOURCE = Path(__file__).resolve().parent.parent / "src" / "orchestrator"
 
 

--- a/orchestrator/tests/test_contract_start_actions_ctx_persist_challenger.py
+++ b/orchestrator/tests/test_contract_start_actions_ctx_persist_challenger.py
@@ -1,0 +1,382 @@
+"""Contract tests for REQ-start-actions-ctx-persist-1777345119.
+
+fix(watchdog+start_challenger): persist challenger_issue_id to ctx + watchdog defensive guard
+
+Black-box behavioral contract verification written by challenger-agent.
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is wrong, escalate to spec_fixer to correct the spec, not the test.
+
+Scenarios covered:
+  SACP-S1  start_challenger.py imports db + req_state and calls update_context with
+           challenger_issue_id (source-code contract)
+  SACP-S2  start_challenger return value dict contains challenger_issue_id key
+  SACP-S3  watchdog._STATE_ISSUE_KEY[CHALLENGER_RUNNING] == "challenger_issue_id"
+  SACP-S4  CHALLENGER_RUNNING + ctx lacks challenger_issue_id → _check_and_escalate returns False
+  SACP-S5  CHALLENGER_RUNNING + issue_id in ctx + session running → returns False (no false escalate)
+  SACP-S6  CHALLENGER_RUNNING + issue_id in ctx + session failed → returns True (escalate)
+  SACP-S7  STAGING_TEST_RUNNING + issue_id=None → escalates (CHALLENGER_RUNNING guard scoped only)
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_PRODUCTION_SOURCE = Path(__file__).resolve().parent.parent / "src" / "orchestrator"
+
+
+# ─── Part 1: Source-code structural contracts ─────────────────────────────────
+
+
+class TestStartChallengerCtxWriteStructural:
+    """SACP-S1, SACP-S2 (structural): start_challenger.py must be wired for ctx persistence."""
+
+    def test_sacp_s1_start_challenger_uses_req_state(self):
+        """S1 structural: start_challenger.py must reference req_state to call update_context."""
+        src = (_PRODUCTION_SOURCE / "actions" / "start_challenger.py").read_text(encoding="utf-8")
+        assert "req_state" in src, (
+            "start_challenger.py must import or use 'req_state' to call update_context "
+            "(SACP-S1: REQ-start-actions-ctx-persist-1777345119)"
+        )
+
+    def test_sacp_s1_start_challenger_calls_update_context(self):
+        """S1 structural: start_challenger.py must call update_context."""
+        src = (_PRODUCTION_SOURCE / "actions" / "start_challenger.py").read_text(encoding="utf-8")
+        assert "update_context" in src, (
+            "start_challenger.py must call req_state.update_context to persist "
+            "challenger_issue_id (SACP-S1: REQ-start-actions-ctx-persist-1777345119)"
+        )
+
+    def test_sacp_s1_start_challenger_writes_challenger_issue_id_key(self):
+        """S1 structural: start_challenger.py must write challenger_issue_id key to ctx."""
+        src = (_PRODUCTION_SOURCE / "actions" / "start_challenger.py").read_text(encoding="utf-8")
+        assert "challenger_issue_id" in src, (
+            "start_challenger.py must write 'challenger_issue_id' via update_context "
+            "(SACP-S1: REQ-start-actions-ctx-persist-1777345119). "
+            "This ctx key is consumed by watchdog._check_and_escalate for CHALLENGER_RUNNING."
+        )
+
+    def test_sacp_s1_start_challenger_uses_db_pool(self):
+        """S1 structural: start_challenger.py must use db pool for update_context call."""
+        src = (_PRODUCTION_SOURCE / "actions" / "start_challenger.py").read_text(encoding="utf-8")
+        assert "db" in src, (
+            "start_challenger.py must reference 'db' to obtain a pool for "
+            "req_state.update_context(pool, ...) (SACP-S1)"
+        )
+
+    def test_sacp_s2_start_challenger_return_includes_challenger_issue_id(self):
+        """S2 structural: start_challenger must surface challenger_issue_id in its return dict."""
+        src = (_PRODUCTION_SOURCE / "actions" / "start_challenger.py").read_text(encoding="utf-8")
+        # The source must contain challenger_issue_id at least twice: once for the ctx write,
+        # once as a key in the return dict. Even once is sufficient for this structural check
+        # because the functional test (S2 behavioral) will validate the actual return value.
+        assert "challenger_issue_id" in src, (
+            "start_challenger.py must include 'challenger_issue_id' in its return value dict "
+            "(SACP-S2: the caller — orchestrator state machine — records it for traceability)."
+        )
+
+
+# ─── Part 2: _STATE_ISSUE_KEY must map CHALLENGER_RUNNING ─────────────────────
+
+
+class TestWatchdogStateIssueKeyContract:
+    """SACP-S3: watchdog._STATE_ISSUE_KEY[CHALLENGER_RUNNING] == 'challenger_issue_id'."""
+
+    def test_sacp_s3_state_issue_key_exists(self):
+        """Spec: orchestrator.watchdog must define _STATE_ISSUE_KEY dict."""
+        import orchestrator.watchdog as wd
+
+        mapping = getattr(wd, "_STATE_ISSUE_KEY", None)
+        assert mapping is not None, (
+            "orchestrator.watchdog must define '_STATE_ISSUE_KEY' dict "
+            "(SACP-S3: REQ-start-actions-ctx-persist-1777345119)"
+        )
+        assert isinstance(mapping, dict), (
+            f"_STATE_ISSUE_KEY must be a dict, got {type(mapping)!r}"
+        )
+
+    def test_sacp_s3_challenger_running_key_present(self):
+        """Spec: CHALLENGER_RUNNING must appear as a key in _STATE_ISSUE_KEY."""
+        import orchestrator.watchdog as wd
+        from orchestrator.state import ReqState
+
+        mapping = wd._STATE_ISSUE_KEY
+        assert ReqState.CHALLENGER_RUNNING in mapping, (
+            f"_STATE_ISSUE_KEY must contain ReqState.CHALLENGER_RUNNING entry; "
+            f"found keys: {[str(k) for k in mapping.keys()]!r}. "
+            "SACP-S3: watchdog needs this mapping to query the BKD session for CHALLENGER_RUNNING."
+        )
+
+    def test_sacp_s3_challenger_running_maps_to_correct_ctx_key(self):
+        """Spec: _STATE_ISSUE_KEY[CHALLENGER_RUNNING] == 'challenger_issue_id'."""
+        import orchestrator.watchdog as wd
+        from orchestrator.state import ReqState
+
+        mapping = wd._STATE_ISSUE_KEY
+        actual = mapping.get(ReqState.CHALLENGER_RUNNING, "<MISSING>")
+        assert actual == "challenger_issue_id", (
+            f"_STATE_ISSUE_KEY[CHALLENGER_RUNNING] must be 'challenger_issue_id'; "
+            f"got {actual!r}. "
+            "SACP-S3: this ctx key is written by start_challenger and read by watchdog."
+        )
+
+    def test_sacp_s3_existing_state_mappings_preserved(self):
+        """Structural coexistence: adding CHALLENGER_RUNNING must not remove other entries."""
+        import orchestrator.watchdog as wd
+        from orchestrator.state import ReqState
+
+        mapping = wd._STATE_ISSUE_KEY
+        # FIXER_RUNNING must still have a mapping (used by fixer_round_cap logic)
+        assert ReqState.FIXER_RUNNING in mapping, (
+            "_STATE_ISSUE_KEY must still contain ReqState.FIXER_RUNNING; "
+            "the new CHALLENGER_RUNNING entry must not remove existing entries."
+        )
+
+
+# ─── Part 3: Behavioral _check_and_escalate contracts ─────────────────────────
+
+
+def _make_settings(
+    watchdog_timeout_secs: int = 1800,
+    fixer_round_cap: int = 5,
+) -> MagicMock:
+    s = MagicMock()
+    s.watchdog_timeout_secs = watchdog_timeout_secs
+    s.watchdog_interval_secs = 30
+    s.fixer_round_cap = fixer_round_cap
+    return s
+
+
+def _make_req_row(
+    state_val: str,
+    ctx: dict,
+    req_id: str = "REQ-sacp-test-1234",
+    stuck_secs: int = 3600,
+) -> dict:
+    """Build a minimal req row dict as watchdog._check_and_escalate expects."""
+    return {
+        "req_id": req_id,
+        "project_id": "test-project",
+        "state": state_val,
+        "context": ctx,
+        "stuck_sec": stuck_secs,
+        "updated_at": datetime.now(UTC) - timedelta(seconds=stuck_secs),
+        "intent_issue_id": "intent-issue-1",
+        "created_at": datetime.now(UTC) - timedelta(seconds=stuck_secs + 100),
+    }
+
+
+def _state_str(state_enum) -> str:
+    """Convert ReqState enum to the string value stored in the DB row."""
+    return state_enum.value if hasattr(state_enum, "value") else str(state_enum)
+
+
+def _make_watchdog_patches(settings, mock_req_state, mock_engine):
+    from orchestrator import watchdog as wd
+    return [
+        patch.object(wd, "settings", settings),
+        patch.object(wd, "req_state", mock_req_state),
+        patch.object(wd, "engine", mock_engine),
+        patch("orchestrator.store.db.get_pool", return_value=AsyncMock()),
+    ]
+
+
+class TestChallengerRunningGuardBehavior:
+    """SACP-S4 through S7: behavioral contracts for _check_and_escalate guard."""
+
+    async def test_sacp_s4_challenger_running_no_issue_id_returns_false(self):
+        """SACP-S4: CHALLENGER_RUNNING + ctx missing challenger_issue_id → return False.
+
+        When challenger_issue_id is absent from ctx, watchdog MUST skip escalation
+        (return False) and MUST NOT call engine.step. The absence is treated as a
+        transient condition (ctx write in flight or pre-fix deployment), not as
+        evidence that the session has ended.
+        """
+        from orchestrator import watchdog as wd
+        from orchestrator.state import ReqState
+
+        settings = _make_settings()
+        mock_req_state = AsyncMock()
+        mock_engine = MagicMock()
+        mock_engine.step = AsyncMock()
+
+        row = _make_req_row(
+            state_val=_state_str(ReqState.CHALLENGER_RUNNING),
+            ctx={},  # challenger_issue_id absent — simulates ctx write race
+            stuck_secs=3600,  # well past watchdog_timeout_secs=1800
+        )
+
+        p = _make_watchdog_patches(settings, mock_req_state, mock_engine)
+        with p[0], p[1], p[2], p[3]:
+            result = await wd._check_and_escalate(row)
+
+        assert result is False, (
+            f"SACP-S4: CHALLENGER_RUNNING + issue_id=None must return False (skip escalation); "
+            f"got {result!r}. "
+            "Absent challenger_issue_id is a transient condition, not an ended session."
+        )
+        mock_engine.step.assert_not_called()
+
+    async def test_sacp_s4_log_warning_emitted_for_missing_issue_id(self):
+        """SACP-S4 guard: watchdog must emit 'watchdog.missing_issue_id' warning.
+
+        Structural check: the source code must contain the log key for observability.
+        """
+        src = (_PRODUCTION_SOURCE / "watchdog.py").read_text(encoding="utf-8")
+        assert "missing_issue_id" in src, (
+            "watchdog.py must emit 'watchdog.missing_issue_id' (or similar) warning "
+            "when CHALLENGER_RUNNING + issue_id is None (SACP-S4 observability contract)."
+        )
+
+    async def test_sacp_s5_challenger_running_session_running_returns_false(self):
+        """SACP-S5: CHALLENGER_RUNNING + challenger_issue_id in ctx + session running → False.
+
+        When the challenger BKD session is still active (session_status='running'),
+        watchdog MUST NOT escalate. engine.step must not be called.
+        """
+        from orchestrator import watchdog as wd
+        from orchestrator.state import ReqState
+
+        settings = _make_settings()
+        mock_req_state = AsyncMock()
+        mock_engine = MagicMock()
+        mock_engine.step = AsyncMock()
+
+        row = _make_req_row(
+            state_val=_state_str(ReqState.CHALLENGER_RUNNING),
+            ctx={"challenger_issue_id": "ch-99"},
+            stuck_secs=3600,
+        )
+
+        mock_issue = SimpleNamespace(
+            id="ch-99",
+            session_status="running",
+            tags=["challenger", "REQ-sacp-test-1234"],
+            statusId="working",
+        )
+
+        # BKD client: try both context-manager and async-with patterns
+        mock_bkd_inner = AsyncMock()
+        mock_bkd_inner.get_issue = AsyncMock(return_value=mock_issue)
+        mock_bkd_inst = AsyncMock()
+        mock_bkd_inst.__aenter__ = AsyncMock(return_value=mock_bkd_inner)
+        mock_bkd_inst.get_issue = AsyncMock(return_value=mock_issue)
+        mock_bkd_cls = MagicMock(return_value=mock_bkd_inst)
+
+        p = _make_watchdog_patches(settings, mock_req_state, mock_engine)
+        with p[0], p[1], p[2], p[3]:
+            with patch.object(wd, "BKDClient", mock_bkd_cls, create=True):
+                result = await wd._check_and_escalate(row)
+
+        assert result is False, (
+            f"SACP-S5: CHALLENGER_RUNNING + session_status='running' must return False "
+            f"(agent still active); got {result!r}. "
+            "Watchdog must not falsely escalate a running challenger session."
+        )
+        mock_engine.step.assert_not_called()
+
+    async def test_sacp_s6_challenger_running_session_failed_escalates(self):
+        """SACP-S6: CHALLENGER_RUNNING + challenger_issue_id in ctx + session failed → True.
+
+        When the challenger BKD session has failed (session_status='failed'),
+        watchdog MUST escalate (return True, engine.step called).
+        """
+        from orchestrator import watchdog as wd
+        from orchestrator.state import ReqState
+
+        settings = _make_settings()
+        mock_req_state = AsyncMock()
+        mock_engine = MagicMock()
+        mock_engine.step = AsyncMock()
+
+        row = _make_req_row(
+            state_val=_state_str(ReqState.CHALLENGER_RUNNING),
+            ctx={"challenger_issue_id": "ch-99"},
+            stuck_secs=3600,
+        )
+
+        mock_issue = SimpleNamespace(
+            id="ch-99",
+            session_status="failed",
+            tags=["challenger", "REQ-sacp-test-1234"],
+            statusId="working",
+        )
+
+        mock_bkd_inner = AsyncMock()
+        mock_bkd_inner.get_issue = AsyncMock(return_value=mock_issue)
+        mock_bkd_inst = AsyncMock()
+        mock_bkd_inst.__aenter__ = AsyncMock(return_value=mock_bkd_inner)
+        mock_bkd_inst.get_issue = AsyncMock(return_value=mock_issue)
+        mock_bkd_cls = MagicMock(return_value=mock_bkd_inst)
+
+        p = _make_watchdog_patches(settings, mock_req_state, mock_engine)
+        with p[0], p[1], p[2], p[3]:
+            with patch.object(wd, "BKDClient", mock_bkd_cls, create=True):
+                result = await wd._check_and_escalate(row)
+
+        assert result is True, (
+            f"SACP-S6: CHALLENGER_RUNNING + session_status='failed' must return True "
+            f"(escalate); got {result!r}. SACP-S6."
+        )
+
+    async def test_sacp_s7_staging_test_running_no_issue_id_escalates(self):
+        """SACP-S7: STAGING_TEST_RUNNING + issue_id=None → escalates (guard not triggered).
+
+        The CHALLENGER_RUNNING guard MUST be scoped only to CHALLENGER_RUNNING.
+        Other states (STAGING_TEST_RUNNING) must follow the existing escalation path:
+        time-based stuck check fires → engine.step called.
+        """
+        from orchestrator import watchdog as wd
+        from orchestrator.state import ReqState
+
+        settings = _make_settings()
+        mock_req_state = AsyncMock()
+        mock_engine = MagicMock()
+        mock_engine.step = AsyncMock()
+
+        row = _make_req_row(
+            state_val=_state_str(ReqState.STAGING_TEST_RUNNING),
+            ctx={},  # no staging_test_issue_id → issue_id=None
+            stuck_secs=3600,  # past watchdog_timeout_secs=1800
+        )
+
+        p = _make_watchdog_patches(settings, mock_req_state, mock_engine)
+        with p[0], p[1], p[2], p[3]:
+            result = await wd._check_and_escalate(row)
+
+        # The CHALLENGER_RUNNING guard must NOT have fired for this state.
+        # Existing behavior: stuck threshold exceeded → escalate (return True).
+        assert result is True, (
+            f"SACP-S7: STAGING_TEST_RUNNING + issue_id=None must escalate (return True); "
+            f"got {result!r}. "
+            "The CHALLENGER_RUNNING guard must be scoped ONLY to CHALLENGER_RUNNING — "
+            "it must NOT suppress escalation for other states."
+        )
+        mock_engine.step.assert_called()
+
+
+# ─── Part 4: Guard scope — CHALLENGER_RUNNING guard structural contract ───────
+
+
+class TestChallengerGuardScopeStructural:
+    """SACP-S4 structural: the guard must be explicitly scoped to CHALLENGER_RUNNING only."""
+
+    def test_sacp_s4_guard_explicitly_scoped_to_challenger_running_in_source(self):
+        """Source structural: watchdog.py must contain an explicit CHALLENGER_RUNNING scope check.
+
+        The guard 'if state == CHALLENGER_RUNNING and issue_id is None' must be present
+        to prevent other states (e.g., FIXER_RUNNING) from being affected.
+        """
+        src = (_PRODUCTION_SOURCE / "watchdog.py").read_text(encoding="utf-8")
+        assert "CHALLENGER_RUNNING" in src, (
+            "watchdog.py must explicitly reference CHALLENGER_RUNNING for the "
+            "defensive guard (SACP-S4 scope: scoped only to CHALLENGER_RUNNING)."
+        )
+        # The guard must check for None issue_id
+        assert "issue_id is None" in src or "issue_id is not None" in src, (
+            "watchdog.py must contain an 'issue_id is None' (or negation) check "
+            "for the CHALLENGER_RUNNING defensive guard (SACP-S4)."
+        )

--- a/orchestrator/tests/test_watchdog.py
+++ b/orchestrator/tests/test_watchdog.py
@@ -206,7 +206,8 @@ async def test_spec_lint_escalates_without_bkd_lookup(monkeypatch):
 # ─── Case 5：ctx 里没 issue_id（比如 create_dev 还没落 ctx 就挂了）→ escalate
 @pytest.mark.asyncio
 async def test_missing_issue_id_in_ctx_escalates(monkeypatch):
-    """stage 有 issue_key 但 ctx 里缺少该 issue_id → 无法查 BKD，保守 escalate。"""
+    """stage has issue_key but ctx is missing the issue_id → proceeds to ended fast
+    lane and escalates. Only CHALLENGER_RUNNING gets the defensive skip guard."""
     pool = FakePool(rows=[
         _row("REQ-5", ReqState.STAGING_TEST_RUNNING.value, ctx={}),
     ])
@@ -218,7 +219,7 @@ async def test_missing_issue_id_in_ctx_escalates(monkeypatch):
     result = await watchdog._tick()
 
     assert result == {"checked": 1, "escalated": 1}
-    # 无 issue_id 不查
+    # 无 issue_id 不查 BKD
     fake_bkd.get_issue.assert_not_called()
     assert len(step_calls) == 1
 
@@ -763,3 +764,76 @@ def test_settings_session_ended_threshold_env_override(monkeypatch):
         bkd_token="x", webhook_token="x", pg_dsn="postgresql://x:x@x/x",  # type: ignore[call-arg]
     )
     assert s.watchdog_session_ended_threshold_sec == 120
+
+
+# ─── REQ-start-actions-ctx-persist: CHALLENGER_RUNNING reconciliation ─────────
+
+
+def test_challenger_running_in_state_issue_key():
+    """CHALLENGER_RUNNING must be in _STATE_ISSUE_KEY so watchdog can reconcile BKD
+    session status instead of blindly escalating after the threshold."""
+    assert ReqState.CHALLENGER_RUNNING in watchdog._STATE_ISSUE_KEY
+    assert watchdog._STATE_ISSUE_KEY[ReqState.CHALLENGER_RUNNING] == "challenger_issue_id"
+
+
+@pytest.mark.asyncio
+async def test_challenger_running_missing_issue_id_skips(monkeypatch):
+    """CHALLENGER_RUNNING + missing challenger_issue_id in ctx → defensive skip.
+
+    Before the fix, start_challenger didn't write challenger_issue_id to ctx, so
+    watchdog would see issue_id=None and immediately escalate after ended_sec.
+    The defensive guard now prevents false escalation while the agent is still live.
+    """
+    pool = FakePool(rows=[
+        _row("REQ-CH-M", ReqState.CHALLENGER_RUNNING.value, ctx={}),
+    ])
+    _patch_pool(monkeypatch, pool)
+    fake_bkd = _patch_bkd(monkeypatch, FakeIssue(session_status="running", id="ch-m"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 0}
+    fake_bkd.get_issue.assert_not_called()
+    assert step_calls == []
+
+
+@pytest.mark.asyncio
+async def test_challenger_running_session_skips_when_still_running(monkeypatch):
+    """CHALLENGER_RUNNING + challenger_issue_id in ctx + session running → skip."""
+    pool = FakePool(rows=[
+        _row("REQ-CH-R", ReqState.CHALLENGER_RUNNING.value,
+             ctx={"challenger_issue_id": "ch-r1", "intent_issue_id": "int-1"},
+             stuck_sec=400),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, FakeIssue(session_status="running", id="ch-r1"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 0}
+    assert step_calls == []
+
+
+@pytest.mark.asyncio
+async def test_challenger_running_session_failed_escalates(monkeypatch):
+    """CHALLENGER_RUNNING + challenger_issue_id in ctx + session failed → escalate."""
+    pool = FakePool(rows=[
+        _row("REQ-CH-F", ReqState.CHALLENGER_RUNNING.value,
+             ctx={"challenger_issue_id": "ch-f1", "intent_issue_id": "int-2"},
+             stuck_sec=400),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _patch_bkd(monkeypatch, FakeIssue(session_status="failed", id="ch-f1"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    assert step_calls[0]["event"] == Event.SESSION_FAILED
+    assert step_calls[0]["cur_state"] == ReqState.CHALLENGER_RUNNING
+    assert step_calls[0]["body_issue"] == "ch-f1"


### PR DESCRIPTION
## Summary

- **Root cause**: `start_challenger.py` never called `req_state.update_context()` after creating the challenger BKD issue, so `CHALLENGER_RUNNING` REQs had no `challenger_issue_id` in ctx. `watchdog._STATE_ISSUE_KEY` also lacked the `CHALLENGER_RUNNING` entry entirely. Combined effect: watchdog skipped the BKD session query (`issue_id=None`) and falsely escalated live challenger agents after ~5 min (issues #474, #467).
- **Fix 1** — `start_challenger.py`: add `db`/`req_state` imports + `req_state.update_context(pool, req_id, {"challenger_issue_id": issue.id})` after `bkd.update_issue`, so `challenger_issue_id` is in ctx before watchdog's next scan.
- **Fix 2** — `watchdog.py`: add `ReqState.CHALLENGER_RUNNING: "challenger_issue_id"` to `_STATE_ISSUE_KEY`; add CHALLENGER_RUNNING-scoped defensive skip when `issue_id is None` (guard is scoped to avoid breaking the FIXER_RUNNING fixer-round-cap safety mechanism).
- **Tests**: autouse DB mock + ctx-write regression test in `test_actions_start_challenger.py`; 4 new CHALLENGER_RUNNING coverage tests in `test_watchdog.py`.

## Test plan

- [x] `pytest orchestrator/tests/test_actions_start_challenger.py` — all 5 tests pass (4 existing + 1 new ctx-write regression)
- [x] `pytest orchestrator/tests/test_watchdog.py` — all watchdog tests pass including 4 new CHALLENGER_RUNNING tests
- [x] `pytest orchestrator/tests/` — 668 pass, 1 pre-existing fail (requires live PG connection, unrelated to this change)
- [x] Verified broad defensive guard would break `test_frc_s8_watchdog_marks_fixer_round_cap_when_cap_exceeded`; guard scoped to CHALLENGER_RUNNING only

---

sisyphus-cross-link: REQ-start-actions-ctx-persist-1777345119