### PR TITLE
feat(orch): dedicated dev/spec fixer prompts replacing generic bugfix

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -15,7 +15,9 @@
 | [challenger.md.j2](../orchestrator/src/orchestrator/prompts/challenger.md.j2) | challenger（M18：黑盒读 spec 写 contract test，**不看 dev 代码**；spec 自相矛盾 / 写不出 test → fail → verifier） | `actions/start_challenger.py` |
 | [accept.md.j2](../orchestrator/src/orchestrator/prompts/accept.md.j2) | accept | `actions/create_accept.py` |
 | [done_archive.md.j2](../orchestrator/src/orchestrator/prompts/done_archive.md.j2) | archive（每仓 `openspec apply` + 关 issue；**不自动合 PR / 不 push main**） | `actions/done_archive.py` |
-| [bugfix.md.j2](../orchestrator/src/orchestrator/prompts/bugfix.md.j2) | （fixer 过渡） | `actions/_verifier.py:start_fixer`（后续替换为专用 dev/spec fixer 模板） |
+| [verifier-fix-dev.md.j2](../orchestrator/src/orchestrator/prompts/verifier-fix-dev.md.j2) | fixer dev（只改业务代码） | `actions/_verifier.py:start_fixer`（fixer=dev 时路由） |
+| [verifier-fix-spec.md.j2](../orchestrator/src/orchestrator/prompts/verifier-fix-spec.md.j2) | fixer spec（只改 spec） | `actions/_verifier.py:start_fixer`（fixer=spec 时路由） |
+| [bugfix.md.j2](../orchestrator/src/orchestrator/prompts/bugfix.md.j2) | fixer fallback（无 fixer 字段时兜底） | `actions/_verifier.py:start_fixer` |
 
 历史遗留模板（v0.1 时代，保留作回退）：
 

--- a/openspec/changes/REQ-dedicated-fixer-prompts-1777420810/proposal.md
+++ b/openspec/changes/REQ-dedicated-fixer-prompts-1777420810/proposal.md
@@ -1,0 +1,73 @@
+# REQ-dedicated-fixer-prompts-1777420810: 专用 fixer prompts 替代过渡 bugfix.md.j2
+
+## 问题
+
+当前 fixer-agent 复用 `bugfix.md.j2` 这一个通用 prompt 过渡，用于两种完全不同的修复场景：
+
+1. **dev fixer**：改业务代码（修复代码逻辑 bug）
+2. **spec fixer**：改 spec（修复验收用例、设计文档）
+
+一个通用 prompt 同时覆盖这两种场景，导致：
+- 修复建议经常跑偏（dev fixer 改到 spec 文件，spec fixer 想改代码）
+- verifier 的 decision JSON 里 `fixer=dev` / `fixer=spec` 的约束在 prompt 里没有真正体现
+- 修复质量在 2 轮后显著下降（IMPACT-REPORT 已观察到）
+
+## 根因分析
+
+1. **prompt 职责不聚焦**：`bugfix.md.j2` 的 "诊断 BUG 类型（CODE / SPEC / ENV）" 让 fixer 自己判断该改什么，而不是由 verifier 的 decision 决定
+2. **无文件类型锁定**：通用 prompt 没有明确禁止 dev fixer 碰 spec 文件，也没有禁止 spec fixer 碰业务代码
+3. **缺少 target_repo 透传**：verifier decision 里的 `target_repo` 字段没有传到 fixer prompt，多仓 REQ 时 fixer 容易盲修
+
+## 方案
+
+### 1. 新建 dev fixer 专用 prompt
+
+文件：`orchestrator/src/orchestrator/prompts/verifier-fix-dev.md.j2`
+
+- **LOCKED：只改业务代码**，不改 spec / openspec / test / Makefile / CI 配置
+- **Scope 限定**：verifier decision 里 `target_repo` 指定了哪仓就改哪仓
+- 保留 env-bug 短路检测（kubectl exec 401 / git clone 401 / 工具链缺 / 磁盘满 OOM）
+- 保留 `make ci-lint` 预 push 自检（Makefile ci 契约）
+- 保留 audit 警告（改动会被 verifier diff-audit）
+
+### 2. 新建 spec fixer 专用 prompt
+
+文件：`orchestrator/src/orchestrator/prompts/verifier-fix-spec.md.j2`
+
+- **LOCKED：只改 spec 文件**（openspec/changes/REQ-*/ 下的 spec.yaml / contract.spec.yaml / spec.md / design.md / tasks.md）
+- **LOCKED：不改业务代码 / 不改测试**
+- 保留 env-bug 短路检测（openspec 工具链缺等）
+- push 前跑 `openspec validate` + `check-scenario-refs.sh` 自检
+- 禁止 spec-drift（不要为让测试通过而扭曲 spec）
+
+### 3. 更新 start_fixer 路由
+
+修改 `orchestrator/src/orchestrator/actions/_verifier.py`：
+
+- `fixer=dev` → `verifier-fix-dev.md.j2`
+- `fixer=spec` → `verifier-fix-spec.md.j2`
+- 无 `fixer` 字段 → fallback 到旧 `bugfix.md.j2`（兼容）
+
+同时把 `target_repo` 从 verifier decision 透传给 prompt 模板。
+
+### 4. webhook 透传 target_repo
+
+修改 `orchestrator/src/orchestrator/webhook.py`：
+
+解析 verifier decision JSON 时，把 `target_repo` 字段写入 ctx（`verifier_target_repo`），供 start_fixer 读取。
+
+## 取舍
+
+- **为什么不直接删 bugfix.md.j2** —— 留作 fallback，等两个专用 prompt 稳定后再删（backward compat）
+- **为什么两个 prompt 都保留 runner_container / tools_whitelist / self_issue_constraint** —— 这些共享 partial 是 sisyphus 的通用基础设施约束，所有 agent prompt 都需要
+- **为什么 spec fixer 也要 env-bug 检测** —— 虽然 spec 修复依赖的工具链不同（openspec vs go），但 runner pod 环境抖动的检测逻辑同样需要
+- **为什么 target_repo 从 webhook 透传而不是让 fixer 自己推断** —— verifier 已经在决策时做了多仓判断，让 fixer 再推断一次是重复劳动且容易错
+
+## 影响面
+
+- 新增 2 个 prompt 模板文件
+- 改 `orchestrator/src/orchestrator/actions/_verifier.py`：start_fixer 模板路由 + target_repo 透传
+- 改 `orchestrator/src/orchestrator/webhook.py`：verifier decision 解析加 target_repo
+- 改 `docs/prompts.md`：索引更新
+- 新增 unit test：`test_verifier.py` 验证模板路由和 target_repo 透传
+- 不动 state.py / router.py / migrations / BKD 集成层 / 机械 checker

