### PR TITLE
feat(thanatos,deploy): build & push image to GHCR + adb client + chart pullPolicy split

### DIFF
--- a/.github/workflows/thanatos-image.yml
+++ b/.github/workflows/thanatos-image.yml
@@ -1,10 +1,16 @@
 name: thanatos-image
 
 # build & push thanatos MCP server image to GHCR.
-# 触发：thanatos/ 或本 workflow 改动 push 到 main / 打 thanatos-v* tag。
-# 输出 tag：sha-<short>（每次 commit）+ dev（main 滚动） + thanatos-v* tag 时打版本号。
+# 触发：
+#   - pull_request: build but don't push（验证 Dockerfile 改动能 build）
+#   - push main / 打 thanatos-v* tag: build + push
+# 输出 tag：sha-<short> + dev（main 滚动）+ tag 版本号（push tag 时）
 
 on:
+  pull_request:
+    paths:
+      - 'thanatos/**'
+      - '.github/workflows/thanatos-image.yml'
   push:
     branches: [main]
     tags: ['thanatos-v*']
@@ -17,7 +23,7 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/thanatos
 
 jobs:
-  build-and-push:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,6 +35,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -39,12 +46,12 @@ jobs:
         id: vars
         run: echo "sha_short=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
-      - name: Build and push
+      - name: Build (push only on push events; PR 阶段只验 Dockerfile 能 build)
         uses: docker/build-push-action@v5
         with:
           context: ./thanatos
           file: ./thanatos/Dockerfile
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ steps.vars.outputs.sha_short }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev

--- a/.github/workflows/thanatos-image.yml
+++ b/.github/workflows/thanatos-image.yml
@@ -1,0 +1,52 @@
+name: thanatos-image
+
+# build & push thanatos MCP server image to GHCR.
+# 触发：thanatos/ 或本 workflow 改动 push 到 main / 打 thanatos-v* tag。
+# 输出 tag：sha-<short>（每次 commit）+ dev（main 滚动） + thanatos-v* tag 时打版本号。
+
+on:
+  push:
+    branches: [main]
+    tags: ['thanatos-v*']
+    paths:
+      - 'thanatos/**'
+      - '.github/workflows/thanatos-image.yml'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/thanatos
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract short SHA
+        id: vars
+        run: echo "sha_short=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./thanatos
+          file: ./thanatos/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ steps.vars.outputs.sha_short }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ sisyphus/
 | 文档 | 内容 |
 |---|---|
 | [docs/architecture.md](docs/architecture.md) | 架构权威：哲学、角色分工、流程图、stage 契约（含 mermaid） |
+| [docs/playbook.md](docs/playbook.md) | **开发节奏 / phase / cap / 反 pattern**（一个人+AI 搭平台的执行手册，产品 owner 自用） |
 | [docs/state-machine.md](docs/state-machine.md) | 状态机权威：state / event / transition 表 + stateDiagram |
 | [docs/integration-contracts.md](docs/integration-contracts.md) | sisyphus ↔ 业务 repo 契约（Makefile target、env、JSON 输出） |
 | [docs/observability.md](docs/observability.md) | 观测设计哲学（Postgres + Metabase） |

--- a/deploy/charts/thanatos/templates/deployment.yaml
+++ b/deploy/charts/thanatos/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         {{- if eq .Values.driver "adb" }}
         - name: redroid
           image: {{ .Values.redroid.image | quote }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.redroid.pullPolicy }}
           securityContext:
             privileged: true
           ports:

--- a/deploy/charts/thanatos/values.yaml
+++ b/deploy/charts/thanatos/values.yaml
@@ -28,6 +28,11 @@ service:
 # redroid sidecar settings (only used when driver=adb).
 redroid:
   image: redroid/redroid:11.0.0-latest
