### PR TITLE
feat(redroid-fixed): patched redroid image + GHCR build workflow

### DIFF
--- a/.github/workflows/redroid-fixed-image.yml
+++ b/.github/workflows/redroid-fixed-image.yml
@@ -1,0 +1,70 @@
+name: redroid-fixed-image
+
+# build & push redroid-fixed image to GHCR.
+#
+# 触发：
+#   - push main 时 redroid-fixed/ 变了（patch 调整 / README 改）
+#   - 打 redroid-fixed-v* tag（手动版本提升）
+#   - workflow_dispatch（要重 build / 上游 redroid 升级）
+#
+# 输出 tag：13.0.0（=upstream 13.0.0_64only-latest patch 后） + latest + sha-<7>
+#
+# 不能用 buildkit / docker build：buildkit COPY 会踩同一个 containerd 2.x
+# 路径校验。必须 docker create + docker export | tar -x + docker import。
+
+on:
+  push:
+    branches: [main]
+    tags: ['redroid-fixed-v*']
+    paths:
+      - 'redroid-fixed/**'
+      - '.github/workflows/redroid-fixed-image.yml'
+  workflow_dispatch:
+    inputs:
+      upstream_image:
+        description: 'Upstream redroid image to patch'
+        required: false
+        default: 'redroid/redroid:13.0.0_64only-latest'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/redroid-fixed
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: vars
+        run: |
+          echo "sha_short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "version_tag=13.0.0" >> "$GITHUB_OUTPUT"
+
+      - name: Build redroid-fixed (patch /etc/passwd in upstream rootfs)
+        env:
+          UPSTREAM_IMAGE: ${{ inputs.upstream_image || 'redroid/redroid:13.0.0_64only-latest' }}
+          OUT_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.version_tag }}
+        run: bash redroid-fixed/build.sh
+
+      - name: Tag and push (version + latest + sha)
+        run: |
+          VERSION_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.version_tag }}"
+          LATEST_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          SHA_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ steps.vars.outputs.sha_short }}"
+          docker tag "$VERSION_TAG" "$LATEST_TAG"
+          docker tag "$VERSION_TAG" "$SHA_TAG"
+          docker push "$VERSION_TAG"
+          docker push "$LATEST_TAG"
+          docker push "$SHA_TAG"

--- a/.github/workflows/redroid-fixed-image.yml
+++ b/.github/workflows/redroid-fixed-image.yml
@@ -3,7 +3,8 @@ name: redroid-fixed-image
 # build & push redroid-fixed image to GHCR.
 #
 # 触发：
-#   - push main 时 redroid-fixed/ 变了（patch 调整 / README 改）
+#   - pull_request：跑 shellcheck + build.sh（验证脚本能跑）但不 push
+#   - push main 时 redroid-fixed/ 变了（patch 调整 / README 改）：build + push
 #   - 打 redroid-fixed-v* tag（手动版本提升）
 #   - workflow_dispatch（要重 build / 上游 redroid 升级）
 #
@@ -13,6 +14,10 @@ name: redroid-fixed-image
 # 路径校验。必须 docker create + docker export | tar -x + docker import。
 
 on:
+  pull_request:
+    paths:
+      - 'redroid-fixed/**'
+      - '.github/workflows/redroid-fixed-image.yml'
   push:
     branches: [main]
     tags: ['redroid-fixed-v*']
@@ -31,7 +36,7 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/redroid-fixed
 
 jobs:
-  build-and-push:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -39,7 +44,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Shellcheck build.sh
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends shellcheck
+          shellcheck redroid-fixed/build.sh
+
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -58,7 +70,8 @@ jobs:
           OUT_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.version_tag }}
         run: bash redroid-fixed/build.sh
 
-      - name: Tag and push (version + latest + sha)
+      - name: Push (skipped on PR — PR 阶段只验 build.sh 能跑通)
+        if: github.event_name != 'pull_request'
         run: |
           VERSION_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.version_tag }}"
           LATEST_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"

