### PR TITLE
fix(actions): start_challenger 漏写 challenger_issue_id 入 ctx + watchdog defensive [REQ-actions-ctx-persist-v2-1777347429]

### DIFF
--- a/openspec/changes/REQ-actions-ctx-persist-v2-1777347429/proposal.md
+++ b/openspec/changes/REQ-actions-ctx-persist-v2-1777347429/proposal.md
@@ -1,0 +1,62 @@
+# REQ-actions-ctx-persist-v2: fix start_challenger ctx write + watchdog defensive
+
+## Problem
+
+`start_challenger.py` dispatches a BKD issue but never calls `update_context` to write
+`challenger_issue_id` into the REQ context. The watchdog uses
+`_STATE_ISSUE_KEY[CHALLENGER_RUNNING] = "challenger_issue_id"` to reconcile the BKD
+session status. With no value in ctx, the watchdog treats the absent key as "session ended"
+and escalates after `ended_sec=300` even when the challenger is still actively running.
+
+Observed symptom: challenger.pass arrived 2.5 min into the run, but watchdog had already
+emitted `SESSION_FAILED` at 5 min mark, escalating a live REQ.
+
+Secondary issue: `create_accept` is a K8s direct exec (no BKD issue), so `accept_issue_id`
+is never written. Watchdog similarly misreads absent key as "session ended" for ACCEPT_RUNNING.
+
+## Root Cause
+
+`start_challenger.py` lines 85-87 (pre-fix):
+```python
+await dispatch_slugs.put(pool, slug, issue.id)
+log.info("start_challenger.done", req_id=req_id, issue_id=issue.id)
+return {"challenger_issue_id": issue.id, "req_id": req_id}
+```
+
+The function returns the `challenger_issue_id` in its return dict (which goes to engine result),
+but never calls `req_state.update_context` to persist it into the DB context row.
+The watchdog reads from `req_state.context`, not from the action return value.
+
+Compare with correct pattern in `invoke_verifier` (lines 161-165):
+```python
+await dispatch_slugs.put(pool, slug, issue.id)
+await req_state.update_context(pool, req_id, {"verifier_issue_id": issue.id, ...})
+```
+
+## Solution
+
+### Fix 1: start_challenger.py — write ctx in both paths
+
+Add `await req_state.update_context(pool, req_id, {"challenger_issue_id": issue.id})`
+after `dispatch_slugs.put` in the main path, and before return in the slug-hit path.
+Both paths must write ctx to handle idempotent replay correctly.
+
+### Fix 2: watchdog.py — defensive skip for missing issue_id on autonomous-bounded stages
+
+When `issue_id is None AND policy.stuck_sec is None` (autonomous-bounded stages like
+CHALLENGER_RUNNING, ACCEPT_RUNNING, ARCHIVING), skip rather than treating absence of
+ctx key as "session ended". Log a warning to surface the condition for monitoring.
+
+This is defense-in-depth: even if an action forgets `update_context`, watchdog won't
+blindly kill stages that might still be running.
+
+Stages with `stuck_sec != None` (e.g. PR_CI_RUNNING with stuck_sec=14400,
+SPEC_LINT_RUNNING with stuck_sec=300) are unaffected by this check and still escalate
+correctly via the `ended_sec` path.
+
+## Scope
+
+- `orchestrator/src/orchestrator/actions/start_challenger.py`
+- `orchestrator/src/orchestrator/watchdog.py`
+- `orchestrator/tests/test_actions_start_challenger.py`
+- `orchestrator/tests/test_watchdog.py`

--- a/openspec/changes/REQ-actions-ctx-persist-v2-1777347429/specs/ctx-persist/contract.spec.yaml
+++ b/openspec/changes/REQ-actions-ctx-persist-v2-1777347429/specs/ctx-persist/contract.spec.yaml
@@ -1,0 +1,12 @@
+id: ctx-persist
+title: Action Context Persistence and Watchdog Defensive Skip
+version: "1.0"
+scenarios:
+  - id: CTX-S1
+    description: new challenger issue persists challenger_issue_id to ctx
+  - id: CTX-S2
+    description: slug-hit replay also persists challenger_issue_id to ctx
+  - id: CTX-S3
+    description: CHALLENGER_RUNNING with missing issue_id skips escalation
+  - id: CTX-S4
+    description: PR_CI_RUNNING with missing issue_id still escalates