--- a/openspec/changes/REQ-dedicated-fixer-prompts-1777420810/specs/fixer-prompts/spec.md
+++ b/openspec/changes/REQ-dedicated-fixer-prompts-1777420810/specs/fixer-prompts/spec.md
@@ -1,0 +1,72 @@
+# fixer-prompts
+
+## ADDED Requirements
+
+### Requirement: start_fixer SHALL route to a dedicated prompt template based on the fixer field in the verifier decision
+
+The `start_fixer` action in `orchestrator/src/orchestrator/actions/_verifier.py` SHALL select the fixer prompt template according to the `fixer` field stored in the REQ context by the webhook decision parser. When `fixer` equals `"dev"`, the action MUST render `verifier-fix-dev.md.j2`. When `fixer` equals `"spec"`, the action MUST render `verifier-fix-spec.md.j2`. When the `fixer` field is absent or has any other value, the action MUST fall back to the legacy `bugfix.md.j2` template for backward compatibility.
+
+#### Scenario: DFP-S1 dev fixer uses dedicated dev prompt
+
+- **GIVEN** a verifier decision with `"fixer": "dev"` has been stored in ctx
+- **WHEN** `start_fixer` is invoked
+- **THEN** the rendered prompt MUST be from `verifier-fix-dev.md.j2`
+- **AND** the prompt MUST contain the text "DEV FIXER"
+- **AND** the prompt MUST contain the constraint "LOCKED：只改业务代码"
+
+#### Scenario: DFP-S2 spec fixer uses dedicated spec prompt
+
+- **GIVEN** a verifier decision with `"fixer": "spec"` has been stored in ctx
+- **WHEN** `start_fixer` is invoked
+- **THEN** the rendered prompt MUST be from `verifier-fix-spec.md.j2`
+- **AND** the prompt MUST contain the text "SPEC FIXER"
+- **AND** the prompt MUST contain the constraint "LOCKED：只改 spec 相关文件"
+
+#### Scenario: DFP-S3 missing fixer field falls back to legacy bugfix prompt
+
+- **GIVEN** a verifier decision with no `"fixer"` field (legacy decision format)
+- **WHEN** `start_fixer` is invoked
+- **THEN** the rendered prompt MUST fall back to `bugfix.md.j2`
+
+### Requirement: verifier-fix-dev.md.j2 SHALL restrict the agent to modifying only business source code
+
+The dev fixer prompt template MUST contain hard constraints that prohibit the agent from modifying spec files, test files, Makefile, CI configuration, openspec files, or any file outside the business implementation directories (such as `src/`, `lib/`, `cmd/`, `internal/`, `pkg/`). The prompt MUST instruct the agent to push fixes to the feat/REQ-x branch and to run `make ci-lint` with `BASE_REV` before pushing.
+
+#### Scenario: DFP-S4 dev prompt contains business-code-only lock
+
+- **GIVEN** `verifier-fix-dev.md.j2` is rendered
+- **THEN** the prompt MUST contain an explicit prohibition against modifying openspec files
+- **AND** the prompt MUST contain an explicit prohibition against modifying test files
+- **AND** the prompt MUST contain an explicit prohibition against modifying Makefile or CI configuration
+
+### Requirement: verifier-fix-spec.md.j2 SHALL restrict the agent to modifying only spec-related files
+
+The spec fixer prompt template MUST contain hard constraints that prohibit the agent from modifying business source code, test files, Makefile, or CI configuration. The prompt MUST instruct the agent to fix openspec validation errors, scenario reference issues, and acceptance criteria problems. The prompt MUST include a pre-push self-check running `openspec validate` and `check-scenario-refs.sh`.
+
+#### Scenario: DFP-S5 spec prompt contains spec-only lock
+
+- **GIVEN** `verifier-fix-spec.md.j2` is rendered
+- **THEN** the prompt MUST contain an explicit prohibition against modifying business source code
+- **AND** the prompt MUST contain an explicit prohibition against modifying test files
+- **AND** the prompt MUST contain a spec-drift warning (do not twist spec to match broken implementation)
+
+### Requirement: webhook decision parser SHALL persist target_repo into the REQ context
+
+The webhook handler in `orchestrator/src/orchestrator/webhook.py` that parses the verifier decision JSON MUST extract the `target_repo` field and store it in the REQ context under the key `verifier_target_repo`, alongside the existing `verifier_fixer`, `verifier_scope`, `verifier_reason`, and `verifier_confidence` fields.
+
+#### Scenario: DFP-S6 target_repo from decision is stored in ctx
+
+- **GIVEN** a verifier decision JSON containing `"target_repo": "owner/repo-a"`
+- **WHEN** the webhook parses the decision
+- **THEN** the REQ context MUST contain `"verifier_target_repo": "owner/repo-a"`
+
+### Requirement: start_fixer SHALL pass target_repo to the rendered prompt template
+
+When rendering the fixer prompt template, `start_fixer` MUST pass the `target_repo` value from the REQ context to the Jinja2 template renderer. The template MUST reference this value to scope the fixer's work to the specified repository.
+
+#### Scenario: DFP-S7 target_repo appears in rendered dev prompt
+
+- **GIVEN** `start_fixer` is invoked with ctx containing `"verifier_target_repo": "owner/repo-a"` and `"verifier_fixer": "dev"`
+- **WHEN** the prompt is rendered
+- **THEN** the rendered prompt MUST contain the target repository identifier
+- **AND** the prompt MUST instruct the agent to modify only that repository

--- a/openspec/changes/REQ-dedicated-fixer-prompts-1777420810/tasks.md
+++ b/openspec/changes/REQ-dedicated-fixer-prompts-1777420810/tasks.md
@@ -1,0 +1,15 @@
+## Stage: spec
+- [x] author proposal.md
+- [x] author specs/fixer-prompts/spec.md scenarios
+
+## Stage: implementation
+- [x] create `orchestrator/src/orchestrator/prompts/verifier-fix-dev.md.j2`
+- [x] create `orchestrator/src/orchestrator/prompts/verifier-fix-spec.md.j2`
+- [x] modify `orchestrator/src/orchestrator/actions/_verifier.py` start_fixer routing
+- [x] modify `orchestrator/src/orchestrator/webhook.py` target_repo passthrough
+- [x] update `docs/prompts.md` index
+- [x] add unit tests in `test_verifier.py`
+
+## Stage: PR
+- [ ] git push feat/REQ-dedicated-fixer-prompts-1777420810
+- [ ] gh pr create --label sisyphus