--- a/redroid-fixed/README.md
+++ b/redroid-fixed/README.md
@@ -1,0 +1,70 @@
+# redroid-fixed
+
+> 修过的 redroid Android-in-container 镜像，专门给 sisyphus thanatos
+> chart 的 ADB driver 当 sidecar 用。
+
+## 为啥要 fork
+
+上游 `redroid/redroid:13.0.0_64only-latest` 在 **containerd 2.x**
+（k3s 1.34+ 自带的 v2.2.x，runc 1.4.x）上**起不来**：
+
+```
+Error: failed to create containerd container:
+  mount callback failed on /var/lib/rancher/k3s/agent/containerd/tmpmounts/...:
+  openat etc/passwd=***FILTERED*** escapes from parent
+```
+
+containerd / runc 用 `openat2(RESOLVE_BENEATH)` 创建 OCI 标准的
+`/etc/passwd` / `/etc/group` 等 sidecar 文件时做路径越界校验，redroid
+rootfs 里 **`/etc/passwd` 不存在**，runc 的 path safefile 解析过程穿过
+顶层绝对 symlink（`/bin → /system/bin` 之类）触发 "escapes from parent"。
+
+vm-node04 实测确认：用 docker run / 旧 containerd 1.7 都能跑，但
+**k3s 1.34 + containerd 2.2 这一组合必死**。
+
+## 本镜像做了啥
+
+1. `docker create` + `docker export | tar -x` 把 upstream rootfs 抽出来
+   （**用 buildkit `COPY` 不行** —— buildkit 自己也踩同一个路径校验）
+2. 在 `etc/passwd` / `etc/group` / `etc/shadow` 写最小 shell 账号信息
+3. `tar -cf | docker import` 重打包，保留 `ENTRYPOINT ["/init"]` +
+   `CMD ["qemu=1", "androidboot.hardware=redroid"]`
+
+**不动 182 个绝对 symlink** —— vm-node04 实测显示 runc 只对它创建的文件
+（如 /etc/passwd）做 RESOLVE_BENEATH 校验，redroid Android init 内部
+syscall 不在校验范围。所以最小 patch 就够。
+
+## tag 策略
+
+| tag | 含义 |
+|---|---|
+| `13.0.0` | 跟随上游 `redroid/redroid:13.0.0_64only-latest`，本仓 patch 应用 |
+| `latest` | 当前推荐 tag（= 13.0.0） |
+| `sha-<7>` | 每次 commit 唯一 tag |
+
+## 用法（thanatos chart）
+
+```yaml
+# values.yaml override
+driver: adb
+redroid:
+  image: ghcr.io/phona/redroid-fixed:13.0.0
+  pullPolicy: IfNotPresent
+```
+
+## host kernel 前置
+
+redroid 需要 binder kernel module。Ubuntu 24.04 不默认带，需要：
+
+```bash
+sudo apt-get install -y linux-modules-extra-$(uname -r)
+echo binder_linux | sudo tee /etc/modules-load.d/redroid.conf
+echo 'options binder_linux num_devices=3' | sudo tee /etc/modprobe.d/redroid.conf
+sudo modprobe binder_linux num_devices=3
+```
+
+## 已知不修
+
+- 顶层 `/bin -> /system/bin` 等 182 个绝对 symlink —— 留着不影响
+- 系统 bloat（SystemUI / Launcher / Phone 占 ~600 MB） —— accept stage
+  跑一次 `pm disable-user` 即可（也可以做 image-level strip 但收益不大）

--- a/redroid-fixed/build.sh
+++ b/redroid-fixed/build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Build redroid-fixed image. Steps explained in README.md.
+#
+# Inputs (env):
+#   UPSTREAM_IMAGE  - upstream redroid tag (default: redroid/redroid:13.0.0_64only-latest)
+#   OUT_IMAGE       - output image name (e.g. ghcr.io/phona/redroid-fixed:13.0.0)
+#   WORKDIR         - scratch dir (default: /tmp/redroid-fixed-build)
+#
+# Notes:
+#   - cannot use buildkit COPY: triggers the same containerd-2.x mount safety
+#     check we're trying to fix. Must go through `docker create | docker export`.
+#   - must run on a host with `docker` CLI; CI uses docker/setup-buildx-action.
+
+set -euo pipefail
+
+UPSTREAM_IMAGE="${UPSTREAM_IMAGE:-redroid/redroid:13.0.0_64only-latest}"
+OUT_IMAGE="${OUT_IMAGE:?OUT_IMAGE is required, e.g. ghcr.io/phona/redroid-fixed:13.0.0}"
+WORKDIR="${WORKDIR:-/tmp/redroid-fixed-build}"
+
+echo "[redroid-fixed] upstream=$UPSTREAM_IMAGE out=$OUT_IMAGE workdir=$WORKDIR" >&2
+
+rm -rf "$WORKDIR"
+mkdir -p "$WORKDIR/rfs"
+
+echo "[redroid-fixed] pull upstream..." >&2
+docker pull "$UPSTREAM_IMAGE" >&2
+
+echo "[redroid-fixed] extract rootfs via docker create + docker export..." >&2
+CID=$(docker create "$UPSTREAM_IMAGE")
+trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
+docker export "$CID" | tar -xf - -C "$WORKDIR/rfs/"
+
+echo "[redroid-fixed] patch /etc/{passwd,group,shadow}..." >&2
+printf 'root:x:0:0:root:/:/system/bin/sh\nshell:x:2000:2000:shell:/:/system/bin/sh\n' \
+    > "$WORKDIR/rfs/etc/passwd"
+printf 'root:x:0:\nshell:x:2000:\n' \
+    > "$WORKDIR/rfs/etc/group"
+printf 'root:!:0:0:99999:7:::\n' \
+    > "$WORKDIR/rfs/etc/shadow"
+chmod 0644 "$WORKDIR/rfs/etc/passwd" "$WORKDIR/rfs/etc/group"
+chmod 0600 "$WORKDIR/rfs/etc/shadow"
+
+echo "[redroid-fixed] re-tar rootfs..." >&2
+tar -C "$WORKDIR/rfs" -cf "$WORKDIR/rfs.tar" .
+
+echo "[redroid-fixed] docker import → $OUT_IMAGE..." >&2
+docker import \
+    --change 'ENTRYPOINT ["/init"]' \
+    --change 'CMD ["qemu=1", "androidboot.hardware=redroid"]' \
+    "$WORKDIR/rfs.tar" \
+    "$OUT_IMAGE" >&2
+
+echo "[redroid-fixed] built $OUT_IMAGE (run \`docker push\` separately)" >&2


