### PR TITLE
fix(webhook): early skip paths must not mark_processed (REQ-550)

### DIFF
--- a/openspec/changes/REQ-550/proposal.md
+++ b/openspec/changes/REQ-550/proposal.md
@@ -1,0 +1,32 @@
+# REQ-550: webhook dedup 过度 mark_processed 导致合法事件丢失
+
+## Problem
+
+`webhook.py` 中多个早期 return 点（skip_no_req_tag / no_event_mapping /
+skip_no_req_or_intent_tag / no_req_id）都会 `await dedup.mark_processed(pool, eid)`。
+
+后果：
+1. 第一次 webhook 到达时被错误标记为已处理
+2. BKD 重发时 dedup 返回 skip
+3. 合法事件永远丢失
+
+根因：这些早期 skip 并非"成功处理完毕"，而是"暂时不满足处理条件"。
+标记 processed 会阻断 BKD 的 at-least-once retry，尤其致命的是 tag 竞争场景
+——BKD  webhook 可能在 tag 尚未写全时就发出，此时无 REQ tag 的合法事件被
+噪声 filter 挡掉并错误标记，后续 retry 被 dedup 直接 skip，事件永久丢失。
+
+## Solution
+
+1. 移除 `webhook.py` 所有早期 skip return 路径上的 `mark_processed` 调用。
+2. 唯一保留 `mark_processed` 的位置：在 `engine.step` 成功返回之后。
+3. 这样，早期 skip 不修改 `processed_at`（保持 NULL），BKD 重发时
+   `check_and_record` 返回 `retry`，handler 重新走完整流程。
+4. 如果 retry 时 tags 已补齐，事件正常进入状态机；如果仍是噪声，
+   再次 early skip 即可——开销极小，不会无限累积（BKD retry 有上限，
+   且 event_id 包含 executionId/timestamp，同事件重发次数有限）。
+
+## Scope
+
+- `orchestrator/src/orchestrator/webhook.py`：移除 4 处 `mark_processed`
+- `orchestrator/tests/test_contract_router_noise_filter.py`：更新 RNF-S1/S5 断言
+- `orchestrator/tests/test_dedup.py`：新增 DEDUP-S7 场景（early skip → retry → success）

--- a/openspec/changes/REQ-550/specs/webhook-dedup-soft-skip/spec.md
+++ b/openspec/changes/REQ-550/specs/webhook-dedup-soft-skip/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: webhook 早期 skip 不得 mark_processed，允许 BKD retry 重新处理
+
+The webhook handler MUST NOT call `dedup.mark_processed` on any early skip or
+short-circuit return path. The `mark_processed` call MUST only occur after
+`engine.step` completes successfully. This ensures that events which are skipped
+due to transient conditions (e.g., missing tags from a race condition) remain
+eligible for BKD at-least-once redelivery via the "retry" path.
+
+Specifically, the following four early return paths MUST NOT call
+`dedup.mark_processed`:
+
+1. `session.completed` without a `REQ-*` tag (noise filter)
+2. `issue.updated` without a `REQ-*` tag and without `intent:intake` or
+   `intent:analyze` (noise filter)
+3. `event` is `None` after `router.derive_event` (no event mapping)
+4. `req_id` is `None` after `router.extract_req_id` (no resolvable REQ ID)
+
+The handler MUST leave `processed_at` as `NULL` on all early skip paths so that
+a subsequent BKD redelivery of the same `event_id` returns `retry` from
+`check_and_record`, allowing re-evaluation with potentially updated tags or state.
+
+#### Scenario: DDS-S1 早期 skip 不 mark_processed，processed_at 保持 NULL
+
+- **GIVEN** `event_seen` 中不存在 event_id `evt-550`
+- **WHEN** webhook handler 收到 `session.completed`，tags 不含 `REQ-*`
+- **THEN** handler 返回 `{"action": "skip", "reason": "session event without REQ tag"}`
+- **AND** `dedup.mark_processed` **未被调用**
+- **AND** `event_seen` 中对应行的 `processed_at` 仍为 `NULL`
+
+#### Scenario: DDS-S2 BKD 重发时走 retry 路径
+
+- **GIVEN** `event_seen` 中存在 event_id `evt-550`，`processed_at IS NULL`
+  （DDS-S1 的 skip 残留）
+- **WHEN** BKD 重发同 event_id，此时 tags 已含 `REQ-550`
+- **THEN** `check_and_record` 返回 `"retry"`
+- **AND** handler 继续执行 `engine.step`
+- **AND** `engine.step` 成功后 `mark_processed` 被调用，`processed_at` 被设置
+
+#### Scenario: DDS-S3 no_event_mapping 早期 skip 同样不 mark_processed
+
+- **GIVEN** `event_seen` 中不存在 event_id `evt-550b`
+- **WHEN** webhook handler 收到事件，`derive_event` 返回 `None`
+- **THEN** handler 返回 `{"action": "skip", "reason": "no event mapping"}`
+- **AND** `dedup.mark_processed` **未被调用**
+- **AND** `event_seen` 中对应行的 `processed_at` 仍为 `NULL`
+
+#### Scenario: DDS-S4 no_req_id 早期 skip 同样不 mark_processed
+
+- **GIVEN** `event_seen` 中不存在 event_id `evt-550c`
+- **WHEN** webhook handler 收到事件，`extract_req_id` 返回 `None`
+- **THEN** handler 返回 `{"action": "skip", "reason": "no req_id resolvable"}`
+- **AND** `dedup.mark_processed` **未被调用**
+- **AND** `event_seen` 中对应行的 `processed_at` 仍为 `NULL`

