### PR TITLE
fix(orch): /healthz 增加 DB 连接探活

### DIFF
--- a/orchestrator/src/orchestrator/main.py
+++ b/orchestrator/src/orchestrator/main.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 
 import structlog
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 from . import accept_env_gc, k8s_runner, runner_gc, snapshot, watchdog
 from .admin import admin as admin_api
@@ -109,4 +109,10 @@ async def shutdown() -> None:
 
 @app.get("/healthz")
 async def healthz() -> dict:
+    pool = db.get_pool()
+    try:
+        async with pool.acquire() as conn:
+            await conn.fetchval("SELECT 1")
+    except Exception:
+        raise HTTPException(status_code=503, detail="db_unavailable") from None
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- 修改 `/healthz` endpoint，使其真实检查 DB 连接池状态
- DB 正常时返回 `200 + {"status": "ok"}`
- DB 不可用时返回 `503`

closes #281