### PR TITLE
fix(k8s_runner): inline `export K=V` instead of `env K=V <cmd>` shim (#280)

### DIFF
--- a/orchestrator/src/orchestrator/k8s_runner.py
+++ b/orchestrator/src/orchestrator/k8s_runner.py
@@ -703,11 +703,17 @@ class RunnerController:
     ) -> ExecResult:
         pod_name = self.pod_name(req_id)
 
+        # 环境变量用 inline `export` 在 bash -c 上下文里赋值，**不**用 `env KEY=VAL <cmd>` shim。
+        # 历史教训（#277 / #280）：`env KEY=VAL <cmd>` 把 <cmd> 头一个 token 当二进制找，
+        # 但 caller 经常传 `cd <dir> && make ...` / `set +e ...` 这种 builtin-headed 命令 →
+        # `env: 'cd': No such file or directory` / `env: 'set': No such file or directory`。
+        # newline-separator 还会让后续行继续跑，让 debug 极难看出根因。
+        # inline export 在同一个 bash -c 子 shell 里完成，所有后续 builtin / 控制结构都正常。
         env_prefix = ""
         if env:
-            env_prefix = "env " + " ".join(
-                f"{k}={_shell_quote(v)}" for k, v in env.items()
-            ) + " "
+            env_prefix = "; ".join(
+                f"export {k}={_shell_quote(v)}" for k, v in env.items()
+            ) + "; "
 
         full_cmd = f"cd {workdir} && {env_prefix}{command}; echo {_EXIT_MARKER}$?"
         exec_argv = ["/bin/bash", "-c", full_cmd]

--- a/orchestrator/tests/test_k8s_runner.py
+++ b/orchestrator/tests/test_k8s_runner.py
@@ -566,6 +566,106 @@ def test_parse_exit_marker_nonzero():
     assert _parse_exit_marker(stdout) == 127
 
 
+# ─── exec env injection (#280): inline export, not `env KEY=VAL <cmd>` shim ──
+
+@pytest.mark.asyncio
+async def test_exec_in_runner_uses_inline_export_not_env_shim(monkeypatch):
+    """Regression #280: env injection must work with builtin-headed commands.
+
+    Old impl wrapped command as `env KEY=VAL <cmd>`, which made `env` try to
+    fork the next token as a binary. For commands like `cd <dir> && make ...`
+    or `set +e`, env saw `cd` / `set` (shell builtins) and exit-127'd with
+    `env: 'cd': No such file or directory` —— exact failure observed on
+    REQ-657 accept-env-up retry. Fix: inline `export K=V; <cmd>` so all
+    builtin / control-flow constructs run inside the bash -c subshell.
+    """
+    captured: dict = {}
+
+    class _FakeStream:
+        def __init__(self):
+            self._open = False  # no I/O — we just want to capture command
+
+        def update(self, timeout=None):
+            self._open = False
+
+        def is_open(self):
+            return self._open
+
+        def peek_stdout(self):
+            return False
+
+        def peek_stderr(self):
+            return False
+
+        def read_stdout(self):
+            return ""
+
+        def read_stderr(self):
+            return ""
+
+    def _fake_exec(api_fn, *args, command=None, **kwargs):
+        captured["command"] = command
+        return _FakeStream()
+
+    rc = _make_controller()
+
+    # patch the internal stream wrapper
+    async def _k8s_passthrough(fn, *args, **kwargs):
+        return _fake_exec(fn, *args, **kwargs)
+
+    monkeypatch.setattr(rc, "_k8s", _k8s_passthrough)
+
+    # Builtin-headed command — old shim would explode.
+    await rc._exec_once(
+        "REQ-test", "cd /workspace/source/foo && make accept-env-up",
+        env={"SISYPHUS_REQ_ID": "REQ-test", "SISYPHUS_STAGE": "accept"},
+        workdir="/workspace", timeout_sec=5,
+    )
+
+    cmd_argv = captured["command"]
+    assert cmd_argv[:2] == ["/bin/bash", "-c"]
+    full_cmd = cmd_argv[2]
+    # New form: env vars exported inline (no `env KEY=VAL <cmd>` shim).
+    assert "export SISYPHUS_REQ_ID=" in full_cmd
+    assert "export SISYPHUS_STAGE=" in full_cmd
+    assert "env SISYPHUS_REQ_ID=" not in full_cmd
+    assert "env SISYPHUS_STAGE=" not in full_cmd
+    # Original command is preserved verbatim downstream of the exports.
+    assert "cd /workspace/source/foo && make accept-env-up" in full_cmd
+
+
+@pytest.mark.asyncio
+async def test_exec_in_runner_no_env_keeps_command_clean(monkeypatch):
+    """No env arg → no export prefix; command runs directly."""
+    captured: dict = {}
+
+    class _FakeStream:
+        def update(self, timeout=None): pass
+        def is_open(self): return False
+        def peek_stdout(self): return False
+        def peek_stderr(self): return False
+        def read_stdout(self): return ""
+        def read_stderr(self): return ""
+
+    rc = _make_controller()
+
+    async def _k8s_passthrough(fn, *args, **kwargs):
+        captured["command"] = kwargs.get("command")
+        return _FakeStream()
+
+    monkeypatch.setattr(rc, "_k8s", _k8s_passthrough)
+
+    await rc._exec_once(
+        "REQ-x", "make ci-unit-test", env=None,
+        workdir="/workspace", timeout_sec=5,
+    )
+
+    full_cmd = captured["command"][2]
+    assert "export " not in full_cmd
+    assert "env " not in full_cmd  # no shim
+    assert "make ci-unit-test" in full_cmd
+
+
 def test_parse_exit_marker_missing():
     assert _parse_exit_marker("no marker here\n") is None
 


### PR DESCRIPTION
## Summary

- \`exec_in_runner\` env 注入从 \`env KEY=VAL <cmd>\` shim 改成 inline \`export K=V; <cmd>\` —— 让 builtin-headed command (\`cd\`, \`set\`, \`shopt\`, ...) 都能正常跑
- 新增两条 regression test 守住 builtin-headed + env 的组合 + no-env 简化路径

详细 root cause 见 #280。

## 实证

REQ-657 accept-env-up 撞两次：
- attempt 1 (PR #278 前): \`env: 'set': No such file\` —— resolver \`_SCAN_SCRIPT\` 头 \`set +e\`
- attempt 2 (PR #278 后): \`env: 'cd': No such file\` —— \`create_accept\` 跑 \`cd <integration_dir> && make accept-env-up\`

PR #278 只绕过了 resolver；\`cd\` 这类 caller 没救到。本 PR 在 wrapper 一处修死，所有 caller 受益。

## Test plan
- [x] \`uv run pytest tests/ -m "not integration"\` 1993 passed
- [x] 新增两个 regression: builtin-headed cmd + env，与 no-env 简化路径
- [ ] CI 绿
- [ ] 部署后 admin/resume REQ-657 重跑 accept 看 thanatos pod 起没起（Phase C 核心目标）

## Refs
- closes #280
- 解锁 #248 Phase C 推进

🤖 Generated with [Claude Code](https://claude.com/claude-code)