### PR TITLE
fix(integration_resolver): drop `set +e` head + `exit 0` tail (#277)

### DIFF
--- a/orchestrator/src/orchestrator/actions/_integration_resolver.py
+++ b/orchestrator/src/orchestrator/actions/_integration_resolver.py
@@ -41,9 +41,18 @@ log = structlog.get_logger(__name__)
 # 用 `make -p -n` 解析 Makefile + include 子 mk（实证 ttpos-server-go：
 # accept-env-up 在 ttpos-scripts/accept-env.mk via include，顶层 grep 漏判 →
 # resolver 误判"无 integration repo"），跟 dev_cross_check / staging_test 同根因。
+#
+# 注意两个历史坑（REQ-integration-resolver-marker-1777250000 修）：
+#   1. 不能开头 `set +e` —— exec_in_runner 用 `env KEY=VAL <cmd>` 注入环境变量，
+#      env 会把 `set` 当二进制找，stderr 喷 `env: 'set': No such file`，整个第一行
+#      退非 0；后续靠 newline-separator 反而正常跑（迷惑 debug）。直接不用 set +e；
+#      下面所有候选探测都 wrap 在 `(cd ... && ...)` 子 shell + 逻辑 OR，本身不会因
+#      单仓 Makefile 怪异 fail 整个脚本。
+#   2. 不能末尾 `exit 0` —— exec_in_runner 在命令尾巴 append `; echo __MARKER__$?` 抓 exit code，
+#      `exit 0` 会跳过 marker echo 让 caller 把 exit_code 解析成 -1（marker 缺失）→
+#      caller 返回 `scan exec returned exit_code=-1` 即使扫描其实跑通了。让脚本自然
+#      结束在最后一个 for loop（`set +e` 心智已不需要了，去掉）。
 _SCAN_SCRIPT = r"""
-set +e
-# 诊断输出到 stderr（供 verifier / 日志审阅时定位空目录根因）
 if [ ! -d /workspace ]; then
   echo "[resolver-diag] /workspace does not exist" >&2
 else
@@ -70,7 +79,6 @@ for d in /workspace/source/*/; do
     printf 'S:%s\n' "${d%/}"
   fi
 done
-exit 0
 """.strip()
 
 
@@ -172,7 +180,6 @@ async def resolve_integration_dir(rc, req_id: str) -> ResolveResult:
     result = await rc.exec_in_runner(
         req_id,
         command=_SCAN_SCRIPT,
-        env={"SISYPHUS_STAGE": "accept-resolve"},
         timeout_sec=15,
     )
     if result.exit_code != 0:

--- a/orchestrator/tests/test_create_accept_self_host.py
+++ b/orchestrator/tests/test_create_accept_self_host.py
@@ -204,7 +204,8 @@ class _RC:
 
     async def exec_in_runner(self, req_id, command, env=None, timeout_sec=None):
         self.calls.append({"command": command, "env": env})
-        if env and env.get("SISYPHUS_STAGE") == "accept-resolve":
+        # Resolver call carries the I:/S: scan loop (no env injection — see _SCAN_SCRIPT comment)
+        if "printf 'I:%s\\n'" in command or "printf 'S:%s\\n'" in command:
             return ExecResult(exit_code=0, stdout=self.scan_stdout, stderr="", duration_sec=0.1)
         return ExecResult(exit_code=self.env_up_exit, stdout=self.env_up_stdout, stderr="", duration_sec=1.0)
 


### PR DESCRIPTION
## Summary

- 改 `_SCAN_SCRIPT` 头去掉 `set +e`（避开 \`env\` 把 \`set\` builtin 当二进制找）+ 末去掉 `exit 0`（避开 marker echo 被 preempt）
- `resolve_integration_dir` 不再注入未使用的 `SISYPHUS_STAGE=accept-resolve` env，免触发上述 \`env: 'set'\` 路径
- test mock 改成靠 command 子串识别 resolver 调用而非 env

详细分析见 #277。

## 实证

REQ-657 @ accept-running:
```
exit_code=-1 stderr="env: 'set': No such file or directory\n[resolver-diag] /workspace/source has 1 subdirs..."
→ create_accept.no_integration_dir reason="scan exec returned exit_code=-1"
```

修后本地 58 testcase 全过；resolver 对 \`S:/workspace/source/sisyphus\` 输出能正常解析。

## Test plan
- [x] `uv run pytest tests/test_create_accept_self_host.py tests/test_create_accept_minimal.py tests/test_actions_smoke.py tests/test_contract_self_accept_stage_challenger.py` 58 passed
- [ ] CI 绿
- [ ] 部署后 admin/resume REQ-657 重跑 accept stage，看 thanatos pod 起没起（Phase C 核心目标）

## Refs
- closes #277
- 解锁 #248 Phase C 推进

🤖 Generated with [Claude Code](https://claude.com/claude-code)