### PR TITLE
fix(orch): reliable BKD sub-agent issue status sync

### DIFF
--- a/openspec/changes/REQ-fix-bkd-sub-issue-status-sync-1777426309/proposal.md
+++ b/openspec/changes/REQ-fix-bkd-sub-issue-status-sync-1777426309/proposal.md
@@ -1,0 +1,32 @@
+# Proposal: Fix unreliable BKD sub-agent issue status synchronization
+
+## Problem
+
+In the sisyphus orchestrator, when sub-agent issues (analyze, challenger, fixer, accept, done-archive) complete their work, the BKD statusId synchronization to "done" is unreliable:
+
+1. `_push_upstream_status` in `webhook.py` executes only once (fire-and-forget). Exceptions are only logged at warning level without retry.
+2. If the PATCH fails (network jitter, BKD 5xx, race condition with BKD auto status changes), the sub-agent issue remains stuck in "review" forever.
+3. Subsequent state transitions (ANALYZE_DONE -> artifact check -> spec lint -> ...) do not go back to sync previously completed sub-agent issues.
+
+This causes the BKD kanban "review" column to be polluted with large numbers of false-positive completed issues, leading users to believe there are many problems requiring manual intervention.
+
+## Solution
+
+Combined approach A + B:
+
+- **A (webhook retry)**: Add exponential backoff retry (max 3 attempts) to `_push_upstream_status`, maximizing the chance of first-sync success.
+- **B (watchdog compensation)**: Add a periodic compensation task to the watchdog loop that scans BKD for `sessionStatus=completed` + `statusId=review` sub-agent issues and auto-PATCHes them to `done`.
+
+## Scope
+
+- `orchestrator/src/orchestrator/webhook.py` — `_push_upstream_status` retry
+- `orchestrator/src/orchestrator/watchdog.py` — compensation cleanup task
+- `orchestrator/tests/test_webhook_upstream_done.py` — retry tests
+- `orchestrator/tests/test_watchdog_bkd_sync.py` — new compensation tests
+
+## Out of scope
+
+- Prompt templates (not touched)
+- State machine transition table (not touched)
+- Action behavior (not touched)
+- Business repo integration (not touched)

--- a/openspec/changes/REQ-fix-bkd-sub-issue-status-sync-1777426309/specs/bkd-status-sync/spec.md
+++ b/openspec/changes/REQ-fix-bkd-sub-issue-status-sync-1777426309/specs/bkd-status-sync/spec.md
@@ -1,0 +1,85 @@
+# bkd-status-sync
+
+## ADDED Requirements
+
+### Requirement: webhook._push_upstream_status SHALL retry with exponential backoff on BKD PATCH failure
+
+The `_push_upstream_status` function in `webhook.py` SHALL retry the BKD `update_issue` PATCH up to 3 times with exponential backoff (1s, 2s) when the call raises an exception. The retry MUST occur within the same `BKDClient` async context to avoid redundant MCP initialization. After all retries are exhausted, the function MUST log a warning and return without raising, preserving the existing "do not block state machine" semantics.
+
+#### Scenario: BSS-S1 transient BKD error succeeds on retry
+
+- **GIVEN** BKD `update_issue` fails on the first 2 attempts with `RuntimeError("timeout")`
+- **WHEN** `_push_upstream_status` is called with `project_id="proj-1"`, `issue_id="iss-a"`, `status_id="done"`
+- **THEN** the function MUST attempt `update_issue` exactly 3 times
+- **AND** the second attempt MUST sleep for 1.0 seconds before retrying
+- **AND** the third attempt MUST sleep for 2.0 seconds before retrying
+- **AND** the function MUST return successfully without raising
+
+#### Scenario: BSS-S2 persistent BKD failure is swallowed after 3 attempts
+
+- **GIVEN** BKD `update_issue` fails on all 3 attempts with `RuntimeError("500")`
+- **WHEN** `_push_upstream_status` is called
+- **THEN** the function MUST attempt `update_issue` exactly 3 times
+- **AND** the function MUST log a warning with `webhook.upstream_status_failed`
+- **AND** the function MUST return without raising an exception
+
+### Requirement: watchdog SHALL periodically compensate stale sub-agent issues stuck in review
+
+The watchdog `run_loop` SHALL invoke a compensation task every 5 ticks (approximately 5 minutes with default 60s interval). The compensation task MUST scan all active BKD projects, list their issues, and PATCH `statusId` to `"done"` for any issue matching ALL of the following criteria:
+
+1. `statusId` is `"review"`
+2. `sessionStatus` is `"completed"`
+3. Contains a tag starting with `"REQ-"` (belongs to a sisyphus workflow)
+4. Contains a sub-agent role tag: `"analyze"`, `"challenger"`, `"fixer"`, `"accept"`, or `"done-archive"`
+
+The task MUST exclude issues tagged `"verifier"` because a verifier issue in `"review"` may be an intentional escalate state that requires human follow-up, and the BKD side cannot distinguish between pass/fix/escalate verdicts. The task MUST tolerate failures on individual issues and continue processing the rest.
+
+#### Scenario: BSS-S3 completed analyze issue stuck in review is patched to done
+
+- **GIVEN** a BKD issue with `statusId="review"`, `sessionStatus="completed"`, tags `["analyze", "REQ-1"]`
+- **WHEN** the watchdog compensation task runs
+- **THEN** the issue MUST be PATCHed to `statusId="done"`
+- **AND** the patched count MUST be 1
+
+#### Scenario: BSS-S4 verifier issue is skipped to preserve escalate resume path
+
+- **GIVEN** a BKD issue with `statusId="review"`, `sessionStatus="completed"`, tags `["verifier", "REQ-1"]`
+- **WHEN** the watchdog compensation task runs
+- **THEN** the issue MUST NOT be PATCHed
+- **AND** the patched count MUST be 0
+
+#### Scenario: BSS-S5 running session is skipped
+
+- **GIVEN** a BKD issue with `statusId="review"`, `sessionStatus="running"`, tags `["analyze", "REQ-1"]`
+- **WHEN** the watchdog compensation task runs
+- **THEN** the issue MUST NOT be PATCHed
+- **AND** the patched count MUST be 0
+
+#### Scenario: BSS-S6 non-review status is skipped
+
+- **GIVEN** a BKD issue with `statusId="done"`, `sessionStatus="completed"`, tags `["analyze", "REQ-1"]`
+- **WHEN** the watchdog compensation task runs
+- **THEN** the issue MUST NOT be PATCHed
+- **AND** the patched count MUST be 0
+
+#### Scenario: BSS-S7 issue without REQ tag is skipped
+
+- **GIVEN** a BKD issue with `statusId="review"`, `sessionStatus="completed"`, tags `["analyze"]` (no REQ tag)
+- **WHEN** the watchdog compensation task runs
+- **THEN** the issue MUST NOT be PATCHed
+- **AND** the patched count MUST be 0
+
+#### Scenario: BSS-S8 individual PATCH failure does not abort batch
+
+- **GIVEN** two BKD issues both matching the criteria, but the first PATCH fails with HTTP 500
+- **WHEN** the watchdog compensation task runs
+- **THEN** the second issue MUST still be PATCHed to `statusId="done"`
+- **AND** the result MUST report `patched=1, failed=1`
+
+#### Scenario: BSS-S9 multiple projects are scanned
+
+- **GIVEN** active REQ rows exist in `req_state` for both `project_id="proj-a"` and `project_id="proj-b"`
+- **AND** each project has one matching stuck sub-agent issue
+- **WHEN** the watchdog compensation task runs
+- **THEN** both issues MUST be PATCHed to `statusId="done"`
+- **AND** the result MUST report `patched=2, failed=0`

