### PR TITLE
feat(helm): runner.image 默认切 full flavor (Flutter SDK 内含)

### DIFF
--- a/orchestrator/helm/values.yaml
+++ b/orchestrator/helm/values.yaml
@@ -128,7 +128,15 @@ runner:
   createRbac: true            # 自动建 Role/RoleBinding 给 orchestrator SA 管 ns
   serviceAccountName: sisyphus-runner-sa   # runner Pod 跑的 SA
 
-  image: ghcr.io/phona/sisyphus-runner-go:main
+  # 默认 full flavor（Flutter SDK + Android SDK + Java + Go + Node + Docker DinD）。
+  # 之前默认 sisyphus-runner-go 是 Go-only 轻量（~1GB），但 Flutter REQ
+  # （如 ttpos-flutter）跑 ci-setup `dart pub global activate melos` 会撞
+  # `dart: No such file or directory`。
+  # full image ~5GB，cold pull 慢一点（~30s vs ~5s），但镜像 cache 命中后所有
+  # REQ 复用，跟 Go-only 实际差不多。换 image 工作量 = 改这一行。
+  # `sisyphus-runner-go` 仍保留 build（runner-image.yml matrix 不动），有需要
+  # 可手动 --set runner.image=ghcr.io/phona/sisyphus-runner-go:main 切回。
+  image: ghcr.io/phona/sisyphus-runner:main
   storageClass: local-path    # K3s 默认；多节点场景换 longhorn / NFS
   workspaceSize: 10Gi         # PVC 大小（runner 峰值 ~5GB + 余量）
   readyTimeoutSec: 120        # ensure_runner 等 Pod Ready 的超时


### PR DESCRIPTION
## Summary

#248 Phase C 派 REQ-649 实测撞：dev_cross_check 阶段 ttpos-flutter 跑 \`make ci-setup\` → \`dart pub global activate melos\` → exit 127 \`dart: No such file or directory\`。

根因：sisyphus orch chart 默认 \`runner.image=ghcr.io/phona/sisyphus-runner-go:main\`（Go-only ~1GB，无 Flutter SDK）。runner-image.yml 实际有 build full flavor（\`ghcr.io/cirruslabs/flutter:stable\` base + Android SDK + Java + Go + Node + DinD），但 chart 没指它。

## 修法

\`orchestrator/helm/values.yaml\` 默认值切 \`ghcr.io/phona/sisyphus-runner:main\`（full）。

## 取舍（讨论决）

| | 单大 image (#1) | flavor 拆分 (#2) |
|---|---|---|
| 镜像数 | 1 | 2-N |
| 单镜像 | 5-7GB | 1-5GB |
| sisyphus 维护成本 | 1 dockerfile | N |
| Per-REQ 选择 logic | 不需要 | 需要 |

sisyphus 当前规模（ttpos 产品矩阵，2 种语言栈定型）**单大够用**，复杂度不抵当前收益。完全可逆 —— 要回 #2 就半天工作量加 flavor 选择逻辑。

## 副作用

- 所有 REQ runner pod 拉 5GB（之前 1GB）。containerd 节点 cache 命中后秒级，多 REQ 复用
- Go 仓 REQ 拉 5GB 略浪费但能跑
- runner-go matrix 仍 build push，留 escape hatch（手动 --set 切回）

## 落地

\`helm upgrade --reuse-values\` 后 K8s rolling restart 生效。下个派的 REQ 自动用 full flavor。

🤖 Generated with [Claude Code](https://claude.com/claude-code)