### PR TITLE
feat(orch): PENDING_USER_PR_REVIEW + GitHub PR review webhook feedback loop [REQ-1777420881]

### DIFF
--- a/openspec/changes/REQ-user-feedback-loop-1777420881/proposal.md
+++ b/openspec/changes/REQ-user-feedback-loop-1777420881/proposal.md
@@ -1,0 +1,100 @@
+# REQ-user-feedback-loop-1777420881: 用户反馈回路——PENDING_USER_PR_REVIEW + GH PR review webhook
+
+## 问题
+
+当前流水线到 accept teardown 后进入 PENDING_USER_REVIEW 状态，等用户在 BKD intent issue
+上改 statusId 表态（done=approve / review=fix）。这导致：
+
+- PR 被 review 人打了 reject → sisyphus 不知道，不会自动修复
+- PR 被 review 人提了修改建议 → 需要人手动创建新 REQ
+- 无法形成"accept → PR review → fix → 再 review"的闭环
+- 用户在 GitHub 上 review PR，BKD 上无感知；两个系统割裂
+
+## 方案
+
+用 GitHub PR review webhook 替代 BKD statusId 作为 accept 后的用户反馈入口：
+
+| 维度 | 旧（BKD statusId） | 新（GitHub PR review） |
+|---|---|---|
+| 触发源 | BKD intent issue statusId 变更 | GitHub `pull_request_review.submitted` / `pull_request_review_comment.created` |
+| approved | `statusId=done` → USER_REVIEW_PASS → ARCHIVING | `review.state=approved` → GH_PR_REVIEW_APPROVED → ARCHIVING |
+| changes_requested | `statusId=review` → USER_REVIEW_FIX → ESCALATED | `review.state=changes_requested` → GH_PR_REVIEW_CHANGES_REQUESTED → REVIEW_RUNNING → verifier → fixer |
+| commented | 不支持 | `review.state=commented` → 内容 NLP 判（LGTM=pass / fix:=fix / 其他=escalate） |
+| 状态名 | PENDING_USER_REVIEW | PENDING_USER_PR_REVIEW |
+
+BKD statusId 路径保留但不作为新 REQ 的主流程（向后兼容）。
+
+### 实现要点
+
+1. **state.py**：
+   - 新增 `PENDING_USER_PR_REVIEW` 状态
+   - 新增 3 个 Event：`GH_PR_REVIEW_APPROVED` / `GH_PR_REVIEW_CHANGES_REQUESTED` / `GH_PR_REVIEW_COMMENTED`
+   - TEARDOWN_DONE_PASS 目标改为 PENDING_USER_PR_REVIEW
+   - PENDING_USER_PR_REVIEW 的 transitions：approved→ARCHIVING, changes_requested→REVIEW_RUNNING+verifier, commented→REVIEW_RUNNING+verifier
+   - PR_MERGED 在 PENDING_USER_PR_REVIEW 也有效（兜底）
+
+2. **webhook.py —— `/github-events` endpoint**：
+   - HMAC-SHA256 签名验证（`github_webhook_secret` 配置）
+   - 解析 `pull_request_review.submitted`：按 `review.state` 直接判
+   - 解析 `pull_request_review_comment.created`：按 `comment.body` 内容判
+   - NLP 轻量规则："LGTM"/"looks good" → approved；"fix:" → changes_requested
+   - 从 PR branch (`feat/REQ-xxx`) 解析 REQ ID，fallback 查 req_state 表
+   - 只有 `state == PENDING_USER_PR_REVIEW` 才处理
+   - dedup：同一 review/comment 只处理一次
+
+3. **actions/_verifier.py**：
+   - 新增 `pr_review` stage
+   - `_PASS_ROUTING`：pr_review → (ARCHIVING, ARCHIVE_DONE)（verifier 判 pass 后直接归档）
+   - 3 个 action handler：`invoke_verifier_for_pr_review_fail/success/comment`
+
+4. **verifier prompts**：
+   - `pr_review_success.md.j2`：approved 时做最终确认（夹带私货 / 藏条件）
+   - `pr_review_fail.md.j2`：changes_requested/commented 时判 fix/escalate
+
+5. **配套更新**：
+   - `engine.py` — STATE_TO_STAGE 加入 pending_user_pr_review
+   - `watchdog.py` — 加入 _SKIP_STATES / _NO_WATCHDOG_STATES（human-in-loop 不杀）
+   - `admin.py` — PR_MERGED_VALID_STATES 加入 PENDING_USER_PR_REVIEW
+   - `config.py` — 新增 `github_webhook_secret`
+   - `post_acceptance_report.py` — 更新文案说明 GitHub PR review 拍板方式
+
+6. **测试**：
+   - 更新 `test_contract_user_acceptance_gate.py`（适应新 TEARDOWN_DONE_PASS 目标）
+   - 新增 `test_contract_pr_review_feedback_loop.py`（PR-WH-S1~S10）
+
+### 与现有系统的关系
+
+```
+accept pass → teardown_accept_env → PENDING_USER_PR_REVIEW
+  ↓ 等 GitHub PR review
+  ├─ approved → ARCHIVING → done
+  ├─ changes_requested → REVIEW_RUNNING → verifier → fixer → 再推 PR → 再 review
+  ├─ commented (LGTM) → ARCHIVING
+  ├─ commented (fix:) → REVIEW_RUNNING → fixer
+  └─ PR merged (兜底) → ARCHIVING
+```
+
+PR review 闭环跟 BKD statusId 闭环并存：新 REQ 走 PR review 路径，旧 REQ（如果还有卡在
+PENDING_USER_REVIEW 的）仍可由 statusId 驱动。
+
+## 取舍
+
+- **为什么 approved 不走 verifier 而是直接 archive** —— approved 是最短路径，verifier
+  只是确认性检查。保留 `invoke_verifier_for_pr_review_success` action 供 manual/admin 调用。
+- **为什么 comment 也进 verifier 而不是直接 escalate** —— 很多 review 的 comment 是
+  "LGTM with nits" 或 "approve but please fix X"，需要 verifier 做语义判断。
+- **为什么不替换 PENDING_USER_REVIEW 而是新增 PENDING_USER_PR_REVIEW** —— 向后兼容。
+  旧 REQ 如果还在 PENDING_USER_REVIEW，statusId 驱动仍然有效。
+- **为什么 GitHub webhook 不走 `/bkd-events`** —— payload 格式完全不同（BKD webhook vs
+  GitHub webhook），独立 endpoint 更干净。签名验证机制也不同（Bearer vs HMAC-SHA256）。
+
+## 影响面
+
+- 改 `orchestrator/src/orchestrator/state.py`：新增状态 + 事件 + transitions
+- 改 `orchestrator/src/orchestrator/webhook.py`：新增 `/github-events` endpoint
+- 改 `orchestrator/src/orchestrator/actions/_verifier.py`：新增 pr_review stage + handlers
+- 改 `orchestrator/src/orchestrator/engine.py`、`watchdog.py`、`admin.py`、`config.py`：配套注册
+- 改 `orchestrator/src/orchestrator/actions/post_acceptance_report.py`：文案更新
+- 新增 prompts：`pr_review_success.md.j2`、`pr_review_fail.md.j2`
+- 新增/更新测试文件
+- 不动数据库 migrations（无 schema 变更）

