### PR TITLE
fix(lint): resolve ruff errors on main

### DIFF
--- a/orchestrator/tests/test_contract_bkd_sub_issue_status_sync_challenger.py
+++ b/orchestrator/tests/test_contract_bkd_sub_issue_status_sync_challenger.py
@@ -30,7 +30,6 @@ import structlog.testing
 
 from orchestrator.bkd import Issue
 
-
 # ─── Fake BKD for webhook retry tests ────────────────────────────────────────
 
 
@@ -112,7 +111,6 @@ async def test_bss_s1_transient_bkd_error_succeeds_on_retry(monkeypatch, caplog)
     monkeypatch.setattr(webhook, "BKDClient", _FakeBKDFlaky)
 
     sleep_calls: list[float] = []
-    orig_sleep = asyncio.sleep
 
     async def _tracked_sleep(delay):
         sleep_calls.append(delay)
@@ -235,7 +233,6 @@ def _patch_pool(monkeypatch, pool):
 async def test_bss_s3_completed_analyze_patched_to_done(monkeypatch):
     """BSS-S3: review + completed + analyze + REQ tag → PATCHed to done."""
     from orchestrator import watchdog
-    from orchestrator.store import db
 
     pool = _FakePool(rows=[{"project_id": "proj-1"}])
     _patch_pool(monkeypatch, pool)
@@ -264,7 +261,6 @@ async def test_bss_s3_completed_analyze_patched_to_done(monkeypatch):
 async def test_bss_s4_verifier_issue_skipped(monkeypatch):
     """BSS-S4: review + completed + verifier tag → NOT PATCHed (preserve escalate path)."""
     from orchestrator import watchdog
-    from orchestrator.store import db
 
     pool = _FakePool(rows=[{"project_id": "proj-1"}])
     _patch_pool(monkeypatch, pool)
@@ -293,7 +289,6 @@ async def test_bss_s4_verifier_issue_skipped(monkeypatch):
 async def test_bss_s5_running_session_skipped(monkeypatch):
     """BSS-S5: review + running + analyze + REQ tag → NOT PATCHed."""
     from orchestrator import watchdog
-    from orchestrator.store import db
 
     pool = _FakePool(rows=[{"project_id": "proj-1"}])
     _patch_pool(monkeypatch, pool)
@@ -322,7 +317,6 @@ async def test_bss_s5_running_session_skipped(monkeypatch):
 async def test_bss_s6_non_review_status_skipped(monkeypatch):
     """BSS-S6: done + completed + analyze + REQ tag → NOT PATCHed."""
     from orchestrator import watchdog
-    from orchestrator.store import db
 
     pool = _FakePool(rows=[{"project_id": "proj-1"}])
     _patch_pool(monkeypatch, pool)
@@ -351,7 +345,6 @@ async def test_bss_s6_non_review_status_skipped(monkeypatch):
 async def test_bss_s7_no_req_tag_skipped(monkeypatch):
     """BSS-S7: review + completed + analyze (no REQ tag) → NOT PATCHed."""
     from orchestrator import watchdog
-    from orchestrator.store import db
 
     pool = _FakePool(rows=[{"project_id": "proj-1"}])
     _patch_pool(monkeypatch, pool)
@@ -380,7 +373,6 @@ async def test_bss_s7_no_req_tag_skipped(monkeypatch):
 async def test_bss_s8_individual_patch_failure_continues(monkeypatch):
     """BSS-S8: first PATCH fails with 500, second still PATCHed; report patched=1, failed=1."""
     from orchestrator import watchdog
-    from orchestrator.store import db
 
     pool = _FakePool(rows=[{"project_id": "proj-1"}])
     _patch_pool(monkeypatch, pool)
@@ -413,7 +405,6 @@ async def test_bss_s8_individual_patch_failure_continues(monkeypatch):
 async def test_bss_s9_multiple_projects_scanned(monkeypatch):
     """BSS-S9: active projects proj-a and proj-b each have one matching issue → both PATCHed."""
     from orchestrator import watchdog
