### PR TITLE
feat(thanatos): M1 — 统一 AI 验收收口落地

### DIFF
--- a/openspec/changes/REQ-thanatos-m1-impl-1777389456/proposal.md
+++ b/openspec/changes/REQ-thanatos-m1-impl-1777389456/proposal.md
@@ -1,0 +1,23 @@
+# Proposal: thanatos M1 — 统一 AI 验收收口落地
+
+## 背景
+
+thanatos 是 sisyphus 的统一 AI 验收收口层。M0 阶段仅冻结了 driver Protocol、scenario parser 和 MCP server 的接口形状，所有 driver 方法抛 `NotImplementedError`。create_accept.py 在 REQ-accept-m1-lite 中被改成了 v0.3-lite（纯 make target 方案），偏离了 thanatos MCP 的设计方向。
+
+## 目标
+
+让 thanatos 从 scaffold 变成可执行的统一验收层，恢复 thanatos MCP 在 sisyphus 流水线中的位置。
+
+## 范围
+
+- HTTP driver 实现（优先）
+- Playwright driver 实现（次之）
+- runner execute flow 补全
+- create_accept.py 恢复 thanatos MCP 路径
+- accept.md.j2 恢复 thanatos MCP 调用指引
+- CI 和测试恢复
+
+## 不做的
+
+- ADB driver 保持 M0 stub（M2/M3 范围）
+- thanatos helm chart 升级（PVC 挂载等 M2 范围）

--- a/openspec/changes/REQ-thanatos-m1-impl-1777389456/specs/thanatos/contract.spec.yaml
+++ b/openspec/changes/REQ-thanatos-m1-impl-1777389456/specs/thanatos/contract.spec.yaml
@@ -1,0 +1,66 @@
+openapi: 3.0.0
+info:
+  title: thanatos MCP contract
+  version: "0.1.0"
+
+paths: {}
+
+components:
+  schemas:
+    ScenarioResult:
+      type: object
+      required: [scenario_id, pass]
+      properties:
+        scenario_id:
+          type: string
+        pass:
+          type: boolean
+        steps:
+          type: array
+          items:
+            $ref: "#/components/schemas/StepResult"
+        kb_updates:
+          type: array
+          items:
+            $ref: "#/components/schemas/KbUpdate"
+        failure_hint:
+          type: string
+          nullable: true
+
+    StepResult:
+      type: object
+      required: [step, ok]
+      properties:
+        step:
+          type: string
+        ok:
+          type: boolean
+        evidence:
+          $ref: "#/components/schemas/Evidence"
+
+    Evidence:
+      type: object
+      properties:
+        dom:
+          type: string
+          nullable: true
+        network:
+          type: array
+          items:
+            type: object
+          nullable: true
+        screenshot:
+          type: string
+          nullable: true
+
+    KbUpdate:
+      type: object
+      required: [path, action, content]
+      properties:
+        path:
+          type: string
+        action:
+          type: string
+          enum: [patch, append]
+        content:
+          type: string

--- a/openspec/changes/REQ-thanatos-m1-impl-1777389456/specs/thanatos/spec.md
+++ b/openspec/changes/REQ-thanatos-m1-impl-1777389456/specs/thanatos/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: thanatos HTTP driver executes REST API acceptance scenarios
+
+The HTTP driver SHALL implement the five-method async contract defined in `drivers/base.py`. It MUST support `preflight` via `GET {endpoint}/healthz`, `act` via parsing When steps like `POST /api/v1/order with body {"foo":"bar"}`, and `assert_` via parsing Then steps like `response code is 200` or `response body.order_id > 0`. JSONPath-style dot notation MUST be supported for body field access.
+
+#### Scenario: THAN-M1-S1 HTTP preflight returns ok on 200 healthz
+- **GIVEN** a mock HTTP server returning 200 on /healthz
+- **WHEN** HttpDriver.preflight("http://localhost:8080") is called
+- **THEN** result.ok is True
+
+#### Scenario: THAN-M1-S2 HTTP act executes POST with JSON body
+- **GIVEN** HttpDriver initialized
+- **WHEN** act('POST /api/order with body {"id":1}') is called
+- **THEN** an HTTP POST is sent to /api/order with body {"id":1}
+
+#### Scenario: THAN-M1-S3 HTTP assert_ checks status code
+- **GIVEN** last response status code is 201
+- **WHEN** assert_("response code is 201") is called
+- **THEN** result.ok is True
+
+#### Scenario: THAN-M1-S4 HTTP assert_ checks JSON body path
+- **GIVEN** last response body is {"order":{"id":42}}
+- **WHEN** assert_("response body.order.id is 42") is called
+- **THEN** result.ok is True
+
+### Requirement: thanatos runner executes full scenario flow
+
+The runner SHALL load skill, parse spec, pick driver, preflight, then execute given/when/then steps in order. On any assertion failure it MUST call capture_evidence and return a ScenarioResult with passed=False.
+
+#### Scenario: THAN-M1-S5 runner executes all steps and reports pass
+- **GIVEN** a spec with one scenario containing Given/When/Then
+- **WHEN** run_all(skill_path, spec_path, endpoint) is called
+- **THEN** all scenarios return passed=True with step results
+
+#### Scenario: THAN-M1-S6 runner captures evidence on assert failure
+- **GIVEN** a spec with a Then step that will fail
+- **WHEN** run_scenario is called
+- **THEN** result.passed is False and evidence is attached to the failing step
+
+### Requirement: create_accept dispatches thanatos MCP path
+
+create_accept SHALL run make accept-env-up, parse the endpoint JSON for a `thanatos` block, and dispatch an accept-agent BKD issue with thanatos parameters. If the `thanatos` block is absent it MUST fallback to the v0.3-lite shell script path.
+
+#### Scenario: THAN-M1-S7 create_accept with thanatos block dispatches agent
+- **GIVEN** accept-env-up returns endpoint JSON containing thanatos block
+- **WHEN** create_accept is called
+- **THEN** a BKD accept-agent issue is created with thanatos parameters
+
+#### Scenario: THAN-M1-S8 create_accept without thanatos block falls back to lite
+- **GIVEN** accept-env-up returns endpoint JSON without thanatos block
+- **WHEN** create_accept is called
+- **THEN** the v0.3-lite shell script path is executed

--- a/openspec/changes/REQ-thanatos-m1-impl-1777389456/tasks.md
+++ b/openspec/changes/REQ-thanatos-m1-impl-1777389456/tasks.md
@@ -1,0 +1,30 @@
+## Stage: implementation
+
+- [x] HTTP driver 实现 (thanatos/src/thanatos/drivers/http.py)
+  - preflight / observe / act / assert_ / capture_evidence
+  - 支持 POST/GET/PUT/PATCH/DELETE + body JSON
+  - 支持 response code / body JSONPath 断言
+- [x] Playwright driver 实现 (thanatos/src/thanatos/drivers/playwright.py)
+  - preflight (chromium launch + navigate)
+  - observe (a11y snapshot)
+  - act (click / type)
+  - assert_ (title / visible / contains)
+  - capture_evidence (screenshot + DOM)
+- [x] runner.py 补全 execute flow
+  - async run_scenario / run_all
+  - given → when → then 执行链
+  - 失败时自动 capture_evidence
+- [x] create_accept.py 恢复 thanatos MCP
+  - env-up → 解析 thanatos block → 派 accept-agent
+  - 无 thanatos block 时 fallback v0.3-lite
+- [x] accept.md.j2 恢复 thanatos MCP 调用指引
+- [x] 测试恢复
+  - test_http_driver.py (mock httpx)
+  - test_runner.py (mock driver flow)
+  - 更新 test_contract_thanatos.py THAN-S5/THAN-S5b
+  - 更新 orchestrator accept 测试适配 thanatos MCP + fallback
+
+## Stage: PR
+
+- [x] git push feat/REQ-thanatos-m1-impl-1777389456
+- [x] gh pr create with sisyphus label

--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -1,34 +1,35 @@
-"""create_accept (v0.3-lite): per-repo accept-env-up + sleep + accept-smoke + accept-env-down.
+"""create_accept: env-up → thanatos MCP dispatch (with v0.3-lite fallback).
 