--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -249,6 +249,7 @@ async def start_fixer(*, body, req_id, tags, ctx):
     fixer = ctx.get("verifier_fixer") or "dev"
     scope = ctx.get("verifier_scope") or ""
     reason = ctx.get("verifier_reason") or ""
+    target_repo = ctx.get("verifier_target_repo") or ""
     branch = ctx.get("branch") or f"feat/{req_id}"
 
     pool = db.get_pool()
@@ -309,11 +310,17 @@ async def start_fixer(*, body, req_id, tags, ctx):
             use_worktree=True,
             model=settings.agent_model,
         )
-        # 通用 bugfix prompt 作为过渡；PR4 再做每类 fixer 专用模板。
+        # 专用 fixer prompt：dev / spec 各走各的模板；无 fixer 字段兜底旧 bugfix。
         # REQ-base-branch-override-1777480690: forward base branch info so fixer
         # lint uses the correct merge-base.
+        if fixer == "dev":
+            template_name = "verifier-fix-dev.md.j2"
+        elif fixer == "spec":
+            template_name = "verifier-fix-spec.md.j2"
+        else:
+            template_name = "bugfix.md.j2"
         prompt = render(
-            "bugfix.md.j2",
+            template_name,
             req_id=req_id, round_n=next_round,
             kind=f"verifier-{fixer}",
             source_issue_id=ctx.get("verifier_issue_id", ""),
@@ -323,10 +330,13 @@ async def start_fixer(*, body, req_id, tags, ctx):
             project_alias=proj,
             base_branch=ctx.get("base_branch"),
             base_branches=ctx.get("base_branches") or {},
+            target_repo=target_repo,
         )
         # 把 verifier 的 scope / reason 叠进 prompt 作为上下文
         if scope or reason:
             prompt += f"\n\n## Verifier 决策\n- fixer: {fixer}\n- scope: {scope}\n- reason: {reason}\n"
+        if target_repo:
+            prompt += f"- target_repo: {target_repo}\n"
         await bkd.follow_up_issue(project_id=proj, issue_id=issue.id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue.id, status_id="working")
 

--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -246,7 +246,8 @@ async def start_fixer(*, body, req_id, tags, ctx):
             break
     if not stage:
         stage = ctx.get("verifier_stage")
-    fixer = ctx.get("verifier_fixer") or "dev"
+    raw_fixer = ctx.get("verifier_fixer")
+    fixer = raw_fixer or "dev"  # 用于 tag / log 展示；template 选择按 raw_fixer
     scope = ctx.get("verifier_scope") or ""
     reason = ctx.get("verifier_reason") or ""
     target_repo = ctx.get("verifier_target_repo") or ""
@@ -310,12 +311,13 @@ async def start_fixer(*, body, req_id, tags, ctx):
             use_worktree=True,
             model=settings.agent_model,
         )
-        # 专用 fixer prompt：dev / spec 各走各的模板；无 fixer 字段兜底旧 bugfix。
-        # REQ-base-branch-override-1777480690: forward base branch info so fixer
-        # lint uses the correct merge-base.
-        if fixer == "dev":
+        # 专用 fixer prompt：dev / spec 各走各的模板；ctx 缺 verifier_fixer 时
+        # 按 spec DFP-S3 兜底走 legacy bugfix.md.j2（这里要看 raw_fixer，不能看
+        # 默认填了 "dev" 的 fixer 变量）。base_branch 透传给 dev fixer prompt
+        # 让 lint 用正确的 merge-base（REQ-base-branch-override-1777480690）。
+        if raw_fixer == "dev":
             template_name = "verifier-fix-dev.md.j2"
-        elif fixer == "spec":
+        elif raw_fixer == "spec":
             template_name = "verifier-fix-spec.md.j2"
         else:
             template_name = "bugfix.md.j2"

--- a/orchestrator/src/orchestrator/prompts/verifier-fix-dev.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier-fix-dev.md.j2
@@ -2,7 +2,7 @@
 
 ─────────
 
-{% include "_shared/self_issue_constraint.md.j2" %}
+{% include "_shared/hooks/self_issue_constraint.md.j2" %}
 
 ─────────
 

