### PR TITLE
feat(state): ESCALATED resumable via stage-issue follow-up

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@
 
 ## 核心哲学
 
+> **定位与边界权威**：[docs/architecture.md §1b](docs/architecture.md)（隐形 infra / 控制面复杂度结构 / 不换通用框架的理由 / 新增机制的判断尺子）
+
 - **薄编排，agent 决定** —— 路由 / 状态机 / checker 是 sisyphus；判 PR 内容、bug 该不该修是 agent。**永远不抢 AI 决定权**。
 - **机械层 ≠ agent 层** —— 跑测试 / 轮 GHA / 校 schema 不绕 agent，sisyphus 是唯一裁判（4 个 checker：spec_lint / dev_cross_check / staging_test / pr_ci_watch）。
 - **失败先验，再试错** —— stage fail 不直接 bugfix，verifier-agent 主观判 pass / fix / escalate（M14b/c，3 路）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,11 @@ intent:analyze → analyze(全责交付：写 spec + 业务码 + push feat/REQ-x
 任何 stage（含 staging-test / pr-ci / accept）失败入 `REVIEW_RUNNING`，verifier-agent 3 路决策：
 - `pass` → 推下一 stage
 - `fix` + `fixer` → 起 dev / spec fixer，回 `REVIEW_RUNNING` 再判
-- `escalate` → 终态 ESCALATED（**包括所有 flaky / 基础设施抖动**：sisyphus 不再机制性兜 retry，由人重起）
+- `escalate` → 进 ESCALATED（**包括所有 flaky / 基础设施抖动**：sisyphus 不再机制性兜 retry）
 
-state 转移完整定义在 [orchestrator/src/orchestrator/state.py](orchestrator/src/orchestrator/state.py)（17 ReqState × 27 Event × 30+ transition）。
+**ESCALATED 是暂停态，不是死终态**——用户在任意 stage agent issue（含 verifier issue）BKD UI 续 follow-up，agent 重跑产出 result tag → router 派出对应主链事件 → ESCALATED 复用主链 transition 继续推。零新概念 / 零新 tag / 零新 endpoint。详见 [docs/state-machine.md §5](docs/state-machine.md)。
+
+state 转移完整定义在 [orchestrator/src/orchestrator/state.py](orchestrator/src/orchestrator/state.py)（17 ReqState × 27 Event × 70 transition）。
 
 ## 技术栈
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,6 +107,74 @@
 └────────────────────────────────────────────────────────┘
 ```
 
+## 1b. 定位与控制面边界
+
+> 这一节回答："sisyphus 这套控制面这么重，是不是必要的？为什么不换通用 workflow 框架？"
+> 影响所有未来新增 / 删减 / 重构机制的判断尺子。
+
+### 1b.1 sisyphus 的产品定位：隐形 infra，不是用户产品
+
+| | 角色 |
+|---|---|
+| **BKD** | **唯一用户入口**。agent chat workspace、worktree、issue / tag / 续聊都在这里。 |
+| **sisyphus** | **隐形控制面**。状态机 / 路由 / checker / 度量。**不给用户做 UI / CLI / dashboard**。 |
+
+设计推论（**所有未来 sisyphus 功能必须遵守**）：
+
+- 任何用户可见操作（含 ESCALATED 恢复 / 触发 / 排障）**必须能在 BKD agent issue 里自然完成**——续 prompt → BKD agent 跑 → session.\* webhook → sisyphus 接住信号
+- sisyphus admin REST endpoint 仅供脚本 / cron / dev 调试，**不是日常路径**
+- 不写"用户怎么 resume / 怎么触发"这种用户文档；用户不需要知道 sisyphus 内部概念（ESCALATED / RESUMING / ctx 等）
+- **但**用户感知不到 sisyphus 内部 = sisyphus 必须**替用户守边界**：cap / hard-reason / 异常告警 / 数据自愈 比"有 UI 时"重要得多
+
+### 1b.2 控制面复杂度结构
+
+| 层 | 占比 | 是否可避免 |
+|---|---|---|
+| 控制面本质 | ~30% | **不可避免**：状态机 / CAS / event_log / ctx——只要想"无人值守 + 可观测 + 自愈" |
+| BKD 同步 | ~30% | 架构选择带来的：BKD 跟 sisyphus 解耦换来 BKD 自身演进 + 用户介入界面 + chat workspace 等价值 |
+| 多 actor 协作 | ~20% | 业务本质：user / verifier / fixer / sisyphus 都能戳 BKD agent → 必须有 race protection / tag dedup / 状态收敛 |
+| 实现抽象债 | ~20% | **可还**：每加 stage 都要碰 N 处的代码 → 修对抽象（如 active\_stage / declarative DSL）能降一个量级 |
+
+前 3 层是**系统化工程的必要税**，跟 k8s controller 跟 kubelet 同步、CI orchestrator 跟 runner 同步、GitOps 跟集群 reconcile 同构。第 4 层是真正可优化的余地。
+
+### 1b.3 为什么不换 Temporal / Cadence / 通用 workflow framework
+
+**框架解决什么** vs **不解决什么**：
+
+| 问题 | Temporal/Cadence | sisyphus 现状 |
+|---|---|---|
+| 状态持久化 | ✅ workflow history 自动 | `req_state` + `history` 列 |
+| CAS / 并发 | ✅ workflow 单线程串行 | 手写 CAS SQL |
+| retry / timeout | ✅ activity 标准 API | watchdog + retry_count |
+| event sourcing | ✅ history 自动 replay | event_log 表 |
+| **业务状态语义**（ESCALATED 是终态还是暂停态？） | ❌ 你自己定义 | state.py |
+| **跨系统状态同步**（BKD ↔ sisyphus） | ❌ activity 自己写 | bkd.py + router.py 全部 |
+| **多 actor 协作协议** | ❌ signal 协议自己设计 | tag 命名规范 + derive_event |
+| **业务指标语义**（哪条 prompt 该改？） | ❌ history 是技术日志，不是业务诊断 | Q1-Q18 那 18 条 Metabase SQL |
+| **领域抽象**（stage / checker / fixer / verifier） | ❌ 你自己建模 | actions/ + checkers/ + prompts/ |
+| **dead-letter / 恢复 UX** | ❌ 你自己设计 | docs/state-machine.md §5 |
+
+横线**以下**才是真正占 sisyphus 复杂度大头的部分，框架一行不省。Temporal 重写估算净收益 **-10% ~ +20%**，加迁移半年 + 双跑期间双倍运维 = **不划算**。
+
+**AI workflow 这个领域没有事实标准框架**：
+
+- LangGraph / CrewAI / AutoGen：砍掉控制面 → 没有可观测 / 没有恢复语义 / 没有并发安全
+- Airflow + LLM operators：DAG 模型对 verifier 这种动态决策很笨拙
+- Prefect 3 / Temporal：通用 workflow 引擎，但 deterministic 约束跟 LLM 本质冲突
+- 这个领域 frameworks-of-the-month 现象严重，**最稳的反而是自研轻量控制面 + 业务认知积累**
+
+### 1b.4 新增 / 删减机制的判断尺子
+
+加任何机制（新 state、新 event、新 action、新 checker、新 ctx 字段）前先问：
+
+1. **数据进了哪张表？**——`stage_runs` / `verifier_decisions` / `artifact_checks` / `event_log` 没人看就别加。"指标驱动改进" 的反向应用。
+2. **用户能在 BKD 里完成对应操作吗？**——如果答案是"用户要去 sisyphus 那边点个按钮 / 加个 tag"，停下来重想。
+3. **抽象修对了未来新 stage 是不是免维护？**——typedef / 通用 ctx 字段 / declarative DSL 比硬编码 stage_map 优。
+4. **sisyphus 在抢 agent 决定权吗？**——如果答案模棱两可，默认不抢。
+5. **复杂度收益递减信号**：如果一个机制的覆盖率永远小于 5%（比如某个特定 stage 的特定边界 case），考虑用日志 + 人工兜底替代代码。
+
+每次"折磨"是抽象修补机会，不是换框架机会。
+
 ## 2. 主流水线
 
 happy path（含 INTAKING）十一段，入口可选 `intent:intake`（推荐）或 `intent:analyze`（跳过澄清）一路自动到 `done`。

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -123,10 +123,20 @@ stateDiagram-v2
     review_running --> escalated: verify.escalate\n(不确定 flaky / 基础设施严重问题)
     review_running --> review_running: verify.infra-retry\n(REQ-428: 确认 infra-flake → 重跑 checker;\n超 cap → escalate)
 
-    %% escalated 不是死终态：用户 follow-up 那个 escalate 的 verifier issue → 走原 verifier 同链
+    %% escalated 不是死终态：续 verifier issue / 续 stage agent issue 都能复活
     escalated --> escalated: verify.pass\n(apply_verify_pass 内部 CAS 推下一 stage)
     escalated --> fixer_running: verify.fix-needed
     escalated --> escalated: verify.escalate\n(verifier 又判 escalate, 留原地)
+
+    %% REQ-escalated-stage-resume: 续 stage agent issue 走主链事件，复用主链 transition
+    escalated --> analyze_artifact_checking: analyze.done\n(stage-issue 续: 用户在 analyze issue follow-up,\nagent 重跑出 result:pass)
+    escalated --> dev_cross_check_running: challenger.pass
+    escalated --> staging_test_running: dev-cross-check.pass
+    escalated --> pr_ci_running: staging-test.pass
+    escalated --> accept_running: pr-ci.pass
+    escalated --> accept_tearing_down: accept.pass / accept.fail
+    escalated --> review_running: any *.fail / fixer.done\n(走 verifier 复查)
+    escalated --> pending_user_review: teardown-done.pass
 
     fixer_running --> review_running: fixer.done\n(invoke_verifier_after_fix)
 
@@ -150,11 +160,23 @@ stateDiagram-v2
   输出 retry 会退回 escalate（这些非机械 checker，无法简单重跑）。
 - `escalate`：不确定是否 flaky / infra 问题持续 / retry cap 到顶 / 所有非 retry 场景。
 
-**ESCALATED 可恢复**：用户在 BKD UI follow-up 那条 escalate 的 verifier issue（webhook
-统一推 statusId="review" 让"待审查"列只剩它）→ BKD wake agent → 写新 decision → 走原
-verifier session.completed 同一套 webhook 链路，直接命中 `(ESCALATED, VERIFY_*)` transition。
-零新概念 / 零新 tag / 零新 endpoint。**注意**只可 follow-up verifier issue 续；analyze
-issue 续会重起整个 analyze 等于新 REQ，文档不推荐。
+**ESCALATED 可恢复（两条入口）**：
+
+1. **续 verifier issue**：用户 follow-up 那条 escalate 的 verifier issue（webhook 统一
+   推 statusId="review" 让"待审查"列只剩它）→ BKD wake agent → 写新 decision → 走原
+   verifier session.completed 同一套链路，命中 `(ESCALATED, VERIFY_*)` transition。
+
+2. **续 stage agent issue**（REQ-escalated-stage-resume）：用户 follow-up 任意 stage
+   agent issue（intake / analyze / challenger / accept / fixer 等）→ BKD wake agent
+   → 重跑并贴 result tag → router 派出对应主链事件（ANALYZE_DONE / CHALLENGER_PASS
+   等）→ ESCALATED 复用主链 transition（next_state / action 跟主链同一份）。19 条
+   `(ESCALATED, <main-chain-event>)` 在 state.py `_ESCALATED_RESUME_EVENT_SOURCES`
+   声明，复用 `TRANSITIONS[(src, ev)]`，主链改了 ESCALATED 复活路径自动跟，零漂移。
+
+零新概念 / 零新 tag / 零新 endpoint / 零新 action。失败信号（`SESSION_FAILED` / 直接进
+ESCALATED 类事件 `PR_CI_TIMEOUT` / `ACCEPT_ENV_UP_FAIL` / `VERIFY_ESCALATE` /
+`INTAKE_FAIL` / `USER_REVIEW_FIX`）和 `PR_MERGED`（escalate.py 入口的 PR-merged
+shortcut 处理）不在恢复列表里，避免恢复语义被误用。
 
 `VERIFY_PASS` 在 transition 表里看起来是 self-loop（next_state 还是 `review-running`），
 但 **action 内部手工 CAS 推到目标 stage_running 再链式 emit 该 stage 的 done/pass 事件**。

--- a/orchestrator/src/orchestrator/state.py
+++ b/orchestrator/src/orchestrator/state.py
@@ -298,6 +298,49 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
 }
 
 
+# ─── ESCALATED 主链反激活：stage-issue 续写 follow-up ─────────────────────
+# 已有：(ESCALATED, VERIFY_*) 让用户续 escalate 的 verifier issue 走原 verifier 链。
+# 这里补：用户在 stage agent issue（intake / analyze / challenger / accept / fixer）
+# 续 follow-up → BKD wake agent → agent 重跑并贴 result tag → router 派出对应主链
+# 事件 → ESCALATED 复用主链 transition（next_state / action 跟主链同一份）。
+#
+# 设计：复用 TRANSITIONS[(src_state, ev)]，主链改了 ESCALATED 复活路径自动跟，
+# 没有 next_state / action 的二次定义，不会漂移。dump_transitions 看起来就像
+# (ESCALATED, X) 跟 (src_state, X) 走同一套；这是有意的。
+#
+# 排除清单（不加）：
+#   - SESSION_FAILED：已在 ESCALATED 再挂还是 escalate，无意义
+#   - 直接进 ESCALATED 的事件：INTAKE_FAIL / PR_CI_TIMEOUT / ACCEPT_ENV_UP_FAIL
+#     / VERIFY_ESCALATE / USER_REVIEW_FIX —— 这些不是"恢复信号"
+#   - PR_MERGED：escalate.py 入口的 PR-merged shortcut 已处理
+#   - VERIFY_PASS / VERIFY_FIX_NEEDED / VERIFY_INFRA_RETRY：已在上面 verifier 反激活段
+_ESCALATED_RESUME_EVENT_SOURCES: list[tuple[Event, ReqState]] = [
+    (Event.INTAKE_PASS,                  ReqState.INTAKING),
+    (Event.ANALYZE_DONE,                 ReqState.ANALYZING),
+    (Event.ANALYZE_ARTIFACT_CHECK_PASS,  ReqState.ANALYZE_ARTIFACT_CHECKING),
+    (Event.ANALYZE_ARTIFACT_CHECK_FAIL,  ReqState.ANALYZE_ARTIFACT_CHECKING),
+    (Event.SPEC_LINT_PASS,               ReqState.SPEC_LINT_RUNNING),
+    (Event.SPEC_LINT_FAIL,               ReqState.SPEC_LINT_RUNNING),
+    (Event.CHALLENGER_PASS,              ReqState.CHALLENGER_RUNNING),
+    (Event.CHALLENGER_FAIL,              ReqState.CHALLENGER_RUNNING),
+    (Event.DEV_CROSS_CHECK_PASS,         ReqState.DEV_CROSS_CHECK_RUNNING),
+    (Event.DEV_CROSS_CHECK_FAIL,         ReqState.DEV_CROSS_CHECK_RUNNING),
+    (Event.STAGING_TEST_PASS,            ReqState.STAGING_TEST_RUNNING),
+    (Event.STAGING_TEST_FAIL,            ReqState.STAGING_TEST_RUNNING),
+    (Event.PR_CI_PASS,                   ReqState.PR_CI_RUNNING),
+    (Event.PR_CI_FAIL,                   ReqState.PR_CI_RUNNING),
+    (Event.ACCEPT_PASS,                  ReqState.ACCEPT_RUNNING),
+    (Event.ACCEPT_FAIL,                  ReqState.ACCEPT_RUNNING),
+    (Event.TEARDOWN_DONE_PASS,           ReqState.ACCEPT_TEARING_DOWN),
+    (Event.TEARDOWN_DONE_FAIL,           ReqState.ACCEPT_TEARING_DOWN),
+    (Event.FIXER_DONE,                   ReqState.FIXER_RUNNING),
+]
+TRANSITIONS.update({
+    (ReqState.ESCALATED, ev): TRANSITIONS[(src, ev)]
+    for ev, src in _ESCALATED_RESUME_EVENT_SOURCES
+})
+
+
 def decide(cur_state: ReqState, event: Event) -> Transition | None:
     """主 API：给 (state, event) 查 transition。None 表示非法/忽略。"""
     return TRANSITIONS.get((cur_state, event))

--- a/orchestrator/tests/test_engine_escalated_resume.py
+++ b/orchestrator/tests/test_engine_escalated_resume.py
@@ -442,15 +442,117 @@ async def test_ert_s9_full_transition_sweep(
     )
 
 
-def test_ert_s9_sweep_covers_exactly_51():
-    """Sanity: TRANSITIONS 必须正好 50 条 —— 加 / 减 transition 时这条 fail 提醒
+def test_ert_s9_sweep_covers_exactly_70():
+    """Sanity: TRANSITIONS 必须正好 70 条 —— 加 / 减 transition 时这条 fail 提醒
     review 是否同步加 spec scenario / 文档（state-machine.md / dump_transitions）。
 
-    REQ-bkd-acceptance-feedback-loop-1777278984 起新增 PENDING_USER_REVIEW 入/出
-    transitions（pr.opened 入站 + acceptance approve/request_changes 出站），从 47
-    增至 49；后续 REQ 再增 1 条至 50。"""
-    assert len(state_mod.TRANSITIONS) == 51, (
-        f"expected 51 transitions, got {len(state_mod.TRANSITIONS)}; "
+    历史：47 → 49（PENDING_USER_REVIEW 入/出）→ 51（再 +1）→ 70（REQ-escalated-stage-resume：
+    + 19 条 ESCALATED 主链反激活，让 stage-issue 续 follow-up 也能恢复）。"""
+    assert len(state_mod.TRANSITIONS) == 70, (
+        f"expected 70 transitions, got {len(state_mod.TRANSITIONS)}; "
         "if you intentionally added/removed a transition, update this assertion "
         "AND add granular ERT/MCT/APT/VLT scenario coverage for it."
     )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# ERT-S10: ESCALATED + ANALYZE_DONE — stage-issue follow-up 端到端复活
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ert_s10_escalated_analyze_done_resumes_to_artifact_check(
+    stub_actions, mock_runner_controller,
+):
+    """REQ-escalated-stage-resume：用户在 analyze BKD issue 续 follow-up，
+    agent 重跑出 result:pass → router 派 ANALYZE_DONE → ESCALATED 复用主链
+    transition (next=ANALYZE_ARTIFACT_CHECKING, action=create_analyze_artifact_check)。
+
+    端到端：pool row 真被推到 ANALYZE_ARTIFACT_CHECKING；不需要新 action / RESUMING
+    中间态 / active_stage_* ctx 字段。"""
+    calls: list = []
+    stub_actions["create_analyze_artifact_check"] = _make_recorder(
+        "create_analyze_artifact_check", calls,
+    )
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ESCALATED.value)})
+    body = _body(issueId="analyze-1", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["analyze", "REQ-1", "result:pass"],
+        cur_state=ReqState.ESCALATED, ctx={"intent_issue_id": "analyze-1"},
+        event=Event.ANALYZE_DONE,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "create_analyze_artifact_check"
+    assert result["next_state"] == ReqState.ANALYZE_ARTIFACT_CHECKING.value
+    assert pool.rows["REQ-1"].state == ReqState.ANALYZE_ARTIFACT_CHECKING.value
+    assert len(calls) == 1
+    # cur 是 terminal (ESCALATED) → engine 跳过 cleanup（防误删 resume 路径已拉的 pod）
+    mock_runner_controller.cleanup_runner.assert_not_awaited()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# ERT-S11: ESCALATED + CHALLENGER_FAIL — stage failure during resume routes to verifier
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ert_s11_escalated_challenger_fail_resumes_to_verifier(
+    stub_actions, mock_runner_controller,
+):
+    """用户在 challenger BKD issue 续，agent 这次跑出 result:fail → router 派
+    CHALLENGER_FAIL → ESCALATED 复用主链 transition (next=REVIEW_RUNNING,
+    action=invoke_verifier_for_challenger_fail)。
+
+    覆盖恢复路径上 fail 分支也通：失败信号同样能从 ESCALATED 走主链推进。"""
+    calls: list = []
+    stub_actions["invoke_verifier_for_challenger_fail"] = _make_recorder(
+        "invoke_verifier_for_challenger_fail", calls,
+    )
+
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ESCALATED.value)})
+    body = _body(issueId="ch-1", projectId="p", event="session.completed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["challenger", "REQ-1", "result:fail"],
+        cur_state=ReqState.ESCALATED, ctx={"challenger_issue_id": "ch-1"},
+        event=Event.CHALLENGER_FAIL,
+    )
+    await _drain_tasks()
+
+    assert result["action"] == "invoke_verifier_for_challenger_fail"
+    assert result["next_state"] == ReqState.REVIEW_RUNNING.value
+    assert pool.rows["REQ-1"].state == ReqState.REVIEW_RUNNING.value
+    assert len(calls) == 1
+
+
+# ───────────────────────────────────────────────────────────────────────
+# ERT-S12: ESCALATED + SESSION_FAILED — agent 在用户续写后又挂了，仍丢弃不接
+# ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ert_s12_escalated_session_failed_remains_no_op(
+    stub_actions, mock_runner_controller,
+):
+    """ESCALATED + SESSION_FAILED 没 transition：用户续 follow-up 后 agent 又挂，
+    sisyphus 不再额外 escalate（已经在 ESCALATED 了），保持原状等下次续。
+
+    防回归：避免后续 PR 误加 (ESCALATED, SESSION_FAILED) → escalate 形成自循环。"""
+    pool = FakePool({"REQ-1": FakeReq(state=ReqState.ESCALATED.value)})
+    body = _body(issueId="x-1", projectId="p", event="session.failed")
+
+    result = await engine.step(
+        pool, body=body, req_id="REQ-1", project_id="p",
+        tags=["analyze", "REQ-1"],
+        cur_state=ReqState.ESCALATED, ctx={}, event=Event.SESSION_FAILED,
+    )
+    await _drain_tasks()
+
+    # 现状：state.decide returns None → engine 走 illegal_transition skip path
+    assert result == {"action": "skip", "reason": "no transition escalated+session.failed"}
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value

--- a/orchestrator/tests/test_state.py
+++ b/orchestrator/tests/test_state.py
@@ -143,17 +143,64 @@ def test_done_terminal_has_no_outgoing():
 
 
 def test_escalated_resumable_via_verifier_followup():
-    """ESCALATED 不是死终态：用户续 verifier issue → BKD 新 decision → 走原 verifier 同链。
+    """ESCALATED 不是死终态：用户续 verifier issue → BKD 新 decision → 走原 verifier 同链。"""
+    for ev in (Event.VERIFY_PASS, Event.VERIFY_FIX_NEEDED, Event.VERIFY_ESCALATE):
+        assert decide(ReqState.ESCALATED, ev) is not None, ev
 
-    其他 event（非 verifier 类）仍然没出口 —— escalated 只通过"人续 verifier issue"复活。
+
+def test_escalated_resumable_via_stage_issue_followup():
+    """REQ-escalated-stage-resume：用户续 stage agent issue（非 verifier issue）也能恢复。
+
+    BKD agent 重跑并贴 result tag → router 派出主链事件 → ESCALATED 复用主链 transition
+    （next_state / action 跟主链同一份），不需要新 action。
     """
-    resumable = {Event.VERIFY_PASS, Event.VERIFY_FIX_NEEDED, Event.VERIFY_ESCALATE}
-    for ev in Event:
+    expected = [
+        # event,                                next_state,                          action
+        (Event.INTAKE_PASS,                     ReqState.ANALYZING,                  "start_analyze_with_finalized_intent"),
+        (Event.ANALYZE_DONE,                    ReqState.ANALYZE_ARTIFACT_CHECKING,  "create_analyze_artifact_check"),
+        (Event.ANALYZE_ARTIFACT_CHECK_PASS,     ReqState.SPEC_LINT_RUNNING,          "create_spec_lint"),
+        (Event.ANALYZE_ARTIFACT_CHECK_FAIL,     ReqState.REVIEW_RUNNING,             "invoke_verifier_for_analyze_artifact_check_fail"),
+        (Event.SPEC_LINT_PASS,                  ReqState.CHALLENGER_RUNNING,         "start_challenger"),
+        (Event.SPEC_LINT_FAIL,                  ReqState.REVIEW_RUNNING,             "invoke_verifier_for_spec_lint_fail"),
+        (Event.CHALLENGER_PASS,                 ReqState.DEV_CROSS_CHECK_RUNNING,    "create_dev_cross_check"),
+        (Event.CHALLENGER_FAIL,                 ReqState.REVIEW_RUNNING,             "invoke_verifier_for_challenger_fail"),
+        (Event.DEV_CROSS_CHECK_PASS,            ReqState.STAGING_TEST_RUNNING,       "create_staging_test"),
+        (Event.DEV_CROSS_CHECK_FAIL,            ReqState.REVIEW_RUNNING,             "invoke_verifier_for_dev_cross_check_fail"),
+        (Event.STAGING_TEST_PASS,               ReqState.PR_CI_RUNNING,              "create_pr_ci_watch"),
+        (Event.STAGING_TEST_FAIL,               ReqState.REVIEW_RUNNING,             "invoke_verifier_for_staging_test_fail"),
+        (Event.PR_CI_PASS,                      ReqState.ACCEPT_RUNNING,             "create_accept"),
+        (Event.PR_CI_FAIL,                      ReqState.REVIEW_RUNNING,             "invoke_verifier_for_pr_ci_fail"),
+        (Event.ACCEPT_PASS,                     ReqState.ACCEPT_TEARING_DOWN,        "teardown_accept_env"),
+        (Event.ACCEPT_FAIL,                     ReqState.ACCEPT_TEARING_DOWN,        "teardown_accept_env"),
+        (Event.TEARDOWN_DONE_PASS,              ReqState.PENDING_USER_REVIEW,        "post_acceptance_report"),
+        (Event.TEARDOWN_DONE_FAIL,              ReqState.REVIEW_RUNNING,             "invoke_verifier_for_accept_fail"),
+        (Event.FIXER_DONE,                      ReqState.REVIEW_RUNNING,             "invoke_verifier_after_fix"),
+    ]
+    for ev, next_st, action in expected:
         t = decide(ReqState.ESCALATED, ev)
-        if ev in resumable:
-            assert t is not None, f"{ev.value} should be resumable from ESCALATED"
-        else:
-            assert t is None, f"{ev.value} should NOT move ESCALATED (non-resume path)"
+        assert t is not None, f"{ev.value} should be resumable from ESCALATED"
+        assert t.next_state == next_st, f"{ev.value}: expected {next_st}, got {t.next_state}"
+        assert t.action == action, f"{ev.value}: expected action {action}, got {t.action}"
+
+
+def test_escalated_non_resume_events_still_blocked():
+    """不该被复活的事件：直接进 ESCALATED 类、SESSION_FAILED、PENDING_USER_REVIEW 出口、PR_MERGED。
+
+    PR_MERGED 由 escalate.py 入口的 PR-merged shortcut 处理，不在 transition 表里出现。
+    """
+    blocked = {
+        Event.SESSION_FAILED,        # 已在 ESCALATED 再挂还是 escalate，无意义
+        Event.INTAKE_FAIL,           # 直接进 ESCALATED 的事件，不是恢复信号
+        Event.PR_CI_TIMEOUT,
+        Event.ACCEPT_ENV_UP_FAIL,
+        Event.USER_REVIEW_FIX,       # PENDING_USER_REVIEW 出口
+        Event.USER_REVIEW_PASS,
+        Event.PR_MERGED,             # escalate.py 入口的 PR-merged shortcut 处理
+        Event.INTENT_INTAKE,         # 入口事件，REQ 已经存在不该重新入口
+        Event.INTENT_ANALYZE,
+    }
+    for ev in blocked:
+        assert decide(ReqState.ESCALATED, ev) is None, f"{ev.value} should NOT move ESCALATED"
 
 
 def test_m5_dropped_test_fix_reviewer_states():

--- a/orchestrator/tests/test_state_transitions_gap.py
+++ b/orchestrator/tests/test_state_transitions_gap.py
@@ -306,20 +306,25 @@ def test_all_transitions_reason_is_str_or_none():
 def test_transition_count_sanity():
     """transition 总数 sanity check：防止未来重构误删/误增。
 
-    当前总数 = 39 显式 + 12 SESSION_FAILED self-loop = 51。
+    当前总数 = 39 显式 + 12 SESSION_FAILED self-loop + 19 ESCALATED stage-resume 反激活
+    （REQ-escalated-stage-resume）= 70。
     如果数字变了，说明有人增删 transition，本测试会 fail 提醒同步测试。
     """
-    assert len(TRANSITIONS) == 51, (
-        f"Expected 51 transitions, got {len(TRANSITIONS)}. "
+    assert len(TRANSITIONS) == 70, (
+        f"Expected 70 transitions, got {len(TRANSITIONS)}. "
         "If this is intentional, update this assertion and add corresponding tests."
     )
 
 
 def test_explicit_transition_count():
-    """非 SESSION_FAILED 的显式 transition 数量 sanity check。"""
+    """非 SESSION_FAILED 的显式 + ESCALATED 反激活 transition 数量 sanity check。
+
+    包含 39 主链显式 + 19 ESCALATED 主链反激活（复用主链 transition 对象，但 key 是
+    (ESCALATED, ev) 独立计数）= 58 条非 SESSION_FAILED transition。
+    """
     explicit = [k for k in TRANSITIONS if k[1] != Event.SESSION_FAILED]
-    assert len(explicit) == 39, (
-        f"Expected 39 explicit transitions, got {len(explicit)}"
+    assert len(explicit) == 58, (
+        f"Expected 58 explicit transitions, got {len(explicit)}"
     )
 
 
@@ -363,8 +368,30 @@ def test_done_no_transitions_at_all():
 
 
 def test_escalated_non_resume_events_all_none():
-    """ESCALATED 只有 3 个 verifier 决策事件有出口，其余全部非法。"""
-    resume_events = {Event.VERIFY_PASS, Event.VERIFY_FIX_NEEDED, Event.VERIFY_ESCALATE}
+    """ESCALATED 接受 3 类恢复事件，其余非法：
+
+    1. verifier 决策续 follow-up：VERIFY_PASS / VERIFY_FIX_NEEDED / VERIFY_ESCALATE
+    2. stage-issue 续 follow-up（REQ-escalated-stage-resume）：19 条主链事件
+       —— intake/analyze/spec_lint/challenger/dev_cross_check/staging_test/pr_ci/
+       accept/teardown/fixer 各 pass+fail（无 timeout/env-up-fail/intake-fail/
+       user-review-fix/PR_MERGED 这类直接进 ESCALATED 或不属于"恢复"语义的事件）
+    """
+    resume_events = {
+        # verifier 决策反激活
+        Event.VERIFY_PASS, Event.VERIFY_FIX_NEEDED, Event.VERIFY_ESCALATE,
+        # stage-issue 反激活
+        Event.INTAKE_PASS,
+        Event.ANALYZE_DONE,
+        Event.ANALYZE_ARTIFACT_CHECK_PASS, Event.ANALYZE_ARTIFACT_CHECK_FAIL,
+        Event.SPEC_LINT_PASS, Event.SPEC_LINT_FAIL,
+        Event.CHALLENGER_PASS, Event.CHALLENGER_FAIL,
+        Event.DEV_CROSS_CHECK_PASS, Event.DEV_CROSS_CHECK_FAIL,
+        Event.STAGING_TEST_PASS, Event.STAGING_TEST_FAIL,
+        Event.PR_CI_PASS, Event.PR_CI_FAIL,
+        Event.ACCEPT_PASS, Event.ACCEPT_FAIL,
+        Event.TEARDOWN_DONE_PASS, Event.TEARDOWN_DONE_FAIL,
+        Event.FIXER_DONE,
+    }
     for ev in Event:
         if ev in resume_events:
             continue


### PR DESCRIPTION
## Summary

两件事一个 PR：

1. **代码改动**：把 ESCALATED 反激活从"只能续 verifier issue"扩展到"任意 stage agent issue 续 follow-up 都能恢复"。这是用户在 BKD UI 续聊排障最自然的恢复路径，之前会被静默丢弃，导致 REQ 卡死。
2. **架构文档** (`docs/architecture.md` §1b)：把这次设计讨论里收敛出来的"sisyphus 定位 / 控制面复杂度结构 / 不换通用 workflow 框架的理由 / 新增机制的判断尺子"沉淀进项目级文档，作为后续设计决策的锚点。

两个 commit 同源——都是"sisyphus 接住信号但不抢判断"哲学的具体落地（代码 + 文档）。

## Part 1: 代码改动 — ESCALATED stage-issue 反激活

### 问题

当前 state.py 只有 `(ESCALATED, VERIFY_*)` 反激活：用户必须在 verifier issue 续 follow-up 才能让 REQ 走出 ESCALATED。

**遗漏的高频场景**：用户在 stage agent issue（intake/analyze/challenger/accept/fixer）续写 prompt 排障 → BKD agent 重跑 → 贴 result tag → router 派出主链事件（`ANALYZE_DONE` / `CHALLENGER_PASS` 等）→ ESCALATED 没接 → 事件丢弃 → REQ 永远卡死。

> 实际触发场景：模型配额耗尽 / runner 抖 / 超时进 ESCALATED → 用户介入 review → BKD 续聊 → sisyphus 不响应。

### 方案

给 ESCALATED 加一组主链事件 transition，**复用主链 `next_state` + `action`**：

```python
_ESCALATED_RESUME_EVENT_SOURCES: list[tuple[Event, ReqState]] = [
    (Event.INTAKE_PASS,                  ReqState.INTAKING),
    (Event.ANALYZE_DONE,                 ReqState.ANALYZING),
    (Event.ANALYZE_ARTIFACT_CHECK_PASS,  ReqState.ANALYZE_ARTIFACT_CHECKING),
    ... 19 条
]
TRANSITIONS.update({
    (ReqState.ESCALATED, ev): TRANSITIONS[(src, ev)]
    for ev, src in _ESCALATED_RESUME_EVENT_SOURCES
})
```

**设计要点**：
- 复用 `TRANSITIONS[(src, ev)]` 引用主链 transition 对象——主链改了 ESCALATED 复活路径自动跟，零漂移
- 不引入 RESUMING 中间态、不新加 action / ctx 字段 / BKD tag / endpoint
- 不改 BKD 一行，用户操作完全在 BKD agent issue 内完成（续 prompt → agent 跑 → result tag）

**排除清单**（不接，避免恢复语义被误用）：
- `SESSION_FAILED`：已在 ESCALATED 再挂还是 escalate，无意义
- 直接进 ESCALATED 类：`INTAKE_FAIL` / `PR_CI_TIMEOUT` / `ACCEPT_ENV_UP_FAIL` / `VERIFY_ESCALATE` / `USER_REVIEW_FIX`
- `PR_MERGED`：escalate.py 入口的 PR-merged shortcut 已处理
- `VERIFY_PASS` / `VERIFY_FIX_NEEDED` / `VERIFY_INFRA_RETRY`：已在原 verifier 反激活段

## Part 2: 架构文档 — `docs/architecture.md` §1b

讨论这个改动期间反复回到一些项目级问题：sisyphus 这套控制面是不是太重？为什么不换 Temporal？BKD 跟 sisyphus 的边界在哪？把答案沉淀进 architecture.md：

- **§1b.1 sisyphus 的产品定位**：隐形控制面，BKD 是唯一用户入口；sisyphus 不做 UI/CLI，但必须替用户守边界
- **§1b.2 控制面复杂度结构**：~30% 控制面本质 + ~30% BKD 同步 + ~20% 多 actor + ~20% 实现抽象债（前 3 层是必要税）
- **§1b.3 为什么不换 Temporal**：框架降固定成本不降业务语义，迁移净收益 -10%~+20%；AI workflow 领域无事实标准框架
- **§1b.4 新增机制判断尺子**：5 条问题（数据进哪张表？用户能在 BKD 完成吗？等）

CLAUDE.md "核心哲学" 段加了一行指向 §1b 的链接。

## 影响

- **transition 总数**：51 → 70（+19）
- **新行为**：用户在 BKD agent issue 续聊，agent 出 result tag 后主链自然续推
- **观测语义变化**：ESCALATED 不再是"sisyphus 放弃"指标，可反复进出。Q1-Q18 中以 ESCALATED 计"放弃"的 SQL 后续可加 `terminal_escalate` filter 区分（**本 PR 不动**，留 follow-up）

## 改动文件

| 文件 | 行数 | 说明 |
|---|---|---|
| `orchestrator/src/orchestrator/state.py` | +43 | 新增 `_ESCALATED_RESUME_EVENT_SOURCES` + `TRANSITIONS.update` |
| `orchestrator/tests/test_state.py` | +51/-9 | 新增 `test_escalated_resumable_via_stage_issue_followup` + `test_escalated_non_resume_events_still_blocked` |
| `orchestrator/tests/test_state_transitions_gap.py` | +33/-10 | 计数 51→70；非恢复事件断言扩展 |
| `orchestrator/tests/test_engine_escalated_resume.py` | +109/-7 | 端到端：ERT-S10/S11/S12 覆盖 stage-resume + 失败分支 + SESSION_FAILED 仍丢弃 |
| `docs/state-machine.md` | +28/-6 | §5 列两条恢复入口 + mermaid 图加 stage-resume 边 |
| `docs/architecture.md` | +68 | 新 §1b 定位与控制面边界 |
| `CLAUDE.md` | +5/-3 | "终态" → "暂停态"；transition 数 30+ → 70；指向 §1b 的链接 |

## 测试

- `test_state.py`、`test_state_transitions_gap.py`、`test_engine_escalated_resume.py` 全过（含 70/70 sweep 自动覆盖每条新 transition）
- 全套 1944 个测试通过（环境依赖测试 deselect：makefile / Postgres / TTL）
- ruff lint 净

## Test plan

- [ ] 主链 transition 不变（sweep 自动验证）
- [ ] ESCALATED 收 ANALYZE_DONE → 推到 ANALYZE_ARTIFACT_CHECKING（ERT-S10）
- [ ] ESCALATED 收 CHALLENGER_FAIL → 推到 REVIEW_RUNNING（ERT-S11）
- [ ] ESCALATED 收 SESSION_FAILED → 仍 no-op（防自循环回归 ERT-S12）
- [ ] verifier issue 续 follow-up 路径不受影响（既有 VLT/ERT-S7/S8 全过）
- [ ] PR-merged shortcut 路径不受影响（escalate.py 入口未动）
- [ ] 部署后人工验证：手工把一个 ESCALATED REQ 在 analyze BKD issue 续 prompt，观察是否走主链推进

## Follow-up（不在本 PR）

- Metabase Q* 加 `terminal_escalate` / `resume_count` / `time_in_escalated` 字段区分"真终态" vs "暂停"
- watchdog 加"ESCALATED 长时间未恢复告警"通道（用户不主动盯 sisyphus）

🤖 Generated with [Claude Code](https://claude.com/claude-code)