--- a/openspec/changes/REQ-fix-bkd-sub-issue-status-sync-1777426309/tasks.md
+++ b/openspec/changes/REQ-fix-bkd-sub-issue-status-sync-1777426309/tasks.md
@@ -1,0 +1,17 @@
+## Stage: contract / spec
+- [x] author proposal.md
+- [x] author specs/bkd-status-sync/spec.md
+
+## Stage: implementation
+- [x] webhook.py: add exponential backoff retry to _push_upstream_status (max 3 attempts)
+- [x] watchdog.py: add _sync_stuck_sub_agent_statuses_tick compensation cleanup
+- [x] watchdog.py: integrate compensation into run_loop (every 5 ticks)
+
+## Stage: test
+- [x] test_webhook_upstream_done.py: add retry success / retry exhausted tests
+- [x] test_watchdog_bkd_sync.py: add 9 compensation scenario tests
+- [x] run all webhook + watchdog tests (65 passed)
+
+## Stage: PR
+- [ ] git push feat/REQ-fix-bkd-sub-issue-status-sync-1777426309
+- [ ] gh pr create with sisyphus label

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -72,6 +72,14 @@ _STATE_FAILURE_EVENT: dict[ReqState, str] = {
     ReqState.ARCHIVING: "archive.failed",
 }
 
+# sub-agent role tag（intake 不在此列：intake 跑在 user 创的 intent issue 上，
+# 那条 issue 的 statusId 反映用户意图，不该被补偿清理动）。
+# verifier 也排除：verifier 判 escalate 时 issue 应保持 review，BKD 侧无法区分 pass/fix/escalate。
+# REQ-fix-bkd-sub-issue-status-sync-1777426309
+_SUB_AGENT_ROLE_TAGS: frozenset[str] = frozenset({
+    "analyze", "challenger", "fixer", "accept", "done-archive",
+})
+
 # 排除：终态 + 等人态（human-in-loop）+ 未入链
 # human-in-loop states 同时存于 _NO_WATCHDOG_STATES（ReqState 对象）和此处（string value），
 # 使 _SKIP_STATES 成为 canonical container（spec USER-S12 / watchdog skip 查询均引用此集合）。
@@ -362,6 +370,82 @@ async def _check_and_escalate(row) -> bool:
     return True
 
 