--- a/openspec/changes/REQ-user-feedback-loop-1777420881/specs/pr-review-feedback-loop/spec.md
+++ b/openspec/changes/REQ-user-feedback-loop-1777420881/specs/pr-review-feedback-loop/spec.md
@@ -1,0 +1,124 @@
+# pr-review-feedback-loop
+
+## ADDED Requirements
+
+### Requirement: sisyphus SHALL expose a PENDING_USER_PR_REVIEW state driven by GitHub PR review webhooks
+
+The orchestrator SHALL add a new `ReqState.PENDING_USER_PR_REVIEW` (`pending-user-pr-review`) that replaces `PENDING_USER_REVIEW` as the default post-accept state. When `ACCEPT_TEARING_DOWN` receives `Event.TEARDOWN_DONE_PASS`, the state machine MUST transition to `PENDING_USER_PR_REVIEW` (action `post_acceptance_report`). From `PENDING_USER_PR_REVIEW`, the state machine MUST support three new events derived from GitHub PR review webhooks:
+
+- `GH_PR_REVIEW_APPROVED` (`gh-pr-review.approved`) — review.state == "approved"
+- `GH_PR_REVIEW_CHANGES_REQUESTED` (`gh-pr-review.changes-requested`) — review.state == "changes_requested"
+- `GH_PR_REVIEW_COMMENTED` (`gh-pr-review.commented`) — review.state == "commented" (or pull_request_review_comment.created)
+
+The transitions from `PENDING_USER_PR_REVIEW` MUST be:
+- approved → `ARCHIVING` + `done_archive` action (shortest path, no verifier)
+- changes_requested → `REVIEW_RUNNING` + `invoke_verifier_for_pr_review_fail`
+- commented → `REVIEW_RUNNING` + `invoke_verifier_for_pr_review_comment`
+- PR_MERGED → `ARCHIVING` + `done_archive` (escape hatch)
+
+The old `PENDING_USER_REVIEW` state and its transitions (`USER_REVIEW_PASS` / `USER_REVIEW_FIX`) MUST remain in the transition table for backward compatibility.
+
+#### Scenario: PR-FL-S1 approved review triggers direct archive
+
+- **GIVEN** a REQ in state `PENDING_USER_PR_REVIEW`
+- **WHEN** GitHub webhook `pull_request_review.submitted` with `review.state="approved"` arrives
+- **THEN** the state machine MUST transition to `ARCHIVING` with action `done_archive`
+- **AND** no verifier agent MUST be started
+
+#### Scenario: PR-FL-S2 changes_requested triggers verifier then fixer
+
+- **GIVEN** a REQ in state `PENDING_USER_PR_REVIEW`
+- **WHEN** GitHub webhook with `review.state="changes_requested"` arrives
+- **THEN** the state machine MUST transition to `REVIEW_RUNNING` with action `invoke_verifier_for_pr_review_fail`
+- **AND** the verifier prompt MUST include the review body text
+
+#### Scenario: PR-FL-S3 commented with LGTM treated as approved
+
+- **GIVEN** a REQ in state `PENDING_USER_PR_REVIEW`
+- **WHEN** GitHub webhook with `review.state="commented"` and body containing "LGTM" arrives
+- **THEN** the derived event MUST be `GH_PR_REVIEW_APPROVED`
+- **AND** the state machine MUST transition to `ARCHIVING`
+
+#### Scenario: PR-FL-S4 commented with fix: treated as changes_requested
+
+- **GIVEN** a REQ in state `PENDING_USER_PR_REVIEW`
+- **WHEN** GitHub webhook with `review.state="commented"` and body starting with "fix:" arrives
+- **THEN** the derived event MUST be `GH_PR_REVIEW_CHANGES_REQUESTED`
+- **AND** the state machine MUST transition to `REVIEW_RUNNING`
+
+#### Scenario: PR-FL-S5 unknown review state returns None
+
+- **GIVEN** any review state string not in {approved, changes_requested, commented}
+- **WHEN** `_derive_event_from_review_state` is called
+- **THEN** it MUST return `None`
+
+### Requirement: sisyphus SHALL expose a /github-events endpoint with HMAC-SHA256 signature verification
+
+The orchestrator SHALL expose `POST /github-events` that accepts GitHub webhook payloads. It MUST verify the `X-Hub-Signature-256` header using HMAC-SHA256 against `settings.github_webhook_secret`. Invalid signatures MUST return HTTP 401. Valid payloads MUST be parsed as JSON. The endpoint MUST handle `pull_request_review.submitted` and `pull_request_review_comment.created` events; all other events MUST be skipped with a logged reason.
+
+The endpoint MUST extract the REQ id from the PR branch name (pattern `feat/REQ-xxx` or `REQ-xxx`). If direct extraction fails, it MUST fall back to querying `req_state` by `context->>'branch'`. It MUST verify that the REQ's current state is `PENDING_USER_PR_REVIEW`; if not, it MUST skip with a logged reason. It MUST deduplicate events using a key derived from `gh_event|review_id|req_id`, writing the dedup record before processing and marking it processed after.
+
+Before calling `engine.step`, it MUST write `gh_pr_review_state`, `gh_pr_review_body`, and `gh_pr_review_url` into the REQ's context.
+
+#### Scenario: PR-WH-S6 valid signature passes
+
+- **GIVEN** a valid `github_webhook_secret` is configured
+- **WHEN** a request arrives with correct `X-Hub-Signature-256`
+- **THEN** signature verification MUST succeed
+
+#### Scenario: PR-WH-S7 invalid signature returns 401
+
+- **GIVEN** a valid `github_webhook_secret` is configured
+- **WHEN** a request arrives with incorrect `X-Hub-Signature-256`
+- **THEN** the endpoint MUST return HTTP 401
+
+#### Scenario: PR-WH-S8 state mismatch skips
+
+- **GIVEN** a REQ whose state is `ARCHIVING` (not `PENDING_USER_PR_REVIEW`)
+- **WHEN** a PR review webhook for that REQ arrives
+- **THEN** the endpoint MUST return {"action": "skip", "reason": "...not pending-user-pr-review..."}
+- **AND** engine.step MUST NOT be called
+
+### Requirement: sisyphus verifier framework SHALL support a pr_review stage
+
+The verifier framework (`actions/_verifier.py`) MUST accept `pr_review` as a valid stage in `_STAGES`. The `_PASS_ROUTING` table MUST map `pr_review` to `(ReqState.ARCHIVING, Event.ARCHIVE_DONE)`, so that `apply_verify_pass` can handle verifier decision=pass for PR review by transitioning directly to ARCHIVING and emitting ARCHIVE_DONE.
+
+The framework MUST expose three action handlers registered in `REGISTRY`:
+- `invoke_verifier_for_pr_review_fail` — triggers verifier with stage="pr_review", trigger="fail", stderr_tail from ctx.gh_pr_review_body
+- `invoke_verifier_for_pr_review_success` — triggers verifier with stage="pr_review", trigger="success"
+- `invoke_verifier_for_pr_review_comment` — triggers verifier with stage="pr_review", trigger="fail" (treated as potential issue)
+
+#### Scenario: PR-VR-S9 pr_review pass routes to archiving
+
+- **GIVEN** a verifier decision with action="pass" for stage="pr_review"
+- **WHEN** `apply_verify_pass` executes
+- **THEN** it MUST CAS from `REVIEW_RUNNING` to `ARCHIVING`
+- **AND** it MUST emit `Event.ARCHIVE_DONE`
+
+#### Scenario: PR-VR-S10 pr_review fail invokes verifier with review body
+
+- **GIVEN** a REQ in state `PENDING_USER_PR_REVIEW` with `ctx.gh_pr_review_body="fix the naming"`
+- **WHEN** `invoke_verifier_for_pr_review_fail` executes
+- **THEN** it MUST call `invoke_verifier` with `stage="pr_review"`, `trigger="fail"`, `stderr_tail="fix the naming"`
+
+### Requirement: sisyphus watchdog SHALL skip PENDING_USER_PR_REVIEW
+
+The watchdog module MUST include `ReqState.PENDING_USER_PR_REVIEW` in both `_SKIP_STATES` and `_NO_WATCHDOG_STATES` (via `_STAGE_POLICY` with `None`). This ensures the watchdog NEVER emits `SESSION_FAILED` or escalates a REQ that is legitimately waiting for human PR review.
+
+#### Scenario: PR-WD-S11 watchdog ignores pending PR review
+
+- **GIVEN** a REQ in state `PENDING_USER_PR_REVIEW` for 24 hours
+- **WHEN** the watchdog tick runs
+- **THEN** the REQ MUST NOT appear in the SQL prefilter results
+- **AND** no escalation MUST occur
+
+### Requirement: sisyphus post_acceptance_report SHALL notify users about GitHub PR review
+
+The `post_acceptance_report` action MUST update its managed block text to instruct users to use GitHub PR review instead of BKD statusId. The block MUST explain that `Approve` triggers auto-archive, `Request changes` triggers auto-fixer, and `Comment` with specific keywords is interpreted accordingly. The backward-compatible BKD statusId path MUST still be mentioned.
+
+#### Scenario: PR-PA-S12 report includes PR review instructions
+
+- **GIVEN** `post_acceptance_report` runs for a REQ with `pr_urls` recorded
+- **WHEN** it patches the BKD intent issue description
+- **THEN** the description MUST contain text explaining GitHub PR review as the primary approval mechanism
+- **AND** it MUST still mention BKD statusId as a compatible fallback

--- a/openspec/changes/REQ-user-feedback-loop-1777420881/tasks.md
+++ b/openspec/changes/REQ-user-feedback-loop-1777420881/tasks.md
@@ -24,5 +24,5 @@
 - [x] 运行 verifier loop / watchdog / engine / PR merged 相关回归测试（全部通过）
 
 ## Stage: PR
-- [ ] git push feat/REQ-user-feedback-loop-1777420881
-- [ ] gh pr create --label sisyphus
+- [x] git push feat/REQ-user-feedback-loop-1777420881
+- [x] gh pr create --label sisyphus