+  # pullPolicy 跟 image.pullPolicy 解耦：自包装的 redroid-fixed 镜像（含 /etc/passwd
+  # 修复 + flatten 顶层符号链接、解 containerd 2.x mount safety check）通常
+  # `k3s ctr images import` 进集群本地 cache，需要走 IfNotPresent / Never；而
+  # thanatos 镜像仍可走 dev tag 滚动 Always。空值则 fallback 到 image.pullPolicy。
+  pullPolicy: ""
   port: 5555
   resources:
     requests:

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -1,0 +1,204 @@
+# Sisyphus Development Playbook
+
+> 一个人 + AI 搭平台的开发节奏。**Cap > Plan**。
+> 本文是产品 owner 自用执行手册，不是技术架构文档。
+
+权威架构：[architecture.md](architecture.md)
+观测哲学：[observability.md](observability.md)
+
+## 1. 当前阶段（0.x → 1.x 过渡）
+
+| 阶段 | 标志 | 关键动作 |
+|---|---|---|
+| 0.x（current） | 核心管道通，dogfood 自己 + 1 个早期 user (ttpos) | 攒 5-10 个真 REQ 跑，不停下改 |
+| 1.x | 可用，挡 80% ttpos 需求 | 接第 2 个业务仓 |
+| 2.x | 规模化，多 user 多场景 | sisyphus 真正"挡需求让我做架构" |
+
+**当前位置**：0.x 末尾。代码层 thanatos M2 已合，业务仓接入 PR 写出但卡 conflict 没合，端到端没真跑过。
+
+## 2. 当前三步 plan（不展开成更多步）
+
+```
+1. 落地 thanatos        cap 1 周
+   - .thanatos/skill.yaml on ttpos-flutter feat/develop-hwt
+   - redroid + thanatos sidecar 在 vm-node04 K3s 实跑
+   - 一个 minimal scenario 端到端跑通
+   见 #248
+
+2. 灌几个需求           cap 这周写 description，下周一批量派
+   - 5 个 ttpos REQ description（每个 ≥200 字）
+   - 不一句话派 REQ
+   - 写在 BACKLOG.md（不在 BKD 不在 issue）
+
+3. 迭代 loop            batch-of-5 节奏
+   - 5 个 REQ 跑完看 pattern
+   - 撞墙 log 不停
+   - >= 3 次同类 pattern 才改 sisyphus
+   - 不 hit-1-stop
+```
+
+**到 1.x 的硬指标**：5 个 ttpos REQ 端到端跑过 + 通过率统计。不是"sisyphus 改完美"。
+
+## 3. 平台 vs 工具 mindset
+
+| | 工具（错） | 平台（对） |
+|---|---|---|
+| 目标 | 一次解一个问题 | 多场景多用户多 driver |
+| 工程量 | 1x | 10x（observability / 调度 / 恢复 / 文档） |
+| 节奏 | hit-1-stop 改完再跑 | batch-of-5 攒 sample 再批量改 |
+| dogfood | 跑通就够 | 跑 5-10 次看分布 |
+
+承认在搭平台后，**termination accounting / retrospective / queue health 不是 over-engineering**——平台运营层必需。但**不在 0.x 阶段做**，1.x 之后再上。
+
+## 4. 角色分工：脑容量是真瓶颈
+
+一个人 + AI 的最大陷阱：AI 产能放大 10x → review/decision 翻 10x → 拍脑袋决策 → reject rate 高 → token 浪费 → self-doubt → 停下改 sisyphus。
+
+**红线分工**：
+
+| 必须你做（不能 AI 替） | AI 做 |
+|---|---|
+| **写 REQ description**（产品定义） | sisyphus 接住实现 |
+| 设计 stage 哲学 / 优先级 | sisyphus 跑各 stage agent |
+| 看 dogfood 反馈写 retrospective | agent 写第一稿 |
+| **决策**（合 PR / reject / 关 issue） | - |
+| 写 fixture（小但跨仓的 yaml） | - |
+
+**最重要红线**：**写 REQ description 不能 AI 替**。这是你的 unique value，AI 只能放大不能 replace。10 分钟想清楚的 REQ description > 10 秒糊出去的，效果差 10x。
+
+## 5. 周节奏
+
+```
+周一 (1-2h)
+  - 看 BACKLOG.md → 挑 3-5 个 REQ
+  - 每个写 200-300 字 description（不是一句话）
+  - 派给 sisyphus
+
+周二-周三 (each 1h，分两次看)
+  - sisyphus 跑，你不参与生产
+  - 看 stage_runs / PR / decision JSON 摘要
+  - 撞墙的 log 一行
+  - 不要回头改 sisyphus
+
+周四 (2-3h)
+  - 收本周 dogfood log
+  - 找 pattern (>= 3 次同类问题)
+  - 列下周改 sisyphus 清单（基于 pattern，不是 1-shot）
+
+周五 (3-4h)
+  - 改 sisyphus
+  - 周末前 release v0.x.y
+
+周末
+  - 不开 sisyphus，离开。脑子需要 idle 时间想宏观
+```
+
+## 6. 月 / 季度节奏
+
+| 周期 | 时长 | 内容 |
+|---|---|---|
+| 月初 | 1h | 定义本月 phase 目标 + cap 每周 REQ 数 + cap 每月 sisyphus 改动数 |
+| 月中 | 1h | mid-review，砍做不完的 |
+| 月末 | 2h | 写 monthly retrospective，更新 phase 计划 |
+
+季度里程碑：
+
+| 时间 | 阶段 | 标志 |
+|---|---|---|
+| 现在 ~ 1.5 月 | 0.x → 1.x | ttpos 端到端跑通 + 5 REQ 跑过 + 80% 命中率初步验证 |
+| 1.5 ~ 3 月 | 1.x | 第二业务仓接入（ttpos-server-go / pma-vkb） |
+| 3 ~ 6 月 | 2.x | 多 user，sisyphus 真正"挡需求让我做架构" |
+
+## 7. 反 Pattern（每条都要警惕）
+
+| 反 pattern | 表现 | 解药 |
+|---|---|---|
+| **"AI 产能 = 我产能" 错觉** | 派太多 REQ 看不过来 | 每天 review PR 上限 5 个，超过 batch / defer |
+| **"想清楚再动手" 完美主义** | hit-1-stop loop | 平台没"想清楚再动手"——边跑边修。**但写 REQ description 必须想清楚**（产品工作） |
+| **"这周改 sisyphus 这件事就解决了" 拖延** | 等改好才下一步 | sisyphus 永远改不完。每周 release 一次哪怕 trivial 也比"等改好"强 |
+| **"周末加班赶进度"** | 一个人项目 burnout 风险 | 周末必须不开。脑子需要 idle 才有产品 sense |
+| **"一句话派 REQ"** | sisyphus 派出 22K 行 PR | 至少 200 字 description，最低门槛 |
+| **"hit 1 次就改 sisyphus"** | 把异常当 pattern | >= 3 次同类才动手；1 次 hit 只 log 不动 |
+| **"AI 替我写 REQ description"** | 产品定义被 AI 替 | 红线，绝对不让 |
+| **"全凭感觉决策"** | 因为没数据看 | 等 #241 落了用 SQL；之前只 trust strong signals |
+
+## 8. Cap 列表（hard limit）
+
+不是建议，是 hard limit。超过就 defer：
+
+- 每周派 REQ：**3-5 个**
+- 每天 review PR：**≤ 5 个**
+- 每月 sisyphus release：**1 次**（哪怕 trivial）
+- REQ description 字数：**≥ 200 字**
+- 周末工作时间：**0**
+- hit pattern 触发改 sisyphus：**≥ 3 次同类**
+
+## 9. 当前已识别 issue 跟 phase 的对应
+
+按 phase 重新审视，不按"立了 issue 就要做"逻辑：
+
+| Issue | Phase 对应 | 现在做不做 |
+|---|---|---|
+| **#248 thanatos M3 落地** | 0.x → 1.x 必须 | ✅ 做 |
+| **#243 intake preflight (含哲学一致性)** | 0.x 后期 | ⚠️ 撞 3 次再做 |
+| **#247 adjustment dispatch** | 0.x → 1.x 必须（dogfood 没它跑不通） | ⚠️ 撞 3 次再做 |
+| #240 verifier-fixer same-session | 1.x | ❌ 0.x 不做 |
+| #241 agent_turns | 1.x（数据采集） | ❌ 0.x 不做 |
+| #242 observability epic | 1.x（闭环） | ❌ 0.x 不做 |
+| #244 termination accounting | 1.x（运营层） | ❌ 0.x 不做 |
+| #245 weekly retrospective | 2.x（运营层） | ❌ 不做 |
+| #246 PR queue health | 2.x（运营层） | ❌ 不做 |
+
+**0.x 阶段只做 3 件事**：#248 thanatos / 必要时 #247 / 必要时 #243。其它全部 defer。
+
+## 10. BACKLOG.md 模板
+
+放在 sisyphus 仓根目录或者你工作目录，每周更新：
+
+```markdown
+# Sisyphus Product Backlog
+
+## Phase 0.5 (this week, due 周五)
+- [ ] thanatos 落地具体步骤
+
+## Phase 0.6 (next week)
+- [ ] 5 个 ttpos REQ description（不立即派）
+- [ ] 周一批量派
+- [ ] 周四看分布
+
+## Phase 0.7 (after 5-REQ batch)
+- [ ] 改 sisyphus 基于 pattern (≥3 次同类)
+
+## Backlog (no commit yet)
+- ttpos 需求 #1: <200 字 description>
+- ttpos 需求 #2: ...
+- ...
+
+## 红线（每天看一眼）
+- 不一句话派 REQ
+- 不 hit-1-stop
+- 不周末加班
+- 不让 AI 写 REQ description
+```
+
+## 11. 一个人 + AI 项目的死亡螺旋警告
+
+如果出现以下任一信号，立即 stop & think：
+
+- 这周派的 REQ reject rate > 50%
+- 周末工作 > 4 小时
+- 连续 2 周 sisyphus 没 release
+- BACKLOG.md 没更新 > 2 周
+- 自己说不出"sisyphus 这周帮我做完了什么 ttpos 需求"
+
+死亡螺旋的解：**stop coding for 1 day, write retrospective**。问自己：
+
+1. 上次真为 ttpos 业务做事是什么时候？
+2. 现在做的所有事跟"挡 80% ttpos 需求"距离多远？
+3. 是不是把工具当成了目的？
+
+## 12. 一句话总结
+
+**节奏不靠规划，靠 cap。** 设定每周 3-5 REQ / 每月 1 个 sisyphus release / 周末空白 / 不一句话派 REQ。Cap 是 hard limit，超过就 defer。
+
+**Cap 比 plan 重要**——一个人 + AI 的项目死在"我应该再做点"的本能上，活在"我今天不做了"的纪律上。