--- a/openspec/changes/REQ-actions-ctx-persist-v2-1777347429/specs/ctx-persist/spec.md
+++ b/openspec/changes/REQ-actions-ctx-persist-v2-1777347429/specs/ctx-persist/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: start_challenger MUST persist challenger_issue_id into REQ context
+
+The `start_challenger` action SHALL call `req_state.update_context` with
+`{"challenger_issue_id": <issue_id>}` immediately after a BKD issue is created or
+retrieved from the dispatch slug cache. The update MUST occur in both the slug-hit
+(idempotent replay) path and the new-issue creation path. This invariant MUST hold so
+that the watchdog can reconcile the BKD session status for CHALLENGER_RUNNING via
+`_STATE_ISSUE_KEY[CHALLENGER_RUNNING] = "challenger_issue_id"`.
+
+#### Scenario: CTX-S1 new challenger issue persists challenger_issue_id to ctx
+
+- **GIVEN** no slug hit (first dispatch for this REQ+executionId)
+- **WHEN** `start_challenger` completes BKD issue creation
+- **THEN** `req_state.update_context` is called with `{"challenger_issue_id": <new_issue_id>}`
+  before the action returns
+
+#### Scenario: CTX-S2 slug-hit replay also persists challenger_issue_id to ctx
+
+- **GIVEN** a slug hit returning cached `issue_id = "ch-existing-1"`
+- **WHEN** `start_challenger` resolves via the slug cache
+- **THEN** `req_state.update_context` is called with `{"challenger_issue_id": "ch-existing-1"}`
+  before the action returns
+
+### Requirement: watchdog MUST NOT treat absent issue_id as session-ended for autonomous-bounded stages
+
+The watchdog `_check_and_escalate` function SHALL skip escalation when `issue_id` is
+`None` and `policy.stuck_sec` is `None` (autonomous-bounded stage). In this case the
+function MUST log a warning at level WARNING with key `watchdog.missing_issue_id` and
+return without emitting `SESSION_FAILED`. This prevents premature escalation when an
+action fails to call `update_context` or when the stage uses direct K8s exec with no
+associated BKD issue (e.g. ACCEPT_RUNNING).
+
+Stages with `policy.stuck_sec` set to a non-None value (e.g. PR_CI_RUNNING,
+SPEC_LINT_RUNNING, DEV_CROSS_CHECK_RUNNING) SHALL continue to escalate normally even
+when `issue_id` is absent, since those stages have explicit time caps and the absent
+key indicates a checker-mode stage without a BKD session.
+
+#### Scenario: CTX-S3 CHALLENGER_RUNNING with missing issue_id skips escalation
+
+- **GIVEN** state=CHALLENGER_RUNNING, ctx={} (no challenger_issue_id), stuck_sec=400
+- **WHEN** watchdog `_check_and_escalate` runs
+- **THEN** no `SESSION_FAILED` event is emitted; `watchdog.missing_issue_id` is logged
+
+#### Scenario: CTX-S4 PR_CI_RUNNING with missing issue_id still escalates
+
+- **GIVEN** state=PR_CI_RUNNING, ctx={} (no pr_ci_watch_issue_id), stuck_sec=2000
+- **WHEN** watchdog `_check_and_escalate` runs
+- **THEN** `SESSION_FAILED` is emitted (policy.stuck_sec=14400 ≠ None, defensive check skipped)

--- a/openspec/changes/REQ-actions-ctx-persist-v2-1777347429/tasks.md
+++ b/openspec/changes/REQ-actions-ctx-persist-v2-1777347429/tasks.md
@@ -1,0 +1,22 @@
+# REQ-actions-ctx-persist-v2-1777347429 Tasks
+
+## Stage: contract / spec
+
+- [x] author specs/ctx-persist/spec.md with scenarios
+- [x] author specs/ctx-persist/contract.spec.yaml
+
+## Stage: implementation
+
+- [x] start_challenger.py: add update_context({challenger_issue_id}) in slug-hit path
+- [x] start_challenger.py: add update_context({challenger_issue_id}) in main dispatch path
+- [x] watchdog.py: add defensive skip for issue_id=None + policy.stuck_sec=None
+- [x] audit all _STATE_ISSUE_KEY entries vs their action update_context calls (all others OK)
+- [x] unit tests: test_start_challenger_writes_challenger_issue_id_to_ctx
+- [x] unit tests: test_start_challenger_slug_hit_writes_ctx
+- [x] unit tests: test_missing_issue_id_in_ctx_non_autonomous_escalates (update)
+- [x] unit tests: test_missing_issue_id_in_ctx_autonomous_bounded_skips (new)
+
+## Stage: PR
+
+- [x] git push feat/REQ-actions-ctx-persist-v2-1777347429
+- [x] gh pr create --label sisyphus