--- a/openspec/changes/REQ-user-feedback-loop-1777420881/tasks.md
+++ b/openspec/changes/REQ-user-feedback-loop-1777420881/tasks.md
@@ -1,0 +1,28 @@
+## Stage: spec
+- [x] 分析现有状态机、webhook、verifier 架构
+- [x] 设计 PENDING_USER_PR_REVIEW 状态转换图
+- [x] 设计 GitHub webhook endpoint（签名验证、事件解析、REQ 解析）
+- [x] 设计 verifier prompt 模板（pr_review_success / pr_review_fail）
+- [x] author proposal.md
+- [x] author spec.md（openspec delta 格式）
+
+## Stage: implementation
+- [x] state.py：新增 PENDING_USER_PR_REVIEW + 3 个 GH PR review Event + transitions
+- [x] webhook.py：新增 /github-events endpoint + HMAC 签名验证 + 事件派生
+- [x] actions/_verifier.py：新增 pr_review stage + _PASS_ROUTING + 3 个 action handler
+- [x] engine.py：STATE_TO_STAGE 加入 pending_user_pr_review
+- [x] watchdog.py：_SKIP_STATES + _NO_WATCHDOG_STATES 加入 PENDING_USER_PR_REVIEW
+- [x] admin.py：PR_MERGED_VALID_STATES 加入 PENDING_USER_PR_REVIEW
+- [x] config.py：新增 github_webhook_secret
+- [x] post_acceptance_report.py：更新文案为 GitHub PR review 拍板方式
+- [x] prompts/verifier/pr_review_success.md.j2
+- [x] prompts/verifier/pr_review_fail.md.j2
+
+## Stage: test
+- [x] 更新 test_contract_user_acceptance_gate.py（TEARDOWN_DONE_PASS 新目标 + PENDING_USER_PR_REVIEW transitions）
+- [x] 新增 test_contract_pr_review_feedback_loop.py（事件推导、签名验证、REQ 解析、transition、apply_verify_pass 路由）
+- [x] 运行 verifier loop / watchdog / engine / PR merged 相关回归测试（全部通过）
+
+## Stage: PR
+- [ ] git push feat/REQ-user-feedback-loop-1777420881
+- [ ] gh pr create --label sisyphus

--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -41,9 +41,10 @@ log = structlog.get_logger(__name__)
 
 # 支持的 stage 名（对应 prompts/verifier/{stage}_{trigger}.md.j2）
 # 包括 agent stage（analyze）和 checker stage（spec_lint / dev_cross_check / staging_test / pr_ci）
+# 以及人审 stage（pr_review）
 _STAGES = {
     "analyze", "analyze_artifact_check", "spec_lint", "challenger",
-    "dev_cross_check", "staging_test", "pr_ci", "accept",
+    "dev_cross_check", "staging_test", "pr_ci", "accept", "pr_review",
 }
 
 # Trigger 类型
@@ -58,9 +59,10 @@ _RETRY_ROUTING: dict[str, tuple[ReqState, str]] = {
     "pr_ci":           (ReqState.PR_CI_RUNNING,           "create_pr_ci_watch"),
 }
 
-# stage → decision=pass 时要 emit 的原主链 event + 目标 stage_running state
+# stage → decision=pass 时要 emit 的原主链 event + 目标 state
 # 用于 apply_verify_pass 手工把 state 从 REVIEW_RUNNING 回推到对应 stage_running，
 # 随后链式 emit 该 stage 的 done/pass 事件走原 transition。