-不接 thanatos MCP（descope）：
-1. 读 ctx.cloned_repos，对 /workspace/source/<name>/ 下每仓跑三段 make：
-   env-up → smoke-delay → accept-smoke → env-down（best-effort）
-2. accept-env-up / accept-smoke target 缺失 → fail-open skip 该仓 + warn
-3. 任一仓 env-up / accept-smoke 失败 → emit accept.fail，ctx 写 accept_fail_repos
-4. 全 pass → emit accept.pass
-5. cloned_repos 为空 → accept.pass（vacuous true）
-
-accept-env-down 在 script 里完成（best-effort）；teardown_accept_env 后续仍会
-重跑一次（幂等，无害）。teardown 按 ctx.accept_result 分流，不再依赖 BKD agent tags。
+Two paths:
+1. thanatos MCP (preferred): run `make accept-env-up`, parse endpoint JSON for
+   `thanatos` block, dispatch accept-agent BKD issue with thanatos params.
+2. v0.3-lite fallback: per-repo shell script env-up → sleep → accept-smoke →
+   env-down (used when `thanatos` block is absent).
 """
 from __future__ import annotations
 
+import json
+
 import structlog
 
-from .. import k8s_runner
+from .. import k8s_runner, pr_links
+from ..bkd import BKDClient
 from ..config import settings
+from ..prompts import render
 from ..state import Event
 from ..store import db, req_state
-from . import register
+from . import register, short_title
+from ._integration_resolver import resolve_integration_dir
 from ._skip import skip_if_enabled
 
 log = structlog.get_logger(__name__)
 
-_TIMEOUT_SEC = 1800  # 30 min：up × N repos + sleep + smoke × N + down × N
+_TIMEOUT_ENV_UP_SEC = 600  # 10 min for helm install + wait ready
+_TIMEOUT_LITE_SEC = 1800   # 30 min for up × N + sleep + smoke × N + down × N
 
 
-def _build_accept_script(req_id: str, delay_sec: int) -> str:
-    """Shell script: per-repo env-up → sleep → accept-smoke → env-down。
+def _build_lite_script(req_id: str, delay_sec: int) -> str:
+    """Shell script: per-repo env-up → sleep → accept-smoke → env-down (v0.3-lite).
 
     最后一行输出 PASS 或 FAIL:<repo1>,<repo2>；exit code 0/1 对应。
     target 缺失时 fail-open skip（不爆整体）。env-down 失败 || true 不计入 fail。
@@ -42,7 +43,6 @@ def _build_accept_script(req_id: str, delay_sec: int) -> str:
         "for repo in /workspace/source/*/; do "
         '  [ -d "$repo" ] || continue; '
         '  name=$(basename "$repo"); '
-        # make -n でターゲット存在チェック（exit!=0 = No rule / other error → skip）
         '  if ! make -C "$repo" -n accept-env-up >/dev/null 2>&1; then '
         '    echo "[warn] accept-env-up target missing in $name, skipping" >&2; '
         "    continue; "
@@ -100,36 +100,31 @@ def _build_accept_script(req_id: str, delay_sec: int) -> str:
     )
 
 
-@register("create_accept", idempotent=False)
-async def create_accept(*, body, req_id, tags, ctx):
-    if rv := skip_if_enabled("accept", Event.ACCEPT_PASS, req_id=req_id):
-        pool = db.get_pool()
-        await req_state.update_context(pool, req_id, {"accept_skipped": True})
-        return rv
-
+async def _run_lite_fallback(*, req_id: str, ctx: dict | None) -> dict:
+    """v0.3-lite fallback: shell script per-repo accept env-up/smoke/down."""
     cloned_repos = list((ctx or {}).get("cloned_repos") or [])
     if not cloned_repos:
-        log.info("create_accept.no_repos", req_id=req_id)
+        log.info("create_accept.lite_no_repos", req_id=req_id)
         return {"emit": Event.ACCEPT_PASS.value, "note": "no cloned repos (vacuous pass)"}
 
     try:
         rc = k8s_runner.get_controller()
     except RuntimeError as e:
-        log.warning("create_accept.no_runner_controller", req_id=req_id, error=str(e))
+        log.warning("create_accept.lite_no_runner", req_id=req_id, error=str(e))
         return {"emit": Event.ACCEPT_PASS.value, "note": "no runner controller, skipped env-up"}
 
     delay = settings.accept_smoke_delay_sec
-    script = _build_accept_script(req_id, delay)
+    script = _build_lite_script(req_id, delay)
 
     try:
         result = await rc.exec_in_runner(
             req_id,
             command=script,
             env={"SISYPHUS_REQ_ID": req_id, "SISYPHUS_STAGE": "accept"},
-            timeout_sec=_TIMEOUT_SEC,
+            timeout_sec=_TIMEOUT_LITE_SEC,
         )
     except Exception as e:
-        log.exception("create_accept.crashed", req_id=req_id, error=str(e))
+        log.exception("create_accept.lite_crashed", req_id=req_id, error=str(e))
         pool = db.get_pool()
         await req_state.update_context(pool, req_id, {
             "accept_result": "fail",
@@ -137,7 +132,6 @@ async def create_accept(*, body, req_id, tags, ctx):
         })
         return {"emit": Event.ACCEPT_FAIL.value, "error": str(e)[:200]}
 
-    # 从最后一行解 PASS / FAIL:<repos>
     fail_repos: list[str] = []
     last_line = ""
     for line in reversed((result.stdout or "").splitlines()):
@@ -152,7 +146,7 @@ async def create_accept(*, body, req_id, tags, ctx):
             raw = last_line[5:].strip()
             fail_repos = [r.strip() for r in raw.split(",") if r.strip()]
         log.warning(
-            "create_accept.failed",
+            "create_accept.lite_failed",
             req_id=req_id,
             exit_code=result.exit_code,
             fail_repos=fail_repos,
@@ -168,6 +162,142 @@ async def create_accept(*, body, req_id, tags, ctx):
             "exit_code": result.exit_code,
         }
 
-    log.info("create_accept.passed", req_id=req_id, duration_sec=result.duration_sec)
+    log.info("create_accept.lite_passed", req_id=req_id, duration_sec=result.duration_sec)
     await req_state.update_context(pool, req_id, {"accept_result": "pass"})
     return {"emit": Event.ACCEPT_PASS.value}
+
+
+@register("create_accept", idempotent=False)
+async def create_accept(*, body, req_id, tags, ctx):
+    if rv := skip_if_enabled("accept", Event.ACCEPT_PASS, req_id=req_id):
+        pool = db.get_pool()
+        await req_state.update_context(pool, req_id, {"accept_skipped": True})
+        return rv
+
+    proj = body.projectId
+    source_issue_id = body.issueId
+    namespace = f"accept-{req_id.lower()}"
+
+    # Phase 1: env-up via sisyphus (runner exec)
+    try:
+        rc = k8s_runner.get_controller()
+    except RuntimeError as e:
+        log.warning("create_accept.no_runner_controller", req_id=req_id, error=str(e))
+        return {"emit": Event.ACCEPT_PASS.value, "note": "no runner controller, skipped env-up"}
+
+    resolved = await resolve_integration_dir(rc, req_id)
+    if resolved.dir is None:
+        log.warning("create_accept.no_integration_dir", req_id=req_id, reason=resolved.reason)
+        return {
+            "emit": Event.ACCEPT_ENV_UP_FAIL.value,
+            "reason": resolved.reason,
+        }
+    integration_dir = resolved.dir
+
+    exec_env = {
+        "SISYPHUS_REQ_ID": req_id,
+        "SISYPHUS_STAGE": "accept-env-up",
+        "SISYPHUS_NAMESPACE": namespace,
+    }
+    try:
+        result = await rc.exec_in_runner(
+            req_id,
+            command=f"cd {integration_dir} && make accept-env-up",
+            env=exec_env,
+            timeout_sec=_TIMEOUT_ENV_UP_SEC,
+        )
+    except Exception as e:
+        log.exception("create_accept.env_up_crashed", req_id=req_id, error=str(e))
+        return {"emit": Event.ACCEPT_ENV_UP_FAIL.value, "error": str(e)[:200]}
+
+    if result.exit_code != 0:
+        log.warning("create_accept.env_up_failed", req_id=req_id,
+                    exit_code=result.exit_code, stderr_tail=result.stderr[-500:])
+        return {
+            "emit": Event.ACCEPT_ENV_UP_FAIL.value,
+            "exit_code": result.exit_code,
+            "stderr_tail": result.stderr[-500:],
+        }
+
+    # Parse endpoint JSON from stdout tail
+    last_line = ""
+    for line in reversed(result.stdout.splitlines()):
+        line = line.strip()
+        if line:
+            last_line = line
+            break
+    try:
+        accept_env = json.loads(last_line)
+    except json.JSONDecodeError:
+        log.warning("create_accept.env_up_bad_json", req_id=req_id,
+                    last_line_preview=last_line[:200])
+        return {
+            "emit": Event.ACCEPT_ENV_UP_FAIL.value,
+            "reason": "env-up stdout tail is not JSON",
+        }
+
+    endpoint = accept_env.get("endpoint") if isinstance(accept_env, dict) else None
+    if not endpoint:
+        log.warning("create_accept.env_up_no_endpoint", req_id=req_id, accept_env=accept_env)
+        return {
+            "emit": Event.ACCEPT_ENV_UP_FAIL.value,
+            "reason": "env-up JSON missing endpoint",
+        }
+
+    # M1: optional thanatos block
+    thanatos_block = accept_env.get("thanatos") or {} if isinstance(accept_env, dict) else {}
+    thanatos_pod = thanatos_block.get("pod") or None
+    thanatos_namespace = thanatos_block.get("namespace") or namespace
+    thanatos_skill_repo = thanatos_block.get("skill_repo") or None
+
+    # Fallback to v0.3-lite if thanatos block absent
+    if not thanatos_pod:
+        log.info("create_accept.thanatos_block_missing", req_id=req_id,
+                 endpoint=endpoint, fallback="v0.3-lite")
+        return await _run_lite_fallback(req_id=req_id, ctx=ctx)
+
+    # Phase 2: dispatch accept-agent (thanatos MCP path)
+    branch_for_links = (ctx or {}).get("branch") or f"feat/{req_id}"
+    links = await pr_links.ensure_pr_links_in_ctx(
+        req_id=req_id, branch=branch_for_links, ctx=ctx, project_id=proj,
+    )
+    extra_tags = pr_links.pr_link_tags(links)
+
+    async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+        issue = await bkd.create_issue(
+            project_id=proj,
+            title=f"[{req_id}] [ACCEPT] AI-QA{short_title(ctx)}",
+            tags=["accept", req_id, f"parent-id:{source_issue_id}", *extra_tags],
+            status_id="todo",
+            model=settings.agent_model,
+        )
+        prompt = render(
+            "accept.md.j2",
+            req_id=req_id,
+            endpoint=endpoint,
+            namespace=namespace,
+            source_issue_id=source_issue_id,
+            accept_env=accept_env,
+            project_id=proj,
+            project_alias=proj,
+            thanatos_pod=thanatos_pod,
+            thanatos_namespace=thanatos_namespace,
+            thanatos_skill_repo=thanatos_skill_repo,
+        )
+        await bkd.follow_up_issue(project_id=proj, issue_id=issue.id, prompt=prompt)
+        await bkd.update_issue(project_id=proj, issue_id=issue.id, status_id="working")
+
+    pool = db.get_pool()
+    await req_state.update_context(pool, req_id, {
+        "accept_issue_id": issue.id,
+        "accept_endpoint": endpoint,
+        "accept_namespace": namespace,
+    })
+
+    log.info("create_accept.done", req_id=req_id, accept_issue=issue.id,
+             endpoint=endpoint, namespace=namespace, thanatos_pod=thanatos_pod)
+    return {
+        "accept_issue_id": issue.id,
+        "endpoint": endpoint,
+        "namespace": namespace,
+    }

--- a/orchestrator/src/orchestrator/prompts/accept.md.j2
+++ b/orchestrator/src/orchestrator/prompts/accept.md.j2
@@ -10,12 +10,17 @@
 
 ─────────
 
-## 验收 (ACCEPT / AI-QA)  M15
+## 验收 (ACCEPT / AI-QA) — thanatos M1
 AGENT_ROLE=accept-agent
 REQ={{ req_id }}
 ENDPOINT={{ endpoint }}
 NAMESPACE={{ namespace }}
 SOURCE_ISSUE={{ source_issue_id }}
+{% if thanatos_pod %}
+THANATOS_POD={{ thanatos_pod }}
+THANATOS_NAMESPACE={{ thanatos_namespace }}
+THANATOS_SKILL_REPO={{ thanatos_skill_repo or '<unset>' }}
+{% endif %}
 
 ---
 
@@ -24,14 +29,86 @@ SOURCE_ISSUE={{ source_issue_id }}
 sisyphus 已经：
 - 在 `$NAMESPACE` 跑 `make accept-env-up`，lab 已拉起
 - 拿到 lab endpoint（上面 `$ENDPOINT`）
+{% if thanatos_pod %}
+- 业务仓 `accept-env-up` 起了 thanatos pod（`$THANATOS_POD`，`$THANATOS_NAMESPACE`）
+{% endif %}
 
-你要做的：跑 spec 里定义的 Acceptance Scenario block（spec.md 中所有 `#### Scenario:`
+你要做的：跑 spec 里定义的 Acceptance Scenario block（所有 `#### Scenario:`
 开头的 block，scenario id 由 spec 作者自定，sisyphus 不预设前缀）判 pass/fail，
 不管环境。跑完不清，sisyphus 会调 `accept-env-down`。
 
 ---
+{% if thanatos_pod %}
+## 步骤（thanatos MCP 路径）
 
-## 步骤
+> 业务仓 accept-env-up 起了 thanatos pod，**走 MCP**。直 curl 路径只在 thanatos
+> 没起的 fallback 模式跑。
+
+### Step 1: 验证 endpoint + thanatos server
+
+```bash
+POD=runner-{{ req_id | lower }}
+NS=sisyphus-runners
+
+# lab endpoint reachable
+kubectl -n $NS exec $POD -- curl -sf "{{ endpoint }}/healthz" || {
+  echo "FAIL: endpoint {{ endpoint }} unreachable" >&2; exit 1; }
+
+# thanatos server 能启动（在 thanatos pod 内）
+kubectl -n {{ thanatos_namespace }} exec -i {{ thanatos_pod }} -- \
+  python -m thanatos.server --help >/dev/null 2>&1 || {
+  echo "FAIL: thanatos server not runnable" >&2; exit 1; }
+```
+
+### Step 2: 解析 skill + spec 路径
+
+```bash
+SKILL_PATH=/workspace/source/{{ thanatos_skill_repo }}/.thanatos/skill.yaml
+
+SPEC_PATH=$(kubectl -n $NS exec $POD -- bash -c \
+  "ls /workspace/source/{{ thanatos_skill_repo }}/openspec/changes/{{ req_id }}/specs/*/spec.md 2>/dev/null | head -1")
+[ -n "$SPEC_PATH" ] || { echo "FAIL: no spec.md found" >&2; exit 1; }
+```
+
+### Step 3: 通过 thanatos MCP 跑 scenario
+
+thanatos MCP server 在 thanatos pod 中以 stdio 方式运行：
+
+```bash
+kubectl -n {{ thanatos_namespace }} exec -i {{ thanatos_pod }} -- python -m thanatos.server
+```
+
+调用 `run_all` tool：
+- `skill_path`: `$SKILL_PATH`
+- `spec_path`: `$SPEC_PATH`
+- `endpoint`: `{{ endpoint }}`
+
+thanatos 会返回每个 scenario 的 pass/fail + evidence。你只需：
+1. 确认 thanatos server 能启动
+2. 调用 `run_all` 或逐个调用 `run_scenario`
+3. 收集结果，写报告
+
+### Step 4: 报告
+
+在本 issue follow-up 追加：
+
+```markdown
+## Accept Result (thanatos MCP)
+
+- <scenario-id>: PASS
+- <scenario-id>: FAIL — <failure_hint>
+```
+
+### Step 5: 贴 tag + move review
+
+- 全过：tags = `[accept, {{ req_id }}, result:pass]`, statusId=review
+- 任一失败：tags = `[accept, {{ req_id }}, result:fail]`, statusId=review
+
+{% else %}
+## 步骤（直 curl 路径 — fallback / sisyphus self-accept）
+
+> 业务仓 accept-env-up 没起 thanatos pod（或 sisyphus 自家 self-accept compose
+> 路径），accept-agent 直接读 spec + curl endpoint 跑 scenario。
 
 ### Step 1: 验证 endpoint
 
@@ -85,8 +162,9 @@ kubectl -n $NS exec $POD -- bash -c \
 
 ### Step 5: 贴 tag + move review
 
-- ✅ 全过：tags = `[accept, {{ req_id }}, result:pass]`, statusId=review
-- ❌ 任一失败：tags = `[accept, {{ req_id }}, result:fail]`, statusId=review
+- 全过：tags = `[accept, {{ req_id }}, result:pass]`, statusId=review
+- 任一失败：tags = `[accept, {{ req_id }}, result:fail]`, statusId=review
+{% endif %}
 
 ---
 
@@ -94,6 +172,6 @@ kubectl -n $NS exec $POD -- bash -c \
 
 - **不部署 lab**：sisyphus 搞好的
 - **不清 lab**：sisyphus 会做
-- **不改代码**：只读 + curl
+- **不改业务代码**：只读 + (curl | thanatos MCP)
 - **真实 endpoint**：不 mock
 - **update-issue** 要指本 accept issue（不是 SOURCE_ISSUE）

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -450,8 +450,9 @@ async def test_done_archive(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_create_accept(monkeypatch):
-    """v0.3-lite: per-repo shell script exits 0 → emit accept.pass (no BKD agent)."""
+    """v0.3-lite fallback: per-repo shell script exits 0 → emit accept.pass (no BKD agent)."""
     from orchestrator.actions import create_accept as mod
+    from orchestrator.actions._integration_resolver import ResolveResult
     from orchestrator.k8s_runner import ExecResult
 
     patch_db(monkeypatch, "create_accept")
@@ -461,11 +462,23 @@ async def test_create_accept(monkeypatch):
 
     class FakeRC:
         async def exec_in_runner(self, req_id, command, env=None, timeout_sec=None):
+            if "make accept-env-up" in command:
+                return ExecResult(
+                    exit_code=0, stdout='{"endpoint": "http://localhost"}\n',
+                    stderr="", duration_sec=1.0,
+                )
             return ExecResult(exit_code=0, stdout="PASS\n", stderr="", duration_sec=1.0)
 
     monkeypatch.setattr(
         "orchestrator.actions.create_accept.k8s_runner.get_controller",
         lambda: FakeRC(),
+    )
+
+    async def fake_resolve(rc, req_id):
+        return ResolveResult(dir="/workspace/source/test")
+    monkeypatch.setattr(
+        "orchestrator.actions.create_accept.resolve_integration_dir",
+        fake_resolve,
     )
 
     ctx_updates: list[dict] = []
@@ -485,6 +498,7 @@ async def test_create_accept(monkeypatch):
 async def test_create_accept_env_up_fail(monkeypatch):
     """Shell script exits 1, stdout ends FAIL:repo → emit accept.fail."""
     from orchestrator.actions import create_accept as mod
+    from orchestrator.actions._integration_resolver import ResolveResult
     from orchestrator.k8s_runner import ExecResult
 
     patch_db(monkeypatch, "create_accept")
@@ -494,6 +508,11 @@ async def test_create_accept_env_up_fail(monkeypatch):
 
     class FakeRC:
         async def exec_in_runner(self, req_id, command, env=None, timeout_sec=None):
+            if "make accept-env-up" in command:
+                return ExecResult(
+                    exit_code=0, stdout='{"endpoint": "http://localhost"}\n',
+                    stderr="", duration_sec=1.0,
+                )
             return ExecResult(
                 exit_code=1, stdout="FAIL:repo-a\n",
                 stderr="make: Error 1", duration_sec=3.0,
@@ -502,6 +521,13 @@ async def test_create_accept_env_up_fail(monkeypatch):
     monkeypatch.setattr(
         "orchestrator.actions.create_accept.k8s_runner.get_controller",
         lambda: FakeRC(),
+    )
+
+    async def fake_resolve(rc, req_id):
+        return ResolveResult(dir="/workspace/source/test")
+    monkeypatch.setattr(
+        "orchestrator.actions.create_accept.resolve_integration_dir",
+        fake_resolve,
     )
 
     ctx_updates: list[dict] = []

--- a/orchestrator/tests/test_contract_thanatos_m1_accept.py
+++ b/orchestrator/tests/test_contract_thanatos_m1_accept.py
@@ -1,0 +1,194 @@
+"""Contract tests for REQ-thanatos-m1-impl-1777389456 — THAN-M1-S7 / THAN-M1-S8.
+
+Black-box contracts for create_accept thanatos MCP dispatch vs v0.3-lite fallback.
+Derived from:
+  openspec/changes/REQ-thanatos-m1-impl-1777389456/specs/thanatos/spec.md
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from orchestrator.state import Event
+
+
+# ─── Shared helpers ──────────────────────────────────────────────────────────
+
+
+def _body():
+    return type("B", (), {
+        "issueId": "source-issue-1",
+        "projectId": "test-project",
+    })()
+
+
+class _FakeExecResult:
+    def __init__(self, exit_code: int = 0, stdout: str = "", stderr: str = ""):
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+        self.duration_sec = 0.5
+
+
+class _FakeRC:
+    def __init__(self, results: list[_FakeExecResult] | None = None):
+        self.results = list(results or [])
+        self.calls: list[dict] = []
+        self._idx = 0
+
+    async def exec_in_runner(self, req_id, command, env=None, timeout_sec=None):
+        self.calls.append({"req_id": req_id, "command": command, "env": env})
+        result = self.results[self._idx] if self._idx < len(self.results) else _FakeExecResult()
+        self._idx += 1
+        return result
+
+
+class _FakePool:
+    async def execute(self, sql, *args):
+        pass
+
+    async def fetchrow(self, sql, *args):
+        return None
+
+
+class _MockBKDClient:
+    def __init__(self):
+        self.create_issue_calls: list[dict] = []
+        self.follow_up_calls: list[dict] = []
+        self.update_calls: list[dict] = []
+        self._issue = MagicMock(id="mock-accept-issue-id")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+    async def create_issue(self, **kwargs):
+        self.create_issue_calls.append(kwargs)
+        return self._issue
+
+    async def follow_up_issue(self, **kwargs):
+        self.follow_up_calls.append(kwargs)
+
+    async def update_issue(self, **kwargs):
+        self.update_calls.append(kwargs)
+
+
+def _patch_common(monkeypatch, rc: _FakeRC, lite_fallback_return: dict | None = None):
+    """Patch all external I/O for create_accept."""
+    from orchestrator.actions import create_accept as mod
+
+    monkeypatch.setattr(mod.k8s_runner, "get_controller", lambda: rc)
+    monkeypatch.setattr(mod.db, "get_pool", lambda: _FakePool())
+    monkeypatch.setattr(mod.req_state, "update_context", AsyncMock())
+    monkeypatch.setattr(mod.pr_links, "ensure_pr_links_in_ctx", AsyncMock(return_value={}))
+    monkeypatch.setattr(mod, "render", MagicMock(return_value="mock accept prompt"))
+    monkeypatch.setattr(mod, "short_title", lambda ctx: "")
+    monkeypatch.setattr(mod.settings, "accept_smoke_delay_sec", 0)
+    monkeypatch.setattr(mod.settings, "agent_model", "claude-sonnet-4-6")
+    monkeypatch.setattr(mod.settings, "bkd_base_url", "http://localhost:3000")
+    monkeypatch.setattr(mod.settings, "bkd_token", "test-token")
+    monkeypatch.setattr(mod, "skip_if_enabled", lambda *a, **k: None)
+
+    async def fake_resolve_integration_dir(rc_obj, req_id):
+        return MagicMock(dir="/workspace/integration/test", reason=None)
+
+    monkeypatch.setattr(mod, "resolve_integration_dir", fake_resolve_integration_dir)
+
+    if lite_fallback_return is not None:
+        async def fake_lite(*, req_id, ctx):
+            mod._lite_fallback_called = True
+            return lite_fallback_return
+        monkeypatch.setattr(mod, "_run_lite_fallback", fake_lite)
+    else:
+        mod._lite_fallback_called = False
+        async def fake_lite(*, req_id, ctx):
+            mod._lite_fallback_called = True
+            return {"emit": Event.ACCEPT_PASS.value}
+        monkeypatch.setattr(mod, "_run_lite_fallback", fake_lite)
+
+
+# ─── THAN-M1-S7: create_accept with thanatos block dispatches agent ──────────
+
+
+@pytest.mark.asyncio
+async def test_than_m1_s7_thanatos_block_dispatches_agent(monkeypatch):
+    """THAN-M1-S7: endpoint JSON with thanatos block → BKD accept-agent issue created."""
+    from orchestrator.actions import create_accept as mod
+
+    endpoint_json = json.dumps({
+        "endpoint": "http://lab.local:8080",
+        "thanatos": {
+            "pod": "thanatos-lab",
+            "namespace": "accept-test",
+            "skill_repo": "phona/sisyphus",
+        },
+    })
+    rc = _FakeRC(results=[
+        _FakeExecResult(exit_code=0, stdout=f"=== env-up ===\n{endpoint_json}\n"),
+    ])
+
+    mock_bkd = _MockBKDClient()
+    monkeypatch.setattr(mod, "BKDClient", lambda *a, **k: mock_bkd)
+
+    _patch_common(monkeypatch, rc, lite_fallback_return=None)
+
+    out = await mod.create_accept(
+        body=_body(), req_id="REQ-thanatos-m1-test", tags=[], ctx={},
+    )
+
+    assert not mod._lite_fallback_called, (
+        "v0.3-lite fallback must NOT be called when thanatos block is present"
+    )
+    assert len(mock_bkd.create_issue_calls) == 1, (
+        "BKD create_issue must be called exactly once"
+    )
+    call = mock_bkd.create_issue_calls[0]
+    assert call.get("project_id") == "test-project"
+    assert "accept" in call.get("tags", [])
+    assert "parent-id:source-issue-1" in call.get("tags", [])
+    assert "mock-accept-issue-id" in out.get("accept_issue_id", ""), (
+        "result must contain accept_issue_id"
+    )
+    assert out.get("endpoint") == "http://lab.local:8080"
+    assert out.get("namespace") == "accept-req-thanatos-m1-test"
+
+
+# ─── THAN-M1-S8: create_accept without thanatos block falls back to lite ─────
+
+
+@pytest.mark.asyncio
+async def test_than_m1_s8_no_thanatos_block_falls_back_to_lite(monkeypatch):
+    """THAN-M1-S8: endpoint JSON without thanatos block → v0.3-lite shell script path executed."""
+    from orchestrator.actions import create_accept as mod
+
+    endpoint_json = json.dumps({
+        "endpoint": "http://lab.local:8080",
+    })
+    rc = _FakeRC(results=[
+        _FakeExecResult(exit_code=0, stdout=f"=== env-up ===\n{endpoint_json}\n"),
+    ])
+
+    mock_bkd = _MockBKDClient()
+    monkeypatch.setattr(mod, "BKDClient", lambda *a, **k: mock_bkd)
+
+    _patch_common(
+        monkeypatch,
+        rc,
+        lite_fallback_return={"emit": Event.ACCEPT_PASS.value, "note": "lite fallback"},
+    )
+
+    out = await mod.create_accept(
+        body=_body(), req_id="REQ-thanatos-m1-test", tags=[], ctx={},
+    )
+
+    assert mod._lite_fallback_called, (
+        "v0.3-lite fallback MUST be called when thanatos block is absent"
+    )
+    assert len(mock_bkd.create_issue_calls) == 0, (
+        "BKD create_issue must NOT be called in lite fallback path"
+    )
+    assert out.get("emit") == Event.ACCEPT_PASS.value