-    from orchestrator.store import db
 
     pool = _FakePool(rows=[
         {"project_id": "proj-a"},

--- a/orchestrator/tests/test_contract_thanatos_m1_accept.py
+++ b/orchestrator/tests/test_contract_thanatos_m1_accept.py
@@ -13,7 +13,6 @@ import pytest
 
 from orchestrator.state import Event
 
-
 # ─── Shared helpers ──────────────────────────────────────────────────────────
 
 

--- a/orchestrator/tests/test_engine_pr_merged_and_user_review.py
+++ b/orchestrator/tests/test_engine_pr_merged_and_user_review.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from test_engine import FakePool, FakeReq, _drain_tasks  # type: ignore[import-not-found]
 
 from orchestrator import engine, k8s_runner

--- a/orchestrator/tests/test_verifier.py
+++ b/orchestrator/tests/test_verifier.py
@@ -184,7 +184,7 @@ def test_derive_with_retry_info_schema_invalid_is_retry_worthy():
 
 
 def test_derive_with_retry_info_no_decision_not_retry_worthy():
-    ev, decision, why, retry = derive_verifier_event_with_retry_info("no json here", [])
+    ev, decision, _why, retry = derive_verifier_event_with_retry_info("no json here", [])
     assert ev == Event.VERIFY_ESCALATE
     assert decision is None
     assert retry is False
@@ -193,7 +193,7 @@ def test_derive_with_retry_info_no_decision_not_retry_worthy():
 def test_derive_with_retry_info_unparseable_but_retry_worthy():
     """找到了 decision-like 文本但解析失败 → retry_worthy=True。"""
     desc = "My decision is {action: pass, fixer: None} because..."
-    ev, decision, why, retry = derive_verifier_event_with_retry_info(desc, [])
+    ev, decision, _why, retry = derive_verifier_event_with_retry_info(desc, [])
     assert ev == Event.VERIFY_ESCALATE
     assert decision is None
     assert retry is True

--- a/orchestrator/tests/test_verifier_parser.py
+++ b/orchestrator/tests/test_verifier_parser.py
@@ -12,19 +12,13 @@ from __future__ import annotations
 import base64
 import json
 
-import pytest
-
 from orchestrator.verifier_parser import (
-    ParseResult,
     _extract_balanced_braces,
-    _extract_from_tags,
-    _extract_from_text,
     _fix_common_json_syntax,
     _preprocess_json,
     _strip_markdown,
     extract_decision_robust,
 )
-
 
 # ─── 1. tag base64 解码 ──────────────────────────────────────────────────
 

--- a/orchestrator/tests/test_webhook_verifier_retry.py
+++ b/orchestrator/tests/test_webhook_verifier_retry.py
@@ -5,7 +5,6 @@ REQ-fix-verifier-json-parse-1777420690：schema invalid 时自动 retry（最多
 from __future__ import annotations
 
 from typing import ClassVar
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -198,7 +197,7 @@ async def test_retry_on_schema_invalid_first_time(fake_bkd, fake_req_state, fake
 @pytest.mark.asyncio
 async def test_retry_on_schema_invalid_second_time(fake_bkd, fake_req_state, fake_obs, fake_dedup, monkeypatch):
     """第二次 schema invalid（retry_count=1）→ follow-up retry，返回 skip。"""
-    rows, ctx_updates = fake_req_state
+    rows, _ctx_updates = fake_req_state
     rows["REQ-1"] = _FakeReqStateRow(context={"verifier_parse_retry_count": 1})
     fake_bkd.set_last_msg("```json\n{\"action\": \"nope\"}\n```")
 
@@ -215,7 +214,7 @@ async def test_retry_on_schema_invalid_second_time(fake_bkd, fake_req_state, fak
 @pytest.mark.asyncio
 async def test_escalate_when_retry_exhausted(fake_bkd, fake_req_state, fake_obs, fake_dedup, monkeypatch):
     """第三次 schema invalid（retry_count=2）→ escalate，不再 retry。"""
-    rows, ctx_updates = fake_req_state
+    rows, _ctx_updates = fake_req_state
     rows["REQ-1"] = _FakeReqStateRow(context={"verifier_parse_retry_count": 2})
     fake_bkd.set_last_msg("```json\n{\"action\": \"nope\"}\n```")
 
@@ -234,7 +233,7 @@ async def test_escalate_when_retry_exhausted(fake_bkd, fake_req_state, fake_obs,
 @pytest.mark.asyncio
 async def test_no_retry_when_no_decision_found(fake_bkd, fake_req_state, fake_obs, fake_dedup, monkeypatch):
     """完全找不到 decision → 直接 escalate，不 retry。"""
-    rows, ctx_updates = fake_req_state
+    rows, _ctx_updates = fake_req_state
     rows["REQ-1"] = _FakeReqStateRow(context={})
     fake_bkd.set_last_msg("no json here at all")
 
@@ -252,7 +251,7 @@ async def test_no_retry_when_no_decision_found(fake_bkd, fake_req_state, fake_ob
 @pytest.mark.asyncio
 async def test_no_retry_when_valid_decision(fake_bkd, fake_req_state, fake_obs, fake_dedup, monkeypatch):
     """decision 合规 → 正常通过，不 retry。"""
-    rows, ctx_updates = fake_req_state
+    rows, _ctx_updates = fake_req_state
     rows["REQ-1"] = _FakeReqStateRow(context={})
     fake_bkd.set_last_msg('```json\n{"action": "pass", "fixer": null, "reason": "ok", "confidence": "high"}\n```')
 


### PR DESCRIPTION
## Summary
- Remove unused imports (F401)
- Fix import block sorting (I001)
- Remove unused variable assignments (F841, RUF059)
- Clean up extra blank lines

All fixes are auto-generated by `ruff check --fix --unsafe-fixes`. No logic changes.

## Test plan
- [ ] `ruff check src/ tests/` passes
- [ ] `pytest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)