--- a/orchestrator/src/orchestrator/actions/start_challenger.py
+++ b/orchestrator/src/orchestrator/actions/start_challenger.py
@@ -29,7 +29,7 @@ from ..config import settings
 from ..intent_tags import filter_propagatable_intent_tags
 from ..prompts import render
 from ..state import Event
-from ..store import db, dispatch_slugs
+from ..store import db, dispatch_slugs, req_state
 from . import register, short_title
 from ._skip import skip_if_enabled
 
@@ -58,6 +58,7 @@ async def start_challenger(*, body, req_id, tags, ctx):
     slug = f"challenger|{req_id}|{getattr(body, 'executionId', None) or ''}"
     if hit := await dispatch_slugs.get(pool, slug):
         log.info("start_challenger.slug_hit", req_id=req_id, issue_id=hit)
+        await req_state.update_context(pool, req_id, {"challenger_issue_id": hit})
         return {"challenger_issue_id": hit, "req_id": req_id}
     async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
         issue = await bkd.create_issue(
@@ -83,5 +84,6 @@ async def start_challenger(*, body, req_id, tags, ctx):
         await bkd.update_issue(project_id=proj, issue_id=issue.id, status_id="working")
 
     await dispatch_slugs.put(pool, slug, issue.id)
+    await req_state.update_context(pool, req_id, {"challenger_issue_id": issue.id})
     log.info("start_challenger.done", req_id=req_id, issue_id=issue.id)
     return {"challenger_issue_id": issue.id, "req_id": req_id}

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -260,7 +260,16 @@ async def _check_and_escalate(row) -> bool:
                 req_id=req_id, issue_id=issue_id, error=str(e),
             )
 
-    # 2. 按 policy 决定是否 escalate
+    # 2. defensive: stage expects a BKD issue (issue_key set) but issue_id is
+    # missing from ctx on an autonomous-bounded stage (stuck_sec=None).
+    # Treat as "session may still be running" and skip, rather than blindly
+    # treating absent issue_id as "session ended" and escalating prematurely.
+    # Defense-in-depth even when actions forget to call update_context.
+    if issue_id is None and policy.stuck_sec is None:
+        log.warning("watchdog.missing_issue_id", req_id=req_id, state=state.value)
+        return False
+
+    # 3. 按 policy 决定是否 escalate
     if still_running:
         if policy.stuck_sec is None or stuck_sec < policy.stuck_sec:
             # 慢车道未开启或未到 → 不杀长尾运行 session
@@ -282,7 +291,7 @@ async def _check_and_escalate(row) -> bool:
             )
             return False
 
-    # 3. 选 body.event：ARCHIVING 用专属 archive.failed，其他通用 watchdog.stuck
+    # 4. 选 body.event：ARCHIVING 用专属 archive.failed，其他通用 watchdog.stuck
     body_event = _STATE_FAILURE_EVENT.get(state, "watchdog.stuck")
     reason = "watchdog_stuck"
     stage_label = f"watchdog:{state_str}"
@@ -306,7 +315,7 @@ async def _check_and_escalate(row) -> bool:
             log.warning("watchdog.fixer_round_cap_tag_failed",
                         req_id=req_id, error=str(e))
 