--- a/openspec/changes/REQ-550/tasks.md
+++ b/openspec/changes/REQ-550/tasks.md
@@ -1,0 +1,20 @@
+# REQ-550 Tasks
+
+## Stage: spec
+- [x] author specs/webhook-dedup-soft-skip/spec.md with scenarios DDS-S1..S4
+
+## Stage: implementation
+- [x] Remove `mark_processed` from `skip_no_req_tag` early return (session.completed without REQ tag)
+- [x] Remove `mark_processed` from `skip_no_req_or_intent_tag` early return (issue.updated without REQ or intent tag)
+- [x] Remove `mark_processed` from `no_event_mapping` early return (event is None after derive_event)
+- [x] Remove `mark_processed` from `no_req_id` early return (req_id is None after resolve)
+- [x] Verify `mark_processed` is still called only after `engine.step` success
+
+## Stage: tests
+- [x] Update RNF-S1: assert `mark_processed` NOT called on noise skip
+- [x] Update RNF-S5: assert `mark_processed` NOT called on noise skip
+- [x] Add DEDUP-S7: early skip + retry path test
+
+## Stage: PR
+- [ ] git push feat/REQ-550
+- [ ] gh pr create --label sisyphus

--- a/orchestrator/src/orchestrator/webhook.py
+++ b/orchestrator/src/orchestrator/webhook.py
@@ -150,7 +150,6 @@ async def webhook(request: Request) -> JSONResponse:
     has_req_tag = bool(router_lib.extract_req_id(tags))
     if body.event == "session.completed" and not has_req_tag:
         log.debug("webhook.skip_no_req_tag", issue_id=body.issueId, tags=tags)
-        await dedup.mark_processed(pool, eid)
         return {"action": "skip", "reason": "session event without REQ tag"}
     if (
         body.event == "issue.updated"
@@ -160,7 +159,6 @@ async def webhook(request: Request) -> JSONResponse:
     ):
         log.debug("webhook.skip_no_req_or_intent_tag",
                   issue_id=body.issueId, tags=tags)
-        await dedup.mark_processed(pool, eid)
         return {"action": "skip", "reason": "issue.updated without REQ or intent tag"}
     await obs.record_event(
         "webhook.received",
@@ -228,7 +226,6 @@ async def webhook(request: Request) -> JSONResponse:
 
     if event is None:
         log.debug("webhook.no_event_mapping", tags=tags, event_type=body.event)
-        await dedup.mark_processed(pool, eid)
         return {"action": "skip", "reason": "no event mapping"}
 
     # ─── 3.5 把上游 BKD issue 推目标 statusId（webhook 已识别为有效完工信号）──────
@@ -249,7 +246,6 @@ async def webhook(request: Request) -> JSONResponse:
     req_id = router_lib.extract_req_id(tags, body.issueNumber)
     if req_id is None:
         log.warning("webhook.no_req_id", tags=tags)
-        await dedup.mark_processed(pool, eid)
         return {"action": "skip", "reason": "no req_id resolvable"}
 
     # ─── 5. fetch / init REQ state（支持任意 state init via init:STATE tag）────────────────

--- a/orchestrator/tests/test_contract_router_noise_filter.py
+++ b/orchestrator/tests/test_contract_router_noise_filter.py
@@ -161,8 +161,9 @@ async def test_rnf_s1_issue_updated_no_req_no_intent_is_skipped(monkeypatch):
     """
     RNF-S1: webhook 收到 issue.updated，tags 不含 REQ-* 也不含 intent:intake /
     intent:analyze 时，必须命中 noise filter，返回 action=skip + 含 issue.updated 的
-    reason；dedup.mark_processed 被调用一次；obs.record_event / derive_event /
-    engine.step 均不被调用。
+    reason；dedup.mark_processed **不被调用**（让 processed_at 保持 NULL，
+    BKD 重发时走 retry 路径，避免合法事件因 tag 竞争丢失）；obs.record_event /
+    derive_event / engine.step 均不被调用。
     """
     from orchestrator import engine, webhook
 
@@ -190,9 +191,10 @@ async def test_rnf_s1_issue_updated_no_req_no_intent_is_skipped(monkeypatch):
         f"RNF-S1: skip reason must identify 'issue.updated' noise, got reason={reason!r}"
     )
 
