### PR TITLE
feat(observability): deploy Metabase + 18 SQL queries + dashboards [REQ-530]

### DIFF
--- a/observability/queries/sisyphus/05-active-req-overview.sql
+++ b/observability/queries/sisyphus/05-active-req-overview.sql
@@ -92,9 +92,9 @@ SELECT
     r.context->>'bkd_intent_url' AS bkd_intent_url,
     pu.pr_urls_md
 FROM req_state r
-LEFT JOIN last_check lc USING (req_id)
+LEFT JOIN last_check lc ON lc.req_id = r.req_id
 LEFT JOIN recent_fail rf
     ON rf.req_id = r.req_id AND rf.stage = lc.last_stage
-LEFT JOIN pr_urls_md pu USING (req_id)
+LEFT JOIN pr_urls_md pu ON pu.req_id = r.req_id
 WHERE r.state NOT IN ('done', 'escalated')
 ORDER BY stuck_min DESC;

--- a/observability/setup_metabase.py
+++ b/observability/setup_metabase.py
@@ -371,14 +371,14 @@ class MetabaseClient:
 
         cards = [
             {
-                "id": None,
+                "id": -1 - idx,
                 "card_id": card_id_map[q_num],
                 "row": row,
                 "col": col,
                 "size_x": size_x,
                 "size_y": size_y,
             }
-            for q_num, row, col, size_x, size_y in layout
+            for idx, (q_num, row, col, size_x, size_y) in enumerate(layout)
             if q_num in card_id_map
         ]
         if cards:

--- a/openspec/changes/REQ-530/proposal.md
+++ b/openspec/changes/REQ-530/proposal.md
@@ -1,0 +1,37 @@
+# REQ-530: 部署 Metabase + 导入 18 条 SQL 查询 + 建立 Dashboard
+
+## Problem
+
+values/metabase.yaml 存在但 Metabase 从未实际部署运行。18 条 Metabase SQL 查询在 observability/queries/sisyphus/ 中无处可跑，dashboard 设计文档 observability/sisyphus-dashboard.md 只停留在纸面。
+
+## Solution
+
+1. **修正 values/metabase.yaml** —— 修正多个部署障碍：
+   - 镜像标签 `v0.50.0` 在 Docker Hub 不存在 → 改为 `v0.50.36`
+   - PostgreSQL host/secret 名错误 → 修正为 `sisyphus-postgresql`
+   - `existingSecretKey` 不支持 → 改为 `existingSecretPasswordKey`
+   - ingress 格式不匹配 pmint/metabase chart → 改为 `className` + `hosts` 字符串数组
+   - `env.JAVA_OPTS` 不被 chart 识别 → 改用 `javaOpts`
+   - `env.MB_SITE_URL` 不被 chart 识别 → 改用 `siteUrl`
+   - 额外 env 改用 `extraEnv` 数组
+
+2. **手动创建 `metabase` 数据库** —— Metabase 应用自身的元数据库，与业务库 `sisyphus` 分离。
+
+3. **首次设置（first-time setup）** —— 通过 `/api/setup` 创建 admin 账号 + 自动添加 `sisyphus` 数据源。
+
+4. **运行 setup_metabase.py** —— 自动导入 18 条 SQL Question（Q1–Q18）和 3 个 Dashboard：
+   - M7 — Checker Health（7 cards）
+   - M14e — Agent Quality（11 cards）
+   - Fixer Audit（3 cards）
+
+5. **修复 setup_metabase.py** —— Metabase v0.50 `PUT /api/dashboard/{id}/cards` 要求每个 card 有唯一 `id`，原脚本 `"id": None` 导致 400。改为用 `enumerate` 生成唯一负数 id（`-1, -2, -3...`）。
+
+6. **修复 Q5 SQL** —— `USING (req_id)` 在多层 JOIN（多个 CTE 都有 `req_id` 列）时导致 `common column name "req_id" appears more than once in left table`。改为 `ON` 语法。
+
+## Scope
+
+- `values/metabase.yaml` —— Helm values 修正
+- `observability/setup_metabase.py` —— Dashboard API 兼容性修复
+- `observability/queries/sisyphus/05-active-req-overview.sql` —— JOIN 语法修复
+
+无业务代码改动，不涉及 orchestrator 核心逻辑。

--- a/openspec/changes/REQ-530/tasks.md
+++ b/openspec/changes/REQ-530/tasks.md
@@ -1,0 +1,24 @@
+# REQ-530 Tasks
+
+## Stage: deploy
+- [x] 检查数据库状态：确认 `sisyphus` 主库和 `sisyphus_obs` 库存在
+- [x] 创建 `metabase` 数据库（Metabase 应用元数据库）
+- [x] 修正 values/metabase.yaml：镜像标签、host、secret、ingress 格式、javaOpts、siteUrl、extraEnv
+- [x] Helm install Metabase（pmint/metabase chart）
+- [x] 等待 Pod ready（首次启动需初始化数据库）
+
+## Stage: setup
+- [x] 首次设置：通过 `/api/setup` 创建 admin + 添加 `sisyphus` 数据源
+- [x] 运行 setup_metabase.py 导入 18 条 SQL Question（Q1–Q18）
+- [x] 修复 setup_metabase.py：dashboard card `id` 用唯一负数（Metabase v0.50 API 兼容性）
+- [x] 运行 setup_metabase.py 创建 3 个 Dashboard（M7 / M14e / Fixer Audit）
+
+## Stage: fix
+- [x] 修复 Q5 SQL（05-active-req-overview.sql）：`USING(req_id)` → `ON` 语法，避免多层 JOIN 列名冲突
+- [x] 验证 Q5 可正常出数（返回 2 行活跃 REQ）
+- [x] 验证 Q1/Q3/Q6/Q8/Q12/Q16/Q18 均可正常执行
+
+## Stage: PR
+- [x] 写 openspec/changes/REQ-530/proposal.md + tasks.md
+- [x] git push feat/REQ-530
+- [x] gh pr create --label sisyphus