--- a/orchestrator/tests/test_create_accept_minimal.py
+++ b/orchestrator/tests/test_create_accept_minimal.py
@@ -1,4 +1,4 @@
-"""REQ-accept-m1-lite: unit tests for the v0.3-lite create_accept.
+"""REQ-accept-m1-lite: unit tests for create_accept (thanatos MCP + v0.3-lite fallback).
 
 4 scenarios specified in the REQ:
   AML-S1: cloned_repos 全 OK + 每仓 make 都返 0 → ACCEPT_PASS, ctx accept_result=pass
@@ -11,24 +11,36 @@ from __future__ import annotations
 import pytest
 
 from orchestrator.actions import create_accept as mod
+from orchestrator.actions._integration_resolver import ResolveResult
 from orchestrator.k8s_runner import ExecResult
 from orchestrator.state import Event
 
 # ─── Fakes ────────────────────────────────────────────────────────────────
 
 class _FakeRC:
-    def __init__(self, exit_code: int = 0, stdout: str = "PASS\n", stderr: str = ""):
-        self.exit_code = exit_code
-        self.stdout = stdout
-        self.stderr = stderr
+    """Fake runner controller that discriminates calls by command content."""
+
+    def __init__(self, lite_exit_code: int = 0, lite_stdout: str = "PASS\n", lite_stderr: str = ""):
+        self.lite_exit_code = lite_exit_code
+        self.lite_stdout = lite_stdout
+        self.lite_stderr = lite_stderr
         self.calls: list[dict] = []
 
     async def exec_in_runner(self, req_id, command, env=None, timeout_sec=None):
         self.calls.append({"req_id": req_id, "command": command, "env": env})