### PR DESCRIPTION
## 背景

[#248](https://github.com/phona/sisyphus/issues/248) Phase B 在 vm-node04 K3s 上最大的基础设施缺口：upstream `redroid/redroid:{11,13}` 在 **containerd 2.x + runc 1.4**（k3s 1.34）上一律 \`CreateContainerError\`，错误：

\`\`\`
openat etc/passwd=***FILTERED*** escapes from parent
\`\`\`

[runc 1.4 用 \`openat2(RESOLVE_BENEATH)\`](https://github.com/opencontainers/runc/releases) 创建 OCI 标准的 \`/etc/passwd\` / \`/etc/group\` 等 sidecar 文件时做严格路径校验。redroid rootfs 里 **`/etc/passwd` 不存在**，runc 的 path safefile 解析过程会穿过顶层绝对 symlink（如 \`/bin → /system/bin\`），触发 \"escapes from parent\"。

vm-node04 实测：写一个最小的 \`etc/passwd\` + \`etc/group\` + \`etc/shadow\` 就能解。**不动那 182 个绝对 symlink**——runc 只校验它创建的文件，redroid Android init 内部的 syscall 不在校验范围。patch 后：

- boot 30s 拿到 \`sys.boot_completed=1\`
- \`adb tcp:5555\` LISTEN
- 真 ttpos APK \`adb install\` + \`am start\` + \`uiautomator dump\` 26 节点
- thanatos AdbDriver \`tap \"Login\"\` ok=True

## 变更

| 文件 | 内容 |
|---|---|
| \`redroid-fixed/build.sh\` | 不能用 buildkit \`COPY\`（自己也踩同一个 RESOLVE_BENEATH check）；改用 \`docker create\` + \`docker export \| tar -x\` 抽 rootfs，写 3 个 \`etc/*\`，\`tar -cf \| docker import\` 重打包，保留 \`ENTRYPOINT [\"/init\"]\` + \`CMD [\"qemu=1\", \"androidboot.hardware=redroid\"]\` |
| \`redroid-fixed/README.md\` | 起源 / 解法 / 用法 / kernel 前置 |
| \`.github/workflows/redroid-fixed-image.yml\` | push main / 打 \`redroid-fixed-v*\` tag / workflow_dispatch 触发，build & push \`ghcr.io/<owner>/redroid-fixed:{13.0.0, latest, sha-<7>}\` |

## 用法（thanatos chart values override）

\`\`\`yaml
driver: adb
redroid:
  image: ghcr.io/phona/redroid-fixed:13.0.0
  pullPolicy: IfNotPresent
\`\`\`

合 [PR #250](https://github.com/phona/sisyphus/pull/250) 之后，\`redroid.pullPolicy\` 跟 \`image.pullPolicy\` 解耦，组合 override 才能干净写。

## host kernel 前置

redroid 需要 binder kernel module。Ubuntu 24.04 不默认带，README 写了步骤。vm-node04 已落盘 \`/etc/modules-load.d/redroid.conf\` + \`/etc/modprobe.d/redroid.conf\`。

## 测试方案

- [x] vm-node04 实测：本 PR build.sh 等价手动跑过——boot ok / adb ok / ttpos APK install ok / Login tap ok
- [ ] CI workflow 推 main 后 GHCR 拉得到 \`ghcr.io/phona/redroid-fixed:13.0.0\`
- [ ] 用 GHCR 镜像 helm install 验拉取链路

🤖 Generated with [Claude Code](https://claude.com/claude-code)