### PR TITLE
fix(spec_lint): 空壳 scenario 检测限到当前 REQ specs，不卡历史遗留

### DIFF
--- a/orchestrator/src/orchestrator/checkers/spec_lint.py
+++ b/orchestrator/src/orchestrator/checkers/spec_lint.py
@@ -37,7 +37,10 @@ def _build_cmd(req_id: str) -> str:
        —— spec/dev 文件由 agent 推到 feat/<REQ> 分支，runner pod 默认在 main。
        fetch 失败 / 没有该 branch → 该仓视为 not involved（agent 没改它），跳过不算 fail。
     2. openspec validate openspec/changes/<REQ>
-    3. check-scenario-refs.sh --specs-search-path /workspace/source .
+    3. check-scenario-refs.sh --specs-search-path /workspace/source --current-change <REQ> .
+       —— `--current-change` 把空壳 scenario 检测限到当前 REQ 的 specs；引用解析
+       （DEFINED 集合）仍全量收集。避免别的 REQ（已合 / 历史遗留 / 别人没合的旧
+       openspec/changes/）的空壳 scenario 把当前 REQ 的 spec_lint 拖红。
 
     任一仓任一检查失败 → exit 1。
     """
@@ -66,7 +69,7 @@ def _build_cmd(req_id: str) -> str:
         '      echo "=== FAIL: $name ===" >&2; '
         "      fail=1; "
         "    fi; "
-        '    if ! (cd "$repo" && check-scenario-refs.sh --specs-search-path /workspace/source .); then '
+        f'    if ! (cd "$repo" && check-scenario-refs.sh --specs-search-path /workspace/source --current-change "{req_id}" .); then '
         '      echo "=== FAIL scenario-refs: $name ===" >&2; '
         "      fail=1; "
         "    fi; "

--- a/scripts/check-scenario-refs.sh
+++ b/scripts/check-scenario-refs.sh
@@ -20,6 +20,10 @@ set -euo pipefail
 
 SEARCH_PATHS=()
 ROOT="."
+# --current-change <REQ>：把空壳 scenario 检测**只限**到 openspec/changes/<REQ>/specs/。
+# 不传时保持原行为（全仓所有 changes/*/specs/* 都做空壳检测）。
+# 引用解析（DEFINED 集合）始终全量收集，保跨 REQ scenario 引用能解析。
+CURRENT_CHANGE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -33,6 +37,18 @@ while [[ $# -gt 0 ]]; do
       ;;
     --specs-search-path=*)
       SEARCH_PATHS+=("${1#--specs-search-path=}")
+      shift
+      ;;
+    --current-change)
+      if [[ $# -lt 2 ]]; then
+        echo "FAIL: --current-change requires an argument" >&2
+        exit 2
+      fi
+      CURRENT_CHANGE="$2"
+      shift 2
+      ;;
+    --current-change=*)
+      CURRENT_CHANGE="${1#--current-change=}"
       shift
       ;;
     -h|--help)
@@ -75,6 +91,7 @@ _STEP_PATTERN='^[[:space:]]*(-[[:space:]]*\*\*)?[[:space:]]*([Gg][Ii][Vv][Ee][Nn
 
 scan_spec_file() {
   local file="$1"
+  local check_empty="${2:-1}"   # 0 = 只 collect DEFINED；1 = 同时检测空壳（默认，向后兼容）
   local line
   local in_scenario=0
   local scen_id=""
@@ -84,7 +101,7 @@ scan_spec_file() {
     # 检测新的 scenario heading
     if [[ "$line" =~ $SCENARIO_HEADING_PATTERN ]]; then
       # 检查上一个 scenario 是否有 step
-      if [[ $in_scenario -eq 1 && $scen_has_step -eq 0 ]]; then
+      if [[ $check_empty -eq 1 && $in_scenario -eq 1 && $scen_has_step -eq 0 ]]; then
         echo "FAIL: $file scenario [$scen_id] has no GIVEN/WHEN/THEN steps"
         FAILED=1
       fi
@@ -114,7 +131,7 @@ scan_spec_file() {
       fi
 
       if [[ $end_scenario -eq 1 ]]; then
-        if [[ $scen_has_step -eq 0 ]]; then
+        if [[ $check_empty -eq 1 && $scen_has_step -eq 0 ]]; then
           echo "FAIL: $file scenario [$scen_id] has no GIVEN/WHEN/THEN steps"
           FAILED=1
         fi
@@ -126,20 +143,45 @@ scan_spec_file() {
   done < "$file"
 
   # 文件结尾检查最后一个 scenario
-  if [[ $in_scenario -eq 1 && $scen_has_step -eq 0 ]]; then
+  if [[ $check_empty -eq 1 && $in_scenario -eq 1 && $scen_has_step -eq 0 ]]; then
     echo "FAIL: $file scenario [$scen_id] has no GIVEN/WHEN/THEN steps"
     FAILED=1
   fi
 }
 
+# helper: 文件是否属于「当前 REQ」的 specs（用于决定是否做空壳检测）
+file_in_current_change() {
+  local file="$1"
+  if [[ -z "$CURRENT_CHANGE" ]]; then
+    # 没传 --current-change → 所有 changes 都算「当前」（向后兼容：全量空壳检测）
+    return 0
+  fi
+  # 路径含 openspec/changes/<CURRENT_CHANGE>/  或  openspec/specs/（baseline 永远扫）
+  case "$file" in
+    *"openspec/specs/"*) return 0 ;;
+    *"openspec/changes/$CURRENT_CHANGE/"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 while IFS= read -r file; do
-  scan_spec_file "$file"
+  # 当前仓 specs：只对「当前 REQ 的 specs」+ baseline 做空壳检测；
+  # 别的 REQ（含已合 / 历史遗留）的空壳 scenario 不应卡当前 REQ 的 spec_lint。
+  if file_in_current_change "$file"; then
+    scan_spec_file "$file" 1
+  else
+    scan_spec_file "$file" 0
+  fi
 done < <(find openspec/specs openspec/changes/*/specs 2>/dev/null -name '*.md' 2>/dev/null || true)
 
 for sp in "${SEARCH_PATHS[@]}"; do
   # P/*/openspec/specs/*.md  — 同时匹配每个 sibling repo 的 in-progress changes
   while IFS= read -r file; do
-    scan_spec_file "$file"
+    if file_in_current_change "$file"; then
+      scan_spec_file "$file" 1
+    else
+      scan_spec_file "$file" 0
+    fi
   done < <(find "$sp"/*/openspec/specs "$sp"/*/openspec/changes/*/specs 2>/dev/null -name '*.md' 2>/dev/null || true)
 done
 


### PR DESCRIPTION
## 背景

#248 Phase C 派 REQ-647 实测撞：spec_lint 阶段挂在 **历史 PR #149 留下的空壳 scenario** 上：

\`\`\`
FAIL: openspec/changes/REQ-ttpos-flutter-sisyphus-onboard-1777420013/specs/pos/spec.md
      scenario [POS-S1] has no GIVEN/WHEN/THEN steps
FAIL: scenario [POS-S2] has no GIVEN/WHEN/THEN steps
\`\`\`

这个 directory 是 ttpos-flutter PR #149（22K 行）的产物，跟当前 REQ-647 没关系，但 `check-scenario-refs.sh` 全量扫所有 `openspec/changes/*/specs/*.md` 做空壳检测 → 一个仓只要有一个老空壳 scenario 存在，**后续所有 REQ 的 spec_lint 都被拖红**。

## 修法

| 文件 | 改动 |
|---|---|
| `scripts/check-scenario-refs.sh` | 加 `--current-change <REQ>` 参数。没传 → 行为同前（向后兼容）；传了 → 空壳检测**只**针对 `openspec/changes/<REQ>/specs/*.md` + `openspec/specs/*.md`（baseline 永远扫）。**引用解析（DEFINED 集合）仍全量** —— cross-REQ scenario 引用照样能解析。 |
| `orchestrator/src/orchestrator/checkers/spec_lint.py` | 调用时套 `--current-change "$req_id"` |

## 测试方案

本地 3 case 全过：

\`\`\`
没 --current-change → REQ-A 历史空壳 fail (兼容)
--current-change=REQ-B (REQ-A 老库有空壳) → OK 通过
--current-change=REQ-A → REQ-A 空壳 fail (精准)
\`\`\`

## 跟 #248 关系

#248 Phase C 落地过程中暴露，立独立 PR 修。其他 sub-issue：
- #262 ✅ closed (PR #269) — accept.md.j2 kb_updates commit
- #263 ✅ closed (PR #264 + #266) — sisyphus base override
- #270 ⏳ open — agent session pre-flight 验 MCP 依赖

🤖 Generated with [Claude Code](https://claude.com/claude-code)