### PR TITLE
fix(runner): write ~/.netrc from GH_TOKEN so private-repo `git clone` works (#286)

### DIFF
--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -34,6 +34,32 @@ if [[ "${SISYPHUS_NO_DOCKER:-0}" != "1" ]]; then
   fi
 fi
 
+# ── Git ambient auth (#286): GH_TOKEN → ~/.netrc ──────────────────────
+# Helm 把 runner secret 里的 gh_token 注成 GH_TOKEN env（contract 见 helm
+# values L137-145：「**只供 runner 内 git clone 私有仓**」）。但 vanilla
+# `git clone https://github.com/...` 不会主动读 env，业务仓 Makefile 里写
+# `git clone https://github.com/<private-repo>` 形式（accept-env-up 跨仓
+# clone lab repo 是常见用法）就会撞 `could not read Username for
+# 'https://github.com'` 死翘翘。
+# 把 GH_TOKEN 落到 ~/.netrc 给 git ambient auth；GitHub 接受任意 username + PAT
+# 作 password，所以 login=oauth2 是惯例占位（也能换成 token-with-x-access-token，
+# 都行）。pod restart 重跑 entrypoint 自动重写，无残留 / 无 PVC 干扰
+# （写在 / 不在 /workspace）。
+if [[ -n "${GH_TOKEN:-}" ]]; then
+  cat > /root/.netrc <<EOF
+machine github.com
+login oauth2
+password ${GH_TOKEN}
+machine api.github.com
+login oauth2
+password ${GH_TOKEN}
+EOF
+  chmod 600 /root/.netrc
+  echo "[sisyphus-entrypoint] git ambient auth configured via ~/.netrc"
+else
+  echo "[sisyphus-entrypoint] GH_TOKEN missing — git private-repo clone will fail" >&2
+fi
+
 # ── Workspace 目录契约 + restart 恢复 ──────────────────────────────────
 # Pod restart（restartPolicy=Always）时，entrypoint.sh 会重新跑。
 # 用 /.sisyphus-runner-init 标记检测 restart：标记存在 → 清掉 /workspace/* 从零开始。


### PR DESCRIPTION
## Summary

- runner entrypoint.sh 在起 dockerd 之后把 GH_TOKEN 落到 \`/root/.netrc\`，给 git ambient auth
- 零业务仓改动，让 helm values L137-145 注释里说的 \"GH_TOKEN —— **只供 runner 内 git clone 私有仓**\" 真正生效

详细 root cause 见 #286。

## 实证

REQ-657 accept-env-up 撞：
\`\`\`
[ttpos-flutter-accept] up: prepare repos (accept-req-657)
Cloning into '/tmp/ttpos-arch-lab'...
fatal: could not read Username for 'https://github.com': No such device or address
make: *** [Makefile:218: accept-env-up] Error 128
\`\`\`

ttpos-arch-lab 是 ZonEaseTech 私有仓；runner pod 有 GH_TOKEN env 但 vanilla git 不读。

## Test plan
- [ ] runner-image CI 绿（推 :main image）
- [ ] kubectl exec runner pod 验 \`cat ~/.netrc\` 内容含 \`machine github.com\`
- [ ] admin/resume REQ-657 重跑 accept，看 git clone ttpos-arch-lab 通过 → thanatos pod 起没起（Phase C 核心目标）

## Refs
- closes #286
- 解锁 #248 Phase C 推进

🤖 Generated with [Claude Code](https://claude.com/claude-code)