### PR TITLE
feat(deploy/thanatos): 切 redroid.image 默认值到 ghcr.io/phona/redroid-fixed:13.0.0

### DIFF
--- a/deploy/charts/thanatos/values.yaml
+++ b/deploy/charts/thanatos/values.yaml
@@ -27,11 +27,13 @@ service:
 
 # redroid sidecar settings (only used when driver=adb).
 redroid:
-  image: redroid/redroid:11.0.0-latest
-  # pullPolicy 跟 image.pullPolicy 解耦：自包装的 redroid-fixed 镜像（含 /etc/passwd
-  # 修复 + flatten 顶层符号链接、解 containerd 2.x mount safety check）通常
-  # `k3s ctr images import` 进集群本地 cache，需要走 IfNotPresent / Never；而
-  # thanatos 镜像仍可走 dev tag 滚动 Always。空值则 fallback 到 image.pullPolicy。
+  # 默认走 phona 自包装的 redroid-fixed（解 containerd 2.x runc1.4
+  # `openat etc/passwd=*** escapes from parent` mount safety check —— 上游
+  # `redroid/redroid:11.0.0-latest` / `:13.0.0_64only-latest` 都炸）。
+  # build 流水：sisyphus repo `redroid-fixed/` + `.github/workflows/redroid-fixed-image.yml`。
+  image: ghcr.io/phona/redroid-fixed:13.0.0
+  # pullPolicy 跟 image.pullPolicy 解耦：thanatos 镜像走 dev tag 滚动可能 Always；
+  # redroid 走稳定 13.0.0 tag IfNotPresent 即可。空值则 fallback 到 image.pullPolicy。
   pullPolicy: ""
   port: 5555
   resources:


### PR DESCRIPTION
## Summary

#250 + #251 合 main 后 GHCR 上 \`ghcr.io/phona/{thanatos:dev, redroid-fixed:13.0.0}\` 都已 push 上去。本 mini PR 把 chart \`values.yaml\` 默认 \`redroid.image\` 切到 redroid-fixed —— 之前默认指 \`redroid/redroid:11.0.0-latest\`（containerd 2.x 上一律死的版本），\`helm install thanatos --set driver=adb\` 出厂即坏。

## 实测验证（vm-node04）

\`\`\`bash
helm upgrade --install thanatos deploy/charts/thanatos --namespace ghcr-smoke \\
  --set driver=adb \\
  --set-json 'imagePullSecrets=[{"name":"ghcr-pull"}]'
\`\`\`

→ Pod 2/2 Running，redroid \`sys.boot_completed=1\`，adb tcp:5555 LISTEN，thanatos sidecar \`adb -s localhost:5555 shell getprop ro.build.version.sdk\` 返 \`33\`（Android 13），MCP \`tools/list\` 返 \`run_scenario / run_all / recall\` 三工具。

## 跟 #248 关系

完成 [#248](https://github.com/phona/sisyphus/issues/248) Phase B 最后一块基础设施清理。Phase C 派 ttpos REQ 时 \`make accept-env-up\` 跑 \`helm install thanatos --set driver=adb\` 不用再手动 \`--set redroid.image=...\` 覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)