### PR TITLE
feat(analyze): 完成前追加 spec_lint 自检，避免 verifier escalate

### DIFF
--- a/orchestrator/src/orchestrator/prompts/analyze.md.j2
+++ b/orchestrator/src/orchestrator/prompts/analyze.md.j2
@@ -373,6 +373,21 @@ kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c \
 kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c \
   "cd /workspace/source/$REPO && gh pr list --head feat/{{ req_id }} --state open --json number"
 # ↑ 必须返回非空 JSON 数组（如 [{"number":208}]）。空数组 [] = PR 没开，立即 gh pr create
+
+# 4. 验证 openspec 产物能通过 spec_lint（自检，避免 verifier escalate）
+kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c \
+  "cd /workspace/source/\$REPO && \
+   git fetch origin feat/{{ req_id }} 2>/dev/null && \
+   git checkout -B feat/{{ req_id }} origin/feat/{{ req_id }} 2>/dev/null && \
+   openspec validate '{{ req_id }}' && \
+   check-scenario-refs.sh --specs-search-path /workspace/source ."
+# ↑ 任一失败 = 立即修复后重跑，不要报完成。openspec validate 红的原因通常是：
+#   - 缺少 ## ADDED Requirements 顶层 heading
+#   - Requirement body 缺少 SHALL/MUST
+#   - scenario heading 格式不对（必须是 #### Scenario: <ID>）
+# check-scenario-refs.sh 红的原因通常是：
+#   - 空壳 scenario（只有 heading 没有 GIVEN/WHEN/THEN step）
+#   - [XXX-S<N>] 引用找不到定义
 ```
 
 **全部验证通过后才能报完成**。如果验证失败，先修复再报，不要先报"完成"再回头补。


### PR DESCRIPTION
## 背景

analyze agent 报完成前只验证 git/PR/openspec 文件存在性，**不跑 \`openspec validate\` + \`check-scenario-refs.sh\`**。导致很多 spec 格式错误（空壳 scenario、SHALL/MUST 缺失、heading 层级错误）要到 verifier spec_lint 阶段才暴露，然后 escalate 起 fixer-agent 回头修，浪费一轮 wall-clock。

## 修改内容

在 \`analyze.md.j2\` 的"完成前强制验证"区块追加第 4 步：

1. 保持现有 3 步验证（git branch / git show / gh pr list）不动
2. 追加第 4 步：在 runner pod 内切到最新 feat 分支后跑 \`openspec validate\` + \`check-scenario-refs.sh\`
3. 任一失败 = 立即修复后重跑，不要报完成

## 自检

- [x] 单仓 REQ，只改 prompt 模板
- [x] commit 到 feat/REQ-analyze-self-lint-1777422227 并 push
- [x] PR 已开，带 \`sisyphus\` label

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-analyze-self-lint-1777422227\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/g2hjz92s)