--- a/orchestrator/src/orchestrator/prompts/verifier-fix-dev.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier-fix-dev.md.j2
@@ -1,0 +1,132 @@
+{% include "_shared/tools_whitelist.md.j2" %}
+
+─────────
+
+{% include "_shared/self_issue_constraint.md.j2" %}
+
+─────────
+
+{% include "_shared/runner_container.md.j2" %}
+
+─────────
+
+## DEV FIXER
+AGENT_ROLE=dev-fix-agent
+REQ={{ req_id }}
+ROUND={{ round_n }}
+KIND={{ kind }}
+SOURCE_ISSUE={{ source_issue_id }}
+BRANCH={{ branch }}
+{% if target_repo %}TARGET_REPO={{ target_repo }}{% endif %}
+
+按"干活容器"段先 idempotent 拉起 runner-{{ req_id | lower }}。
+
+## 职责
+- **LOCKED：只改业务代码**（`src/`、`lib/`、`cmd/`、`internal/`、`pkg/` 等实现文件）
+- **LOCKED：不改 spec / openspec / test / Makefile / CI 配置**
+- 诊断 BUG 类型（CODE / ENV）
+- 直接在 feat/{{ req_id }} 分支上改代码、commit、push
+- 诊断到 **ENV BUG**：加 tag `diagnosis:env-bug` 直接 move review（→ Escalate）
+  - 例：runner 镜像缺工具/版本不对、调试机器磁盘满、网络断、外部依赖挂
+  - 凡是"代码没毛病，是 sisyphus 自身环境问题"就是 env-bug
+  - AI 改不动 sisyphus 自身环境（runner Dockerfile 在 sisyphus repo），escalate 通知运维
+- CODE BUG: 在 feat/{{ req_id }} 分支上改代码 commit push
+
+> ⚠️ **Audit 告知**：你的改动会被 verifier-after-fix 用 `gh pr diff` 审计。
+> **禁止**：删 assertion / 加 `t.Skip` / hardcode 期望值 / 注释掉业务逻辑来让测试绕过。
+> 每一行改动都要有实质性理由，测试覆盖需真实有效。
+
+## Scope 限定
+{% if target_repo %}
+- **只改 `{{ target_repo }}` 这一个仓的业务代码**
+- 多仓 REQ 时 verifier 已锁定 target_repo；不要跨仓盲修
+{% else %}
+- 单仓 REQ：改该仓业务代码
+- 多仓 REQ（无 target_repo）：根据失败日志自行判断哪个仓的代码有问题，修最相关的那个
+{% endif %}
+
+## 步骤
+
+### ⚠️ Step 0 — 环境短路检测（必跑，3 个 tool call 内完成）
+
+跑代码诊断前先快速摸 runner 环境健康度。**任一症状 → 立即停手不绕路**，按 ENV BUG
+路径走（tag `diagnosis:env-bug` + move review 给运维）：
+
+| 症状 | 检测 | 触发条件 |
+|---|---|---|
+- **kubectl exec 401 / Pod 不存在**：`kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- echo ok` 非 0 退码 / `Unauthorized` / `not found`
+- **git clone 401 / 404**：runner 内 `git ls-remote https://github.com/<owner>/<repo>.git HEAD` 出 `Authentication failed` / `repository not found` / 403 / 404
+- **工具链缺**：runner 内 `go version && make --version && which kubectl` 出 `command not found`
+- **磁盘满 / OOM**：runner 内 `df -h /workspace` usage > 90%，或上轮 SOURCE_ISSUE 退码=137 (OOMKilled)
+
+任一红 → 不再 tool_use，直接：
+1. BKD chat 一句：`🚫 env-bug: <症状>。runner 环境不对，escalate 给运维。`
+2. `update-issue` tags 加 `diagnosis:env-bug`
+3. `update-issue` statusId=review
+
+**禁止**：自装 Go / 自配 git token / kubectl cp 代码绕过 / 超过 3 个 tool_use 死磕环境。
+环境是 sisyphus 自己的事，绕过会掩盖运维问题；CODE bug 才走 Step 1+。
+
+Step 1 进 runner pod，切到 feat 分支（对你这轮要修的每个 source repo 都跑一次；
+`REPO` 替换成该仓的 basename，与同文件 Step 3 / 3.5 / 4 占位一致）:
+```bash
+kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c \
+  "cd /workspace/source/REPO && git fetch origin && git checkout feat/{{ req_id }}"
+```
+
+Step 2 读 SOURCE_ISSUE 拿 CI 失败日志。
+用 curl BKD REST 取 issue：
+```bash
+curl -sS http://localhost:3000/api/projects/{{ project_id }}/issues/{{ source_issue_id }}
+```
+看 `## CI Result` 或 `## Accept Result`，从 stderr_tail / failed_tests 推断 root cause。
+
+Step 3 改代码 → commit → push feat/{{ req_id }}:
+```bash
+kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c \
+  "cd /workspace/source/REPO && \
+   git add -p && \
+   git commit -m 'fix(REQ): <具体修了什么>'"
+```
+
+### Step 3.5 — push 前 `make ci-lint` 自检（**必跑，按 Makefile ci 契约** —— 详见 docs/integration-contracts.md）
+
+防 trivial 回归把球踢回 verifier 多走一轮（本来 fixer 就是来修问题的，又引入新的 lint 错就是浪费 round）。
+
+对你这轮**修过的每个 source repo** 跑（BASE_REV 用仓真实 default_branch，
+default 非 main 的仓如 ttpos-server-go/release 同样能算到 merge-base，避免全量
+扫历史包袱）：
+```bash
+kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c \
+  "cd /workspace/source/REPO && \
+   default_branch=\$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@') && \
+   BASE_REV=\$(git merge-base HEAD \"origin/\${default_branch:-main}\") make ci-lint"
+```
+
+`BASE_REV` 让 lint 只校变更文件，不卷历史包袱（契约见 docs/integration-contracts.md §2）。
+
+退码处理：
+- **0** → 走 Step 4 push
+- **非 0 且报错来自你这轮 commit 改的文件** → 修，amend commit，再跑一次。**最多 2 次内修完**；超 2 次说明你判断不准，停手按原样 push 让 verifier 再看
+- **非 0 且报错来自历史包袱**（你没动的文件）→ 不修；follow-up 写一句"pre-existing lint debt: <文件>:<行>，未触碰"然后照常 push
+
+如果业务 repo 没 `ci-lint` target → `make: *** No rule to make target 'ci-lint'` → 直接跳过 Step 3.5（contract 要求，但老 repo 可能没接，不阻塞 fix），照常 push。
+
+### Step 4 — push:
+```bash
+kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c \
+  "cd /workspace/source/REPO && git push origin feat/{{ req_id }}"
+```
+
+Step 5 写结果到**本 issue**：
+  A. follow-up 追加 `## Bugfix Result`: diagnosis / commit_sha / 改了什么 / lint-pre-push (pass/skipped/pre-existing-debt)
+  B. update-issue tags（保留 fixer + {{ req_id }} + round-N + parent-id），追加 diagnosis:<code-bug|env-bug>
+  C. update-issue statusId=review
+
+## 硬规则
+- 直接 push 到 feat/{{ req_id }}，不建子分支
+- 禁加 result:* tag
+- 所有 update-issue 的 issueId 必须是**本** issue
+- **LOCKED**：不改 openspec/ 下的任何文件
+- **LOCKED**：不改 test/ 下的任何文件（包括删 assert、加 skip、改期望值）
+- **LOCKED**：不改 Makefile、Dockerfile、.github/workflows/ 等 CI/构建配置