+        # env-up call
+        if "make accept-env-up" in command:
+            return ExecResult(
+                exit_code=0,
+                stdout='{"endpoint": "http://localhost"}\n',
+                stderr="",
+                duration_sec=0.5,
+            )
+        # lite fallback call (shell script)
         return ExecResult(
-            exit_code=self.exit_code,
-            stdout=self.stdout,
-            stderr=self.stderr,
+            exit_code=self.lite_exit_code,
+            stdout=self.lite_stdout,
+            stderr=self.lite_stderr,
             duration_sec=0.5,
         )
 
@@ -59,6 +71,13 @@ def _patch(monkeypatch, rc: _FakeRC, pool: _FakePool, skip_accept: bool = False)
     monkeypatch.setattr("orchestrator.actions.create_accept.settings.test_mode", False)
     monkeypatch.setattr("orchestrator.actions.create_accept.settings.accept_smoke_delay_sec", 0)
 
+    async def fake_resolve_integration_dir(rc, req_id):
+        return ResolveResult(dir="/workspace/source/test")
+    monkeypatch.setattr(
+        "orchestrator.actions.create_accept.resolve_integration_dir",
+        fake_resolve_integration_dir,
+    )
+
     ctx_updates = pool.ctx_updates
     async def fake_update_ctx(p, req_id, updates):
         ctx_updates.append(updates)
@@ -70,7 +89,7 @@ def _patch(monkeypatch, rc: _FakeRC, pool: _FakePool, skip_accept: bool = False)
 @pytest.mark.asyncio
 async def test_aml_s1_all_repos_pass(monkeypatch):
     """Script exits 0, stdout='PASS' → ACCEPT_PASS, ctx accept_result=pass."""
-    rc = _FakeRC(exit_code=0, stdout="=== accept-env-up: sisyphus ===\nPASS\n")
+    rc = _FakeRC(lite_exit_code=0, lite_stdout="=== accept-env-up: sisyphus ===\nPASS\n")
     pool = _FakePool()
     _patch(monkeypatch, rc, pool)
 
@@ -79,7 +98,8 @@ async def test_aml_s1_all_repos_pass(monkeypatch):
     )
 
     assert out["emit"] == Event.ACCEPT_PASS.value
-    assert len(rc.calls) == 1, "exactly one exec_in_runner call expected"
+    # env-up + lite fallback = 2 calls
+    assert len(rc.calls) == 2, "expected env-up + lite fallback calls"
     assert any(u.get("accept_result") == "pass" for u in pool.ctx_updates), (
         "accept_result='pass' must be stored in ctx"
     )
@@ -91,9 +111,9 @@ async def test_aml_s1_all_repos_pass(monkeypatch):
 async def test_aml_s2_envup_fail_emits_accept_fail(monkeypatch):
     """Script exits 1, stdout ends with FAIL:repo-a → ACCEPT_FAIL, fail_repos in ctx."""
     rc = _FakeRC(
-        exit_code=1,
-        stdout="=== accept-env-up: repo-a ===\n=== FAIL accept-env-up: repo-a ===\nFAIL:repo-a\n",
-        stderr="make: *** [accept-env-up] Error 1",
+        lite_exit_code=1,
+        lite_stdout="=== accept-env-up: repo-a ===\n=== FAIL accept-env-up: repo-a ===\nFAIL:repo-a\n",
+        lite_stderr="make: *** [accept-env-up] Error 1",
     )
     pool = _FakePool()
     _patch(monkeypatch, rc, pool)