--- a/values/metabase.yaml
+++ b/values/metabase.yaml
@@ -4,7 +4,7 @@
 # chart 源：https://github.com/pmint93/helm-charts/tree/master/charts/metabase
 
 image:
-  tag: v0.50.0  # LTS
+  tag: v0.50.36  # LTS，实际可用标签
 
 replicaCount: 1
 
@@ -22,12 +22,12 @@ resources:
 #   CREATE DATABASE metabase OWNER sisyphus;
 database:
   type: postgres
-  host: sisyphus-pg-postgresql.sisyphus.svc.cluster.local
+  host: sisyphus-postgresql.sisyphus.svc.cluster.local
   port: 5432
   dbname: metabase
   username: sisyphus
-  existingSecret: sisyphus-pg-postgresql
-  existingSecretKey: password
+  existingSecret: sisyphus-postgresql
+  existingSecretPasswordKey: password
 
 service:
   type: ClusterIP
@@ -35,34 +35,36 @@ service:
 
 ingress:
   enabled: true
-  ingressClassName: traefik
+  className: traefik
   hosts:
-    - host: metabase.43.239.84.24.nip.io
-      paths:
-        - path: /
-          pathType: Prefix
+    - metabase.43.239.84.24.nip.io
+  path: /
+  pathType: Prefix
 
 persistence:
   enabled: false  # 状态全在元数据库，Pod 无本地状态
 
-# 环境变量：设置 JVM 内存 + 站点 URL
-env:
-  MB_SITE_URL: "http://metabase.43.239.84.24.nip.io"
-  MB_JETTY_PORT: "3000"
-  JAVA_OPTS: "-Xmx768m -XX:+UseG1GC"
-  # 禁用匿名 telemetry
-  MB_ANON_TRACKING_ENABLED: "false"
+# chart 使用 javaOpts（不是 env.JAVA_OPTS）
+javaOpts: "-Xmx768m -XX:+UseG1GC"
+
+# chart 使用 siteUrl（不是 env.MB_SITE_URL）
+siteUrl: "http://metabase.43.239.84.24.nip.io"
+
+# 额外环境变量用 extraEnv 数组
+extraEnv:
+  - name: MB_ANON_TRACKING_ENABLED
+    value: "false"
 
 # 不装 metrics exporter
 serviceMonitor:
   enabled: false
 
-# 部署后手动配置：
-# 1. 首次登录创建 admin 账号
+# 部署后配置：
+# 1. 首次登录创建 admin 账号（或运行 setup_metabase.py --setup）
 # 2. Admin → Databases → Add database
 #    - Engine: PostgreSQL
-#    - Host: sisyphus-pg-postgresql.sisyphus.svc.cluster.local
+#    - Host: sisyphus-postgresql.sisyphus.svc.cluster.local
 #    - Port: 5432
-#    - Database name: sisyphus_obs
+#    - Database name: sisyphus
 #    - Username: sisyphus / Password: 见 postgresql values
-# 3. 按 docs/observability.md 导入 5 个看板 + 4 个 Alert
+# 3. 运行 setup_metabase.py 自动导入 18 条 SQL + 3 个 dashboard


### PR DESCRIPTION
## Summary

部署 Metabase 并导入 18 条 SQL 查询 + 3 个 Dashboard，让 sisyphus 可观测性从纸面落地。

### 变更

- **values/metabase.yaml**: 修正镜像标签、PostgreSQL host/secret、ingress 格式、JVM 内存配置（改用 chart 原生 `javaOpts`/`siteUrl`/`extraEnv`）
- **observability/setup_metabase.py**: 修复 Metabase v0.50 dashboard card API 兼容性（唯一负数 id）
- **observability/queries/sisyphus/05-active-req-overview.sql**: 修复 `USING(req_id)` → `ON` 语法，避免多层 JOIN 列名冲突

### 部署验证

- Metabase Pod 运行正常，Ingress `http://metabase.43.239.84.24.nip.io` 可访问
- sisyphus 数据源已配置（指向 `sisyphus` 主库）
- 18 条 SQL Question 全部创建成功
- 3 个 Dashboard（M7 / M14e / Fixer Audit）共 21 张卡片布局正确
- Q5 返回 2 行活跃 REQ，Q1/Q3/Q6/Q8/Q12/Q16/Q18 均正常执行

## Test plan

- [ ] `helm upgrade sisyphus-bi pmint/metabase -n sisyphus -f values/metabase.yaml` 可重复应用
- [ ] `python3 observability/setup_metabase.py --force` idempotent（已有 item skip，force 则覆盖）
- [ ] Dashboard 中每张图表能正常渲染数据

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-530`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/pmc6ucrt)