### PR TITLE
fix(acceptance): 堵死空壳scenario + analyze不知验收标准两个漏网 [REQ-fix-acceptance-leaks-1777420049]

### DIFF
--- a/orchestrator/src/orchestrator/prompts/analyze.md.j2
+++ b/orchestrator/src/orchestrator/prompts/analyze.md.j2
@@ -20,6 +20,18 @@
 AGENT_ROLE=analyze-agent
 REQ={{ req_id }}
 
+### Intake 摘要（验收标准）
+
+以下是从 intake 阶段确定的验收要求，**你写 spec 时必须把每一条 acceptance criteria 翻译成一个或多个 `#### Scenario`**，不能漏、不能写空壳 scenario（只有 heading 没有 GIVEN/WHEN/THEN）：
+
+- **Business behavior**：{{ intake_summary.business_behavior }}
+- **Data constraints**：{{ intake_summary.data_constraints }}
+- **Edge cases**：{{ intake_summary.edge_cases }}
+- **Acceptance（怎么算实现完）**：{{ intake_summary.acceptance }}
+- **Do not touch**：{{ intake_summary.do_not_touch }}
+
+> **关键**：spec.md 里的 scenario 不是装饰，是之后 `accept-env-up` 阶段 thanatos MCP 会直接读取并执行的验收用例。每个 scenario 必须有清晰的 GIVEN/WHEN/THEN step，否则 check-scenario-refs.sh 会报空壳 scenario 直接 fail。
+
 你**全权负责**这个 REQ 从 0 到可合并 PR 的端到端交付。
 
 > 重要：M15 砍掉了 sisyphus 主动起的 spec / dev BKD 子 agent —— 状态机里已经没人接手 spec/dev

--- a/scripts/check-scenario-refs.sh
+++ b/scripts/check-scenario-refs.sh
@@ -65,14 +65,71 @@ HEADING_PATTERN='^##+ Scenario:[[:space:]]+([A-Z][A-Z0-9-]+-S[0-9]+)([[:space:]]
 # NB: 必须显式初始化为空 ()，否则 set -u + 空 ${#DEFINED[@]} 会报 unbound variable（bash 5.2）
 declare -A DEFINED=()
 