--- a/orchestrator/src/orchestrator/prompts/verifier-fix-spec.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier-fix-spec.md.j2
@@ -1,0 +1,130 @@
+{% include "_shared/tools_whitelist.md.j2" %}
+
+─────────
+
+{% include "_shared/self_issue_constraint.md.j2" %}
+
+─────────
+
+{% include "_shared/runner_container.md.j2" %}
+
+─────────
+
+## SPEC FIXER
+AGENT_ROLE=spec-fix-agent
+REQ={{ req_id }}
+ROUND={{ round_n }}
+KIND={{ kind }}
+SOURCE_ISSUE={{ source_issue_id }}
+BRANCH={{ branch }}
+{% if target_repo %}TARGET_REPO={{ target_repo }}{% endif %}
+
+按"干活容器"段先 idempotent 拉起 runner-{{ req_id | lower }}。
+
+## 职责
+- **LOCKED：只改 spec 相关文件**（`openspec/changes/{{ req_id }}/` 下的 `spec.yaml` / `contract.spec.yaml`、`spec.md`、`design.md`、`tasks.md`、 acceptance criteria）
+- **LOCKED：不改业务代码 / 不改测试 / 不改 Makefile / CI 配置**
+- 修复 openspec validate 报错、scenario 引用缺失、acceptance criteria 语法错误、spec 与实现契约不一致
+- 直接在 feat/{{ req_id }} 分支上改 spec、commit、push
+- 诊断到 **ENV BUG**（runner 缺 openspec 工具 / check-scenario-refs.sh 不在 PATH / git 不可用）：加 tag `diagnosis:env-bug` 直接 move review（→ Escalate）
+
+> ⚠️ **Audit 告知**：你的改动会被 verifier-after-fix 用 `gh pr diff` 审计。
+> **禁止**：为迎合错误实现而扭曲 spec（spec-drift）。spec 是权威，实现必须对齐 spec。
+> 每一行 spec 改动都要有实质性理由。
+
+## Scope 限定
+{% if target_repo %}
+- **只改 `{{ target_repo }}` 这一个仓的 spec 文件**
+- 多仓 REQ 时 verifier 已锁定 target_repo；不要跨仓盲修
+{% else %}
+- 单仓 REQ：改该仓 spec 文件
+- 多仓 REQ（无 target_repo）：根据失败日志自行判断哪个仓的 spec 有问题，修最相关的那个
+{% endif %}
+
+## 步骤
+
+### ⚠️ Step 0 — 环境短路检测（必跑，3 个 tool call 内完成）
+
+跑 spec 诊断前先快速摸 runner 环境健康度。**任一症状 → 立即停手不绕路**，按 ENV BUG
+路径走（tag `diagnosis:env-bug` + move review 给运维）：
+
+| 症状 | 检测 | 触发条件 |
+|---|---|---|
+- **kubectl exec 401 / Pod 不存在**：`kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- echo ok` 非 0 退码 / `Unauthorized` / `not found`
+- **git clone 401 / 404**：runner 内 `git ls-remote https://github.com/<owner>/<repo>.git HEAD` 出 `Authentication failed` / `repository not found` / 403 / 404
+- **openspec 工具链缺**：runner 内 `which openspec && which check-scenario-refs.sh` 出 `command not found`
+- **磁盘满 / OOM**：runner 内 `df -h /workspace` usage > 90%
+
+任一红 → 不再 tool_use，直接：
+1. BKD chat 一句：`🚫 env-bug: <症状>。runner 环境不对，escalate 给运维。`
+2. `update-issue` tags 加 `diagnosis:env-bug`
+3. `update-issue` statusId=review
+
+**禁止**：自装 openspec / 自配 git token / kubectl cp 文件绕过 / 超过 3 个 tool_use 死磕环境。
+环境是 sisyphus 自己的事；SPEC bug 才走 Step 1+。
+
+Step 1 进 runner pod，切到 feat 分支（`REPO` 替换成 target_repo 的 basename）：
+```bash
+kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c \
+  "cd /workspace/source/REPO && git fetch origin && git checkout feat/{{ req_id }}"
+```
+
+Step 2 读 SOURCE_ISSUE 拿 spec-lint / challenger 失败日志。
+用 curl BKD REST 取 issue：
+```bash
+curl -sS http://localhost:3000/api/projects/{{ project_id }}/issues/{{ source_issue_id }}
+```
+看 `## Spec Lint Result` 或 `## Challenger Result`，从 stderr_tail 推断 root cause：
+- openspec validate schema 结构错（字段类型 / enum / required 缺失）
+- check-scenario-refs.sh 报 scenario 引用不存在
+- acceptance Gherkin parse 错（语法 / 缺 step）
+- challenger 指出 spec 自相矛盾 / 缺关键定义
+
+Step 3 改 spec → commit → push feat/{{ req_id }}:
+```bash
+kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c \
+  "cd /workspace/source/REPO && \
+   git add -p && \
+   git commit -m 'fix(spec,REQ): <具体修了什么>'"
+```
+
+### Step 3.5 — push 前 spec 自检（必跑）
+
+对你这轮**修过的 source repo** 跑：
+
+```bash
+# 3.5a — openspec validate
+kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c \
+  "cd /workspace/source/REPO && openspec validate openspec/changes/{{ req_id }}/spec.yaml"
+
+# 3.5b — check-scenario-refs.sh（如果 repo 接了）
+kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c \
+  "cd /workspace/source/REPO && check-scenario-refs.sh openspec/changes/{{ req_id }}/"
+```
+
+退码处理：
+- **0** → 走 Step 4 push
+- **非 0 且报错来自你这轮 commit 改的文件/段落** → 修，amend commit，再跑一次。**最多 2 次内修完**；超 2 次说明你判断不准，停手按原样 push 让 verifier 再看
+- **非 0 且报错来自历史包袱**（你没动的 spec 段落）→ 不修；follow-up 写一句"pre-existing spec debt: <文件>:<行>，未触碰"然后照常 push
+
+如果业务 repo 没 `openspec` 或 `check-scenario-refs.sh` → 直接跳过 Step 3.5，照常 push。
+
+### Step 4 — push:
+```bash
+kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c \
+  "cd /workspace/source/REPO && git push origin feat/{{ req_id }}"
+```
+
+Step 5 写结果到**本 issue**：
+  A. follow-up 追加 `## Specfix Result`: diagnosis / commit_sha / 改了什么 / spec-pre-push (pass/skipped/pre-existing-debt)
+  B. update-issue tags（保留 fixer + {{ req_id }} + round-N + parent-id），追加 diagnosis:spec-bug
+  C. update-issue statusId=review
+
+## 硬规则
+- 直接 push 到 feat/{{ req_id }}，不建子分支
+- 禁加 result:* tag
+- 所有 update-issue 的 issueId 必须是**本** issue
+- **LOCKED**：不改 `src/` / `lib/` / `cmd/` / `internal/` / `pkg/` 等业务代码
+- **LOCKED**：不改 test/ 下的任何文件
+- **LOCKED**：不改 Makefile、Dockerfile、.github/workflows/ 等 CI/构建配置
+- **禁止 spec-drift**：不要为让测试通过而降低 acceptance 标准、删 scenario、放宽约束