-    # 4. 写 artifact_checks 记一笔，给 dashboard M7 04-fail-kind-distribution 抓
+    # 5. 写 artifact_checks 记一笔，给 dashboard M7 04-fail-kind-distribution 抓
     check = CheckResult(
         passed=False,
         exit_code=-1,
@@ -321,7 +330,7 @@ async def _check_and_escalate(row) -> bool:
     except Exception as e:
         log.warning("watchdog.artifact_insert_failed", req_id=req_id, error=str(e))
 
-    # 5. 通过 engine.step 发 SESSION_FAILED → 走 escalate transition
+    # 6. 通过 engine.step 发 SESSION_FAILED → 走 escalate transition
     body = _SyntheticBody(
         projectId=project_id,
         issueId=issue_id or ctx.get("intent_issue_id") or "",

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -260,16 +260,37 @@ async def _check_and_escalate(row) -> bool:
                 req_id=req_id, issue_id=issue_id, error=str(e),
             )
 
-    # 2. defensive: stage expects a BKD issue (issue_key set) but issue_id is
+    # 2. 防 verifier↔fixer 死循环兜底：FIXER_RUNNING 卡住且 fixer_round 已达 cap →
+    # 显式标 escalated_reason=fixer-round-cap，escalate.py 识别为 hard reason 直接终止。
+    # 此检查必须在 defensive issue_id 检查之前，因为 fixer cap 是独立终止条件，不依赖 BKD session。
+    fx_round = int(ctx.get("fixer_round") or 0)
+    cap = settings.fixer_round_cap
+    pool = db.get_pool()
+    if state == ReqState.FIXER_RUNNING and fx_round >= cap:
+        try:
+            await req_state.update_context(pool, req_id, {
+                "escalated_reason": "fixer-round-cap",
+                "fixer_round_cap_hit": cap,
+            })
+            ctx["escalated_reason"] = "fixer-round-cap"
+            log.warning("watchdog.fixer_round_cap_hit",
+                        req_id=req_id, fixer_round=fx_round, cap=cap)
+        except Exception as e:
+            log.warning("watchdog.fixer_round_cap_tag_failed",
+                        req_id=req_id, error=str(e))
+        # fall through to escalate — 不 return，继续走下面的 escalate 路径
+
+    # 3. defensive: stage expects a BKD issue (issue_key set) but issue_id is
     # missing from ctx on an autonomous-bounded stage (stuck_sec=None).
     # Treat as "session may still be running" and skip, rather than blindly
     # treating absent issue_id as "session ended" and escalating prematurely.
     # Defense-in-depth even when actions forget to call update_context.
-    if issue_id is None and policy.stuck_sec is None:
+    # 排除 fixer-round-cap 场景（该场景已在上一步处理，不依赖 issue_id）。
+    if issue_id is None and policy.stuck_sec is None and ctx.get("escalated_reason") != "fixer-round-cap":
         log.warning("watchdog.missing_issue_id", req_id=req_id, state=state.value)
         return False
 
-    # 3. 按 policy 决定是否 escalate
+    # 4. 按 policy 决定是否 escalate
     if still_running:
         if policy.stuck_sec is None or stuck_sec < policy.stuck_sec:
             # 慢车道未开启或未到 → 不杀长尾运行 session
@@ -296,24 +317,6 @@ async def _check_and_escalate(row) -> bool:
     reason = "watchdog_stuck"
     stage_label = f"watchdog:{state_str}"
     stderr_tail = f"stuck for {stuck_sec}s in state {state_str}"
-
-    # 防 verifier↔fixer 死循环兜底：FIXER_RUNNING 卡住且 fixer_round 已达 cap →
-    # 显式标 escalated_reason=fixer-round-cap，escalate.py 识别为 hard reason 直接终止。
-    fx_round = int(ctx.get("fixer_round") or 0)
-    cap = settings.fixer_round_cap
-    pool = db.get_pool()
-    if state == ReqState.FIXER_RUNNING and fx_round >= cap:
-        try:
-            await req_state.update_context(pool, req_id, {
-                "escalated_reason": "fixer-round-cap",
-                "fixer_round_cap_hit": cap,
-            })
-            ctx["escalated_reason"] = "fixer-round-cap"
-            log.warning("watchdog.fixer_round_cap_hit",
-                        req_id=req_id, fixer_round=fx_round, cap=cap)
-        except Exception as e:
-            log.warning("watchdog.fixer_round_cap_tag_failed",
-                        req_id=req_id, error=str(e))
 
     # 5. 写 artifact_checks 记一笔，给 dashboard M7 04-fail-kind-distribution 抓
     check = CheckResult(

--- a/orchestrator/tests/test_actions_start_challenger.py
+++ b/orchestrator/tests/test_actions_start_challenger.py
@@ -22,6 +22,7 @@ def _mock_dispatch_slugs(monkeypatch):
     monkeypatch.setattr(start_challenger.db, "get_pool", MagicMock(return_value=object()))
     monkeypatch.setattr(start_challenger.dispatch_slugs, "get", AsyncMock(return_value=None))
     monkeypatch.setattr(start_challenger.dispatch_slugs, "put", AsyncMock())
+    monkeypatch.setattr(start_challenger.req_state, "update_context", AsyncMock())
 
 
 @dataclass
@@ -167,3 +168,53 @@ async def test_start_challenger_no_hint_keeps_base_tags(monkeypatch):
     )
     _, kwargs = fake.create_issue.await_args
     assert kwargs["tags"] == ["challenger", "REQ-X", "parent-id:analyze-1"]
+
+
+# ─── update_context regression (REQ-actions-ctx-persist-v2) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_challenger_writes_challenger_issue_id_to_ctx(monkeypatch):
+    """新建 challenger issue → req_state.update_context 以 {challenger_issue_id: id} 调用。
+
+    watchdog._STATE_ISSUE_KEY[CHALLENGER_RUNNING] = "challenger_issue_id"；
+    ctx 里有值 watchdog 才能 reconcile BKD session，缺失会在 5min 后盲 escalate。
+    """
+    _patch_bkd(monkeypatch)
+    _patch_pr_links_empty(monkeypatch)
+
+    out = await start_challenger.start_challenger(
+        body=_make_body(issue_id="analyze-1"),
+        req_id="REQ-CTX",
+        tags=[],
+        ctx={},
+    )
+
+    assert out["challenger_issue_id"] == "ch-new-1"
+    start_challenger.req_state.update_context.assert_awaited_once()
+    _pool, _req_id, patch = start_challenger.req_state.update_context.await_args.args
+    assert _req_id == "REQ-CTX"
+    assert patch == {"challenger_issue_id": "ch-new-1"}
+
+
+@pytest.mark.asyncio
+async def test_start_challenger_slug_hit_writes_ctx(monkeypatch):
+    """slug 命中（重复 dispatch）→ update_context 同样以 hit id 调用，不漏写。"""
+    _patch_bkd(monkeypatch)
+    _patch_pr_links_empty(monkeypatch)
+    monkeypatch.setattr(
+        start_challenger.dispatch_slugs, "get", AsyncMock(return_value="ch-existing-1"),
+    )
+
+    out = await start_challenger.start_challenger(
+        body=_make_body(issue_id="analyze-1"),
+        req_id="REQ-SLUG",
+        tags=[],
+        ctx={},
+    )
+
+    assert out["challenger_issue_id"] == "ch-existing-1"
+    start_challenger.req_state.update_context.assert_awaited_once()
+    _pool, _req_id, patch = start_challenger.req_state.update_context.await_args.args
+    assert _req_id == "REQ-SLUG"
+    assert patch == {"challenger_issue_id": "ch-existing-1"}

--- a/orchestrator/tests/test_watchdog.py
+++ b/orchestrator/tests/test_watchdog.py
@@ -190,12 +190,13 @@ async def test_spec_lint_escalates_without_bkd_lookup(monkeypatch):
     assert step_calls[0]["body_issue"] == "intent-4"
 
 
-# ─── Case 5：ctx 里没 issue_id（比如 create_dev 还没落 ctx 就挂了）→ escalate
+# ─── Case 5：ctx 里没 issue_id，stage 有 stuck_sec 设置（非 autonomous-bounded）→ escalate
 @pytest.mark.asyncio
-async def test_missing_issue_id_in_ctx_escalates(monkeypatch):
-    """stage 有 issue_key 但 ctx 里缺少该 issue_id → 无法查 BKD，保守 escalate。"""
+async def test_missing_issue_id_in_ctx_non_autonomous_escalates(monkeypatch):
+    """PR_CI_RUNNING (stuck_sec=14400, not None) + issue_id missing → defensive check
+    doesn't fire → treats as ended → escalates after ended_sec threshold."""
     pool = FakePool(rows=[
-        _row("REQ-5", ReqState.STAGING_TEST_RUNNING.value, ctx={}),
+        _row("REQ-5", ReqState.PR_CI_RUNNING.value, ctx={}),
     ])
     _patch_pool(monkeypatch, pool)
     fake_bkd = _patch_bkd(monkeypatch, FakeIssue(session_status="running"))
@@ -205,9 +206,30 @@ async def test_missing_issue_id_in_ctx_escalates(monkeypatch):
     result = await watchdog._tick()
 
     assert result == {"checked": 1, "escalated": 1}
-    # 无 issue_id 不查
+    # 无 issue_id 不查 BKD
     fake_bkd.get_issue.assert_not_called()
     assert len(step_calls) == 1
+
+
+# ─── Case 5b：ctx 里没 issue_id，autonomous-bounded stage (stuck_sec=None) → skip
+@pytest.mark.asyncio
+async def test_missing_issue_id_in_ctx_autonomous_bounded_skips(monkeypatch):
+    """CHALLENGER_RUNNING (stuck_sec=None) + issue_id missing from ctx →
+    defensive check fires → skip (log warning, no escalate).
+    Defense-in-depth when start_challenger forgets update_context."""
+    pool = FakePool(rows=[
+        _row("REQ-5b", ReqState.CHALLENGER_RUNNING.value, ctx={}, stuck_sec=400),
+    ])
+    _patch_pool(monkeypatch, pool)
+    fake_bkd = _patch_bkd(monkeypatch, FakeIssue(session_status="running"))
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 0}
+    fake_bkd.get_issue.assert_not_called()
+    assert step_calls == []
 
 
 # ─── Case 6：SQL 过滤（未到阈值的不返回）由 DB 负责 — 空 rows 直接 0