@@ -118,7 +138,7 @@ async def test_aml_s3_no_target_skips_repo_not_fail(monkeypatch):
     The exec IS called (Python doesn't short-circuit); the script decides to skip
     the repo and still exits 0 with 'PASS'.
     """
-    rc = _FakeRC(exit_code=0, stdout="PASS\n")  # script internally skipped the repo
+    rc = _FakeRC(lite_exit_code=0, lite_stdout="PASS\n")  # script internally skipped the repo
     pool = _FakePool()
     _patch(monkeypatch, rc, pool)
 
@@ -127,7 +147,8 @@ async def test_aml_s3_no_target_skips_repo_not_fail(monkeypatch):
     )
 
     assert out["emit"] == Event.ACCEPT_PASS.value
-    assert len(rc.calls) == 1, "exec_in_runner must still be called even when target might be absent"
+    # env-up + lite fallback = 2 calls
+    assert len(rc.calls) == 2, "expected env-up + lite fallback calls"
 
 
 # ─── AML-S4: empty cloned_repos → vacuous pass ───────────────────────────
@@ -144,4 +165,5 @@ async def test_aml_s4_empty_cloned_repos_vacuous_pass(monkeypatch):
     )
 
     assert out["emit"] == Event.ACCEPT_PASS.value
-    assert len(rc.calls) == 0, "exec_in_runner must NOT be called when there are no repos"
+    # env-up is still called (integration dir resolved), then lite fallback sees empty repos
+    assert len(rc.calls) == 1, "env-up call expected even when cloned_repos is empty"

--- a/thanatos/pyproject.toml
+++ b/thanatos/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "mcp>=1.2",
     "pydantic>=2.9",
     "pyyaml>=6.0",
+    "httpx>=0.27",
+    "playwright>=1.49",
 ]
 
 [project.optional-dependencies]

--- a/thanatos/src/thanatos/drivers/http.py
+++ b/thanatos/src/thanatos/drivers/http.py
@@ -1,6 +1,12 @@
-"""HTTP driver — REST/JSON API — M0 stub."""
+"""HTTP driver — REST/JSON API — M1 implementation."""
 
 from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import httpx
 
 from thanatos.drivers.base import (
     ActResult,
@@ -10,23 +16,255 @@ from thanatos.drivers.base import (
     SemanticTree,
 )
 
-_M0_MSG = "M0: scaffold only"
+# When POST /api/v1/order with body {"foo":"bar"}
+# When GET /api/v1/order/{id}
+_ACT_RE = re.compile(
+    r"^(?:When\s+)?"  # optional "When " prefix
+    r"(?P<method>GET|POST|PUT|PATCH|DELETE)\s+"
+    r"(?P<path>\S+)"
+    r"(?:\s+with\s+body\s+(?P<body>.+))?",
+    re.IGNORECASE,
+)
+
+# Then response code is 200
+# Then response body contains "foo"
+# Then response body order_id > 0
+_ASSERT_RE = re.compile(
+    r"^(?:Then\s+)?"
+    r"response\s+(?P<target>\S+)\s+"
+    r"(?P<op>is|contains|equals|==|!=|>|<|>=|<=)\s*"
+    r"(?P<expected>.+)?",
+    re.IGNORECASE,
+)
+
+# Dot-path for JSON body: body.order_id or body.items.0.name
+_DOT_PATH = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*|\.[0-9]+)*$")
 
 
 class HttpDriver:
     name: str = "http"
 
+    def __init__(self) -> None:
+        self._client: httpx.AsyncClient | None = None
+        self._last_response: httpx.Response | None = None
+        self._last_request_info: dict[str, Any] | None = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=30.0, follow_redirects=True)
+        return self._client
+
     async def preflight(self, endpoint: str) -> PreflightResult:
-        raise NotImplementedError(_M0_MSG)
+        client = await self._get_client()
+        try:
+            resp = await client.get(f"{endpoint}/healthz")
+            if resp.status_code == 200:
+                return PreflightResult(ok=True)
+            return PreflightResult(
+                ok=False,
+                failure_hint=f"healthz returned {resp.status_code}",
+            )
+        except Exception as exc:
+            return PreflightResult(
+                ok=False,
+                failure_hint=f"healthz failed: {exc}",
+            )
 
     async def observe(self) -> SemanticTree:
-        raise NotImplementedError(_M0_MSG)
+        if self._last_response is None:
+            return SemanticTree(kind="http", payload={})
+        payload = {
+            "status_code": self._last_response.status_code,
+            "headers": dict(self._last_response.headers),
+            "body": self._safe_json_body(self._last_response),
+        }
+        return SemanticTree(kind="http", payload=payload)
 
     async def act(self, step: str) -> ActResult:
-        raise NotImplementedError(_M0_MSG)
+        m = _ACT_RE.match(step.strip())
+        if m is None:
+            return ActResult(ok=False, failure_hint=f"unrecognised HTTP step: {step!r}")
+
+        method = m.group("method").upper()
+        path = m.group("path")
+        body_str = m.group("body")
+
+        body: Any = None
+        if body_str is not None:
+            body_str = body_str.strip()
+            try:
+                body = json.loads(body_str)
+            except json.JSONDecodeError:
+                body = body_str
+
+        client = await self._get_client()
+
+        try:
+            resp = await client.request(method, path, json=body if isinstance(body, (dict, list)) else None, content=body if isinstance(body, str) else None)
+        except Exception as exc:
+            self._last_response = None
+            self._last_request_info = {"method": method, "path": path, "error": str(exc)}
+            return ActResult(ok=False, failure_hint=f"{method} {path} failed: {exc}")
+
+        self._last_response = resp
+        self._last_request_info = {"method": method, "path": path, "status_code": resp.status_code}
+        return ActResult(ok=True)
 
     async def assert_(self, step: str) -> AssertResult:
-        raise NotImplementedError(_M0_MSG)
+        m = _ASSERT_RE.match(step.strip())
+        if m is None:
+            return AssertResult(ok=False, failure_hint=f"unrecognised assert step: {step!r}")
+
+        target = m.group("target").lower()
+        op = (m.group("op") or "is").lower()
+        expected_raw = (m.group("expected") or "").strip()
+
+        # "code" is a special target
+        if target == "code":
+            return self._assert_code(op, expected_raw)
+
+        # "body" or "body.xxx" targets
+        if target.startswith("body"):
+            return self._assert_body(target, op, expected_raw)
+
+        return AssertResult(
+            ok=False,
+            failure_hint=f"unsupported assert target: {target!r}",
+        )
+
+    def _assert_code(self, op: str, expected_raw: str) -> AssertResult:
+        if self._last_response is None:
+            return AssertResult(ok=False, failure_hint="no response to assert on")
+
+        try:
+            expected_val = int(expected_raw)
+        except ValueError:
+            return AssertResult(
+                ok=False,
+                failure_hint=f"expected status code must be int, got {expected_raw!r}",
+            )
+
+        actual = self._last_response.status_code
+        ok = self._compare(actual, op, expected_val)
+        if not ok:
+            return AssertResult(
+                ok=False,
+                failure_hint=f"status code {actual} {op} {expected_val} is false",
+            )
+        return AssertResult(ok=True)
+
+    def _assert_body(self, target: str, op: str, expected_raw: str) -> AssertResult:
+        if self._last_response is None:
+            return AssertResult(ok=False, failure_hint="no response to assert on")
+
+        body = self._safe_json_body(self._last_response)
+        if body is None:
+            return AssertResult(ok=False, failure_hint="response body is not JSON")
+
+        # target = "body" or "body.x.y.z"
+        if target == "body":
+            value = body
+        else:
+            # strip "body." prefix and walk
+            path = target[5:]  # after "body."
+            value = self._walk_path(body, path)
+            if value is self._NOT_FOUND:
+                return AssertResult(
+                    ok=False,
+                    failure_hint=f"JSON path '{path}' not found in body",
+                )
+
+        expected = self._coerce(expected_raw)
+        ok = self._compare(value, op, expected)
+        if not ok:
+            return AssertResult(
+                ok=False,
+                failure_hint=f"body {target} = {value!r} {op} {expected!r} is false",
+            )
+        return AssertResult(ok=True)
+
+    def _compare(self, actual: Any, op: str, expected: Any) -> bool:
+        if op in ("is", "equals", "=="):
+            return actual == expected
+        if op == "!=":
+            return actual != expected
+        if op == ">":
+            return actual is not None and expected is not None and actual > expected
+        if op == "<":
+            return actual is not None and expected is not None and actual < expected
+        if op == ">=":
+            return actual is not None and expected is not None and actual >= expected
+        if op == "<=":
+            return actual is not None and expected is not None and actual <= expected
+        if op == "contains":
+            if isinstance(actual, str) and isinstance(expected, str):
+                return expected in actual
+            if isinstance(actual, list):
+                return expected in actual
+            if isinstance(actual, dict):
+                return expected in actual.values()
+            return False
+        return False
+
+    def _coerce(self, raw: str) -> Any:
+        raw = raw.strip()
+        # JSON literal
+        if raw == "true":
+            return True
+        if raw == "false":
+            return False
+        if raw == "null" or raw == "None":
+            return None
+        # Quoted string
+        if (raw.startswith('"') and raw.endswith('"')) or (raw.startswith("'") and raw.endswith("'")):
+            return raw[1:-1]
+        # Integer
+        try:
+            return int(raw)
+        except ValueError:
+            pass
+        # Float
+        try:
+            return float(raw)
+        except ValueError:
+            pass
+        return raw
+
+    _NOT_FOUND = object()
+
+    def _walk_path(self, obj: Any, path: str) -> Any:
+        parts = path.split(".")
+        current = obj
+        for part in parts:
+            if isinstance(current, dict):
+                current = current.get(part, self._NOT_FOUND)
+            elif isinstance(current, list):
+                try:
+                    idx = int(part)
+                    current = current[idx] if 0 <= idx < len(current) else self._NOT_FOUND
+                except ValueError:
+                    return self._NOT_FOUND
+            else:
+                return self._NOT_FOUND
+            if current is self._NOT_FOUND:
+                return self._NOT_FOUND
+        return current
+
+    def _safe_json_body(self, response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except Exception:
+            return None
 
     async def capture_evidence(self) -> Evidence:
-        raise NotImplementedError(_M0_MSG)
+        network: list[dict[str, Any]] = []
+        if self._last_request_info is not None:
+            entry: dict[str, Any] = {"request": self._last_request_info.copy()}
+            if self._last_response is not None:
+                entry["response"] = {
+                    "status_code": self._last_response.status_code,
+                    "headers": dict(self._last_response.headers),
+                    "body": self._safe_json_body(self._last_response),
+                }
+            network.append(entry)
+        return Evidence(network=network)

--- a/thanatos/src/thanatos/drivers/playwright.py
+++ b/thanatos/src/thanatos/drivers/playwright.py
@@ -1,6 +1,10 @@
-"""Playwright driver — web (chromium subprocess) — M0 stub."""
+"""Playwright driver — web (chromium subprocess) — M1 implementation."""
 
 from __future__ import annotations
+
+import base64
+import re
+from typing import Any
 
 from thanatos.drivers.base import (
     ActResult,
@@ -10,23 +14,237 @@ from thanatos.drivers.base import (
     SemanticTree,
 )
 
-_M0_MSG = "M0: scaffold only"
+# UI action patterns
+# When click "Submit button"
+# When type "email@example.com" into "Email field"
+_ACT_CLICK_RE = re.compile(
+    r'^(?:When\s+)?click\s+"(?P<name>[^"]+)"',
+    re.IGNORECASE,
+)
+_ACT_TYPE_RE = re.compile(
+    r'^(?:When\s+)?type\s+"(?P<text>[^"]+)"\s+into\s+"(?P<name>[^"]+)"',
+    re.IGNORECASE,
+)
+
+# Assertion patterns
+# Then page title contains "Dashboard"
+# Then element "Success message" is visible
+_ASSERT_TITLE_RE = re.compile(
+    r'^(?:Then\s+)?page\s+title\s+contains\s+"(?P<text>[^"]+)"',
+    re.IGNORECASE,
+)
+_ASSERT_ELEMENT_VISIBLE_RE = re.compile(
+    r'^(?:Then\s+)?element\s+"(?P<name>[^"]+)"\s+is\s+visible',
+    re.IGNORECASE,
+)
+_ASSERT_ELEMENT_TEXT_RE = re.compile(
+    r'^(?:Then\s+)?element\s+"(?P<name>[^"]+)"\s+contains\s+"(?P<text>[^"]+)"',
+    re.IGNORECASE,
+)
 
 
 class PlaywrightDriver:
     name: str = "playwright"
 
+    def __init__(self) -> None:
+        self._playwright: Any | None = None
+        self._browser: Any | None = None
+        self._page: Any | None = None
+        self._endpoint: str | None = None
+
     async def preflight(self, endpoint: str) -> PreflightResult:
-        raise NotImplementedError(_M0_MSG)
+        self._endpoint = endpoint
+        try:
+            from playwright.async_api import async_playwright
+        except ImportError as exc:
+            return PreflightResult(
+                ok=False,
+                failure_hint=f"playwright not installed: {exc}",
+            )
+
+        try:
+            self._playwright = await async_playwright().start()
+            self._browser = await self._playwright.chromium.launch(headless=True)
+            self._page = await self._browser.new_page()
+            await self._page.goto(endpoint, wait_until="networkidle")
+        except Exception as exc:
+            return PreflightResult(
+                ok=False,
+                failure_hint=f"browser launch or navigate failed: {exc}",
+            )
+
+        try:
+            snapshot = await self._page.accessibility.snapshot()
+            node_count = self._count_a11y_nodes(snapshot)
+        except Exception:
+            node_count = None
+
+        return PreflightResult(ok=True, a11y_node_count=node_count)
 
     async def observe(self) -> SemanticTree:
-        raise NotImplementedError(_M0_MSG)
+        if self._page is None:
+            return SemanticTree(kind="a11y", payload={})
+        try:
+            snapshot = await self._page.accessibility.snapshot()
+        except Exception:
+            snapshot = {}
+        return SemanticTree(kind="a11y", payload=snapshot or {})
 
     async def act(self, step: str) -> ActResult:
-        raise NotImplementedError(_M0_MSG)
+        step = step.strip()
+
+        m = _ACT_CLICK_RE.match(step)
+        if m:
+            return await self._act_click(m.group("name"))
+
+        m = _ACT_TYPE_RE.match(step)
+        if m:
+            return await self._act_type(m.group("name"), m.group("text"))
+
+        return ActResult(ok=False, failure_hint=f"unrecognised UI step: {step!r}")
+
+    async def _act_click(self, name: str) -> ActResult:
+        if self._page is None:
+            return ActResult(ok=False, failure_hint="browser not initialised")
+        try:
+            elem = self._page.get_by_role("button", name=name)
+            count = await elem.count()
+            if count == 0:
+                elem = self._page.get_by_text(name)
+                count = await elem.count()
+            if count == 0:
+                elem = self._page.locator(f"[aria-label='{name}']")
+                count = await elem.count()
+            if count == 0:
+                return ActResult(ok=False, failure_hint=f"element '{name}' not found")
+            await elem.first.click()
+            return ActResult(ok=True)
+        except Exception as exc:
+            return ActResult(ok=False, failure_hint=f"click '{name}' failed: {exc}")
+
+    async def _act_type(self, name: str, text: str) -> ActResult:
+        if self._page is None:
+            return ActResult(ok=False, failure_hint="browser not initialised")
+        try:
+            elem = self._page.get_by_role("textbox", name=name)
+            count = await elem.count()
+            if count == 0:
+                elem = self._page.get_by_label(name)
+                count = await elem.count()
+            if count == 0:
+                elem = self._page.locator(f"[placeholder='{name}']")
+                count = await elem.count()
+            if count == 0:
+                return ActResult(ok=False, failure_hint=f"field '{name}' not found")
+            await elem.first.fill(text)
+            return ActResult(ok=True)
+        except Exception as exc:
+            return ActResult(ok=False, failure_hint=f"type '{text}' into '{name}' failed: {exc}")
 
     async def assert_(self, step: str) -> AssertResult:
-        raise NotImplementedError(_M0_MSG)
+        step = step.strip()
+
+        m = _ASSERT_TITLE_RE.match(step)
+        if m:
+            return await self._assert_title_contains(m.group("text"))
+
+        m = _ASSERT_ELEMENT_VISIBLE_RE.match(step)
+        if m:
+            return await self._assert_element_visible(m.group("name"))
+
+        m = _ASSERT_ELEMENT_TEXT_RE.match(step)
+        if m:
+            return await self._assert_element_contains(m.group("name"), m.group("text"))
+
+        return AssertResult(ok=False, failure_hint=f"unrecognised assert step: {step!r}")
+
+    async def _assert_title_contains(self, text: str) -> AssertResult:
+        if self._page is None:
+            return AssertResult(ok=False, failure_hint="browser not initialised")
+        try:
+            title = await self._page.title()
+        except Exception as exc:
+            return AssertResult(ok=False, failure_hint=f"get title failed: {exc}")
+        if text in title:
+            return AssertResult(ok=True)
+        return AssertResult(
+            ok=False,
+            failure_hint=f"page title '{title}' does not contain '{text}'",
+        )
+
+    async def _assert_element_visible(self, name: str) -> AssertResult:
+        if self._page is None:
+            return AssertResult(ok=False, failure_hint="browser not initialised")
+        try:
+            elem = self._page.get_by_text(name)
+            count = await elem.count()
+            if count == 0:
+                elem = self._page.get_by_role("generic", name=name)
+                count = await elem.count()
+            if count == 0:
+                return AssertResult(
+                    ok=False,
+                    failure_hint=f"element '{name}' not found",
+                )
+            visible = await elem.first.is_visible()
+            if visible:
+                return AssertResult(ok=True)
+            return AssertResult(
+                ok=False,
+                failure_hint=f"element '{name}' is not visible",
+            )
+        except Exception as exc:
+            return AssertResult(
+                ok=False,
+                failure_hint=f"assert visible '{name}' failed: {exc}",
+            )
+
+    async def _assert_element_contains(self, name: str, text: str) -> AssertResult:
+        if self._page is None:
+            return AssertResult(ok=False, failure_hint="browser not initialised")
+        try:
+            elem = self._page.get_by_text(name)
+            count = await elem.count()
+            if count == 0:
+                elem = self._page.locator(f"text={name}")
+                count = await elem.count()
+            if count == 0:
+                return AssertResult(
+                    ok=False,
+                    failure_hint=f"element '{name}' not found",
+                )
+            inner = await elem.first.inner_text()
+            if text in inner:
+                return AssertResult(ok=True)
+            return AssertResult(
+                ok=False,
+                failure_hint=f"element '{name}' text '{inner}' does not contain '{text}'",
+            )
+        except Exception as exc:
+            return AssertResult(
+                ok=False,
+                failure_hint=f"assert contains '{name}' failed: {exc}",
+            )
 
     async def capture_evidence(self) -> Evidence:
-        raise NotImplementedError(_M0_MSG)
+        screenshot_b64: str | None = None
+        dom: str | None = None
+        if self._page is not None:
+            try:
+                png_bytes = await self._page.screenshot()
+                screenshot_b64 = base64.b64encode(png_bytes).decode("ascii")
+            except Exception:
+                pass
+            try:
+                dom = await self._page.content()
+            except Exception:
+                pass
+        return Evidence(screenshot=screenshot_b64, dom=dom)
+
+    def _count_a11y_nodes(self, node: dict[str, Any] | None) -> int:
+        if node is None:
+            return 0
+        count = 1
+        for child in node.get("children") or []:
+            count += self._count_a11y_nodes(child)
+        return count

--- a/thanatos/src/thanatos/runner.py
+++ b/thanatos/src/thanatos/runner.py
@@ -1,9 +1,9 @@
 """Scenario runner.
 
-M0 dispatch: load skill → pick driver class by ``skill.driver`` → return a
-``ScenarioResult`` with ``passed=False`` and a ``failure_hint`` explaining the
-M0 stub. The scenario parser *is* called for real (so a malformed spec.md
-errors before MCP returns), but no driver method is invoked.
+M1 dispatch: load skill → pick driver → preflight → for each scenario
+execute given/when steps via driver.act and then steps via driver.assert_.
+On any assertion failure capture_evidence is called and the scenario is
+marked failed.
 """
 
 from __future__ import annotations
@@ -11,14 +11,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from thanatos.drivers import AdbDriver, Driver, HttpDriver, PlaywrightDriver
-from thanatos.result import ScenarioResult
+from thanatos.result import Evidence, ScenarioResult, StepResult
 from thanatos.scenario import parse_spec_file
 from thanatos.skill import load_skill
 
 if TYPE_CHECKING:
     pass
-
-_M0_HINT = "M0: thanatos scaffold only, drivers not implemented"
 
 
 def _pick_driver(driver_name: str) -> Driver:
@@ -31,10 +29,10 @@ def _pick_driver(driver_name: str) -> Driver:
     raise ValueError(f"unknown driver: {driver_name!r}")
 
 
-def run_scenario(
+async def run_scenario(
     skill_path: str, spec_path: str, scenario_id: str, endpoint: str
 ) -> ScenarioResult:
-    """Run a single scenario by id. M0: stub — parser runs, drivers don't."""
+    """Run a single scenario by id."""
     skill = load_skill(skill_path)
     parsed = parse_spec_file(spec_path)
     found = next((s for s in parsed if s.scenario_id == scenario_id), None)
@@ -44,26 +42,92 @@ def run_scenario(
             passed=False,
             failure_hint=f"scenario id {scenario_id!r} not found in {spec_path}",
         )
-    # In M1 we'd: pick driver, preflight, then for each step act/assert with
-    # capture_evidence on failure. M0 records the dispatch decision without
-    # actually invoking the driver.
-    _ = _pick_driver(skill.driver)
+
+    driver = _pick_driver(skill.driver)
+
+    # Preflight
+    preflight = await driver.preflight(endpoint)
+    if not preflight.ok:
+        return ScenarioResult(
+            scenario_id=scenario_id,
+            passed=False,
+            failure_hint=f"preflight failed: {preflight.failure_hint}",
+        )
+
+    steps: list[StepResult] = []
+
+    # Execute given steps
+    for step in found.given:
+        act_result = await driver.act(step)
+        steps.append(
+            StepResult(
+                step=step,
+                ok=act_result.ok,
+                evidence=Evidence() if act_result.ok else await driver.capture_evidence(),
+            )
+        )
+        if not act_result.ok:
+            return ScenarioResult(
+                scenario_id=scenario_id,
+                passed=False,
+                failure_hint=f"GIVEN step failed: {act_result.failure_hint}",
+                steps=steps,
+            )
+
+    # Execute when steps
+    for step in found.when:
+        act_result = await driver.act(step)
+        steps.append(
+            StepResult(
+                step=step,
+                ok=act_result.ok,
+                evidence=Evidence() if act_result.ok else await driver.capture_evidence(),
+            )
+        )
+        if not act_result.ok:
+            return ScenarioResult(
+                scenario_id=scenario_id,
+                passed=False,
+                failure_hint=f"WHEN step failed: {act_result.failure_hint}",
+                steps=steps,
+            )
+
+    # Execute then steps
+    for step in found.then:
+        assert_result = await driver.assert_(step)
+        if not assert_result.ok:
+            evidence = await driver.capture_evidence()
+            steps.append(
+                StepResult(
+                    step=step,
+                    ok=False,
+                    evidence=evidence,
+                )
+            )
+            return ScenarioResult(
+                scenario_id=scenario_id,
+                passed=False,
+                failure_hint=f"THEN step failed: {assert_result.failure_hint}",
+                steps=steps,
+            )
+        steps.append(StepResult(step=step, ok=True))
+
     return ScenarioResult(
         scenario_id=scenario_id,
-        passed=False,
-        failure_hint=_M0_HINT,
+        passed=True,
+        steps=steps,
     )
 
 
-def run_all(skill_path: str, spec_path: str, endpoint: str) -> list[ScenarioResult]:
-    """Run every scenario in a spec. M0: parses then stubs each one."""
+async def run_all(skill_path: str, spec_path: str, endpoint: str) -> list[ScenarioResult]:
+    """Run every scenario in a spec."""
     parsed = parse_spec_file(spec_path)
     return [
-        run_scenario(skill_path, spec_path, p.scenario_id, endpoint) for p in parsed
+        await run_scenario(skill_path, spec_path, p.scenario_id, endpoint) for p in parsed
     ]
 
 
 def recall(skill_path: str, intent: str) -> list[dict]:
-    """Look up product knowledge by intent. M0: always returns empty list."""
+    """Look up product knowledge by intent. M1: always returns empty list."""
     _ = (skill_path, intent)
     return []

--- a/thanatos/src/thanatos/server.py
+++ b/thanatos/src/thanatos/server.py
@@ -29,7 +29,7 @@ def _build_server() -> Server:
                 name="run_scenario",
                 description=(
                     "Run a single scenario from a spec.md against an endpoint. "
-                    "M0 returns pass=false with a scaffold-only hint."
+                    "M1 executes driver act/assert steps and returns pass/fail with evidence."
                 ),
                 inputSchema={
                     "type": "object",
@@ -46,7 +46,7 @@ def _build_server() -> Server:
                 name="run_all",
                 description=(
                     "Run every scenario in a spec.md against an endpoint. "
-                    "M0 returns one stub result per scenario."
+                    "M1 executes all scenarios and returns results with evidence."
                 ),
                 inputSchema={
                     "type": "object",
@@ -80,7 +80,7 @@ def _build_server() -> Server:
         import json as _json
 
         if name == "run_scenario":
-            res = _run_scenario(
+            res = await _run_scenario(
                 arguments["skill_path"],
                 arguments["spec_path"],
                 arguments["scenario_id"],
@@ -88,7 +88,7 @@ def _build_server() -> Server:
             )
             return [TextContent(type="text", text=_json.dumps(res.to_dict()))]
         if name == "run_all":
-            results = _run_all(
+            results = await _run_all(
                 arguments["skill_path"],
                 arguments["spec_path"],
                 arguments["endpoint"],

--- a/thanatos/tests/test_contract_thanatos.py
+++ b/thanatos/tests/test_contract_thanatos.py
@@ -135,21 +135,18 @@ def test_than_s4_mixed_format_raises():
     )
 
 
-# ─── THAN-S5: every M0 driver method raises NotImplementedError ──────────────
+# ─── THAN-S5: AdbDriver remains M0 stub; Http/Playwright drivers are M1 ──────
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("driver_name", ["PlaywrightDriver", "AdbDriver", "HttpDriver"])
 @pytest.mark.parametrize(
     "method_name", ["preflight", "observe", "act", "assert_", "capture_evidence"]
 )
-async def test_than_s5_driver_raises_not_implemented(driver_name, method_name):
-    """THAN-S5: every M0 driver method raises NotImplementedError('M0: scaffold only')."""
-    import importlib
+async def test_than_s5_adb_driver_raises_not_implemented(method_name):
+    """THAN-S5: AdbDriver is still M0 scaffold — every method raises NotImplementedError."""
+    from thanatos.drivers import AdbDriver
 
-    drivers_mod = importlib.import_module("thanatos.drivers")
-    driver_class = getattr(drivers_mod, driver_name)
-    instance = driver_class()
+    instance = AdbDriver()
     method = getattr(instance, method_name)
 
     if method_name == "preflight":
@@ -162,8 +159,27 @@ async def test_than_s5_driver_raises_not_implemented(driver_name, method_name):
     with pytest.raises(NotImplementedError) as exc_info:
         await coro
     assert str(exc_info.value) == "M0: scaffold only", (
-        f"{driver_name}.{method_name}: got '{exc_info.value}'"
+        f"AdbDriver.{method_name}: got '{exc_info.value}'"
     )
+
+
+@pytest.mark.integration
+async def test_than_s5b_http_driver_no_longer_stub():
+    """THAN-S5b: HttpDriver M1 preflight returns a PreflightResult, not NotImplementedError."""
+    from thanatos.drivers import HttpDriver
+    from thanatos.drivers.base import PreflightResult
+
+    driver = HttpDriver()
+    # preflight hits network; mock it via overriding _client
+    import httpx
+    mock_client = httpx.AsyncClient(transport=httpx.MockTransport(lambda req: httpx.Response(200)))
+    driver._client = mock_client
+    try:
+        result = await driver.preflight("http://localhost")
+        assert isinstance(result, PreflightResult)
+        assert result.ok is True
+    finally:
+        await mock_client.aclose()
 
 
 # ─── THAN-S6: driver=adb → two-container Pod (redroid + thanatos) ─────────────

--- a/thanatos/tests/test_contract_thanatos_m1.py
+++ b/thanatos/tests/test_contract_thanatos_m1.py
@@ -1,0 +1,278 @@
+"""Contract tests for REQ-thanatos-m1-impl-1777389456 — THAN-M1-S1 through THAN-M1-S6.
+
+Black-box only: public API, driver protocol, and runner behavior. No internal
+implementation details. All tests marked @pytest.mark.integration.
+
+Derived from:
+  openspec/changes/REQ-thanatos-m1-impl-1777389456/specs/thanatos/spec.md
+"""
+from __future__ import annotations
+
+import json
+import textwrap
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import httpx
+import pytest
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+class _MockHandler(BaseHTTPRequestHandler):
+    """Base handler that suppresses request logging."""
+
+    def log_message(self, format, *args):
+        pass
+
+
+class _Healthz200Handler(_MockHandler):
+    """Returns 200 on /healthz, 404 on everything else."""
+
+    def do_GET(self):
+        if self.path == "/healthz":
+            self.send_response(200)
+            self.end_headers()
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+class _All200Handler(_MockHandler):
+    """Returns 200 for any GET or POST."""
+
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+
+    def do_POST(self):
+        self.send_response(200)
+        self.end_headers()
+
+
+class _CaptureRequestHandler(_MockHandler):
+    """Captures the last request for inspection."""
+
+    last_request: dict | None = None
+
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+
+    def do_POST(self):
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length) if content_length else b""
+        _CaptureRequestHandler.last_request = {
+            "method": "POST",
+            "path": self.path,
+            "body": body,
+        }
+        self.send_response(200)
+        self.end_headers()
+
+
+class _JSONResponseHandler(_MockHandler):
+    """Returns configurable JSON responses."""
+
+    responses: dict[str, tuple[int, dict]] = {}
+
+    def do_GET(self):
+        status, data = self.responses.get(self.path, (200, {}))
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(data).encode())
+
+
+class _ThreadedMockServer:
+    def __init__(self, handler_class):
+        self.server = HTTPServer(("127.0.0.1", 0), handler_class)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def start(self):
+        self.thread.start()
+        return self
+
+    def stop(self):
+        self.server.shutdown()
+
+    @property
+    def url(self):
+        return f"http://127.0.0.1:{self.port}"
+
+
+def _make_skill_file(path, driver: str = "http", entry: str = ""):
+    path.write_text(
+        f"name: test-skill\ndriver: {driver}\nentry: {entry}\n",
+        encoding="utf-8",
+    )
+
+
+def _make_spec_file(path, scenario_id: str, given: list[str], when: list[str], then: list[str]):
+    lines = [f"#### Scenario: {scenario_id}", ""]
+    for step in given:
+        lines.append(f"- **GIVEN** {step}")
+    for step in when:
+        lines.append(f"- **WHEN** {step}")
+    for step in then:
+        lines.append(f"- **THEN** {step}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ─── THAN-M1-S1: HTTP preflight returns ok on 200 healthz ────────────────────
+
+
+@pytest.mark.integration
+async def test_than_m1_s1_http_preflight_healthz_200():
+    """THAN-M1-S1: HttpDriver.preflight returns ok=True when /healthz returns 200."""
+    from thanatos.drivers import HttpDriver
+    from thanatos.drivers.base import PreflightResult
+
+    driver = HttpDriver()
+    mock_transport = httpx.MockTransport(lambda req: httpx.Response(200))
+    mock_client = httpx.AsyncClient(transport=mock_transport)
+    driver._client = mock_client
+    try:
+        result = await driver.preflight("http://localhost:8080")
+        assert isinstance(result, PreflightResult)
+        assert result.ok is True
+    finally:
+        await mock_client.aclose()
+
+
+# ─── THAN-M1-S2: HTTP act executes POST with JSON body ───────────────────────
+
+
+@pytest.mark.integration
+async def test_than_m1_s2_http_act_post_json():
+    """THAN-M1-S2: act('POST /api/order with body {"id":1}') sends correct request."""
+    from thanatos.drivers import HttpDriver
+
+    captured: dict = {}
+
+    def handler(req):
+        captured["method"] = req.method
+        captured["path"] = req.url.path
+        captured["body"] = req.content
+        return httpx.Response(200)
+
+    driver = HttpDriver()
+    mock_transport = httpx.MockTransport(handler)
+    mock_client = httpx.AsyncClient(transport=mock_transport)
+    driver._client = mock_client
+    try:
+        result = await driver.act('POST /api/order with body {"id":1}')
+        assert result.ok is True
+        assert captured.get("method") == "POST"
+        assert captured.get("path") == "/api/order"
+        assert json.loads(captured.get("body", b"{}")) == {"id": 1}
+    finally:
+        await mock_client.aclose()
+
+
+# ─── THAN-M1-S3: HTTP assert_ checks status code ─────────────────────────────
+
+
+@pytest.mark.integration
+async def test_than_m1_s3_http_assert_status_code():
+    """THAN-M1-S3: assert_('response code is 201') returns ok=True when response is 201."""
+    from thanatos.drivers import HttpDriver
+
+    driver = HttpDriver()
+    mock_transport = httpx.MockTransport(lambda req: httpx.Response(201))
+    mock_client = httpx.AsyncClient(transport=mock_transport)
+    driver._client = mock_client
+    try:
+        await driver.act("GET /something")
+        result = await driver.assert_("response code is 201")
+        assert result.ok is True
+    finally:
+        await mock_client.aclose()
+
+
+# ─── THAN-M1-S4: HTTP assert_ checks JSON body path ──────────────────────────
+
+
+@pytest.mark.integration
+async def test_than_m1_s4_http_assert_json_path():
+    """THAN-M1-S4: assert_('response body.order.id is 42') returns ok=True."""
+    from thanatos.drivers import HttpDriver
+
+    driver = HttpDriver()
+    mock_transport = httpx.MockTransport(
+        lambda req: httpx.Response(200, json={"order": {"id": 42}})
+    )
+    mock_client = httpx.AsyncClient(transport=mock_transport)
+    driver._client = mock_client
+    try:
+        await driver.act("GET /something")
+        result = await driver.assert_("response body.order.id is 42")
+        assert result.ok is True
+    finally:
+        await mock_client.aclose()
+
+
+# ─── THAN-M1-S5: runner executes all steps and reports pass ──────────────────
+
+
+@pytest.mark.integration
+async def test_than_m1_s5_runner_all_steps_pass(tmp_path):
+    """THAN-M1-S5: run_all with a passing scenario returns passed=True with step results."""
+    from thanatos.runner import run_all
+
+    server = _ThreadedMockServer(_All200Handler).start()
+    try:
+        skill_path = tmp_path / "skill.yaml"
+        _make_skill_file(skill_path, driver="http", entry=server.url)
+
+        spec_path = tmp_path / "spec.md"
+        _make_spec_file(
+            spec_path,
+            scenario_id="TEST-PASS-S1",
+            given=[f"GET {server.url}/healthz"],
+            when=[f"POST {server.url}/api/test with body {{}}"],
+            then=["response code is 200"],
+        )
+
+        results = await run_all(str(skill_path), str(spec_path), server.url)
+        assert len(results) == 1
+        result = results[0]
+        assert result.passed is True
+        assert len(result.steps) == 3
+        assert all(s.ok for s in result.steps)
+    finally:
+        server.stop()
+
+
+# ─── THAN-M1-S6: runner captures evidence on assert failure ──────────────────
+
+
+@pytest.mark.integration
+async def test_than_m1_s6_runner_captures_evidence_on_failure(tmp_path):
+    """THAN-M1-S6: run_scenario with a failing THEN step returns passed=False and attaches evidence."""
+    from thanatos.runner import run_scenario
+
+    server = _ThreadedMockServer(_Healthz200Handler).start()
+    try:
+        skill_path = tmp_path / "skill.yaml"
+        _make_skill_file(skill_path, driver="http", entry=server.url)
+
+        spec_path = tmp_path / "spec.md"
+        _make_spec_file(
+            spec_path,
+            scenario_id="TEST-FAIL-S1",
+            given=[f"GET {server.url}/healthz"],
+            when=[],
+            then=["response code is 404"],
+        )
+
+        result = await run_scenario(str(skill_path), str(spec_path), "TEST-FAIL-S1", server.url)
+        assert result.passed is False
+        assert result.steps
+        failing_step = result.steps[-1]
+        assert failing_step.ok is False
+        assert failing_step.evidence is not None
+    finally:
+        server.stop()

--- a/thanatos/tests/test_http_driver.py
+++ b/thanatos/tests/test_http_driver.py
@@ -1,0 +1,262 @@
+"""Unit tests for HTTP driver — mock httpx.
+
+All tests mock httpx.AsyncClient to avoid real network calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from thanatos.drivers.http import HttpDriver
+
+
+@pytest.fixture
+def driver():
+    return HttpDriver()
+
+
+@pytest.fixture
+def mock_response():
+    """Return a mock httpx.Response with configurable attributes."""
+    def _make(status_code=200, json_data=None, headers=None, text=""):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.headers = headers or {}
+        if json_data is not None:
+            resp.json.return_value = json_data
+        else:
+            resp.json.side_effect = Exception("not json")
+        resp.text = text
+        return resp
+    return _make
+
+
+@pytest.fixture
+def mock_client(mock_response):
+    """Patch httpx.AsyncClient on the driver instance."""
+    def _patch(driver: HttpDriver, response: Any = None, request_exc: Exception | None = None):
+        client = AsyncMock()
+        if request_exc:
+            client.request.side_effect = request_exc
+            client.get.side_effect = request_exc
+        else:
+            client.request.return_value = response
+            client.get.return_value = response
+        driver._client = client
+        return client
+    return _patch
+
+
+# ─── preflight ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_preflight_ok(driver, mock_response, mock_client):
+    resp = mock_response(status_code=200, json_data={"status": "ok"})
+    mock_client(driver, resp)
+
+    result = await driver.preflight("http://example.com")
+    assert result.ok is True
+    assert result.failure_hint is None
+
+
+@pytest.mark.asyncio
+async def test_preflight_bad_status(driver, mock_response, mock_client):
+    resp = mock_response(status_code=503)
+    mock_client(driver, resp)
+
+    result = await driver.preflight("http://example.com")
+    assert result.ok is False
+    assert "503" in (result.failure_hint or "")
+
+
+@pytest.mark.asyncio
+async def test_preflight_network_error(driver, mock_client):
+    mock_client(driver, request_exc=ConnectionError("refused"))
+
+    result = await driver.preflight("http://example.com")
+    assert result.ok is False
+    assert "refused" in (result.failure_hint or "")
+
+
+# ─── observe ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def testobserve_no_response(driver):
+    tree = await driver.observe()
+    assert tree.kind == "http"
+    assert tree.payload == {}
+
+
+@pytest.mark.asyncio
+async def test_observe_with_response(driver, mock_response, mock_client):
+    resp = mock_response(
+        status_code=201,
+        json_data={"id": 42},
+        headers={"content-type": "application/json"},
+    )
+    mock_client(driver, resp)
+
+    # seed last_response via act
+    await driver.act("POST /api/order with body {}")
+    tree = await driver.observe()
+    assert tree.kind == "http"
+    assert tree.payload["status_code"] == 201
+    assert tree.payload["body"] == {"id": 42}
+
+
+# ─── act ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_act_post_with_body(driver, mock_response, mock_client):
+    resp = mock_response(status_code=200, json_data={"ok": True})
+    client = mock_client(driver, resp)
+
+    result = await driver.act('POST /api/v1/order with body {"foo":"bar"}')
+    assert result.ok is True
+    client.request.assert_awaited_once_with(
+        "POST", "/api/v1/order",
+        json={"foo": "bar"}, content=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_act_get_path(driver, mock_response, mock_client):
+    resp = mock_response(status_code=200, json_data={"id": 1})
+    client = mock_client(driver, resp)
+
+    result = await driver.act("GET /api/v1/order/123")
+    assert result.ok is True
+    client.request.assert_awaited_once_with(
+        "GET", "/api/v1/order/123",
+        json=None, content=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_act_unrecognised_step(driver):
+    result = await driver.act("Something weird")
+    assert result.ok is False
+    assert "unrecognised" in (result.failure_hint or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_act_network_error(driver, mock_client):
+    mock_client(driver, request_exc=TimeoutError("slow"))
+
+    result = await driver.act("GET /api/v1/order")
+    assert result.ok is False
+    assert "slow" in (result.failure_hint or "")
+
+
+# ─── assert_ ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_assert_code_equals(driver, mock_response, mock_client):
+    resp = mock_response(status_code=200)
+    mock_client(driver, resp)
+    await driver.act("GET /api/v1/order")
+
+    result = await driver.assert_("Then response code is 200")
+    assert result.ok is True
+
+
+@pytest.mark.asyncio
+async def test_assert_code_not_equals(driver, mock_response, mock_client):
+    resp = mock_response(status_code=404)
+    mock_client(driver, resp)
+    await driver.act("GET /api/v1/order")
+
+    result = await driver.assert_("Then response code is 200")
+    assert result.ok is False
+    assert "404" in (result.failure_hint or "")
+
+
+@pytest.mark.asyncio
+async def test_assert_body_jsonpath(driver, mock_response, mock_client):
+    resp = mock_response(status_code=200, json_data={"order": {"id": 42}})
+    mock_client(driver, resp)
+    await driver.act("GET /api/v1/order")
+
+    result = await driver.assert_("Then response body.order.id is 42")
+    assert result.ok is True
+
+
+@pytest.mark.asyncio
+async def test_assert_body_contains(driver, mock_response, mock_client):
+    resp = mock_response(status_code=200, json_data={"status": "success"})
+    mock_client(driver, resp)
+    await driver.act("GET /api/v1/order")
+
+    result = await driver.assert_("Then response body contains success")
+    assert result.ok is True
+
+
+@pytest.mark.asyncio
+async def test_assert_no_response(driver):
+    result = await driver.assert_("Then response code is 200")
+    assert result.ok is False
+    assert "no response" in (result.failure_hint or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_assert_unrecognised_target(driver, mock_response, mock_client):
+    resp = mock_response(status_code=200)
+    mock_client(driver, resp)
+    await driver.act("GET /api/v1/order")
+
+    result = await driver.assert_("Then response header x-foo is bar")
+    assert result.ok is False
+    assert "unrecognised" in (result.failure_hint or "").lower()
+
+
+# ─── capture_evidence ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_capture_evidence_empty(driver):
+    evidence = await driver.capture_evidence()
+    assert evidence.network == []
+
+
+@pytest.mark.asyncio
+async def test_capture_evidence_with_request(driver, mock_response, mock_client):
+    resp = mock_response(status_code=200, json_data={"ok": True}, headers={"h": "v"})
+    mock_client(driver, resp)
+    await driver.act("POST /api/v1/order with body {}")
+
+    evidence = await driver.capture_evidence()
+    assert len(evidence.network) == 1
+    entry = evidence.network[0]
+    assert entry["request"]["method"] == "POST"
+    assert entry["response"]["status_code"] == 200
+    assert entry["response"]["body"] == {"ok": True}
+
+
+# ─── coercion / comparison edge cases ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_assert_coerce_string_quoted(driver, mock_response, mock_client):
+    resp = mock_response(status_code=200, json_data={"name": "alice"})
+    mock_client(driver, resp)
+    await driver.act("GET /api/v1/user")
+
+    result = await driver.assert_('Then response body.name is "alice"')
+    assert result.ok is True
+
+
+@pytest.mark.asyncio
+async def test_assert_coerce_boolean(driver, mock_response, mock_client):
+    resp = mock_response(status_code=200, json_data={"active": True})
+    mock_client(driver, resp)
+    await driver.act("GET /api/v1/user")
+
+    result = await driver.assert_("Then response body.active is true")
+    assert result.ok is True

--- a/thanatos/tests/test_runner.py
+++ b/thanatos/tests/test_runner.py
@@ -1,0 +1,182 @@
+"""Unit tests for thanatos.runner — mock driver to verify execute flow."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from thanatos.drivers.base import ActResult, AssertResult, Evidence, PreflightResult
+from thanatos.runner import _pick_driver, run_all, run_scenario
+
+
+@pytest.fixture
+def fake_skill_file(tmp_path):
+    p = tmp_path / ".thanatos" / "skill.yaml"
+    p.parent.mkdir(parents=True)
+    p.write_text(
+        'name: "test-skill"\ndriver: http\nentry: /api\n',
+        encoding="utf-8",
+    )
+    return str(p)
+
+
+@pytest.fixture
+def fake_spec_file(tmp_path):
+    p = tmp_path / "spec.md"
+    p.write_text(
+        "#### Scenario: S1\n\n"
+        "```gherkin\n"
+        "Given setup\n"
+        "When POST /api/test with body {}\n"
+        "Then response code is 200\n"
+        "```\n",
+        encoding="utf-8",
+    )
+    return str(p)
+
+
+@pytest.fixture
+def fake_spec_multi(tmp_path):
+    p = tmp_path / "spec_multi.md"
+    p.write_text(
+        "#### Scenario: S1\n\n"
+        "```gherkin\n"
+        "Given setup\n"
+        "When POST /api/test with body {}\n"
+        "Then response code is 200\n"
+        "```\n\n"
+        "#### Scenario: S2\n\n"
+        "```gherkin\n"
+        "Given other\n"
+        "When GET /api/other\n"
+        "Then response code is 404\n"
+        "```\n",
+        encoding="utf-8",
+    )
+    return str(p)
+
+
+class _MockHttpDriver:
+    """Stand-in for HttpDriver with async methods."""
+
+    name = "http"
+
+    def __init__(self) -> None:
+        self.preflight = AsyncMock(return_value=PreflightResult(ok=True))
+        self.act = AsyncMock(return_value=ActResult(ok=True))
+        self.assert_ = AsyncMock(return_value=AssertResult(ok=True))
+        self.capture_evidence = AsyncMock(return_value=Evidence(network=[{"mock": True}]))
+        self.observe = AsyncMock()
+
+
+@pytest.fixture
+def mock_http_driver(monkeypatch):
+    """Patch _pick_driver to return a fully mocked HttpDriver."""
+    instance = _MockHttpDriver()
+
+    def _pick(name: str) -> Any:
+        return instance
+
+    monkeypatch.setattr("thanatos.runner._pick_driver", _pick)
+    return instance
+
+
+# ─── _pick_driver ───────────────────────────────────────────────────────────
+
+
+def test_pick_driver_http():
+    d = _pick_driver("http")
+    assert d.name == "http"
+
+
+def test_pick_driver_playwright():
+    d = _pick_driver("playwright")
+    assert d.name == "playwright"
+
+
+def test_pick_driver_unknown():
+    with pytest.raises(ValueError, match="unknown driver"):
+        _pick_driver("grpc")
+
+
+# ─── run_scenario ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_scenario_not_found(fake_skill_file, fake_spec_file, mock_http_driver):
+    result = await run_scenario(fake_skill_file, fake_spec_file, "MISSING", "http://localhost")
+    assert result.passed is False
+    assert "not found" in (result.failure_hint or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_run_scenario_happy_path(fake_skill_file, fake_spec_file, mock_http_driver):
+    result = await run_scenario(fake_skill_file, fake_spec_file, "S1", "http://localhost")
+    assert result.passed is True
+    assert result.scenario_id == "S1"
+    assert len(result.steps) == 3  # given + when + then
+
+    mock_http_driver.preflight.assert_awaited_once_with("http://localhost")
+    mock_http_driver.act.assert_any_await("setup")
+    mock_http_driver.act.assert_any_await("POST /api/test with body {}")
+    mock_http_driver.assert_.assert_awaited_once_with("response code is 200")
+
+
+@pytest.mark.asyncio
+async def test_run_scenario_preflight_fail(fake_skill_file, fake_spec_file, mock_http_driver):
+    mock_http_driver.preflight.return_value = PreflightResult(ok=False, failure_hint="down")
+
+    result = await run_scenario(fake_skill_file, fake_spec_file, "S1", "http://localhost")
+    assert result.passed is False
+    assert "preflight failed" in (result.failure_hint or "").lower()
+    mock_http_driver.act.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_scenario_given_act_fail(fake_skill_file, fake_spec_file, mock_http_driver):
+    mock_http_driver.act.side_effect = [
+        ActResult(ok=False, failure_hint="bad setup"),
+    ]
+
+    result = await run_scenario(fake_skill_file, fake_spec_file, "S1", "http://localhost")
+    assert result.passed is False
+    assert "given step failed" in (result.failure_hint or "").lower()
+    assert len(result.steps) == 1
+    assert result.steps[0].ok is False
+    # evidence captured on failure
+    mock_http_driver.capture_evidence.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_scenario_then_assert_fail(fake_skill_file, fake_spec_file, mock_http_driver):
+    mock_http_driver.assert_.return_value = AssertResult(ok=False, failure_hint="expected 201")
+
+    result = await run_scenario(fake_skill_file, fake_spec_file, "S1", "http://localhost")
+    assert result.passed is False
+    assert "then step failed" in (result.failure_hint or "").lower()
+    assert len(result.steps) == 3
+    assert result.steps[2].ok is False
+    mock_http_driver.capture_evidence.assert_awaited()
+
+
+# ─── run_all ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_all_multi(fake_skill_file, fake_spec_multi, mock_http_driver):
+    results = await run_all(fake_skill_file, fake_spec_multi, "http://localhost")
+    assert len(results) == 2
+    assert results[0].scenario_id == "S1"
+    assert results[1].scenario_id == "S2"
+    assert all(r.passed for r in results)
+
+
+@pytest.mark.asyncio
+async def test_run_all_empty_spec(tmp_path, fake_skill_file, mock_http_driver):
+    empty_spec = tmp_path / "empty.md"
+    empty_spec.write_text("# no scenarios\n", encoding="utf-8")
+
+    results = await run_all(fake_skill_file, str(empty_spec), "http://localhost")
+    assert results == []

--- a/thanatos/uv.lock
+++ b/thanatos/uv.lock
@@ -178,6 +178,53 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cb/baa584cb00532126ffe12d9787db0a60c5a4f55c27bfe2666df5d4c30a32/greenlet-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2", size = 235615, upload-time = "2026-04-27T12:21:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -424,6 +471,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -543,6 +609,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -828,7 +906,9 @@ name = "thanatos"
 version = "0.0.1"
 source = { editable = "." }
 dependencies = [
+    { name = "httpx" },
     { name = "mcp" },
+    { name = "playwright" },
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
@@ -851,8 +931,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
     { name = "mcp", specifier = ">=1.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
+    { name = "playwright", specifier = ">=1.49" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },


### PR DESCRIPTION
## 动机

thanatos M0 仅冻结了 driver Protocol 和 MCP server 接口，所有 driver 方法抛 `NotImplementedError`。create_accept.py 在 REQ-accept-m1-lite 中被改成了 v0.3-lite（纯 make target 方案），偏离了 thanatos MCP 的设计方向。

本 PR 让 thanatos 从 scaffold 变成**可执行的统一验收层**，恢复 thanatos MCP 在 sisyphus 流水线中的位置。

## 变更内容

### thanatos 模块
- **HTTP driver** (`drivers/http.py`): 实现 5 方法 async 契约
  - `preflight`: curl `GET {endpoint}/healthz`
  - `act`: 解析 When POST/GET/PUT/PATCH/DELETE + body JSON，用 httpx 执行
  - `assert_`: 解析 Then `response code is 200` / `response.body.order_id > 0`，支持 JSONPath 点号路径
  - `capture_evidence`: 记录 request/response network trace
- **Playwright driver** (`drivers/playwright.py`): 实现 5 方法
  - `preflight`: 启动 chromium + navigate
  - `act`: click / type UI 操作（a11y snapshot 定位）
  - `assert_`: page title / element visible / text contains
  - `capture_evidence`: screenshot (base64 PNG) + DOM
- **runner** (`runner.py`): `run_scenario` / `run_all` 改为 async，实现完整执行链
  - preflight → given → when → then
  - 断言失败自动 `capture_evidence()`
- **MCP server** (`server.py`): 适配 async runner 调用

### orchestrator 模块
- **create_accept.py**: 恢复 thanatos MCP 路径
  - env-up → 解析 endpoint JSON 中的 `thanatos` block → 派 accept-agent BKD issue
  - 无 `thanatos` block 时 fallback 到 v0.3-lite shell script
- **accept.md.j2**: 恢复 thanatos MCP 调用指引（验证 endpoint → 解析 skill/spec → 调 `run_all`）

### 测试
- 新建 `test_http_driver.py`: 19 个 mock httpx 单元测试
- 新建 `test_runner.py`: 10 个 mock driver flow 测试
- 更新 `test_contract_thanatos.py`: THAN-S5 改为仅验证 AdbDriver 仍为 stub，新增 THAN-S5b 验证 HttpDriver 已实现
- 更新 orchestrator `test_create_accept_minimal.py` / `test_actions_smoke.py` 适配 thanatos MCP + fallback 逻辑

## 测试方案

- `cd thanatos && uv run pytest -m 'not integration'` — 44 passed
- `make ci-lint` — ruff 全绿
- `make ci-unit-test` — orchestrator 1834 passed + thanatos 44 passed
- `python -m thanatos.server` — MCP stdio server 正常启动并响应 initialize

## 约束

- ADB driver 保持 M0 stub（M2/M3 范围）
- thanatos helm chart PVC 挂载等是 M2 范围，不在本 PR

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-thanatos-m1-impl-1777389456`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/zp16x9ob)