+# 全局 FAIL 标志，必须在 scan_spec_file 调用前设为 0（覆盖引用扫描段的旧值）
+FAILED=0
+
+# Scenario heading 匹配（用于空壳检测，精确匹配 #### Scenario:）
+SCENARIO_HEADING_PATTERN='^#{4}[[:space:]]+Scenario:[[:space:]]+([A-Z][A-Z0-9-]+-S[0-9]+)([[:space:]]|$|[^A-Z0-9-])'
+# Step 检测正则（匹配 gherkin 和 bullet 两种格式，大小写不敏感）
+_STEP_PATTERN='^[[:space:]]*(-[[:space:]]*\*\*)?[[:space:]]*([Gg][Ii][Vv][Ee][Nn]|[Ww][Hh][Ee][Nn]|[Tt][Hh][Ee][Nn]|[Aa][Nn][Dd]|[Bb][Uu][Tt])([^[:alnum:]_]|$)'
+
 scan_spec_file() {
   local file="$1"
   local line
+  local in_scenario=0
+  local scen_id=""
+  local scen_has_step=0
+
   while IFS= read -r line; do
-    if [[ "$line" =~ $HEADING_PATTERN ]]; then
-      DEFINED["${BASH_REMATCH[1]}"]="$file"
+    # 检测新的 scenario heading
+    if [[ "$line" =~ $SCENARIO_HEADING_PATTERN ]]; then
+      # 检查上一个 scenario 是否有 step
+      if [[ $in_scenario -eq 1 && $scen_has_step -eq 0 ]]; then
+        echo "FAIL: $file scenario [$scen_id] has no GIVEN/WHEN/THEN steps"
+        FAILED=1
+      fi
+      # 开始新 scenario
+      in_scenario=1
+      scen_id="${BASH_REMATCH[1]}"
+      scen_has_step=0
+      # 同时记录到 DEFINED（原有行为）
+      DEFINED["$scen_id"]="$file"
+      continue
+    fi
+
+    # 在 scenario 范围内检测 step 和结束条件
+    if [[ $in_scenario -eq 1 ]]; then
+      # 检测 step 行
+      if [[ "$line" =~ $_STEP_PATTERN ]]; then
+        scen_has_step=1
+      fi
+
+      # 检测是否遇到结束 scenario 的 heading
+      # 结束条件：1-3个#号（更高级/同级Requirement）或4个#号但不是Scenario（同级非Scenario）
+      local end_scenario=0
+      if [[ "$line" =~ ^#{1,3}[[:space:]] ]]; then
+        end_scenario=1
+      elif [[ "$line" =~ ^#{4}[[:space:]] && ! "$line" =~ $SCENARIO_HEADING_PATTERN ]]; then
+        end_scenario=1
+      fi
+
+      if [[ $end_scenario -eq 1 ]]; then
+        if [[ $scen_has_step -eq 0 ]]; then
+          echo "FAIL: $file scenario [$scen_id] has no GIVEN/WHEN/THEN steps"
+          FAILED=1
+        fi
+        in_scenario=0
+        scen_id=""
+        scen_has_step=0
+      fi
     fi
   done < "$file"
+
+  # 文件结尾检查最后一个 scenario
+  if [[ $in_scenario -eq 1 && $scen_has_step -eq 0 ]]; then
+    echo "FAIL: $file scenario [$scen_id] has no GIVEN/WHEN/THEN steps"
+    FAILED=1
+  fi
 }
 
 while IFS= read -r file; do
@@ -91,7 +148,6 @@ if [[ ${#DEFINED[@]} -eq 0 ]]; then
 fi
 
 # 扫所有引用位置，查找每一个 [XXX-S<N>]
-FAILED=0
 while IFS= read -r file; do
   # grep 出本文件所有 scenario 引用
   while IFS=: read -r lineno content; do


### PR DESCRIPTION
## Summary

修复 sisyphus acceptance 流程中两个漏网之鱼，导致 analyze 阶段不写验收用例、或写了空壳 scenario 也能通过 lint，最终 accept 阶段无 scenario 可跑。

### Bug 1: `scripts/check-scenario-refs.sh` 不检测空壳 scenario

- 在 `scan_spec_file()` 中增加 scenario 状态跟踪（`in_scenario` / `scen_id` / `scen_has_step`）
- 定义 step 检测正则，匹配 gherkin 和 bullet 两种格式
- 遇到新的 `#### Scenario:` heading 时检查上一个 scenario 是否有 step
- 文件结尾处检查最后一个 scenario
- `FAILED=0` 移到 `scan_spec_file` 调用循环之前，避免被引用扫描段覆盖

### Bug 2: `analyze.md.j2` 缺失验收标准

- 在 `## 全责交付 (M17)` 区块新增 `### Intake 摘要（验收标准）`
- 注入 `intake_summary` 的 5 个关键字段（business_behavior / data_constraints / edge_cases / acceptance / do_not_touch）
- 明确要求 analyze agent 把每条 acceptance criteria 翻译成 `#### Scenario`，禁止空壳 scenario

## Test plan

- [x] 空壳 scenario 检测：`mkdir -p /tmp/test/openspec/specs` + 写无 step 的 `#### Scenario: TEST-S1` → `scripts/check-scenario-refs.sh /tmp/test` 输出 FAIL，exit=1
- [x] 有 step scenario 通过：写含 GIVEN/WHEN/THEN 的 scenario → exit=0
- [x] Jinja2 渲染验证：`intake_summary` 各字段正确注入模板

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-fix-acceptance-leaks-1777420049`