--- a/orchestrator/src/orchestrator/prompts/verifier-fix-spec.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier-fix-spec.md.j2
@@ -2,7 +2,7 @@
 
 ─────────
 
-{% include "_shared/self_issue_constraint.md.j2" %}
+{% include "_shared/hooks/self_issue_constraint.md.j2" %}
 
 ─────────
 

--- a/orchestrator/src/orchestrator/webhook.py
+++ b/orchestrator/src/orchestrator/webhook.py
@@ -705,6 +705,7 @@ async def webhook(request: Request) -> JSONResponse:
             "verifier_scope": decision_payload.get("scope"),
             "verifier_reason": decision_payload.get("reason"),
             "verifier_confidence": decision_payload.get("confidence"),
+            "verifier_target_repo": decision_payload.get("target_repo"),
         }
         await req_state.update_context(pool, req_id, patch)
         ctx = {**ctx, **patch}

--- a/orchestrator/tests/test_contract_fixer_prompts.py
+++ b/orchestrator/tests/test_contract_fixer_prompts.py
@@ -1,0 +1,280 @@
+"""Challenger contract tests for REQ-dedicated-fixer-prompts-1777420810.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-dedicated-fixer-prompts-1777420810/specs/fixer-prompts/spec.md
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is truly wrong, escalate to spec_fixer to correct the spec, not the test.
+
+Scenarios covered:
+  DFP-S1  fixer=dev → verifier-fix-dev.md.j2 prompt with "DEV FIXER" + "LOCKED：只改业务代码"
+  DFP-S2  fixer=spec → verifier-fix-spec.md.j2 prompt with "SPEC FIXER" + "LOCKED：只改 spec 相关文件"
+  DFP-S3  missing fixer → fallback bugfix.md.j2
+  DFP-S4  dev prompt contains openspec/test/Makefile prohibition
+  DFP-S5  spec prompt contains business-code/test prohibition + spec-drift warning
+  DFP-S6  webhook derives target_repo from decision JSON
+  DFP-S7  target_repo appears in rendered dev prompt + scopes to one repo
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from orchestrator import prompts
+from orchestrator.router import derive_verifier_event
+from orchestrator.state import Event
+
+_REQ_ID = "REQ-dedicated-fixer-prompts-1777420810"
+_PROJECT = "nnvxh8wj"
+
+
+class _FakeBody:
+    projectId = _PROJECT
+
+
+# ─── Shared fixtures ────────────────────────────────────────────────────────
+
+@pytest.fixture
+def _patch_start_fixer_deps(monkeypatch):
+    """Patch all external I/O in start_fixer; return list that captures render() calls."""
+    from orchestrator.actions import _verifier
+
+    # settings
+    monkeypatch.setattr(_verifier.settings, "fixer_round_cap", 5)
+    monkeypatch.setattr(_verifier.settings, "workdir_root", "/workspace")
+    monkeypatch.setattr(_verifier.settings, "bkd_base_url", "http://localhost:3000")
+    monkeypatch.setattr(_verifier.settings, "bkd_token", "test")
+    monkeypatch.setattr(_verifier.settings, "agent_model", "claude-sonnet-4-6")
+
+    # DB / store
+    fake_pool = object()
+    monkeypatch.setattr(_verifier.db, "get_pool", lambda: fake_pool)
+    monkeypatch.setattr(_verifier.dispatch_slugs, "get", AsyncMock(return_value=None))
+    monkeypatch.setattr(_verifier.dispatch_slugs, "put", AsyncMock())
+    monkeypatch.setattr(_verifier.req_state, "update_context", AsyncMock())
+
+    # PR links
+    monkeypatch.setattr(_verifier.pr_links, "ensure_pr_links_in_ctx", AsyncMock(return_value={}))
+    monkeypatch.setattr(_verifier.pr_links, "pr_link_tags", lambda links: [])
+
+    # Capture every call to _verifier.render()
+    # NOTE: _verifier imported render at module load time, so we must patch
+    # _verifier.render, not prompts.render.
+    render_calls = []
+    _orig_render = _verifier.render
+
+    def _capture(template_name, **kwargs):
+        result = _orig_render(template_name, **kwargs)
+        render_calls.append({"template": template_name, "kwargs": dict(kwargs), "result": result})
+        return result
+
+    monkeypatch.setattr(_verifier, "render", _capture)
+
+    # BKDClient
+    fake_issue = MagicMock()
+    fake_issue.id = "fixer-issue-123"
+
+    class _FakeBKD:
+        def __init__(self):
+            self.create_issue = AsyncMock(return_value=fake_issue)
+            self.follow_up_issue = AsyncMock()
+            self.update_issue = AsyncMock()
+
+    class _FakeCtxMgr:
+        async def __aenter__(self):
+            return _FakeBKD()
+        async def __aexit__(self, *args, **kwargs):
+            pass
+
+    def _mock_bkd_client(*args, **kwargs):
+        return _FakeCtxMgr()
+
+    monkeypatch.setattr(_verifier, "BKDClient", _mock_bkd_client)
+
+    return render_calls
+
+
+# ─── DFP-S1 ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_DFP_S1_dev_fixer_uses_dedicated_dev_prompt(_patch_start_fixer_deps, monkeypatch):
+    """GIVEN fixer=dev in ctx WHEN start_fixer invoked
+    THEN rendered prompt is from verifier-fix-dev.md.j2
+    AND contains "DEV FIXER" AND "LOCKED：只改业务代码".
+    """
+    from orchestrator.actions._verifier import start_fixer
+
+    render_calls = _patch_start_fixer_deps
+
+    result = await start_fixer(
+        body=_FakeBody(),
+        req_id=_REQ_ID,
+        tags=["verify:dev_cross_check"],
+        ctx={
+            "verifier_fixer": "dev",
+            "verifier_issue_id": "v-issue-456",
+        },
+    )
+
+    assert len(render_calls) == 1
+    call = render_calls[0]
+    assert call["template"] == "verifier-fix-dev.md.j2"
+    assert "DEV FIXER" in call["result"]
+    assert "LOCKED：只改业务代码" in call["result"]
+
+
+# ─── DFP-S2 ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_DFP_S2_spec_fixer_uses_dedicated_spec_prompt(_patch_start_fixer_deps, monkeypatch):
+    """GIVEN fixer=spec in ctx WHEN start_fixer invoked
+    THEN rendered prompt is from verifier-fix-spec.md.j2
+    AND contains "SPEC FIXER" AND "LOCKED：只改 spec 相关文件".
+    """
+    from orchestrator.actions._verifier import start_fixer
+
+    render_calls = _patch_start_fixer_deps
+
+    result = await start_fixer(
+        body=_FakeBody(),
+        req_id=_REQ_ID,
+        tags=["verify:spec_lint"],
+        ctx={
+            "verifier_fixer": "spec",
+            "verifier_issue_id": "v-issue-456",
+        },
+    )
+
+    assert len(render_calls) == 1
+    call = render_calls[0]
+    assert call["template"] == "verifier-fix-spec.md.j2"
+    assert "SPEC FIXER" in call["result"]
+    assert "LOCKED：只改 spec 相关文件" in call["result"]
+
+
+# ─── DFP-S3 ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_DFP_S3_missing_fixer_fallback_to_bugfix(_patch_start_fixer_deps, monkeypatch):
+    """GIVEN no fixer field in ctx WHEN start_fixer invoked
+    THEN rendered prompt falls back to bugfix.md.j2.
+    """
+    from orchestrator.actions._verifier import start_fixer
+
+    render_calls = _patch_start_fixer_deps
+
+    result = await start_fixer(
+        body=_FakeBody(),
+        req_id=_REQ_ID,
+        tags=["verify:dev_cross_check"],
+        ctx={
+            "verifier_issue_id": "v-issue-456",
+            # intentionally no verifier_fixer
+        },
+    )
+
+    assert len(render_calls) == 1
+    call = render_calls[0]
+    assert call["template"] == "bugfix.md.j2"
+
+
+# ─── DFP-S4 ─────────────────────────────────────────────────────────────────
+
+def test_DFP_S4_dev_prompt_contains_openspec_test_makefile_prohibition():
+    """GIVEN verifier-fix-dev.md.j2 rendered
+    THEN prompt contains explicit prohibition against modifying openspec files
+    AND test files AND Makefile / CI configuration.
+    """
+    rendered = prompts.render(
+        "verifier-fix-dev.md.j2",
+        req_id=_REQ_ID,
+        round_n=1,
+        kind="verifier-dev",
+        source_issue_id="src-123",
+        branch=f"feat/{_REQ_ID}",
+        workdir=f"/workspace/feat-{_REQ_ID}",
+        project_id=_PROJECT,
+        project_alias=_PROJECT,
+        target_repo="",
+    )
+    assert "openspec" in rendered
+    assert "test" in rendered.lower()
+    assert "Makefile" in rendered or "CI 配置" in rendered
+
+
+# ─── DFP-S5 ─────────────────────────────────────────────────────────────────
+
+def test_DFP_S5_spec_prompt_contains_business_code_test_prohibition_and_spec_drift():
+    """GIVEN verifier-fix-spec.md.j2 rendered
+    THEN prompt contains explicit prohibition against modifying business source code
+    AND test files AND a spec-drift warning.
+    """
+    rendered = prompts.render(
+        "verifier-fix-spec.md.j2",
+        req_id=_REQ_ID,
+        round_n=1,
+        kind="verifier-spec",
+        source_issue_id="src-123",
+        branch=f"feat/{_REQ_ID}",
+        workdir=f"/workspace/feat-{_REQ_ID}",
+        project_id=_PROJECT,
+        project_alias=_PROJECT,
+        target_repo="",
+    )
+    assert "业务代码" in rendered
+    assert "test" in rendered.lower()
+    assert "spec-drift" in rendered.lower() or "spec drift" in rendered.lower()
+
+
+# ─── DFP-S6 ─────────────────────────────────────────────────────────────────
+
+def test_DFP_S6_target_repo_extracted_from_decision_json():
+    """GIVEN verifier decision JSON with target_repo WHEN webhook parses decision
+    THEN extracted decision dict contains target_repo.
+    """
+    decision_json = (
+        '```json\n'
+        '{"action": "fix", "fixer": "dev", "scope": "src/orchestrator", '
+        '"reason": "routing bug", "confidence": "high", '
+        '"target_repo": "owner/repo-a"}\n'
+        '```'
+    )
+    event, decision, reason = derive_verifier_event(decision_json, tags=[])
+    assert event == Event.VERIFY_FIX_NEEDED
+    assert decision is not None
+    assert decision.get("target_repo") == "owner/repo-a"
+
+
+# ─── DFP-S7 ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_DFP_S7_target_repo_appears_in_rendered_dev_prompt(_patch_start_fixer_deps, monkeypatch):
+    """GIVEN start_fixer invoked with verifier_target_repo=owner/repo-a and fixer=dev
+    WHEN prompt is rendered
+    THEN prompt contains the target repository identifier
+    AND instructs agent to modify only that repository.
+    """
+    from orchestrator.actions._verifier import start_fixer
+
+    render_calls = _patch_start_fixer_deps
+
+    result = await start_fixer(
+        body=_FakeBody(),
+        req_id=_REQ_ID,
+        tags=["verify:dev_cross_check"],
+        ctx={
+            "verifier_fixer": "dev",
+            "verifier_issue_id": "v-issue-456",
+            "verifier_target_repo": "owner/repo-a",
+        },
+    )
+
+    assert len(render_calls) == 1
+    call = render_calls[0]
+    assert call["template"] == "verifier-fix-dev.md.j2"
+    rendered = call["result"]
+    assert "owner/repo-a" in rendered
+    # The prompt should instruct the agent to scope work to that repo
+    assert "只改" in rendered and "这一个仓" in rendered

--- a/orchestrator/tests/test_contract_fixer_prompts.py
+++ b/orchestrator/tests/test_contract_fixer_prompts.py
@@ -17,8 +17,7 @@ Scenarios covered:
 """
 from __future__ import annotations
 