+# 特例：pr_review 的 pass 直接到 ARCHIVING（emit ARCHIVE_DONE）。
 _PASS_ROUTING: dict[str, tuple[ReqState, Event]] = {
     "analyze":                 (ReqState.ANALYZING,                Event.ANALYZE_DONE),
     "analyze_artifact_check":  (ReqState.ANALYZE_ARTIFACT_CHECKING,
@@ -71,6 +73,7 @@ _PASS_ROUTING: dict[str, tuple[ReqState, Event]] = {
     "staging_test":            (ReqState.STAGING_TEST_RUNNING,     Event.STAGING_TEST_PASS),
     "pr_ci":                   (ReqState.PR_CI_RUNNING,            Event.PR_CI_PASS),
     "accept":                  (ReqState.ACCEPT_RUNNING,           Event.ACCEPT_PASS),
+    "pr_review":               (ReqState.ARCHIVING,                Event.ARCHIVE_DONE),
 }
 
 # ─── invoke_verifier：起 BKD verifier issue ──────────────────────────────
@@ -502,6 +505,59 @@ async def invoke_verifier_for_challenger_fail(*, body, req_id, tags, ctx):
     """
     return await _invoke_verifier_fail(
         stage="challenger", body=body, req_id=req_id, ctx=ctx,
+    )
+
+
+# ─── REQ-user-feedback-loop-1777420881: PR review verifier handlers ─────────
+
+@register("invoke_verifier_for_pr_review_fail", idempotent=False)
+async def invoke_verifier_for_pr_review_fail(*, body, req_id, tags, ctx):
+    """PR review changes_requested → 起 verifier-agent(stage=pr_review, trigger=fail)。"""
+    ctx = ctx or {}
+    review_body = ctx.get("gh_pr_review_body") or ""
+    return await invoke_verifier(
+        stage="pr_review",
+        trigger="fail",
+        req_id=req_id,
+        project_id=body.projectId,
+        stderr_tail=review_body,
+        ctx=ctx,
+    )
+
+
+@register("invoke_verifier_for_pr_review_success", idempotent=False)
+async def invoke_verifier_for_pr_review_success(*, body, req_id, tags, ctx):
+    """PR review approved → 起 verifier-agent(stage=pr_review, trigger=success)。
+
+    通常 approved 直接 archive（不走 verifier），但本 action 保留供 manual/admin 调用。
+    """
+    ctx = ctx or {}
+    review_body = ctx.get("gh_pr_review_body") or ""
+    return await invoke_verifier(
+        stage="pr_review",
+        trigger="success",
+        req_id=req_id,
+        project_id=body.projectId,
+        stderr_tail=review_body,
+        ctx=ctx,
+    )
+
+
+@register("invoke_verifier_for_pr_review_comment", idempotent=False)
+async def invoke_verifier_for_pr_review_comment(*, body, req_id, tags, ctx):
+    """PR review commented → 起 verifier-agent(stage=pr_review, trigger=comment)。
+
+    verifier 根据 comment 内容判：LGTM=pass / fix:=fix / 其他=escalate。
+    """
+    ctx = ctx or {}
+    review_body = ctx.get("gh_pr_review_body") or ""
+    return await invoke_verifier(
+        stage="pr_review",
+        trigger="fail",  # comment 视为"潜在问题"，verifier prompt 里说明按内容判
+        req_id=req_id,
+        project_id=body.projectId,
+        stderr_tail=review_body,
+        ctx=ctx,
     )
 
 

--- a/orchestrator/src/orchestrator/actions/post_acceptance_report.py
+++ b/orchestrator/src/orchestrator/actions/post_acceptance_report.py
@@ -34,7 +34,7 @@ def _render_acceptance_block(*, req_id: str, pr_urls: dict[str, str] | None) -> 
     """构造以 ACCEPTANCE_MARKER 开头的 managed block。"""
     lines = [
         ACCEPTANCE_MARKER,
-        f"## sisyphus 验收已通过（REQ {req_id}）— 等你拍板",
+        f"## sisyphus 验收已通过（REQ {req_id}）— 请 review PR",
         "",
         "**PR**",
     ]
@@ -45,12 +45,15 @@ def _render_acceptance_block(*, req_id: str, pr_urls: dict[str, str] | None) -> 
         lines.append("- (no PR URLs recorded in ctx; check feat/<REQ> on involved repos)")
     lines.extend([
         "",
-        "**拍板方式**：改本 BKD issue 的 **statusId** 即可（不解释自由文本）：",
+        "**拍板方式**：在 GitHub PR 上提交 review：",
         "",
-        "- `done` → approve，sisyphus 立即合 PR 归档",
-        "- `review` 或 `blocked` → 不满意，sisyphus 进 escalated（reason=user-requested-fix）",
-        "  之后你可以在 chat 里 follow-up 描述具体要改啥",
-        "- 其他 statusId（`working` / `todo` 等）→ sisyphus 继续等",
+        "- **Approve** → sisyphus 自动合 PR 归档",
+        "- **Request changes** → sisyphus 自动起 fixer 修复",
+        "- **Comment** 含 `LGTM` → 视为 approve",
+        "- **Comment** 含 `fix: xxx` → 视为 fix，起 fixer",
+        "",
+        "（兼容路径：改本 BKD issue 的 statusId 仍可生效：",
+        "`done` → approve / `review`/`blocked` → escalated）",
     ])
     return "\n".join(lines) + "\n"
 

--- a/orchestrator/src/orchestrator/admin.py
+++ b/orchestrator/src/orchestrator/admin.py
@@ -656,6 +656,7 @@ _PR_MERGED_NOOP_STATES = frozenset({ReqState.DONE, ReqState.ESCALATED})
 # States that accept PR_MERGED → DONE transition (via state.py TRANSITIONS).
 _PR_MERGED_VALID_STATES = frozenset({
     ReqState.PENDING_USER_REVIEW,
+    ReqState.PENDING_USER_PR_REVIEW,
     ReqState.REVIEW_RUNNING,
     ReqState.PR_CI_RUNNING,
 })

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -24,6 +24,8 @@ class Settings(BaseSettings):
 
     # 入站 webhook 共享 token（BKD webhook 配置里加 `Authorization: Bearer <token>` header）
     webhook_token: str = Field(..., description="Bearer token expected in Authorization header on /bkd-events")
+    # GitHub webhook secret（用于验证 /github-events 的 X-Hub-Signature-256）
+    github_webhook_secret: str = Field(default="", description="GitHub webhook secret for HMAC-SHA256 signature verification")
 
     # ─── v0.2 K8s runner 配置 ─────────────────────────────────────────────
     # sisyphus 在 sisyphus-runners namespace 拉起 per-REQ Pod（runner-<REQ>），

--- a/orchestrator/src/orchestrator/engine.py
+++ b/orchestrator/src/orchestrator/engine.py
@@ -52,6 +52,7 @@ STATE_TO_STAGE: dict[ReqState, str] = {
     ReqState.PR_CI_RUNNING:          "pr_ci",
     ReqState.ACCEPT_RUNNING:         "accept",
     ReqState.ACCEPT_TEARING_DOWN:    "accept_teardown",
+    ReqState.PENDING_USER_PR_REVIEW: "pending_user_pr_review",
     ReqState.REVIEW_RUNNING:         "verifier",
     ReqState.FIXER_RUNNING:          "fixer",
 }

--- a/orchestrator/src/orchestrator/prompts/verifier/pr_review_fail.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/pr_review_fail.md.j2
@@ -1,0 +1,34 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（pr_review / fail）
+PR review 人提交了 **Changes requested** 或 **Comment**，给出了具体修改意见。
+
+{% if stderr_tail %}
+### PR review 内容
+```
+{{ stderr_tail }}
+```
+{% endif %}
+
+你要判：这些意见是**本次 REQ 必须修的**、**可以 defer 的**、还是 **超出 REQ 范围的**。
+
+### 关注点
+- review 意见是否指向本次 REQ 引入的问题（新 bug / 逻辑错误 / 命名不规范）
+- 意见是否是 repo 既有规范（跟本次改动无关，属于 hygiene comment）
+- 意见是否涉及架构大改（"应该整个重写"类）
+- 如果是 comment（非 changes_requested），内容含 "LGTM" 或等价表达 → `pass`
+- 如果是 comment 含 "fix:" 或明确修改指令 → `fix`
+
+### NOT 该做
+- 不直接改代码 —— 只出决策，fixer agent 会执行
+- 不关闭 PR / 不 force-push
+
+### 典型决策
+- `pass`：comment 只是 LGTM / 格式 nit / 跟本次 REQ 无关的 hygiene
+- `fix` + `fixer=dev`：review 指出了本次代码的具体 bug 或改进点
+- `fix` + `fixer=spec`：review 指出 spec / acceptance scenario 有问题
+- `escalate`：review 意见太模糊（"感觉不对"），或要求超出 REQ 范围的大重构
+
+─────────
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/prompts/verifier/pr_review_success.md.j2
+++ b/orchestrator/src/orchestrator/prompts/verifier/pr_review_success.md.j2
@@ -1,0 +1,23 @@
+{% include "verifier/_header.md.j2" %}
+
+## 职责（pr_review / success）
+PR review 人已提交 **Approve**。你要做最终确认：这批改动是否真的可以合。
+
+### 关注点
+- PR 改动的文件范围是否跟 REQ 目标一致（有没有夹带私货）
+- review 人的 approve comment 里有没有藏条件（"approve but please fix X in follow-up"）
+- 如果 evidence 目录存在，验收证据是否完整（scenario 覆盖、screenshot、thanatos result）
+
+### NOT 该做
+- 不动 PR 状态（merge 留给 archive 阶段）
+- 不自己再跑测试（之前的 staging-test / pr-ci 已覆盖）
+
+### 典型决策
+- `pass`：review 人明确 approve，无隐藏条件，改动范围正确
+- `escalate`：approve 评论里藏了必须本次修的条件，或改动范围明显越界
+
+─────────
+
+{% if history %}{% include 'verifier/_audit.md.j2' %}{% endif %}
+
+{% include "verifier/_decision.md.j2" %}

--- a/orchestrator/src/orchestrator/state.py
+++ b/orchestrator/src/orchestrator/state.py
@@ -35,6 +35,7 @@ class ReqState(StrEnum):
     ACCEPT_RUNNING = "accept-running"           # env-up 完，accept-agent 跑 FEATURE-A*
     ACCEPT_TEARING_DOWN = "accept-tearing-down" # env-down 清 lab，后续按 accept_result 分流
     PENDING_USER_REVIEW = "pending-user-review" # accept 全过 → 等用户验收（statusId 表态，watchdog skip）
+    PENDING_USER_PR_REVIEW = "pending-user-pr-review"  # accept 全过 → 等 GitHub PR review（webhook 驱动）
     GH_INCIDENT_OPEN = "gh-incident-open"       # GitHub issue 已开，等人
     # verifier-agent 框架
     REVIEW_RUNNING = "review-running"           # verifier-agent 在跑（success / fail 两触发统一入口）
@@ -74,6 +75,10 @@ class Event(StrEnum):
     # 信号通道 = BKD intent issue statusId（webhook 在 PENDING_USER_REVIEW state 收 issue.updated 时派事件）
     USER_REVIEW_PASS = "user-review.pass"           # statusId → done：用户 approve，发车
     USER_REVIEW_FIX = "user-review.fix"             # statusId → review/blocked：用户要返工 → escalate
+    # REQ-user-feedback-loop-1777420881: GitHub PR review webhook 事件
+    GH_PR_REVIEW_APPROVED = "gh-pr-review.approved"              # PR review = approved
+    GH_PR_REVIEW_CHANGES_REQUESTED = "gh-pr-review.changes-requested"  # PR review = changes_requested
+    GH_PR_REVIEW_COMMENTED = "gh-pr-review.commented"            # PR review = commented（内容需 NLP 判）
     # verifier-agent 决策事件（webhook.py 从 verifier issue 的 decision JSON 派发）
     # 3 路决策：pass / fix / escalate（retry_checker 已砍 —— flaky/外部抖动直接 escalate）
     VERIFY_PASS = "verify.pass"                     # decision.action = pass → 推下一 stage
@@ -189,18 +194,40 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
         Transition(ReqState.ACCEPT_TEARING_DOWN, "teardown_accept_env",
                    "accept fail → 清 lab 再走 verifier"),
 
-    # REQ-bkd-acceptance-feedback-loop-1777278984 改：原本直进 ARCHIVING，现在先停一手
-    # 等用户验收。post_acceptance_report 把验收报告 PATCH 进 BKD intent issue body，
-    # 用户改 statusId 表态后 webhook 派 USER_REVIEW_PASS / USER_REVIEW_FIX 推下去。
+    # REQ-user-feedback-loop-1777420881: accept teardown 后等 GitHub PR review
+    # 不再是 BKD statusId 驱动；PR review webhook 来后自动推 verifier / archive / fixer
     (ReqState.ACCEPT_TEARING_DOWN, Event.TEARDOWN_DONE_PASS):
-        Transition(ReqState.PENDING_USER_REVIEW, "post_acceptance_report",
-                   "teardown 完 → 等用户 BKD intent issue statusId 表态"),
+        Transition(ReqState.PENDING_USER_PR_REVIEW, "post_acceptance_report",
+                   "teardown 完 → 等 GitHub PR review"),
 
     (ReqState.ACCEPT_TEARING_DOWN, Event.TEARDOWN_DONE_FAIL):
         Transition(ReqState.REVIEW_RUNNING, "invoke_verifier_for_accept_fail",
                    "accept fail + teardown 完 → verifier"),
 
-    # ─── PENDING_USER_REVIEW 出口（REQ-bkd-acceptance-feedback-loop-1777278984）───
+    # ─── PENDING_USER_PR_REVIEW 出口（REQ-user-feedback-loop-1777420881）────────
+    # GitHub PR review webhook 驱动：
+    #   - approved → 直接 ARCHIVING（最短路径，不需要 verifier）
+    #   - changes_requested → REVIEW_RUNNING + verifier（trigger=fail）
+    #   - commented → REVIEW_RUNNING + verifier（trigger=comment，由 verifier 判内容）
+    # 没 SESSION_FAILED self-loop —— 该 state 没 BKD agent 在跑
+    (ReqState.PENDING_USER_PR_REVIEW, Event.GH_PR_REVIEW_APPROVED):
+        Transition(ReqState.ARCHIVING, "done_archive",
+                   "PR approved → 直接归档发车"),
+
+    (ReqState.PENDING_USER_PR_REVIEW, Event.GH_PR_REVIEW_CHANGES_REQUESTED):
+        Transition(ReqState.REVIEW_RUNNING, "invoke_verifier_for_pr_review_fail",
+                   "PR changes requested → verifier 判 fix/escalate"),
+
+    (ReqState.PENDING_USER_PR_REVIEW, Event.GH_PR_REVIEW_COMMENTED):
+        Transition(ReqState.REVIEW_RUNNING, "invoke_verifier_for_pr_review_comment",
+                   "PR commented → verifier 判内容（LGTM=pass / fix:=fix / 其他=escalate）"),
+
+    # PR_MERGED 兜底：人在 PENDING_USER_PR_REVIEW 阶段直接合了 PR
+    (ReqState.PENDING_USER_PR_REVIEW, Event.PR_MERGED):
+        Transition(ReqState.ARCHIVING, "done_archive",
+                   "PR merged while waiting review → skip gate → archive"),
+
+    # ─── PENDING_USER_REVIEW 出口（REQ-bkd-acceptance-feedback-loop-1777278984，保留兼容）───
     # 用户改 BKD intent issue statusId：
     #   - "done" → USER_REVIEW_PASS → DONE（archive 作为 fire-and-forget 副作用）
     #   - "review" / "blocked" → USER_REVIEW_FIX → ESCALATED（reason=user-requested-fix）
@@ -216,8 +243,8 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
 
     # ─── PR_MERGED：人手合 PR 后 GHA 钩 → admin endpoint 注入，跳 gate 直达 DONE ───────────
     # REQ-pr-merge-archive-hook-1777344443
-    # 主场景：PENDING_USER_REVIEW（最常见的卡死态：accept 全过但 sisyphus 不知道 PR 被人合了）。
-    # 兜底：REVIEW_RUNNING / PR_CI_RUNNING（极少：verifier 或 CI 还在跑时人已合 PR）。
+    # 主场景：PENDING_USER_PR_REVIEW（accept 全过等 review 时 PR 被人合了）。
+    # 兜底：PENDING_USER_REVIEW / REVIEW_RUNNING / PR_CI_RUNNING。
     # CAS 保证并发安全：如果 verifier/CI 也在尝试 transition，两者竞争，输的一方 CAS_LOST。
     (ReqState.PENDING_USER_REVIEW, Event.PR_MERGED):
         Transition(ReqState.DONE, None,

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -87,6 +87,7 @@ _SKIP_STATES = {
     ReqState.INIT.value,
     ReqState.INTAKING.value,
     ReqState.PENDING_USER_REVIEW.value,
+    ReqState.PENDING_USER_PR_REVIEW.value,
 }
 
 @dataclass(frozen=True)
@@ -126,6 +127,7 @@ _STAGE_POLICY: dict[ReqState, _StagePolicy | None] = {
     # human-loop-conversation
     ReqState.INTAKING: None,
     ReqState.PENDING_USER_REVIEW: None,
+    ReqState.PENDING_USER_PR_REVIEW: None,  # 等 GitHub PR review，没 BKD agent 在跑
     # deterministic-checker（紧 5min ended + 5min stuck 双线）
     ReqState.SPEC_LINT_RUNNING: _StagePolicy(ended_sec=300, stuck_sec=300),
     ReqState.DEV_CROSS_CHECK_RUNNING: _StagePolicy(ended_sec=300, stuck_sec=300),

--- a/orchestrator/src/orchestrator/webhook.py
+++ b/orchestrator/src/orchestrator/webhook.py
@@ -1,13 +1,19 @@
 """Webhook handler：BKD → 状态机 → action dispatch。
 
-唯一入口 /bkd-events，收所有 BKD webhook（issue.updated / session.completed / session.failed）。
+入口：
+- /bkd-events：收所有 BKD webhook（issue.updated / session.completed / session.failed）
+- /github-events：收 GitHub webhook（pull_request_review.submitted / pull_request_review_comment.created）
+
 handler 内部按 body.event 字段分流。
 内部 decide+CAS+dispatch 走 engine.step（让 action 也能链式 emit 事件）。
 """
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import hmac
+import json
+import re
 from typing import Any
 
 import structlog
@@ -602,5 +608,215 @@ async def webhook(request: Request) -> JSONResponse:
         event=event,
     )
     # handler 跑完，标 processed_at。engine.step 抛异常时不到这里，BKD 重发会走 retry 路径。
+    await dedup.mark_processed(pool, eid)
+    return result
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# REQ-user-feedback-loop-1777420881: GitHub PR review webhook handler
+# ═══════════════════════════════════════════════════════════════════════
+
+_GH_EVENT_HEADER = "x-github-event"
+_GH_SIGNATURE_HEADER = "x-hub-signature-256"
+
+# 从 branch 名提取 REQ ID：feat/REQ-xxx → REQ-xxx
+_REQ_FROM_BRANCH_RE = re.compile(r"(?:feat/)?(REQ-[\w-]+)$")
+
+
+def _verify_github_signature(payload: bytes, signature: str | None) -> bool:
+    """GitHub webhook HMAC-SHA256 签名验证。"""
+    secret = settings.github_webhook_secret
+    if not secret:
+        log.warning("github_webhook.secret_not_set")
+        return False
+    if not signature or not signature.startswith("sha256="):
+        return False
+    expected = signature[7:]  # 去掉 "sha256=" 前缀
+    mac = hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(mac, expected)
+
+
+def _derive_event_from_review_state(review_state: str, body_text: str) -> Event | None:
+    """根据 PR review state + body 内容推导 Event。"""
+    review_state = review_state.lower()
+    body_lower = body_text.lower()
+
+    if review_state == "approved":
+        return Event.GH_PR_REVIEW_APPROVED
+
+    if review_state == "changes_requested":
+        return Event.GH_PR_REVIEW_CHANGES_REQUESTED
+
+    if review_state == "commented":
+        # NLP 轻量规则
+        if "lgtm" in body_lower or "looks good" in body_lower:
+            return Event.GH_PR_REVIEW_APPROVED
+        if body_lower.startswith("fix:") or body_lower.startswith("fix "):
+            return Event.GH_PR_REVIEW_CHANGES_REQUESTED
+        return Event.GH_PR_REVIEW_COMMENTED
+
+    return None
+
+
+async def _resolve_req_id_from_pr(
+    pool: Any, branch: str, pr_url: str,
+) -> tuple[str | None, dict | None]:
+    """从 PR branch / URL 解析 REQ ID，并返回 req_state row（如果找到）。
+
+    优先从 branch 名提取（feat/REQ-xxx）；失败则查 req_state 表 match branch 或 pr_urls。
+    """
+    # 1. branch 名提取
+    m = _REQ_FROM_BRANCH_RE.search(branch)
+    if m:
+        req_id = m.group(1)
+        row = await req_state.get(pool, req_id)
+        if row is not None:
+            return req_id, row
+
+    # 2. fallback：查 req_state 表 context->>'branch' 匹配
+    rows = await pool.fetch(
+        "SELECT req_id, project_id, state, history, context, created_at, updated_at "
+        "FROM req_state WHERE context->>'branch' = $1 LIMIT 5",
+        branch,
+    )
+    if rows:
+        r = rows[0]
+        from .store.req_state import ReqRow
+        return r["req_id"], ReqRow(
+            req_id=r["req_id"],
+            project_id=r["project_id"],
+            state=ReqState(r["state"]),
+            history=json.loads(r["history"]) if isinstance(r["history"], str) else (r["history"] or []),
+            context=json.loads(r["context"]) if isinstance(r["context"], str) else (r["context"] or {}),
+            created_at=r["created_at"],
+            updated_at=r["updated_at"],
+        )
+
+    # 3. fallback：查 req_state 表 pr_urls 匹配
+    rows = await pool.fetch(
+        "SELECT req_id, project_id, state, history, context, created_at, updated_at "
+        "FROM req_state WHERE context->'pr_urls' @> $1::jsonb LIMIT 5",
+        json.dumps({pr_url: pr_url}),
+    )
+    # 这个查询不太准，先不用
+
+    return None, None
+
+
+@api.get("/github-events")
+async def github_webhook_probe() -> dict:
+    """GET 探活，给 GitHub webhook 注册 / 健康巡检用。无需 auth。"""
+    return {"status": "ok", "endpoint": "github-events", "method": "POST", "auth": "X-Hub-Signature-256"}
+
+
+@api.post("/github-events")
+async def github_webhook(request: Request) -> JSONResponse:
+    """GitHub webhook 入口：处理 PR review 事件，驱动 PENDING_USER_PR_REVIEW 状态。
+
+    支持的事件：
+    - pull_request_review.submitted → 根据 review.state 判 approved/changes_requested/commented
+    - pull_request_review_comment.created → 根据 comment.body 内容判
+    """
+    raw = await request.body()
+    signature = request.headers.get(_GH_SIGNATURE_HEADER)
+    if not _verify_github_signature(raw, signature):
+        log.warning("github_webhook.signature_invalid")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid signature",
+        )
+
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid JSON body") from None
+
+    gh_event = request.headers.get(_GH_EVENT_HEADER, "")
+    action = payload.get("action", "")
+
+    log.info("github_webhook.received", event=gh_event, action=action)
+
+    # 只处理 pull_request_review.submitted 和 pull_request_review_comment.created
+    if gh_event == "pull_request_review" and action == "submitted":
+        review = payload.get("review", {})
+        review_state = review.get("state", "")
+        review_body = review.get("body", "")
+        event = _derive_event_from_review_state(review_state, review_body)
+        pr = payload.get("pull_request", {})
+        branch = pr.get("head", {}).get("ref", "")
+        pr_url = pr.get("html_url", "")
+        review_id = review.get("id")
+    elif gh_event == "pull_request_review_comment" and action == "created":
+        comment = payload.get("comment", {})
+        comment_body = comment.get("body", "")
+        event = _derive_event_from_review_state("commented", comment_body)
+        pr = payload.get("pull_request", {})
+        branch = pr.get("head", {}).get("ref", "")
+        pr_url = pr.get("html_url", "")
+        review_id = comment.get("id")
+    else:
+        log.debug("github_webhook.event_skipped", event=gh_event, action=action)
+        return {"action": "skip", "reason": f"unhandled event: {gh_event}.{action}"}
+
+    if event is None:
+        log.debug("github_webhook.no_event", review_state=review_state if 'review_state' in locals() else 'n/a')
+        return {"action": "skip", "reason": "no derivable event"}
+
+    pool = db.get_pool()
+    req_id, row = await _resolve_req_id_from_pr(pool, branch, pr_url)
+    if req_id is None or row is None:
+        log.warning("github_webhook.req_not_found", branch=branch, pr_url=pr_url)
+        return {"action": "skip", "reason": "req not found for PR"}
+
+    # 只有 state == PENDING_USER_PR_REVIEW 才处理（其他 state 的 PR review 忽略）
+    if row.state != ReqState.PENDING_USER_PR_REVIEW:
+        log.info(
+            "github_webhook.state_mismatch",
+            req_id=req_id, state=row.state.value, expected=ReqState.PENDING_USER_PR_REVIEW.value,
+        )
+        return {"action": "skip", "reason": f"req state is {row.state.value}, not pending-user-pr-review"}
+
+    # dedup：同一 review/comment 只处理一次（GitHub 可能重发）
+    eid = f"gh|{gh_event}|{review_id}|{req_id}"
+    dedup_status = await dedup.check_and_record(pool, eid)
+    if dedup_status == "skip":
+        log.debug("github_webhook.dedup.skip", event_id=eid)
+        return {"action": "skip", "reason": "duplicate event"}
+
+    # 把 review body 写进 ctx 供 verifier prompt 用
+    body_text = review_body if 'review_body' in locals() else comment_body
+    ctx_patch = {
+        "gh_pr_review_state": review_state if 'review_state' in locals() else "commented",
+        "gh_pr_review_body": body_text,
+        "gh_pr_review_url": pr_url,
+    }
+    await req_state.update_context(pool, req_id, ctx_patch)
+    ctx = {**(row.context or {}), **ctx_patch}
+
+    log.info(
+        "github_webhook.derived",
+        req_id=req_id, event=event.value, branch=branch, pr_url=pr_url,
+    )
+
+    # 推进状态机
+    fake_body = type("_FakeBody", (), {
+        "issueId": f"gh-{review_id}",
+        "projectId": row.project_id,
+        "event": gh_event,
+        "title": "",
+        "tags": [req_id],
+        "issueNumber": None,
+    })()
+
+    result = await engine.step(
+        pool,
+        body=fake_body,
+        req_id=req_id,
+        project_id=row.project_id,
+        tags=[req_id],
+        cur_state=row.state,
+        ctx=ctx,
+        event=event,
+    )
     await dedup.mark_processed(pool, eid)
     return result

--- a/orchestrator/tests/test_contract_pr_review_feedback_loop.py
+++ b/orchestrator/tests/test_contract_pr_review_feedback_loop.py
@@ -1,0 +1,178 @@
+"""Contract tests for REQ-user-feedback-loop-1777420881.
+
+Scenarios:
+  PR-WH-S1  approved review derives GH_PR_REVIEW_APPROVED
+  PR-WH-S2  changes_requested review derives GH_PR_REVIEW_CHANGES_REQUESTED
+  PR-WH-S3  commented review with "LGTM" derives GH_PR_REVIEW_APPROVED
+  PR-WH-S4  commented review with "fix:" derives GH_PR_REVIEW_CHANGES_REQUESTED
+  PR-WH-S5  commented review without keyword derives GH_PR_REVIEW_COMMENTED
+  PR-WH-S6  unknown review state derives None
+  PR-WH-S7  signature mismatch returns 401
+  PR-WH-S8  req not in PENDING_USER_PR_REVIEW state is skipped
+  PR-WH-S9  branch feat/REQ-xxx resolves req_id
+  PR-WH-S10 apply_verify_pass routes pr_review → ARCHIVING + ARCHIVE_DONE
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+
+from orchestrator import webhook
+from orchestrator.actions._verifier import _PASS_ROUTING
+from orchestrator.state import Event, ReqState, decide
+
+
+# ── _derive_event_from_review_state ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "review_state,body,expected",
+    [
+        ("approved", "", Event.GH_PR_REVIEW_APPROVED),
+        ("changes_requested", "fix the bug", Event.GH_PR_REVIEW_CHANGES_REQUESTED),
+        ("commented", "LGTM", Event.GH_PR_REVIEW_APPROVED),
+        ("commented", "looks good to me", Event.GH_PR_REVIEW_APPROVED),
+        ("commented", "fix: rename variable", Event.GH_PR_REVIEW_CHANGES_REQUESTED),
+        ("commented", "fix variable name", Event.GH_PR_REVIEW_CHANGES_REQUESTED),
+        ("commented", "nice work", Event.GH_PR_REVIEW_COMMENTED),
+    ],
+)
+def test_PR_WH_S1_S5_event_derivation(review_state, body, expected):
+    """PR-WH-S1..S5: review state + body content correctly maps to Event."""
+    result = webhook._derive_event_from_review_state(review_state, body)
+    assert result == expected
+
+
+def test_PR_WH_S6_unknown_review_state():
+    """PR-WH-S6: unknown review state returns None."""
+    assert webhook._derive_event_from_review_state("dismissed", "") is None
+
+
+# ── _verify_github_signature ─────────────────────────────────────────────────
+
+
+def test_PR_WH_S7_valid_signature(monkeypatch):
+    """PR-WH-S7: valid signature passes verification."""
+    monkeypatch.setattr(webhook.settings, "github_webhook_secret", "secret123")
+    payload = b'{"action":"submitted"}'
+    sig = "sha256=" + hmac.new(b"secret123", payload, hashlib.sha256).hexdigest()
+    assert webhook._verify_github_signature(payload, sig) is True
+
+
+def test_PR_WH_S7_invalid_signature(monkeypatch):
+    """PR-WH-S7: invalid signature fails verification."""
+    monkeypatch.setattr(webhook.settings, "github_webhook_secret", "secret123")
+    assert webhook._verify_github_signature(b"test", "sha256=bad") is False
+
+
+def test_PR_WH_S7_missing_secret(monkeypatch):
+    """PR-WH-S7: empty secret fails verification."""
+    monkeypatch.setattr(webhook.settings, "github_webhook_secret", "")
+    sig = "sha256=" + "a" * 64
+    assert webhook._verify_github_signature(b"test", sig) is False
+
+
+# ── _resolve_req_id_from_pr (async) ──────────────────────────────────────────
+
+
+class _FakeRow:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+@pytest.mark.asyncio
+async def test_PR_WH_S9_resolve_from_branch_name(monkeypatch):
+    """PR-WH-S9: branch feat/REQ-xxx resolves req_id directly."""
+    fake_row = _FakeRow(
+        req_id="REQ-test", project_id="p", state=ReqState.PENDING_USER_PR_REVIEW,
+        history=[], context={"branch": "feat/REQ-test"},
+        created_at=None, updated_at=None,
+    )
+
+    async def fake_get(_pool, req_id):
+        return fake_row
+
+    monkeypatch.setattr(webhook.req_state, "get", fake_get)
+
+    req_id, row = await webhook._resolve_req_id_from_pr(None, "feat/REQ-test", "http://pr")
+    assert req_id == "REQ-test"
+    assert row is not None
+
+
+@pytest.mark.asyncio
+async def test_PR_WH_S9_resolve_fallback_by_branch(monkeypatch):
+    """PR-WH-S9: fallback query by branch when direct extraction fails."""
+    fake_rows = [
+        {
+            "req_id": "REQ-fallback",
+            "project_id": "p",
+            "state": "pending-user-pr-review",
+            "history": "[]",
+            "context": '{"branch": "feature/some-branch"}',
+            "created_at": None,
+            "updated_at": None,
+        }
+    ]
+
+    class FakePool:
+        async def fetch(self, *_a, **_kw):
+            return fake_rows
+
+    monkeypatch.setattr(webhook.req_state, "get", lambda _p, _r: None)
+
+    req_id, row = await webhook._resolve_req_id_from_pr(FakePool(), "feature/some-branch", "http://pr")
+    assert req_id == "REQ-fallback"
+    assert row is not None
+    assert row.state == ReqState.PENDING_USER_PR_REVIEW
+
+
+# ── State machine: PENDING_USER_PR_REVIEW transitions ─────────────────────────
+
+
+def test_pending_pr_review_approved():
+    """approved → ARCHIVING + done_archive."""
+    t = decide(ReqState.PENDING_USER_PR_REVIEW, Event.GH_PR_REVIEW_APPROVED)
+    assert t.next_state == ReqState.ARCHIVING
+    assert t.action == "done_archive"
+
+
+def test_pending_pr_review_changes():
+    """changes_requested → REVIEW_RUNNING + invoke_verifier_for_pr_review_fail."""
+    t = decide(ReqState.PENDING_USER_PR_REVIEW, Event.GH_PR_REVIEW_CHANGES_REQUESTED)
+    assert t.next_state == ReqState.REVIEW_RUNNING
+    assert t.action == "invoke_verifier_for_pr_review_fail"
+
+
+def test_pending_pr_review_comment():
+    """commented → REVIEW_RUNNING + invoke_verifier_for_pr_review_comment."""
+    t = decide(ReqState.PENDING_USER_PR_REVIEW, Event.GH_PR_REVIEW_COMMENTED)
+    assert t.next_state == ReqState.REVIEW_RUNNING
+    assert t.action == "invoke_verifier_for_pr_review_comment"
+
+
+def test_pending_pr_review_pr_merged():
+    """PR_MERGED from PENDING_USER_PR_REVIEW → ARCHIVING."""
+    t = decide(ReqState.PENDING_USER_PR_REVIEW, Event.PR_MERGED)
+    assert t.next_state == ReqState.ARCHIVING
+    assert t.action == "done_archive"
+
+
+def test_pending_pr_review_illegal_events():
+    """Illegal events from PENDING_USER_PR_REVIEW return None."""
+    for ev in (Event.USER_REVIEW_PASS, Event.USER_REVIEW_FIX, Event.SESSION_FAILED):
+        assert decide(ReqState.PENDING_USER_PR_REVIEW, ev) is None
+
+
+# ── apply_verify_pass routing for pr_review ───────────────────────────────────
+
+
+def test_PR_WH_S10_pr_review_pass_routing():
+    """PR-WH-S10: pr_review decision=pass routes to ARCHIVING + ARCHIVE_DONE."""
+    route = _PASS_ROUTING.get("pr_review")
+    assert route is not None
+    assert route[0] == ReqState.ARCHIVING
+    assert route[1] == Event.ARCHIVE_DONE

--- a/orchestrator/tests/test_contract_pr_review_feedback_loop.py
+++ b/orchestrator/tests/test_contract_pr_review_feedback_loop.py
@@ -17,15 +17,13 @@ from __future__ import annotations
 
 import hashlib
 import hmac
-import json
+from unittest.mock import AsyncMock
 
 import pytest
-from unittest.mock import AsyncMock
 
 from orchestrator import webhook
 from orchestrator.actions._verifier import _PASS_ROUTING
 from orchestrator.state import Event, ReqState, decide
-
 
 # ── _derive_event_from_review_state ───────────────────────────────────────────
 

--- a/orchestrator/tests/test_contract_pr_review_feedback_loop.py
+++ b/orchestrator/tests/test_contract_pr_review_feedback_loop.py
@@ -1,16 +1,17 @@
 """Contract tests for REQ-user-feedback-loop-1777420881.
 
 Scenarios:
-  PR-WH-S1  approved review derives GH_PR_REVIEW_APPROVED
-  PR-WH-S2  changes_requested review derives GH_PR_REVIEW_CHANGES_REQUESTED
-  PR-WH-S3  commented review with "LGTM" derives GH_PR_REVIEW_APPROVED
-  PR-WH-S4  commented review with "fix:" derives GH_PR_REVIEW_CHANGES_REQUESTED
-  PR-WH-S5  commented review without keyword derives GH_PR_REVIEW_COMMENTED
-  PR-WH-S6  unknown review state derives None
-  PR-WH-S7  signature mismatch returns 401
-  PR-WH-S8  req not in PENDING_USER_PR_REVIEW state is skipped
-  PR-WH-S9  branch feat/REQ-xxx resolves req_id
-  PR-WH-S10 apply_verify_pass routes pr_review → ARCHIVING + ARCHIVE_DONE
+  PR-WH-S1   approved review derives GH_PR_REVIEW_APPROVED
+  PR-WH-S2   changes_requested review derives GH_PR_REVIEW_CHANGES_REQUESTED
+  PR-WH-S3   commented review with "LGTM" derives GH_PR_REVIEW_APPROVED
+  PR-WH-S4   commented review with "fix:" derives GH_PR_REVIEW_CHANGES_REQUESTED
+  PR-WH-S5   commented review without keyword derives GH_PR_REVIEW_COMMENTED
+  PR-WH-S6   unknown review state derives None
+  PR-WH-S7   signature mismatch returns 401
+  PR-WH-S8   req not in PENDING_USER_PR_REVIEW state is skipped
+  PR-WH-S9   branch feat/REQ-xxx resolves req_id
+  PR-VR-S10  pr_review fail invokes verifier with review body
+  PR-WH-S10  apply_verify_pass routes pr_review → ARCHIVING + ARCHIVE_DONE
 """
 from __future__ import annotations
 
@@ -19,6 +20,7 @@ import hmac
 import json
 
 import pytest
+from unittest.mock import AsyncMock
 
 from orchestrator import webhook
 from orchestrator.actions._verifier import _PASS_ROUTING
@@ -176,3 +178,86 @@ def test_PR_WH_S10_pr_review_pass_routing():
     assert route is not None
     assert route[0] == ReqState.ARCHIVING
     assert route[1] == Event.ARCHIVE_DONE
+
+
+# ── PR-WH-S8: state mismatch skips ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_PR_WH_S8_state_mismatch_skips(monkeypatch):
+    """PR-WH-S8: req not in PENDING_USER_PR_REVIEW state returns skip."""
+    monkeypatch.setattr(webhook.settings, "github_webhook_secret", "secret123")
+
+    payload = b'{"action":"submitted","review":{"state":"approved","id":123},"pull_request":{"head":{"ref":"feat/REQ-test"},"html_url":"http://pr"}}'
+    sig = "sha256=" + hmac.new(b"secret123", payload, hashlib.sha256).hexdigest()
+
+    fake_row = _FakeRow(
+        req_id="REQ-test", project_id="p", state=ReqState.ARCHIVING,
+        history=[], context={"branch": "feat/REQ-test"},
+        created_at=None, updated_at=None,
+    )
+
+    async def fake_resolve(_pool, _branch, _pr_url):
+        return "REQ-test", fake_row
+
+    monkeypatch.setattr(webhook, "_resolve_req_id_from_pr", fake_resolve)
+    monkeypatch.setattr(webhook, "_verify_github_signature", lambda _raw, _sig: True)
+
+    request = AsyncMock()
+    request.body = AsyncMock(return_value=payload)
+    request.headers = {
+        "x-hub-signature-256": sig,
+        "x-github-event": "pull_request_review",
+    }
+
+    result = await webhook.github_webhook(request)
+    assert result["action"] == "skip"
+    assert "not pending-user-pr-review" in result["reason"]
+
+
+# ── PR-VR-S10: pr_review fail invokes verifier with review body ───────────────
+
+
+@pytest.mark.asyncio
+async def test_PR_VR_S10_pr_review_fail_invokes_verifier_with_body(monkeypatch):
+    """PR-VR-S10: invoke_verifier_for_pr_review_fail passes review body as stderr_tail."""
+    calls = []
+
+    async def fake_invoke_verifier(*, stage, trigger, req_id, project_id, stderr_tail, ctx, **kwargs):
+        calls.append({"stage": stage, "trigger": trigger, "stderr_tail": stderr_tail})
+        return {"verifier_issue_id": "v-1", "stage": stage, "trigger": trigger}
+
+    monkeypatch.setattr("orchestrator.actions._verifier.invoke_verifier", fake_invoke_verifier)
+
+    from orchestrator.actions._verifier import invoke_verifier_for_pr_review_fail
+
+    result = await invoke_verifier_for_pr_review_fail(
+        body=type("B", (), {"projectId": "p"})(),
+        req_id="REQ-test",
+        tags=["REQ-test"],
+        ctx={"gh_pr_review_body": "fix the naming"},
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["stage"] == "pr_review"
+    assert calls[0]["trigger"] == "fail"
+    assert calls[0]["stderr_tail"] == "fix the naming"
+    assert result["verifier_issue_id"] == "v-1"
+
+
+# ── PR-WD-S11: watchdog ignores pending PR review ─────────────────────────────
+
+
+def test_PR_WD_S11_pending_user_pr_review_in_no_watchdog_states():
+    """PR-WD-S11: watchdog._NO_WATCHDOG_STATES must contain PENDING_USER_PR_REVIEW.
+
+    Spec contract:
+      PENDING_USER_PR_REVIEW is a human-in-loop state (waiting for GitHub PR review).
+      The watchdog MUST NOT emit SESSION_FAILED or escalate REQs in this state.
+      _NO_WATCHDOG_STATES is the canonical container for this exemption.
+    """
+    from orchestrator import watchdog
+    assert ReqState.PENDING_USER_PR_REVIEW in watchdog._NO_WATCHDOG_STATES, (
+        "PENDING_USER_PR_REVIEW must be in watchdog._NO_WATCHDOG_STATES "
+        "(human-in-loop state waiting for GitHub PR review)"
+    )

--- a/orchestrator/tests/test_contract_user_acceptance_gate.py
+++ b/orchestrator/tests/test_contract_user_acceptance_gate.py
@@ -87,11 +87,11 @@ def _has_status_id_in_call(call_args) -> bool:
 # ── USER-S1..S4: pure state-machine contracts ────────────────────────────────
 
 
-def test_USER_S1_teardown_pass_to_pending_user_review():
-    """Scenario USER-S1: TEARDOWN_DONE_PASS routes to PENDING_USER_REVIEW via post_acceptance_report."""
+def test_USER_S1_teardown_pass_to_pending_user_pr_review():
+    """Scenario USER-S1: TEARDOWN_DONE_PASS routes to PENDING_USER_PR_REVIEW via post_acceptance_report."""
     t = decide(ReqState.ACCEPT_TEARING_DOWN, Event.TEARDOWN_DONE_PASS)
     assert t is not None
-    assert t.next_state == ReqState.PENDING_USER_REVIEW
+    assert t.next_state == ReqState.PENDING_USER_PR_REVIEW
     assert t.action == "post_acceptance_report"
 
 
@@ -128,6 +128,56 @@ def test_USER_S3_pending_fix_to_escalated():
 def test_USER_S4_pending_illegal_events_return_none(illegal_event):
     """Scenario USER-S4: any event other than USER_REVIEW_PASS/FIX returns None from PENDING_USER_REVIEW."""
     assert decide(ReqState.PENDING_USER_REVIEW, illegal_event) is None
+
+
+# ── REQ-user-feedback-loop-1777420881: PENDING_USER_PR_REVIEW contracts ──────
+
+
+def test_PR_S1_pending_pr_review_approved_to_archiving():
+    """PR-S1: GH_PR_REVIEW_APPROVED from PENDING_USER_PR_REVIEW → ARCHIVING + done_archive."""
+    t = decide(ReqState.PENDING_USER_PR_REVIEW, Event.GH_PR_REVIEW_APPROVED)
+    assert t is not None
+    assert t.next_state == ReqState.ARCHIVING
+    assert t.action == "done_archive"
+
+
+def test_PR_S2_pending_pr_review_changes_to_verifier():
+    """PR-S2: GH_PR_REVIEW_CHANGES_REQUESTED → REVIEW_RUNNING + invoke_verifier_for_pr_review_fail."""
+    t = decide(ReqState.PENDING_USER_PR_REVIEW, Event.GH_PR_REVIEW_CHANGES_REQUESTED)
+    assert t is not None
+    assert t.next_state == ReqState.REVIEW_RUNNING
+    assert t.action == "invoke_verifier_for_pr_review_fail"
+
+
+def test_PR_S3_pending_pr_review_comment_to_verifier():
+    """PR-S3: GH_PR_REVIEW_COMMENTED → REVIEW_RUNNING + invoke_verifier_for_pr_review_comment."""
+    t = decide(ReqState.PENDING_USER_PR_REVIEW, Event.GH_PR_REVIEW_COMMENTED)
+    assert t is not None
+    assert t.next_state == ReqState.REVIEW_RUNNING
+    assert t.action == "invoke_verifier_for_pr_review_comment"
+
+
+def test_PR_S4_pending_pr_review_pr_merged_to_archiving():
+    """PR-S4: PR_MERGED from PENDING_USER_PR_REVIEW → ARCHIVING + done_archive."""
+    t = decide(ReqState.PENDING_USER_PR_REVIEW, Event.PR_MERGED)
+    assert t is not None
+    assert t.next_state == ReqState.ARCHIVING
+    assert t.action == "done_archive"
+
+
+@pytest.mark.parametrize(
+    "illegal_event",
+    [
+        Event.ARCHIVE_DONE,
+        Event.SESSION_FAILED,
+        Event.USER_REVIEW_PASS,
+        Event.USER_REVIEW_FIX,
+        Event.INTAKE_PASS,
+    ],
+)
+def test_PR_S5_pending_pr_review_illegal_events(illegal_event):
+    """PR-S5: illegal events from PENDING_USER_PR_REVIEW return None."""
+    assert decide(ReqState.PENDING_USER_PR_REVIEW, illegal_event) is None
 
 
 # ── USER-S5..S8: webhook routing contracts ───────────────────────────────────
@@ -440,6 +490,11 @@ def test_USER_S12_pending_user_review_in_skip_states():
     assert ReqState.PENDING_USER_REVIEW.value in watchdog._SKIP_STATES, (
         "spec requires PENDING_USER_REVIEW.value to be in watchdog._SKIP_STATES "
         "(human-loop-conversation state; no BKD agent to crash-check)"
+    )
+    # REQ-user-feedback-loop-1777420881: PENDING_USER_PR_REVIEW 也必须在 skip 里
+    assert ReqState.PENDING_USER_PR_REVIEW.value in watchdog._SKIP_STATES, (
+        "PENDING_USER_PR_REVIEW.value must be in watchdog._SKIP_STATES "
+        "(human-in-loop state waiting for GitHub PR review)"
     )
     # Legacy entries must still be present (regression guard)
     for legacy in (

--- a/orchestrator/tests/test_contract_user_acceptance_gate.py
+++ b/orchestrator/tests/test_contract_user_acceptance_gate.py
@@ -507,3 +507,54 @@ def test_USER_S12_pending_user_review_in_skip_states():
         assert legacy in watchdog._SKIP_STATES, (
             f"watchdog._SKIP_STATES must still contain legacy entry {legacy!r}"
         )
+
+
+# ── PR-PA-S12: post_acceptance_report includes PR review instructions ─────────
+
+
+@pytest.mark.asyncio
+async def test_PR_PA_S12_report_includes_pr_review_instructions(monkeypatch):
+    """Scenario PR-PA-S12: post_acceptance_report description contains PR review instructions.
+
+    Spec contract:
+      - The description MUST explain that GitHub PR review is the primary approval mechanism
+      - The description MUST mention Approve → auto-archive
+      - The description MUST mention Request changes → auto-fixer
+      - The description MUST mention Comment with LGTM → approve
+      - The description MUST mention Comment with fix: → fix
+      - The backward-compatible BKD statusId path MUST still be mentioned
+    """
+    from orchestrator.actions import post_acceptance_report as mod
+
+    bkd = _make_action_bkd(description="existing body without block")
+    _patch_action_bkd(monkeypatch, bkd)
+    _patch_action_db(monkeypatch)
+
+    ctx = {
+        "intent_issue_id": "intent-1",
+        "pr_urls": {"phona/sisyphus": "https://github.com/phona/sisyphus/pull/200"},
+    }
+
+    await mod.post_acceptance_report(
+        body=_make_action_body(),
+        req_id="REQ-test",
+        tags=["REQ-test"],
+        ctx=ctx,
+    )
+
+    bkd.update_issue.assert_awaited()
+    desc = _extract_description(bkd.update_issue.call_args)
+    assert desc is not None, "update_issue must receive a description argument"
+
+    # Spec: must explain GitHub PR review as primary approval mechanism
+    assert "Approve" in desc, "description must mention Approve as approval mechanism"
+    assert "Request changes" in desc, "description must mention Request changes"
+
+    # Spec: must mention LGTM and fix: keywords
+    assert "LGTM" in desc, "description must mention LGTM keyword"
+    assert "fix:" in desc, "description must mention fix: keyword"
+
+    # Spec: backward-compatible BKD statusId path must still be mentioned
+    assert "statusId" in desc or "done" in desc, (
+        "description must still mention backward-compatible BKD statusId path"
+    )


### PR DESCRIPTION
## Summary

实现 REQ-user-feedback-loop-1777420881：用 GitHub PR review webhook 替代 BKD statusId 作为 accept teardown 后的用户反馈入口，形成 "accept → PR review → fix → 再 review" 的闭环。

- **PR approve** → 直接 ARCHIVING（最短路径，无 verifier）
- **Request changes** → REVIEW_RUNNING → verifier → fixer → 再推 PR → 再 review
- **Comment (LGTM/looks good)** → 视为 approved → ARCHIVING
- **Comment (fix:)** → 视为 changes_requested → REVIEW_RUNNING → fixer
- **PR merged** → ARCHIVING（兜底）

旧 BKD statusId 路径（PENDING_USER_REVIEW）保留兼容，新 REQ 默认走 PENDING_USER_PR_REVIEW。

## 主要改动

| 文件 | 改动 |
|---|---|
| `state.py` | 新增 `PENDING_USER_PR_REVIEW` + 3 个 GH PR review Event + transitions；`TEARDOWN_DONE_PASS` 目标改为新状态 |
| `webhook.py` | 新增 `POST /github-events`：HMAC-SHA256 签名校验、事件解析、REQ 解析（branch + fallback）、dedup、state guard |
| `actions/_verifier.py` | 新增 `pr_review` stage + `_PASS_ROUTING` + 3 个 action handler |
| `prompts/verifier/pr_review_*.md.j2` | 新增 verifier prompt 模板（success / fail） |
| `engine.py` | `STATE_TO_STAGE` 加入 `pending_user_pr_review` |
| `watchdog.py` | 跳过 `PENDING_USER_PR_REVIEW`（human-in-loop 不杀） |
| `admin.py` | `PR_MERGED_VALID_STATES` 加入新状态 |
| `config.py` | 新增 `github_webhook_secret` |
| `post_acceptance_report.py` | 更新 acceptance block 文案，说明 GitHub PR review 为主路径 |
| 测试 | 更新 `test_contract_user_acceptance_gate.py`，新增 `test_contract_pr_review_feedback_loop.py`（S1–S10） |
| openspec | `proposal.md` / `spec.md` / `tasks.md` |

## Test plan
- [x] `test_contract_pr_review_feedback_loop.py` 全量通过（事件推导、签名验证、REQ 解析、transition、apply_verify_pass 路由）
- [x] `test_contract_user_acceptance_gate.py` 回归通过（TEARDOWN_DONE_PASS 新目标 + PENDING_USER_PR_REVIEW transitions）
- [x] verifier loop / watchdog / engine / PR merged 相关回归测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)