### PR TITLE
feat(prompts): intake/analyze 派 REQ 前对照现有 OPEN/closed REQ (#243)

### DIFF
--- a/orchestrator/src/orchestrator/prompts/_shared/check_related_reqs.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/check_related_reqs.md.j2
@@ -1,0 +1,37 @@
+## 派 REQ 之前先看相关 PR / issue
+
+正式开始之前，**先花一分钟对照一下现有 OPEN REQ 和最近被关掉的 REQ**，避免派出去之后才发现跟别的 REQ 在做反向的事 / 重复派 / 重蹈覆辙（参考 #243 reframe 后的轻量方案）。
+
+### 怎么做
+
+```bash
+# 1. 看现在有哪些 OPEN REQ 在跑（同 sisyphus label）
+gh issue list --repo <owner>/<sisyphus-repo> \
+  --state open --label sisyphus --limit 30 \
+  --json number,title,labels
+
+# 2. 看最近被关掉的 REQ（30 天内），尤其看 reject reason
+gh issue list --repo <owner>/<sisyphus-repo> \
+  --state closed --label sisyphus --limit 20 \
+  --search "<本 intent 关键词>" \
+  --json number,title,closedAt,stateReason
+```
+
+### 命中要怎么处理
+
+如果发现这次 intent 跟现有 REQ 有以下任一关系，**在 BKD chat 里跟用户提一下**，让用户拍板（supersede / 等 / 重派 / 继续 / "误判 continue"）：
+
+- **方向反向**：另一个 OPEN REQ 在做相反的事（例：你要删 X，#N 在加强 X）
+- **主题重复**：另一个 OPEN REQ 已经在做这件事
+- **重蹈覆辙**：最近被 reject 的 REQ 描述跟你这次很像，看下上次的 reject reason 是不是已经被解决
+
+提示语气要克制：每条对照一句话 + 引用 issue 编号 + 给用户选项。**不要硬阻塞**，最终拍板权在用户。
+
+### 命中不到怎么办
+
+完全没相关 REQ → **不要在 chat 里提**，正常走流程。这一步是后台自查，不是固定汇报项。
+
+### 边缘情况
+
+- `gh` 调用失败 / 超时 → 跳过本步，正常推进（fail-open，跟现有 admission 一致）
+- 低置信度 / 模糊关联 → 自己判断要不要提，宁可漏报不要轰炸用户

--- a/orchestrator/src/orchestrator/prompts/analyze.md.j2
+++ b/orchestrator/src/orchestrator/prompts/analyze.md.j2
@@ -68,6 +68,10 @@ REQ={{ req_id }}
 
 本 REQ 未经过 intake 阶段，请直接基于 intent description 和上下文进行需求分析，确定验收标准，并在 spec 中写出完整的 `#### Scenario`。
 
+**注意：直跳 analyze 没走 intake，下面"派 REQ 之前先看相关 PR / issue"段你要自己跑一遍**，命中相关 REQ（反向 / 重复 / 重蹈覆辙）时在 BKD intent issue chat 里给用户一条 follow-up message 提示，再继续执行。命中不到正常推进。
+
+{% include "_shared/check_related_reqs.md.j2" %}
+
 {% endif -%}
 你**全权负责**这个 REQ 从 0 到可合并 PR 的端到端交付。
 

--- a/orchestrator/src/orchestrator/prompts/intake.md.j2
+++ b/orchestrator/src/orchestrator/prompts/intake.md.j2
@@ -16,6 +16,10 @@
 
 ─────────
 
+{% include "_shared/check_related_reqs.md.j2" %}
+
+─────────
+
 ## 你是 intake-agent
 
 REQ={{ req_id }}
@@ -36,10 +40,11 @@ REQ={{ req_id }}
 ### 工作流
 1. 读 intent issue prompt + 任何 GitHub issue 链接
 2. **必须** clone / kubectl exec 看相关仓现状（哪些文件、什么 pattern、错误格式、命名约定）
-3. 列疑问清单，发 BKD chat 问用户（**结束本轮 session**，等 follow-up）
-4. 用户答完，**还有疑问继续问**
-5. 满意后发 finalized intent draft 给用户审："我准备这么写下去，OK?"
-6. 用户 chat 回 "go" / "好" / 没补充 → finalize
+3. **对照现有 REQ**（见下方 "派 REQ 之前先看相关 PR / issue" 段）
+4. 列疑问清单（含步骤 3 命中的关系澄清），发 BKD chat 问用户（**结束本轮 session**，等 follow-up）
+5. 用户答完，**还有疑问继续问**
+6. 满意后发 finalized intent draft 给用户审："我准备这么写下去，OK?"
+7. 用户 chat 回 "go" / "好" / 没补充 → finalize
 7. **finalize 步骤（强制执行，不做 = 任务失败）**：
    - 在 BKD chat 最后一条 message 里贴 ```` ```json ``` ```` 块（同 verifier 模式）
    - ⚠️ **立即用 Bash curl PATCH 本 issue 加 tag `result:pass`**


### PR DESCRIPTION
## Summary

Reframe #243 后的最小落地：派 REQ 之前让 intake/analyze agent 先调 \`gh issue list\` 对照现有 OPEN + 最近 closed REQ，命中反向/重复/重蹈覆辙时在 BKD chat 给用户提示，让用户拍板。

- 新增 \`_shared/check_related_reqs.md.j2\` partial（~50 行 jinja）
- \`intake.md.j2\` 工作流第 3 步 include partial
- \`analyze.md.j2\` 直跳分支 include partial（post-intake 分支不重复，intake 已经做过）

**纯 prompt 改动**：不新建模块、不动 state machine、不动 admission、不加 metric/表。砍掉 issue 原 6 类检查中的次要项（hot-file allowlist / obs 反向索引 / scope archive / philosophy 红线），只做主线"REQ 间语义关系"对照（覆盖 #243 缺陷 A + E）。

## Reframe 经过

完整讨论 + 砍掉哪些项 + 已知 gap 见 #243 归档评论：https://github.com/phona/sisyphus/issues/243#issuecomment-4359853278

## Test plan

- [x] jinja2 render 三种路径都跑过：intake / analyze 直跳 / analyze post-intake
- [x] \`uv run pytest -m "not integration" -k "intake or analyze or prompt or repo_agnostic"\` —— 229 passed
- [x] 完整单测 1976 passed（3 个 ruff 失败是环境无 ruff binary，跟本 PR 无关）
- [ ] sisyphus pr-ci-watch on this PR
- [ ] 真实派一个 REQ 观察 intake agent 是否会调 \`gh issue list\` 并在 chat 提示

## 不做的事（参考 #243 归档）

- 不结构化 \`relationships\` JSON 字段（confidence/type 是 LLM 编出来的，没数据支撑这个 schema）
- 不加 Metabase Q19（没数据先别预设 metric）
- 不动 \`admission.py\`（资源 admission ≠ 语义 preflight，两层）

🤖 Generated with [Claude Code](https://claude.com/claude-code)