+async def _sync_stuck_sub_agent_statuses_tick() -> dict:
+    """补偿清理：把 BKD 中 sessionStatus=completed 但 statusId=review 的 sub-agent issue 推 done。
+
+    只动非 verifier 的 sub-agent issue（analyze / challenger / fixer / accept / done-archive）。
+    verifier issue 在 escalate 时应保持 review，BKD 侧无法区分 verdict，保守排除。
+    REQ-fix-bkd-sub-issue-status-sync-1777426309
+    """
+    pool = db.get_pool()
+    # 从 req_state 取活跃 project_id（去重），避免扫到无关 project
+    try:
+        project_rows = await pool.fetch(
+            """
+            SELECT DISTINCT project_id FROM req_state
+             WHERE state <> ALL($1::text[])
+            """,
+            list(_SKIP_STATES),
+        )
+    except Exception as e:
+        log.warning("watchdog.bkd_sync.fetch_projects_failed", error=str(e))
+        return {"patched": 0, "failed": 0, "skipped": 0}
+
+    patched = 0
+    failed = 0
+    for prow in project_rows:
+        project_id = prow["project_id"]
+        try:
+            async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+                issues = await bkd.list_issues(project_id)
+        except Exception as e:
+            log.warning("watchdog.bkd_sync.list_issues_failed",
+                        project_id=project_id, error=str(e))
+            continue
+
+        for issue in issues:
+            if issue.status_id != "review":
+                continue
+            if issue.session_status != "completed":
+                continue
+            tags = issue.tags or []
+            # 必须有 REQ tag（属于 sisyphus 工作流）
+            if not any((t or "").startswith("REQ-") for t in tags):
+                continue
+            # 命中 sub-agent role tag 且排除 verifier
+            role_tag = None
+            for t in tags:
+                if t in _SUB_AGENT_ROLE_TAGS:
+                    role_tag = t
+                    break
+            if role_tag is None:
+                continue
+
+            try:
+                async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+                    await bkd.update_issue(
+                        project_id=project_id,
+                        issue_id=issue.id,
+                        status_id="done",
+                    )
+                patched += 1
+                log.info(
+                    "watchdog.bkd_sync.patched",
+                    project_id=project_id, issue_id=issue.id,
+                    role_tag=role_tag,
+                    req_id=next((t for t in tags if t.startswith("REQ-")), None),
+                )
+            except Exception as e:
+                failed += 1
+                log.warning(
+                    "watchdog.bkd_sync.patch_failed",
+                    project_id=project_id, issue_id=issue.id,
+                    error=str(e),
+                )
+
+    return {"patched": patched, "failed": failed}
+
+
 async def run_loop() -> None:
     """orchestrator 启动起的后台任务。"""
     if not settings.watchdog_enabled:
@@ -373,6 +457,7 @@ async def run_loop() -> None:
         interval_sec=interval,
         stuck_threshold_sec=settings.watchdog_stuck_threshold_sec,
     )
+    tick_count = 0
     while True:
         try:
             result = await _tick()
@@ -380,6 +465,18 @@ async def run_loop() -> None:
                 log.warning("watchdog.swept", **result)
             else:
                 log.debug("watchdog.tick", **result)
+
+            # 每 5 个 tick（默认 ~5min）跑一次 BKD 补偿清理
+            tick_count += 1
+            if tick_count % 5 == 0:
+                try:
+                    sync_result = await _sync_stuck_sub_agent_statuses_tick()
+                    if sync_result.get("patched") or sync_result.get("failed"):
+                        log.info("watchdog.bkd_sync", **sync_result)
+                    else:
+                        log.debug("watchdog.bkd_sync", **sync_result)
+                except Exception as e:
+                    log.exception("watchdog.bkd_sync.error", error=str(e))
         except asyncio.CancelledError:
             log.info("watchdog.loop.stopped")
             raise

--- a/orchestrator/src/orchestrator/webhook.py
+++ b/orchestrator/src/orchestrator/webhook.py
@@ -6,6 +6,7 @@ handler 内部按 body.event 字段分流。
 """
 from __future__ import annotations
 
+import asyncio
 import hmac
 from typing import Any
 
@@ -138,13 +139,32 @@ async def _push_upstream_status(project_id: str, issue_id: str, status_id: str) 
     - "review" —— verifier 判 escalate 时用，issue 进"待审查"列让用户能定位 follow-up
       （resume 路径：用户在该 issue chat 续聊 → BKD wake agent → 新 decision → 主链继续）
 
-    幂等。失败只记 warning，不阻塞状态机。
+    幂等。失败指数退避重试 3 次，最终仍失败只记 warning，不阻塞状态机。
+    REQ-fix-bkd-sub-issue-status-sync-1777426309
     """
+    max_attempts = 3
+    base_delay = 1.0
+
     try:
         async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
-            await bkd.update_issue(
-                project_id=project_id, issue_id=issue_id, status_id=status_id,
-            )
+            for attempt in range(max_attempts):
+                try:
+                    await bkd.update_issue(
+                        project_id=project_id, issue_id=issue_id, status_id=status_id,
+                    )
+                    return
+                except Exception as e:
+                    if attempt < max_attempts - 1:
+                        delay = base_delay * (2 ** attempt)
+                        log.warning(
+                            "webhook.upstream_status_retry",
+                            issue_id=issue_id, status_id=status_id,
+                            attempt=attempt + 1, max_attempts=max_attempts,
+                            delay=delay, error=str(e),
+                        )
+                        await asyncio.sleep(delay)
+                    else:
+                        raise
     except Exception as e:
         log.warning("webhook.upstream_status_failed",
                     issue_id=issue_id, status_id=status_id, error=str(e))

