### PR TITLE
feat(obs): auto-apply observability schema on startup [REQ-533]

### DIFF
--- a/openspec/changes/REQ-533/proposal.md
+++ b/openspec/changes/REQ-533/proposal.md
@@ -1,0 +1,32 @@
+# REQ-533: feat(orchestrator): 启动时自动 apply observability schema
+
+## Why
+
+`observability/schema.sql` 定义了 sisyphus_obs 数据库的完整 schema（4 张表 + 5 个索引 + 3 个 view），但目前 orchestrator 启动时**不自动执行**该 schema。新环境部署需要手动建表，易遗漏，导致 observability 数据写入失败或缺失。
+
+## What changes
+
+**NEW** `orchestrator/src/orchestrator/obs_schema.py` — 封装 observability schema 自动应用逻辑：
+
+1. `apply_obs_schema()` 在 `main.py` startup 流程中于 `init_obs_pool` 之后调用
+2. 自动定位 `observability/schema.sql`（env 覆盖 > cwd 相对 > 包相对 fallback）
+3. 幂等：schema.sql 全用 `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` / `CREATE OR REPLACE VIEW`
+4. best-effort：obs DSN 未配、schema 文件不存在、或执行失败 —— 均 log warning，不阻断主服务启动
+5. 无 schema_version 表：依赖 SQL 本身的 `IF NOT EXISTS` 语义做幂等，保持简单
+
+**MOD** `orchestrator/src/orchestrator/main.py` — startup 流程第 2b 步插入 `await apply_obs_schema()`
+
+**NEW** `orchestrator/tests/test_obs_schema.py` — 7 个单元测试覆盖：
+- obs pool 未配时跳过
+- schema 文件不存在时跳过
+- 空 schema 文件时跳过
+- 正常执行 schema SQL
+- 执行异常时 swallow 并返回 False
+- env 覆盖路径解析
+- fallback 路径存在性验证
+
+## Impact
+
+- 无 schema 变更，无 migration 变更。
+- 全新部署后 `event_log` 等 observability 表自动存在，无需人工干预。
+- 失败时主服务仍可启动，符合 observability "best-effort" 设计原则。

--- a/openspec/changes/REQ-533/specs/obs-schema-auto-apply/spec.md
+++ b/openspec/changes/REQ-533/specs/obs-schema-auto-apply/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: orchestrator startup automatically applies observability schema
+
+The system SHALL apply `observability/schema.sql` to the observability database during orchestrator startup, after the obs pool is initialized and before background tasks begin. The application MUST be idempotent and MUST NOT block main service startup on failure.
+
+#### Scenario: OBS-S1 applies schema on startup when obs pool is configured
+- **GIVEN** `SISYPHUS_OBS_PG_DSN` is set to a valid PostgreSQL DSN
+- **WHEN** orchestrator startup runs
+- **THEN** `observability/schema.sql` is executed against the obs database
+
+#### Scenario: OBS-S2 skips schema apply when obs pool is not configured
+- **GIVEN** `SISYPHUS_OBS_PG_DSN` is empty or unset
+- **WHEN** orchestrator startup runs
+- **THEN** schema apply is skipped with an info log and startup continues normally
+
+#### Scenario: OBS-S3 skips schema apply when schema file is missing
+- **GIVEN** obs pool is configured and the resolved schema file path does not exist
+- **WHEN** `apply_obs_schema()` is called
+- **THEN** it logs a warning, returns True, and does not throw
+
+#### Scenario: OBS-S4 does not block startup on schema apply failure
+- **GIVEN** obs pool is configured and schema file exists
+- **WHEN** the database execute fails (e.g., PG is unreachable)
+- **THEN** `apply_obs_schema()` logs a warning, returns False, and orchestrator startup continues
+
+#### Scenario: OBS-S5 schema application is idempotent
+- **GIVEN** the observability schema has already been applied
+- **WHEN** orchestrator restarts and `apply_obs_schema()` runs again
+- **THEN** it succeeds without error because schema.sql uses `IF NOT EXISTS` and `OR REPLACE`
+
+#### Scenario: OBS-S6 supports env override for schema file path
+- **GIVEN** `SISYPHUS_OBS_SCHEMA_PATH` is set to a custom file path
+- **WHEN** `_resolve_schema_path()` is called
+- **THEN** it returns the path specified by the environment variable