-    assert len(tracking["mark_calls"]) == 1, (
-        f"RNF-S1: dedup.mark_processed must be called exactly once so BKD at-least-once "
-        f"retry also short-circuits; called {len(tracking['mark_calls'])} times"
+    assert len(tracking["mark_calls"]) == 0, (
+        f"RNF-S1: dedup.mark_processed must NOT be called for noise skip — "
+        f"processed_at must remain NULL so BKD retry can reprocess if tags "
+        f"were missing due to race; called {len(tracking['mark_calls'])} times"
     )
 
     assert len(tracking["obs_calls"]) == 0, (
@@ -294,7 +296,8 @@ async def test_rnf_s5_session_completed_no_req_still_skipped(monkeypatch):
     """
     RNF-S5: 新 issue.updated noise filter 加入后，既有 session.completed filter
     必须仍然生效：session.completed 且 tags 无 REQ-* 时返回 action=skip，
-    reason 包含 'session'，mark_processed 被调用，engine.step 不被调用。
+    reason 包含 'session'，mark_processed **不被调用**（让 BKD 重发走 retry），
+    engine.step 不被调用。
     """
     from orchestrator import engine, webhook
 
@@ -323,8 +326,9 @@ async def test_rnf_s5_session_completed_no_req_still_skipped(monkeypatch):
         f"got reason={reason!r}"
     )
 
-    assert len(tracking["mark_calls"]) == 1, (
-        f"RNF-S5: mark_processed must be called exactly once; "
+    assert len(tracking["mark_calls"]) == 0, (
+        f"RNF-S5: mark_processed must NOT be called for noise skip — "
+        f"processed_at must remain NULL so BKD retry can reprocess; "
         f"called {len(tracking['mark_calls'])} times"
     )
 

--- a/orchestrator/tests/test_dedup.py
+++ b/orchestrator/tests/test_dedup.py
@@ -242,3 +242,102 @@ async def test_webhook_dedup_no_mark_on_crash(monkeypatch):
 
     # mark_processed は呼ばれてはいけない
     assert not mark_called, "mark_processed must NOT be called when handler crashes"
+
+
+@pytest.mark.asyncio
+async def test_webhook_dedup_no_mark_on_early_skip_allows_retry(monkeypatch):
+    """
+    早期 skip（no_req_tag / no_event_mapping / no_req_id）不 mark_processed，
+    BKD 重发同 event_id 时 check_and_record 返回 retry，允许重新处理。
+    这是防止 tag 竞争导致合法事件丢失的关键修复（REQ-550）。
+    """
+    import orchestrator.observability as obs
+    from orchestrator import engine, webhook
+    from orchestrator import router as router_lib
+    from orchestrator.state import Event, ReqState
+    from orchestrator.store import db, dedup
+    from orchestrator.store import req_state as req_state_mod
+
+    mark_called = []
+    check_calls = []
+
+    # 第一次 new，第二次 retry（因为 mark_processed 没被调）
+    _check_seq = iter(["new", "retry"])
+
+    async def _seq_check(pool, eid):
+        val = next(_check_seq)
+        check_calls.append((val, eid))
+        return val
+
+    monkeypatch.setattr(dedup, "check_and_record", _seq_check)
+    monkeypatch.setattr(dedup, "mark_processed", AsyncMock(side_effect=lambda *a: mark_called.append(a)))
+    monkeypatch.setattr(db, "get_pool", lambda: FakePool())
+    monkeypatch.setattr(obs, "record_event", AsyncMock())
+
+    class FakeBKD:
+        def __init__(self, *a, **kw): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def get_issue(self, *a, **kw):
+            class R:
+                tags: ClassVar = ["analyze"]  # 第一次没 REQ tag
+            return R()
+        async def update_issue(self, *a, **kw): pass
+
+    monkeypatch.setattr(webhook, "BKDClient", FakeBKD)
+    monkeypatch.setattr(router_lib, "extract_req_id", lambda tags, num=None: None)  # 无 REQ
+    monkeypatch.setattr(router_lib, "derive_event", lambda evt, tags: None)  # 无映射
+
+    class MockReq:
+        headers: ClassVar = {"authorization": "Bearer test-webhook-token"}
+        async def json(self):
+            return {
+                "event": "session.completed",
+                "issueId": "issue-550",
+                "projectId": "proj-550",
+                "executionId": "exec-550",
+                "tags": ["analyze"],
+            }
+
+    # ── 第一次：无 REQ tag → 早期 skip，mark_processed 不调 ──
+    result1 = await webhook.webhook(MockReq())
+    assert result1["action"] == "skip"
+    assert not mark_called, "early skip must NOT call mark_processed"
+
+    # ── 第二次：BKD 重发，同 event_id → dedup 返 retry（processed_at 仍为 NULL）──
+    # 这次 tags 里已有 REQ tag（模拟 tag 竞争已解决）
+    monkeypatch.setattr(
+        router_lib, "extract_req_id",
+        lambda tags, num=None: "REQ-550",
+    )
+    monkeypatch.setattr(router_lib, "derive_event", lambda evt, tags: Event.INTENT_ANALYZE)
+
+    class FakeBKD2:
+        def __init__(self, *a, **kw): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def get_issue(self, *a, **kw):
+            class R:
+                tags: ClassVar = ["REQ-550", "analyze"]
+            return R()
+        async def update_issue(self, *a, **kw): pass
+
+    monkeypatch.setattr(webhook, "BKDClient", FakeBKD2)
+
+    class FakeRow:
+        state = ReqState.INIT
+        context: ClassVar = {}
+
+    monkeypatch.setattr(req_state_mod, "get", AsyncMock(return_value=FakeRow()))
+    monkeypatch.setattr(req_state_mod, "insert_init", AsyncMock())
+    monkeypatch.setattr(req_state_mod, "update_context", AsyncMock())
+    monkeypatch.setattr(engine, "step", AsyncMock(return_value={"action": "start_analyze"}))
+
+    result2 = await webhook.webhook(MockReq())
+
+    # 第二次 dedup 返回 retry，handler 成功走完，mark_processed 被调
+    assert check_calls[1][0] == "retry", (
+        f"second delivery must be 'retry' (processed_at still NULL), got {check_calls[1][0]!r}"
+    )
+    assert result2["action"] == "start_analyze"
+    assert len(mark_called) == 1, "mark_processed called once after successful retry"


### PR DESCRIPTION
## Summary

修复 webhook dedup 过度 `mark_processed` 导致合法事件丢失的问题。

## 问题

`webhook.py` 中 4 个早期 return skip 路径都会调用 `dedup.mark_processed`：
- `skip_no_req_tag` (session.completed 无 REQ tag)
- `skip_no_req_or_intent_tag` (issue.updated 无 REQ/intent tag)
- `no_event_mapping` (derive_event 返回 None)
- `no_req_id` (extract_req_id 返回 None)

后果：第一次 webhook 到达时 tags 可能尚未写全（竞争条件），事件被 skip 并错误标记为已处理；BKD 重发时 dedup 返回 skip，合法事件永久丢失。

## 修复

- 移除上述 4 个早期 skip 路径上的 `mark_processed` 调用
- 唯一保留 `mark_processed` 的位置：`engine.step` 成功返回之后
- 早期 skip 不修改 `processed_at`（保持 NULL），BKD 重发时 `check_and_record` 返回 `retry`，handler 重新走完整流程

## 测试

- 更新 RNF-S1/S5 契约测试：assert `mark_processed` **不被调用**
- 新增 DEDUP-S7 测试：验证早期 skip → retry → success 的完整路径

## 变更文件

- `orchestrator/src/orchestrator/webhook.py`
- `orchestrator/tests/test_contract_router_noise_filter.py`
- `orchestrator/tests/test_dedup.py`
- `openspec/changes/REQ-550/`

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-550`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/1ikcad0x)