--- a/thanatos/Dockerfile
+++ b/thanatos/Dockerfile
@@ -2,7 +2,14 @@ FROM python:3.12-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1
+    PIP_NO_CACHE_DIR=1 \
+    DEBIAN_FRONTEND=noninteractive
+
+# adb client：M2 ADB driver (#238) 调用 `adb -s <ep> shell ...`，需要 client 二进制；
+# playwright/http driver 不需要但 thin overhead 可接受。
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends adb \
+    && apt-get clean
 
 WORKDIR /opt/thanatos
 
@@ -11,7 +18,5 @@ COPY src ./src
 
 RUN pip install --no-cache-dir .
 
-# Stdio MCP server. Drivers (playwright/adb-tools/etc.) are *not* installed in M0:
-# all driver methods raise NotImplementedError, so adding the heavy runtime now
-# would just bloat the image with unused capability.
+# Stdio MCP server.
 ENTRYPOINT ["python", "-m", "thanatos.server"]


### PR DESCRIPTION
## 背景

落地 [#248](https://github.com/phona/sisyphus/issues/248) Phase B 在 vm-node04 实测撞出来的 3 个基础设施缺口。

ttpos APK 已在 vm-node04 上端到端走过：thanatos sidecar `adb connect localhost:5555` → uiautomator dump 看到 Flutter Semantics（`content-desc='Login'` / `'TTPOS Shop'`）→ `AdbDriver.tap('Login')` ok=True。本 PR 把那次手动 patch 落到代码里。

## 变更

| 文件 | 内容 |
|---|---|
| `.github/workflows/thanatos-image.yml`（新） | mirror orchestrator-image.yml 模式：push main / 打 `thanatos-v*` tag 时 build & push `ghcr.io/<owner>/thanatos:{sha-XXX, dev}` |
| `thanatos/Dockerfile` | `apt install -y adb`：M2 #238 加了 ADB driver 代码但 image 没装 adb 二进制 |
| `deploy/charts/thanatos/templates/deployment.yaml` | redroid container 用 `default .Values.image.pullPolicy .Values.redroid.pullPolicy`，从 `image.pullPolicy` 拆出来 |
| `deploy/charts/thanatos/values.yaml` | 加 `redroid.pullPolicy: \"\"` 默认值 + 注释 |

## 三个修法分别解什么

### 1. ghcr image 缺失（401/403）

之前 `thanatos-ci.yml` 只跑 lint+pytest。chart 默认 `image.repository: ghcr.io/phona/thanatos`、`tag: dev`，但实际拉镜像 401/403——image 从来没 build/push 过。新 workflow 第一次 push main 之后 ghcr 就有了。

### 2. thanatos sidecar 缺 adb client

M2 #238 加 ADB driver 代码（`thanatos/src/thanatos/drivers/adb.py` 调 `adb -s <ep> shell uiautomator dump`），但 Dockerfile 没装 adb。vm-node04 实测：thanatos 容器 `which adb` exit 1。

### 3. chart pullPolicy 共用 bug

原 redroid + thanatos 共用 `.Values.image.pullPolicy`。实际部署时 redroid 镜像通常 `k3s ctr images import` 进本地 cache（自包装的 redroid-fixed 解 containerd 2.x mount safety check），需要 `Never`/`IfNotPresent`；thanatos 走 ghcr `:dev` 滚动 tag，需要 `Always`。`--set image.pullPolicy=Never` 会把 redroid 一起变成 Never → ErrImageNeverPull。

解：`redroid.pullPolicy` 默认空字符串，fallback 到 `image.pullPolicy`。

## 测试方案

helm template 3 case 全过：
- 默认值 → 两 container `imagePullPolicy: IfNotPresent`
- `redroid.pullPolicy=IfNotPresent` + `image.pullPolicy=Always` → 各自独立
- 只设 `image.pullPolicy=Never` → redroid fallback 到 Never

## 跟 #248 关系

| Phase B prerequisite | 状态 |
|---|---|
| thanatos image GHCR | ✅ 本 PR |
| thanatos image 含 adb | ✅ 本 PR |
| chart pullPolicy 拆 | ✅ 本 PR |
| redroid-fixed image push GHCR（修 containerd 2.x mount fail） | ⏳ 等仓决策 |
| vm-node04 binder kernel module 永久化 | ⏳ ssh 一条命令 |
| ttpos-flutter PR #157（含包名 fix）merge | ⏳ 待 review |

合本 PR 后 thanatos image 就在 GHCR 上了，chart 默认值能直接拉。剩 redroid-fixed 那块单独立。

🤖 Generated with [Claude Code](https://claude.com/claude-code)