--- a/openspec/changes/REQ-533/tasks.md
+++ b/openspec/changes/REQ-533/tasks.md
@@ -1,0 +1,14 @@
+## Stage: contract / spec
+- [x] author openspec/changes/REQ-533/proposal.md
+- [x] author openspec/changes/REQ-533/specs/obs-schema-auto-apply/spec.md
+- [x] author openspec/changes/REQ-533/tasks.md
+
+## Stage: implementation
+- [x] 新建 orchestrator/src/orchestrator/obs_schema.py（apply_obs_schema + _resolve_schema_path）
+- [x] 修改 orchestrator/src/orchestrator/main.py（startup 插入 await apply_obs_schema()）
+- [x] 新建 orchestrator/tests/test_obs_schema.py（7 个单元测试）
+- [x] 本地 pytest 通过
+
+## Stage: PR
+- [x] git push feat/REQ-533
+- [x] gh pr create

--- a/orchestrator/src/orchestrator/main.py
+++ b/orchestrator/src/orchestrator/main.py
@@ -12,6 +12,7 @@ from .admin import admin as admin_api
 from .config import settings
 from .maintenance import table_ttl
 from .migrate import apply_pending
+from .obs_schema import apply_obs_schema
 from .store import db
 from .webhook import api as webhook_api
 
@@ -45,6 +46,8 @@ async def startup() -> None:
     # 2. 起业务 pool + observability pool（obs DSN 空就跳过）
     await db.init_pool(settings.pg_dsn)
     await db.init_obs_pool(settings.obs_pg_dsn)
+    # 2b. 自动 apply observability schema（幂等，失败不阻断）
+    await apply_obs_schema()
     # 3. 起 snapshot 后台同步 task（interval 0 不起）。
     # 这个 loop 现在两件事：obs UPSERT（依赖 obs pool） + intent:analyze orphan 恢复
     # （只依赖 main pool）。后者跟 obs DSN 无关，所以 startup gate 不再 require obs_pg_dsn。