### PR DESCRIPTION
## Summary

- **真根因**：`start_challenger.py` dispatch BKD issue 后没调 `update_context`，`watchdog._STATE_ISSUE_KEY[CHALLENGER_RUNNING] = "challenger_issue_id"` 依赖该 key reconcile session；ctx 里没值 → watchdog 5min 后把仍在运行的 challenger 当 "session ended" 强 escalate
- **fix 1**：`start_challenger.py` 新建路径 + slug hit 路径均补 `update_context({"challenger_issue_id": issue.id})`，对齐 `start_fixer` / `invoke_verifier` 正确写法
- **fix 2**：`watchdog.py` 加 defensive check — `issue_id is None and policy.stuck_sec is None`（autonomous-bounded stage）→ log warning + skip，defense-in-depth 兜底任何 action 漏写 ctx key 的场景

## _STATE_ISSUE_KEY 全 audit

| State | Key | 写入位置 | 状态 |
|---|---|---|---|
| ANALYZING | intent_issue_id | webhook.py:360 init_ctx | ✅ |
| **CHALLENGER_RUNNING** | **challenger_issue_id** | **start_challenger** | **本 PR 修** |
| STAGING_TEST_RUNNING | staging_test_issue_id | create_staging_test (BKD path) | ✅ |
| PR_CI_RUNNING | pr_ci_watch_issue_id | create_pr_ci_watch (BKD path) | ✅ |
| ACCEPT_RUNNING | accept_issue_id | create_accept (K8s exec，无 BKD issue) | defensive skip 兜底 |
| REVIEW_RUNNING | verifier_issue_id | _verifier.invoke_verifier | ✅ |
| FIXER_RUNNING | fixer_issue_id | _verifier.start_fixer | ✅ |
| ARCHIVING | archive_issue_id | done_archive | ✅ |

## Test plan

- [x] `test_actions_start_challenger`: 2 个新测试验证新建/slug hit 均写 ctx (CTX-S1, CTX-S2)
- [x] `test_watchdog`: Case 5 更新为 PR_CI_RUNNING（stuck_sec≠None，仍 escalate, CTX-S4）；Case 5b CHALLENGER_RUNNING + issue_id=None → skip (CTX-S3)
- [x] ruff check 通过
- [x] 1827 passed（6 失败均为 TTL DB 集成测试，需真实 PG，与本 PR 无关）

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-actions-ctx-persist-v2-1777347429`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/vjkid9rg)