--- a/orchestrator/tests/test_contract_bkd_sub_issue_status_sync_challenger.py
+++ b/orchestrator/tests/test_contract_bkd_sub_issue_status_sync_challenger.py
@@ -1,0 +1,447 @@
+"""Challenger contract tests for REQ-fix-bkd-sub-issue-status-sync-1777426309.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-fix-bkd-sub-issue-status-sync-1777426309/specs/bkd-status-sync/spec.md
+
+Scenarios:
+  BSS-S1  transient BKD error → retry succeeds (exponential backoff 1s, 2s)
+  BSS-S2  persistent BKD failure → 3 attempts, warning log, no raise
+  BSS-S3  completed analyze issue stuck in review → patched to done
+  BSS-S4  verifier issue skipped (preserve escalate resume path)
+  BSS-S5  running session skipped
+  BSS-S6  non-review status skipped
+  BSS-S7  issue without REQ tag skipped
+  BSS-S8  individual PATCH failure does not abort batch
+  BSS-S9  multiple projects scanned
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation instead.
+If a test is truly wrong, escalate to spec_fixer to correct the spec.
+"""
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import ClassVar
+from unittest.mock import AsyncMock
+
+import pytest
+import structlog.testing
+
+from orchestrator.bkd import Issue
+
+
+# ─── Fake BKD for webhook retry tests ────────────────────────────────────────
+
+
+class _FakeBKDFlaky:
+    """Fails first N calls to update_issue, then succeeds."""
+
+    captured: ClassVar[list[tuple[str, str, str]]] = []
+    fail_count: ClassVar[int] = 0
+
+    def __init__(self, *_a, **_kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def update_issue(self, *, project_id, issue_id, status_id):
+        fails_so_far = len([c for c in self.captured if c[2].startswith("fail-")])
+        if fails_so_far < self.fail_count:
+            self.captured.append((project_id, issue_id, f"fail-{status_id}"))
+            raise RuntimeError(f"BKD down (attempt {fails_so_far + 1})")
+        self.captured.append((project_id, issue_id, status_id))
+
+
+class _FakeBKDPersistentFail:
+    """Always fails update_issue."""
+
+    captured: ClassVar[list[tuple[str, str, str]]] = []
+
+    def __init__(self, *_a, **_kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def update_issue(self, *, project_id, issue_id, status_id):
+        self.captured.append((project_id, issue_id, status_id))
+        raise RuntimeError("BKD 500")
+
+
+# ─── Fake pool for watchdog tests ────────────────────────────────────────────
+
+
+@dataclass
+class _FakePool:
+    rows: list = field(default_factory=list)
+
+    async def fetch(self, sql, *args):
+        return self.rows
+
+    async def fetchrow(self, sql, *args):
+        return None
+
+    async def execute(self, sql, *args):
+        pass
+
+
+# ─── BSS-S1: transient BKD error succeeds on retry ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bss_s1_transient_bkd_error_succeeds_on_retry(monkeypatch, caplog):
+    """BSS-S1: BKD fails first 2 attempts; _push_upstream_status retries with backoff.
+
+    - exactly 3 update_issue attempts
+    - 2nd attempt sleeps 1.0s before retry
+    - 3rd attempt sleeps 2.0s before retry
+    - function returns without raising
+    """
+    from orchestrator import webhook
+
+    _FakeBKDFlaky.captured = []
+    _FakeBKDFlaky.fail_count = 2
+    monkeypatch.setattr(webhook, "BKDClient", _FakeBKDFlaky)
+
+    sleep_calls: list[float] = []
+    orig_sleep = asyncio.sleep
+
+    async def _tracked_sleep(delay):
+        sleep_calls.append(delay)
+        # no actual sleep in test
+
+    monkeypatch.setattr(asyncio, "sleep", _tracked_sleep)
+
+    # Should not raise
+    await webhook._push_upstream_status("proj-1", "iss-a", "done")
+
+    # Exactly 3 attempts total
+    attempts = [c for c in _FakeBKDFlaky.captured if c[1] == "iss-a"]
+    assert len(attempts) == 3, (
+        f"BSS-S1: MUST attempt update_issue exactly 3 times; got {len(attempts)}"
+    )
+
+    # First 2 are failures (prefixed with fail-)
+    assert attempts[0][2] == "fail-done", "BSS-S1: first attempt MUST be a failure"
+    assert attempts[1][2] == "fail-done", "BSS-S1: second attempt MUST be a failure"
+    # Third succeeds
+    assert attempts[2][2] == "done", "BSS-S1: third attempt MUST succeed"
+
+    # Sleep delays: 1.0s before 2nd attempt, 2.0s before 3rd attempt
+    assert sleep_calls == [1.0, 2.0], (
+        f"BSS-S1: backoff delays MUST be [1.0, 2.0]; got {sleep_calls!r}"
+    )
+
+
+# ─── BSS-S2: persistent BKD failure is swallowed after 3 attempts ────────────
+
+
+@pytest.mark.asyncio
+async def test_bss_s2_persistent_bkd_failure_swallowed_after_3(monkeypatch):
+    """BSS-S2: BKD fails all 3 attempts; _push_upstream_status logs warning and returns.
+
+    - exactly 3 update_issue attempts
+    - warning logged with 'webhook.upstream_status_failed'
+    - returns without raising an exception
+    """
+    from orchestrator import webhook
+
+    _FakeBKDPersistentFail.captured = []
+    monkeypatch.setattr(webhook, "BKDClient", _FakeBKDPersistentFail)
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())  # skip real sleeps
+
+    with structlog.testing.capture_logs() as log_records:
+        # Must not raise
+        await webhook._push_upstream_status("proj-1", "iss-b", "done")
+
+    attempts = [c for c in _FakeBKDPersistentFail.captured if c[1] == "iss-b"]
+    assert len(attempts) == 3, (
+        f"BSS-S2: MUST attempt update_issue exactly 3 times; got {len(attempts)}"
+    )
+
+    # Warning must be logged
+    assert any("webhook.upstream_status_failed" in (r.get("event", "") or str(r)) for r in log_records), (
+        "BSS-S2: MUST log warning containing 'webhook.upstream_status_failed'"
+    )
+
+
+# ─── Fake BKD for watchdog compensation tests ────────────────────────────────
+
+
+def _patch_bkd_for_sync(monkeypatch, issues_by_project: dict[str, list[Issue]],
+                        patch_raises: set[str] | None = None):
+    """Mock BKDClient for watchdog sync: list_issues + update_issue."""
+    patch_raises = patch_raises or set()
+    captured_updates: list[tuple[str, str, str]] = []
+
+    @asynccontextmanager
+    async def _ctx(*a, **kw):
+        fake = AsyncMock()
+
+        async def _list_issues(project_id: str, limit: int = 200) -> list[Issue]:
+            return issues_by_project.get(project_id, [])
+
+        async def _update_issue(project_id: str, issue_id: str, *, status_id: str | None = None,
+                                tags: list[str] | None = None, title: str | None = None,
+                                description: str | None = None) -> Issue:
+            key = f"{project_id}:{issue_id}"
+            if key in patch_raises:
+                raise RuntimeError("BKD PATCH 500")
+            captured_updates.append((project_id, issue_id, status_id or ""))
+            return Issue(
+                id=issue_id, project_id=project_id, issue_number=0,
+                title="", status_id=status_id or "", tags=tags or [],
+                session_status="completed",
+            )
+
+        fake.list_issues = _list_issues
+        fake.update_issue = _update_issue
+        yield fake
+
+    monkeypatch.setattr("orchestrator.watchdog.BKDClient", _ctx)
+    return captured_updates
+
+
+def _make_issue(
+    issue_id: str,
+    status_id: str,
+    session_status: str,
+    tags: list[str],
+    project_id: str = "proj-1",
+) -> Issue:
+    return Issue(
+        id=issue_id, project_id=project_id, issue_number=0,
+        title="", status_id=status_id, tags=tags,
+        session_status=session_status,
+    )
+
+
+def _patch_pool(monkeypatch, pool):
+    monkeypatch.setattr("orchestrator.watchdog.db.get_pool", lambda: pool)
+
+
+# ─── BSS-S3: completed analyze issue stuck in review is patched to done ──────
+
+
+@pytest.mark.asyncio
+async def test_bss_s3_completed_analyze_patched_to_done(monkeypatch):
+    """BSS-S3: review + completed + analyze + REQ tag → PATCHed to done."""
+    from orchestrator import watchdog
+    from orchestrator.store import db
+
+    pool = _FakePool(rows=[{"project_id": "proj-1"}])
+    _patch_pool(monkeypatch, pool)
+
+    issues = {
+        "proj-1": [
+            _make_issue("iss-1", "review", "completed", ["analyze", "REQ-1"]),
+        ]
+    }
+    captured = _patch_bkd_for_sync(monkeypatch, issues)
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert ("proj-1", "iss-1", "done") in captured, (
+        "BSS-S3: matching analyze issue MUST be PATCHed to statusId='done'"
+    )
+    assert result.get("patched") == 1, (
+        f"BSS-S3: patched count MUST be 1; got {result!r}"
+    )
+
+
+# ─── BSS-S4: verifier issue is skipped ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bss_s4_verifier_issue_skipped(monkeypatch):
+    """BSS-S4: review + completed + verifier tag → NOT PATCHed (preserve escalate path)."""
+    from orchestrator import watchdog
+    from orchestrator.store import db
+
+    pool = _FakePool(rows=[{"project_id": "proj-1"}])
+    _patch_pool(monkeypatch, pool)
+
+    issues = {
+        "proj-1": [
+            _make_issue("iss-v", "review", "completed", ["verifier", "REQ-1"]),
+        ]
+    }
+    captured = _patch_bkd_for_sync(monkeypatch, issues)
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert captured == [], (
+        "BSS-S4: verifier issue MUST NOT be PATCHed"
+    )
+    assert result.get("patched") == 0, (
+        f"BSS-S4: patched count MUST be 0; got {result!r}"
+    )
+
+
+# ─── BSS-S5: running session is skipped ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bss_s5_running_session_skipped(monkeypatch):
+    """BSS-S5: review + running + analyze + REQ tag → NOT PATCHed."""
+    from orchestrator import watchdog
+    from orchestrator.store import db
+
+    pool = _FakePool(rows=[{"project_id": "proj-1"}])
+    _patch_pool(monkeypatch, pool)
+
+    issues = {
+        "proj-1": [
+            _make_issue("iss-run", "review", "running", ["analyze", "REQ-1"]),
+        ]
+    }
+    captured = _patch_bkd_for_sync(monkeypatch, issues)
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert captured == [], (
+        "BSS-S5: running session issue MUST NOT be PATCHed"
+    )
+    assert result.get("patched") == 0, (
+        f"BSS-S5: patched count MUST be 0; got {result!r}"
+    )
+
+
+# ─── BSS-S6: non-review status is skipped ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bss_s6_non_review_status_skipped(monkeypatch):
+    """BSS-S6: done + completed + analyze + REQ tag → NOT PATCHed."""
+    from orchestrator import watchdog
+    from orchestrator.store import db
+
+    pool = _FakePool(rows=[{"project_id": "proj-1"}])
+    _patch_pool(monkeypatch, pool)
+
+    issues = {
+        "proj-1": [
+            _make_issue("iss-done", "done", "completed", ["analyze", "REQ-1"]),
+        ]
+    }
+    captured = _patch_bkd_for_sync(monkeypatch, issues)
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert captured == [], (
+        "BSS-S6: non-review status issue MUST NOT be PATCHed"
+    )
+    assert result.get("patched") == 0, (
+        f"BSS-S6: patched count MUST be 0; got {result!r}"
+    )
+
+
+# ─── BSS-S7: issue without REQ tag is skipped ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bss_s7_no_req_tag_skipped(monkeypatch):
+    """BSS-S7: review + completed + analyze (no REQ tag) → NOT PATCHed."""
+    from orchestrator import watchdog
+    from orchestrator.store import db
+
+    pool = _FakePool(rows=[{"project_id": "proj-1"}])
+    _patch_pool(monkeypatch, pool)
+
+    issues = {
+        "proj-1": [
+            _make_issue("iss-no-req", "review", "completed", ["analyze"]),
+        ]
+    }
+    captured = _patch_bkd_for_sync(monkeypatch, issues)
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert captured == [], (
+        "BSS-S7: issue without REQ tag MUST NOT be PATCHed"
+    )
+    assert result.get("patched") == 0, (
+        f"BSS-S7: patched count MUST be 0; got {result!r}"
+    )
+
+
+# ─── BSS-S8: individual PATCH failure does not abort batch ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_bss_s8_individual_patch_failure_continues(monkeypatch):
+    """BSS-S8: first PATCH fails with 500, second still PATCHed; report patched=1, failed=1."""
+    from orchestrator import watchdog
+    from orchestrator.store import db
+
+    pool = _FakePool(rows=[{"project_id": "proj-1"}])
+    _patch_pool(monkeypatch, pool)
+
+    issues = {
+        "proj-1": [
+            _make_issue("iss-fail", "review", "completed", ["analyze", "REQ-1"]),
+            _make_issue("iss-ok", "review", "completed", ["analyze", "REQ-1"]),
+        ]
+    }
+    captured = _patch_bkd_for_sync(monkeypatch, issues, patch_raises={"proj-1:iss-fail"})
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert ("proj-1", "iss-ok", "done") in captured, (
+        "BSS-S8: second issue MUST still be PATCHed after first failure"
+    )
+    assert result.get("patched") == 1, (
+        f"BSS-S8: patched count MUST be 1; got {result!r}"
+    )
+    assert result.get("failed") == 1, (
+        f"BSS-S8: failed count MUST be 1; got {result!r}"
+    )
+
+
+# ─── BSS-S9: multiple projects are scanned ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bss_s9_multiple_projects_scanned(monkeypatch):
+    """BSS-S9: active projects proj-a and proj-b each have one matching issue → both PATCHed."""
+    from orchestrator import watchdog
+    from orchestrator.store import db
+
+    pool = _FakePool(rows=[
+        {"project_id": "proj-a"},
+        {"project_id": "proj-b"},
+    ])
+    _patch_pool(monkeypatch, pool)
+
+    issues = {
+        "proj-a": [
+            _make_issue("iss-a", "review", "completed", ["analyze", "REQ-a"], project_id="proj-a"),
+        ],
+        "proj-b": [
+            _make_issue("iss-b", "review", "completed", ["fixer", "REQ-b"], project_id="proj-b"),
+        ],
+    }
+    captured = _patch_bkd_for_sync(monkeypatch, issues)
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert ("proj-a", "iss-a", "done") in captured, (
+        "BSS-S9: proj-a issue MUST be PATCHed"
+    )
+    assert ("proj-b", "iss-b", "done") in captured, (
+        "BSS-S9: proj-b issue MUST be PATCHed"
+    )
+    assert result.get("patched") == 2, (
+        f"BSS-S9: patched count MUST be 2; got {result!r}"
+    )
+    assert result.get("failed") == 0, (
+        f"BSS-S9: failed count MUST be 0; got {result!r}"
+    )

--- a/orchestrator/tests/test_watchdog_bkd_sync.py
+++ b/orchestrator/tests/test_watchdog_bkd_sync.py
@@ -1,0 +1,236 @@
+"""watchdog BKD 补偿清理测试：_sync_stuck_sub_agent_statuses_tick。
+
+REQ-fix-bkd-sub-issue-status-sync-1777426309
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock
+
+import pytest
+
+from orchestrator import watchdog
+from orchestrator.bkd import Issue
+
+
+# ─── Fake pool ───────────────────────────────────────────────────────────
+@dataclass
+class FakePool:
+    rows: list = field(default_factory=list)
+
+    async def fetch(self, sql, *args):
+        return self.rows
+
+
+def _patch_pool(monkeypatch, pool):
+    monkeypatch.setattr("orchestrator.watchdog.db.get_pool", lambda: pool)
+
+
+# ─── Fake BKD ────────────────────────────────────────────────────────────
+def _patch_bkd_for_sync(monkeypatch, issues_by_project: dict[str, list[Issue]],
+                        patch_raises: set[str] | None = None):
+    """mock BKDClient：list_issues 按 project_id 返回；update_issue 可选抛异常。"""
+    patch_raises = patch_raises or set()
+    captured_updates: list[tuple[str, str, str]] = []
+
+    @asynccontextmanager
+    async def _ctx(*a, **kw):
+        fake = AsyncMock()
+
+        async def _list_issues(project_id: str, limit: int = 200) -> list[Issue]:
+            return issues_by_project.get(project_id, [])
+
+        async def _update_issue(project_id: str, issue_id: str, *, status_id: str | None = None,
+                                tags: list[str] | None = None, title: str | None = None,
+                                description: str | None = None) -> Issue:
+            key = f"{project_id}:{issue_id}"
+            if key in patch_raises:
+                raise RuntimeError("BKD PATCH 500")
+            captured_updates.append((project_id, issue_id, status_id or ""))
+            # 返回 dummy issue
+            return Issue(
+                id=issue_id, project_id=project_id, issue_number=0,
+                title="", status_id=status_id or "", tags=tags or [],
+                session_status="completed",
+            )
+
+        fake.list_issues = _list_issues
+        fake.update_issue = _update_issue
+        yield fake
+
+    monkeypatch.setattr("orchestrator.watchdog.BKDClient", _ctx)
+    return captured_updates
+
+
+def _make_issue(issue_id: str, status_id: str, session_status: str, tags: list[str]) -> Issue:
+    return Issue(
+        id=issue_id, project_id="proj-1", issue_number=0,
+        title="", status_id=status_id, tags=tags,
+        session_status=session_status,
+    )
+
+
+# ─── Case 1：review + completed + analyze tag + REQ tag → patched ─────────
+@pytest.mark.asyncio
+async def test_patches_stuck_analyze_issue(monkeypatch):
+    pool = FakePool(rows=[{"project_id": "proj-1"}])
+    _patch_pool(monkeypatch, pool)
+    issues = {
+        "proj-1": [
+            _make_issue("iss-a", "review", "completed", ["analyze", "REQ-1"]),
+        ],
+    }
+    captured = _patch_bkd_for_sync(monkeypatch, issues)
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert result == {"patched": 1, "failed": 0}
+    assert captured == [("proj-1", "iss-a", "done")]
+
+
+# ─── Case 2：verifier tag → 跳过（保守策略，避免误动 escalate verifier）──
+@pytest.mark.asyncio
+async def test_skips_verifier_issue(monkeypatch):
+    pool = FakePool(rows=[{"project_id": "proj-1"}])
+    _patch_pool(monkeypatch, pool)
+    issues = {
+        "proj-1": [
+            _make_issue("iss-v", "review", "completed", ["verifier", "REQ-1"]),
+        ],
+    }
+    captured = _patch_bkd_for_sync(monkeypatch, issues)
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert result == {"patched": 0, "failed": 0}
+    assert captured == []
+
+
+# ─── Case 3：sessionStatus=running → 跳过 ─────────────────────────────────
+@pytest.mark.asyncio
+async def test_skips_running_session(monkeypatch):
+    pool = FakePool(rows=[{"project_id": "proj-1"}])
+    _patch_pool(monkeypatch, pool)
+    issues = {
+        "proj-1": [
+            _make_issue("iss-a", "review", "running", ["analyze", "REQ-1"]),
+        ],
+    }
+    captured = _patch_bkd_for_sync(monkeypatch, issues)
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert result == {"patched": 0, "failed": 0}
+    assert captured == []
+
+
+# ─── Case 4：statusId != review → 跳过 ────────────────────────────────────
+@pytest.mark.asyncio
+async def test_skips_non_review_status(monkeypatch):
+    pool = FakePool(rows=[{"project_id": "proj-1"}])
+    _patch_pool(monkeypatch, pool)
+    issues = {
+        "proj-1": [
+            _make_issue("iss-a", "done", "completed", ["analyze", "REQ-1"]),
+        ],
+    }
+    captured = _patch_bkd_for_sync(monkeypatch, issues)
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert result == {"patched": 0, "failed": 0}
+    assert captured == []
+
+
+# ─── Case 5：无 REQ tag → 跳过 ────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_skips_issue_without_req_tag(monkeypatch):
+    pool = FakePool(rows=[{"project_id": "proj-1"}])
+    _patch_pool(monkeypatch, pool)
+    issues = {
+        "proj-1": [
+            _make_issue("iss-a", "review", "completed", ["analyze"]),
+        ],
+    }
+    captured = _patch_bkd_for_sync(monkeypatch, issues)
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert result == {"patched": 0, "failed": 0}
+    assert captured == []
+
+
+# ─── Case 6：无 role tag → 跳过 ───────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_skips_issue_without_role_tag(monkeypatch):
+    pool = FakePool(rows=[{"project_id": "proj-1"}])
+    _patch_pool(monkeypatch, pool)
+    issues = {
+        "proj-1": [
+            _make_issue("iss-a", "review", "completed", ["REQ-1", "some-tag"]),
+        ],
+    }
+    captured = _patch_bkd_for_sync(monkeypatch, issues)
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert result == {"patched": 0, "failed": 0}
+    assert captured == []
+
+
+# ─── Case 7：PATCH 失败 → 计数 failed，不抛异常 ───────────────────────────
+@pytest.mark.asyncio
+async def test_counts_patch_failure(monkeypatch):
+    pool = FakePool(rows=[{"project_id": "proj-1"}])
+    _patch_pool(monkeypatch, pool)
+    issues = {
+        "proj-1": [
+            _make_issue("iss-a", "review", "completed", ["analyze", "REQ-1"]),
+            _make_issue("iss-b", "review", "completed", ["fixer", "REQ-2"]),
+        ],
+    }
+    captured = _patch_bkd_for_sync(monkeypatch, issues, patch_raises={"proj-1:iss-a"})
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert result == {"patched": 1, "failed": 1}
+    assert captured == [("proj-1", "iss-b", "done")]
+
+
+# ─── Case 8：多 project ──────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_scans_multiple_projects(monkeypatch):
+    pool = FakePool(rows=[
+        {"project_id": "proj-a"},
+        {"project_id": "proj-b"},
+    ])
+    _patch_pool(monkeypatch, pool)
+    issues = {
+        "proj-a": [
+            _make_issue("iss-a1", "review", "completed", ["analyze", "REQ-A1"]),
+        ],
+        "proj-b": [
+            _make_issue("iss-b1", "review", "completed", ["challenger", "REQ-B1"]),
+        ],
+    }
+    captured = _patch_bkd_for_sync(monkeypatch, issues)
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert result == {"patched": 2, "failed": 0}
+    assert ("proj-a", "iss-a1", "done") in captured
+    assert ("proj-b", "iss-b1", "done") in captured
+
+
+# ─── Case 9：空 project rows → 无事发生 ───────────────────────────────────
+@pytest.mark.asyncio
+async def test_empty_projects_does_nothing(monkeypatch):
+    pool = FakePool(rows=[])
+    _patch_pool(monkeypatch, pool)
+    captured = _patch_bkd_for_sync(monkeypatch, {})
+
+    result = await watchdog._sync_stuck_sub_agent_statuses_tick()
+
+    assert result == {"patched": 0, "failed": 0}
+    assert captured == []

--- a/orchestrator/tests/test_webhook_upstream_done.py
+++ b/orchestrator/tests/test_webhook_upstream_done.py
@@ -33,6 +33,28 @@ class _FakeBKD:
         self.captured.append((project_id, issue_id, status_id))
 
 
+class _FakeBKDFlaky:
+    """前 N 次 update_issue 抛异常，第 N+1 次成功。"""
+
+    captured: ClassVar[list[tuple[str, str, str]]] = []
+    fail_count: ClassVar[int] = 0
+
+    def __init__(self, *_a, **_kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def update_issue(self, *, project_id, issue_id, status_id):
+        if len(self.captured) < self.fail_count:
+            self.captured.append((project_id, issue_id, f"fail-{status_id}"))
+            raise RuntimeError(f"BKD down (attempt {len(self.captured)})")
+        self.captured.append((project_id, issue_id, status_id))
+
+
 @pytest.mark.asyncio
 async def test_pushes_done_for_session_completed(monkeypatch):
     _FakeBKD.captured = []
@@ -65,3 +87,33 @@ async def test_swallows_bkd_errors(monkeypatch):
 
     # 不抛 = 通过
     await webhook._push_upstream_status("proj-1", "issue-abc", "done")
+
+
+@pytest.mark.asyncio
+async def test_retries_on_failure_then_succeeds(monkeypatch):
+    """REQ-fix-bkd-sub-issue-status-sync-1777426309：失败时重试，成功则停。"""
+    _FakeBKDFlaky.captured = []
+    _FakeBKDFlaky.fail_count = 2  # 前 2 次失败，第 3 次成功
+    monkeypatch.setattr(webhook, "BKDClient", _FakeBKDFlaky)
+
+    await webhook._push_upstream_status("proj-1", "issue-abc", "done")
+
+    # 总共调了 3 次（2 次失败 + 1 次成功）
+    assert len(_FakeBKDFlaky.captured) == 3
+    assert _FakeBKDFlaky.captured[0] == ("proj-1", "issue-abc", "fail-done")
+    assert _FakeBKDFlaky.captured[1] == ("proj-1", "issue-abc", "fail-done")
+    assert _FakeBKDFlaky.captured[2] == ("proj-1", "issue-abc", "done")
+
+
+@pytest.mark.asyncio
+async def test_retries_exhausted_then_swallows(monkeypatch):
+    """REQ-fix-bkd-sub-issue-status-sync-1777426309：3 次都失败，最终 swallow 不阻塞状态机。"""
+    _FakeBKDFlaky.captured = []
+    _FakeBKDFlaky.fail_count = 10  # 永远失败
+    monkeypatch.setattr(webhook, "BKDClient", _FakeBKDFlaky)
+
+    # 不抛 = 通过
+    await webhook._push_upstream_status("proj-1", "issue-abc", "done")
+
+    # 最多 3 次尝试
+    assert len(_FakeBKDFlaky.captured) == 3


### PR DESCRIPTION
## Summary

修复 sub-agent issue BKD status 同步不可靠导致 review 列污染的问题。

## Changes

- **webhook.py**: `_push_upstream_status` 增加指数退避重试（最多 3 次，1s/2s），提升首次同步成功率
- **watchdog.py**: 新增补偿清理任务，每 5 个 tick（~5min）扫描 BKD 中 `sessionStatus=completed` 但 `statusId=review` 的非 verifier sub-agent issue，自动 PATCH 到 done
- **测试**: 新增 14 个测试覆盖重试成功/耗尽、补偿清理的 9 个场景

## Test Plan

- [x] `pytest tests/test_webhook*.py tests/test_watchdog*.py` — 65 passed
- [x] `openspec validate REQ-fix-bkd-sub-issue-status-sync-1777426309` — valid

## Backwards Compatibility

- 状态机 transition 表未改
- action 行为未改
- prompt 模板未改
- 失败仍 swallow 不阻塞状态机

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-fix-bkd-sub-issue-status-sync-1777426309`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/ed4hzabm)