-import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -108,7 +107,7 @@ async def test_DFP_S1_dev_fixer_uses_dedicated_dev_prompt(_patch_start_fixer_dep
 
     render_calls = _patch_start_fixer_deps
 
-    result = await start_fixer(
+    await start_fixer(
         body=_FakeBody(),
         req_id=_REQ_ID,
         tags=["verify:dev_cross_check"],
@@ -137,7 +136,7 @@ async def test_DFP_S2_spec_fixer_uses_dedicated_spec_prompt(_patch_start_fixer_d
 
     render_calls = _patch_start_fixer_deps
 
-    result = await start_fixer(
+    await start_fixer(
         body=_FakeBody(),
         req_id=_REQ_ID,
         tags=["verify:spec_lint"],
@@ -165,7 +164,7 @@ async def test_DFP_S3_missing_fixer_fallback_to_bugfix(_patch_start_fixer_deps, 
 
     render_calls = _patch_start_fixer_deps
 
-    result = await start_fixer(
+    await start_fixer(
         body=_FakeBody(),
         req_id=_REQ_ID,
         tags=["verify:dev_cross_check"],
@@ -241,7 +240,7 @@ def test_DFP_S6_target_repo_extracted_from_decision_json():
         '"target_repo": "owner/repo-a"}\n'
         '```'
     )
-    event, decision, reason = derive_verifier_event(decision_json, tags=[])
+    event, decision, _reason = derive_verifier_event(decision_json, tags=[])
     assert event == Event.VERIFY_FIX_NEEDED
     assert decision is not None
     assert decision.get("target_repo") == "owner/repo-a"
@@ -260,7 +259,7 @@ async def test_DFP_S7_target_repo_appears_in_rendered_dev_prompt(_patch_start_fi
 
     render_calls = _patch_start_fixer_deps
 
-    result = await start_fixer(
+    await start_fixer(
         body=_FakeBody(),
         req_id=_REQ_ID,
         tags=["verify:dev_cross_check"],

--- a/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
+++ b/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import httpx
 import pytest
@@ -148,7 +148,7 @@ def _make_stale_row(req_id="REQ-stuck-1", stale_for_sec=2400, *,
         "req_id": req_id,
         "project_id": "proj-test",
         "state": "escalated",
-        "updated_at": datetime.now(timezone.utc) - timedelta(seconds=stale_for_sec),
+        "updated_at": datetime.now(UTC) - timedelta(seconds=stale_for_sec),
         "stuck_sec": stale_for_sec,
         "context": dict(context or {}),
     }

--- a/orchestrator/tests/test_verifier.py
+++ b/orchestrator/tests/test_verifier.py
@@ -552,6 +552,80 @@ async def test_start_fixer_creates_issue_with_fixer_tags(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_start_fixer_dev_uses_dedicated_prompt(monkeypatch):
+    """fixer=dev 时用 verifier-fix-dev.md.j2，不是通用 bugfix。"""
+    from orchestrator.actions import _verifier as v
+    fake = make_fake_bkd()
+    fake.create_issue.return_value = FakeIssue(id="fix-dev")
+    patch_bkd(monkeypatch, fake)
+
+    async def fake_update(pool, req_id, patch):
+        pass
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+
+    out = await v.start_fixer(
+        body=make_body(), req_id="REQ-9", tags=[],
+        ctx={"verifier_stage": "dev_cross_check", "verifier_fixer": "dev"},
+    )
+    assert out["fixer"] == "dev"
+    _, fu = fake.follow_up_issue.await_args
+    assert "DEV FIXER" in fu["prompt"]
+    assert "LOCKED：只改业务代码" in fu["prompt"]
+    assert "LOCKED：不改 spec" in fu["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_start_fixer_spec_uses_dedicated_prompt(monkeypatch):
+    """fixer=spec 时用 verifier-fix-spec.md.j2，不是通用 bugfix。"""
+    from orchestrator.actions import _verifier as v
+    fake = make_fake_bkd()
+    fake.create_issue.return_value = FakeIssue(id="fix-spec")
+    patch_bkd(monkeypatch, fake)
+
+    async def fake_update(pool, req_id, patch):
+        pass
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+
+    out = await v.start_fixer(
+        body=make_body(), req_id="REQ-9", tags=[],
+        ctx={"verifier_stage": "spec_lint", "verifier_fixer": "spec"},
+    )
+    assert out["fixer"] == "spec"
+    _, fu = fake.follow_up_issue.await_args
+    assert "SPEC FIXER" in fu["prompt"]
+    assert "LOCKED：只改 spec 相关文件" in fu["prompt"]
+    assert "LOCKED：不改业务代码" in fu["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_start_fixer_target_repo_passed_to_prompt(monkeypatch):
+    """ctx.verifier_target_repo 透传给 prompt 模板。"""
+    from orchestrator.actions import _verifier as v
+    fake = make_fake_bkd()
+    fake.create_issue.return_value = FakeIssue(id="fix-tr")
+    patch_bkd(monkeypatch, fake)
+
+    async def fake_update(pool, req_id, patch):
+        pass
+    monkeypatch.setattr("orchestrator.actions._verifier.req_state.update_context", fake_update)
+    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
+
+    await v.start_fixer(
+        body=make_body(), req_id="REQ-9", tags=[],
+        ctx={
+            "verifier_stage": "staging_test",
+            "verifier_fixer": "dev",
+            "verifier_target_repo": "owner/repo-a",
+        },
+    )
+    _, fu = fake.follow_up_issue.await_args
+    assert "TARGET_REPO=owner/repo-a" in fu["prompt"]
+    assert "只改 `owner/repo-a` 这一个仓的业务代码" in fu["prompt"]
+
+
+@pytest.mark.asyncio
 async def test_start_fixer_defaults_to_dev(monkeypatch):
     """ctx 里没 verifier_fixer 时兜底 dev。"""
     from orchestrator.actions import _verifier as v


### PR DESCRIPTION
## Summary

Replace the generic `bugfix.md.j2` fixer prompt with two dedicated prompts:

- **dev fixer** (`verifier-fix-dev.md.j2`): locked to business code only, with `make ci-lint` pre-push check and `target_repo` scoping
- **spec fixer** (`verifier-fix-spec.md.j2`): locked to spec files only, with `openspec validate` pre-push check and spec-drift prevention

## Changes

- Add `verifier-fix-dev.md.j2` and `verifier-fix-spec.md.j2` prompt templates
- Update `start_fixer` routing in `actions/_verifier.py`:
  - `fixer=dev` → dev prompt
  - `fixer=spec` → spec prompt
  - missing → fallback to legacy `bugfix.md.j2`
- Pass `target_repo` from verifier decision through webhook ctx to fixer prompts
- Update `docs/prompts.md` index
- Add unit tests verifying template routing and `target_repo` passthrough

## Test plan

- [x] `uv run pytest tests/test_verifier.py` — 62 passed
- [x] `uv run pytest tests/test_contract_fixer_audit_v2.py` — passed
- [x] `uv run pytest tests/test_contract_prompts_repo_agnostic_challenger.py` — passed
- [x] openspec validate `REQ-dedicated-fixer-prompts-1777420810` — valid

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-dedicated-fixer-prompts-1777420810`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/basg0eig)