--- a/orchestrator/src/orchestrator/obs_schema.py
+++ b/orchestrator/src/orchestrator/obs_schema.py
@@ -1,0 +1,66 @@
+"""observability schema 自动应用。
+
+启动时把 observability/schema.sql 刷到 obs DB。
+幂等（全用 CREATE IF NOT EXISTS / OR REPLACE），失败不阻断主服务。
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import structlog
+
+from .store import db
+
+log = structlog.get_logger(__name__)
+
+
+def _resolve_schema_path() -> Path:
+    """定位 observability/schema.sql。
+
+    优先级：env > cwd 相对 > 包相对（dev editable 装时）。
+    """
+    env = os.environ.get("SISYPHUS_OBS_SCHEMA_PATH", "")
+    if env:
+        return Path(env)
+    # dev 跑 pytest / uvicorn：cwd 在 orchestrator/，同级有 observability/
+    cwd_schema = Path.cwd().parent / "observability" / "schema.sql"
+    if cwd_schema.is_file():
+        return cwd_schema
+    # 兜底：从 src/orchestrator/obs_schema.py 往上 3 级到 repo 根
+    return Path(__file__).resolve().parents[3] / "observability" / "schema.sql"
+
+
+_DEFAULT_SCHEMA_PATH = _resolve_schema_path()
+
+
+async def apply_obs_schema(
+    schema_path: Path | None = None,
+) -> bool:
+    """把 schema.sql 刷到 obs pool；dsn 未配或文件不存在则跳过。
+
+    返回 True = 执行了（或无需执行），False = 抛了异常。
+    调用方应 catch 并 log warning，不阻断启动。
+    """
+    pool = db.get_obs_pool()
+    if pool is None:
+        log.info("obs_schema.skip_no_pool")
+        return True
+
+    path = schema_path or _DEFAULT_SCHEMA_PATH
+    if not path.is_file():
+        log.warning("obs_schema.not_found", path=str(path))
+        return True
+
+    sql = path.read_text()
+    if not sql.strip():
+        log.warning("obs_schema.empty", path=str(path))
+        return True
+
+    try:
+        await pool.execute(sql)
+        log.info("obs_schema.applied", path=str(path))
+        return True
+    except Exception as e:
+        log.warning("obs_schema.failed", path=str(path), error=str(e))
+        return False

--- a/orchestrator/tests/test_obs_schema.py
+++ b/orchestrator/tests/test_obs_schema.py
@@ -1,0 +1,89 @@
+"""obs_schema.apply_obs_schema 烟测：幂等、失败不阻断。"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from orchestrator import obs_schema
+from orchestrator.store import db
+
+
+class FakeObsPool:
+    def __init__(self):
+        self.calls: list[str] = []
+        self.execute = AsyncMock(side_effect=self._exec)
+
+    async def _exec(self, sql: str) -> None:
+        self.calls.append(sql)
+
+
+@pytest.fixture(autouse=True)
+def reset_default_path(monkeypatch):
+    """每测完恢复 _DEFAULT_SCHEMA_PATH，避免测间污染。"""
+    original = obs_schema._DEFAULT_SCHEMA_PATH
+    yield
+    monkeypatch.setattr(obs_schema, "_DEFAULT_SCHEMA_PATH", original)
+
+
+@pytest.mark.asyncio
+async def test_apply_skip_when_no_pool(monkeypatch):
+    monkeypatch.setattr(db, "get_obs_pool", lambda: None)
+    result = await obs_schema.apply_obs_schema()
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_apply_skip_when_schema_file_missing(monkeypatch):
+    monkeypatch.setattr(db, "get_obs_pool", lambda: FakeObsPool())
+    monkeypatch.setattr(obs_schema, "_DEFAULT_SCHEMA_PATH", Path("/nonexistent/schema.sql"))
+    result = await obs_schema.apply_obs_schema()
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_apply_skip_when_schema_file_empty(monkeypatch, tmp_path):
+    empty_file = tmp_path / "schema.sql"
+    empty_file.write_text("   \n  ")
+    monkeypatch.setattr(db, "get_obs_pool", lambda: FakeObsPool())
+    result = await obs_schema.apply_obs_schema(schema_path=empty_file)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_apply_executes_schema_sql(monkeypatch, tmp_path):
+    schema_file = tmp_path / "schema.sql"
+    schema_file.write_text("CREATE TABLE IF NOT EXISTS t (id INT);")
+    pool = FakeObsPool()
+    monkeypatch.setattr(db, "get_obs_pool", lambda: pool)
+    result = await obs_schema.apply_obs_schema(schema_path=schema_file)
+    assert result is True
+    assert len(pool.calls) == 1
+    assert "CREATE TABLE IF NOT EXISTS t" in pool.calls[0]
+
+
+@pytest.mark.asyncio
+async def test_apply_swallows_exception(monkeypatch, tmp_path):
+    schema_file = tmp_path / "schema.sql"
+    schema_file.write_text("CREATE TABLE t (id INT);")
+    pool = FakeObsPool()
+    pool.execute.side_effect = RuntimeError("PG down")
+    monkeypatch.setattr(db, "get_obs_pool", lambda: pool)
+    result = await obs_schema.apply_obs_schema(schema_path=schema_file)
+    assert result is False
+
+
+def test_resolve_schema_path_env_override(monkeypatch, tmp_path):
+    schema_file = tmp_path / "obs.sql"
+    schema_file.write_text("SELECT 1;")
+    monkeypatch.setenv("SISYPHUS_OBS_SCHEMA_PATH", str(schema_file))
+    path = obs_schema._resolve_schema_path()
+    assert path == schema_file
+
+
+def test_resolve_schema_path_fallback_exists():
+    """fallback 路径（repo 根/observability/schema.sql）在 CI 环境应存在。"""
+    path = obs_schema._resolve_schema_path()
+    assert path.is_file(), f"schema.sql not found at {path}"
+    assert "CREATE TABLE IF NOT EXISTS event_log" in path.read_text()


### PR DESCRIPTION
## Summary

在 orchestrator 启动流程中自动 apply `observability/schema.sql`，解决新环境部署需手动建表的问题。

## Changes

- **NEW** `orchestrator/src/orchestrator/obs_schema.py`：`apply_obs_schema()` 封装
  - 启动时于 `init_obs_pool` 之后调用
  - 自动定位 `observability/schema.sql`（env 覆盖 > cwd 相对 > 包相对 fallback）
  - 幂等：依赖 schema.sql 中已有的 `CREATE IF NOT EXISTS` / `OR REPLACE`
  - best-effort：dsn 未配 / 文件缺失 / DB 失败 均 log warning，不阻断启动
- **MOD** `orchestrator/src/orchestrator/main.py`：startup 第 2b 步插入 `await apply_obs_schema()`
- **NEW** `orchestrator/tests/test_obs_schema.py`：7 个单元测试

## Test Plan

- [x] `test_apply_skip_when_no_pool` — obs DSN 未配时跳过
- [x] `test_apply_skip_when_schema_file_missing` — 文件不存在时跳过
- [x] `test_apply_skip_when_schema_file_empty` — 空文件时跳过
- [x] `test_apply_executes_schema_sql` — 正常执行 schema SQL
- [x] `test_apply_swallows_exception` — DB 失败时 swallow 并返回 False
- [x] `test_resolve_schema_path_env_override` — env 覆盖路径
- [x] `test_resolve_schema_path_fallback_exists` — fallback 路径存在性

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-533`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/v6uopbph)