### PR TITLE
feat(watchdog): self-heal empty-text stuck sessions (#279)

### DIFF
--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -77,6 +77,23 @@ _SUB_AGENT_ROLE_TAGS: frozenset[str] = frozenset({
     "analyze", "challenger", "fixer", "accept",
 })
 
+# REQ-feat-watchdog-self-heal-1777723955：这些 stage 的 session.completed 必须带 result tag
+# 才能被 router 识别并推进状态机。若 session ended 但 result tag 缺失，说明是 BKD empty-text
+# 双 retry 用尽或 PATCH race 导致 —— 直接 follow-up 唤醒 agent，不消耗 auto_retry_count。
+_STAGES_NEEDING_RESULT_TAG: frozenset[ReqState] = frozenset({
+    ReqState.INTAKING,
+    ReqState.CHALLENGER_RUNNING,
+    ReqState.STAGING_TEST_RUNNING,
+    ReqState.PR_CI_RUNNING,
+    ReqState.ACCEPT_RUNNING,
+    ReqState.FIXER_RUNNING,
+})
+
+
+def _has_result_tag(tags: list[str]) -> bool:
+    """issue tags 中是否包含 result/pr-ci 类完工标记。"""
+    return any(t.startswith(("result:", "pr-ci:")) for t in tags)
+
 # 排除：终态 + 等人态（human-in-loop）+ 未入链
 # human-in-loop states 同时存于 _NO_WATCHDOG_STATES（ReqState 对象）和此处（string value），
 # 使 _SKIP_STATES 成为 canonical container（spec USER-S12 / watchdog skip 查询均引用此集合）。
@@ -251,6 +268,7 @@ async def _check_and_escalate(row) -> bool:
 
     # 1. 查 BKD session 状态（有 issue_id 才查）
     still_running = False
+    issue = None
     if issue_id:
         try:
             async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
@@ -315,6 +333,43 @@ async def _check_and_escalate(row) -> bool:
                 stuck_sec=stuck_sec, ended_cap=policy.ended_sec,
             )
             return False
+
+        # REQ-feat-watchdog-self-heal-1777723955：session ended 但 result tag 缺失
+        # → BKD empty-text 双 retry 用尽或 PATCH race。直接 follow-up 唤醒 agent，
+        # 不消耗 auto_retry_count，避免误 escalate 正常只差 tag 的 session。
+        # 限制：
+        #   - issue 必须能查到（BKD lookup 失败 → 保守 escalate）
+        #   - session_status 必须是 "completed"（"failed" 是真失败，走 escalate）
+        if issue is not None and issue.session_status == "completed" and state in _STAGES_NEEDING_RESULT_TAG:
+            if not _has_result_tag(issue.tags or []):
+                log.warning(
+                    "watchdog.session_ended_without_result",
+                    req_id=req_id, state=state_str,
+                    issue_id=issue_id, stuck_sec=stuck_sec,
+                )
+                try:
+                    async with BKDClient(
+                        settings.bkd_base_url, settings.bkd_token,
+                    ) as bkd:
+                        await bkd.follow_up_issue(
+                            project_id, issue_id,
+                            "Session completed but no result tag was found. "
+                            "Please review your previous work and output "
+                            "the required result tag.",
+                        )
+                    log.info(
+                        "watchdog.self_healed",
+                        req_id=req_id, state=state_str,
+                        issue_id=issue_id,
+                    )
+                    return False
+                except Exception as e:
+                    log.warning(
+                        "watchdog.self_heal_follow_up_failed",
+                        req_id=req_id, issue_id=issue_id,
+                        error=str(e),
+                    )
+                    # fall through to normal escalate
 
     # 4. 选 body.event：未列出的 state 通用 watchdog.stuck
     body_event = _STATE_FAILURE_EVENT.get(state, "watchdog.stuck")

--- a/orchestrator/tests/test_contract_watchdog_self_heal.py
+++ b/orchestrator/tests/test_contract_watchdog_self_heal.py
@@ -1,0 +1,335 @@
+"""Contract tests for REQ-feat-watchdog-self-heal-1777723955.
+
+Black-box behavioral contracts:
+  SH-S1   session ended + no result tag + stage needs result tag → follow-up self-heal
+  SH-S2   session ended + has result tag → normal escalate (not self-heal)
+  SH-S3   session ended + no result tag + stage does NOT need result tag → normal escalate
+  SH-S4   self-heal follow_up fails → fall through to normal escalate
+  SH-S5   pr-ci stage with pr-ci:timeout tag → normal escalate
+  SH-S6   session still running → skip regardless of result tags
+  SH-S7   BKD lookup fails + stage needs result tag → normal escalate
+"""
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock
+
+import pytest
+
+# ─── shared fakes ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakePool:
+    rows: list = field(default_factory=list)
+    fetch_calls: list = field(default_factory=list)
+    executed: list = field(default_factory=list)
+
+    async def fetch(self, sql, *args):
+        self.fetch_calls.append((sql, args))
+        return self.rows
+
+    async def execute(self, sql, *args):
+        self.executed.append((sql, args))
+
+
+@dataclass
+class _FakeIssue:
+    session_status: str | None = "completed"
+    id: str = "issue-1"
+    project_id: str = "proj-1"
+    issue_number: int = 0
+    title: str = ""
+    status_id: str = "todo"
+    tags: list = field(default_factory=list)
+
+
+def _make_row(state: str, *, req_id="REQ-x", project_id="proj-1",
+              ctx: dict | None = None, stuck_sec: int = 7200):
+    return {
+        "req_id": req_id,
+        "project_id": project_id,
+        "state": state,
+        "context": json.dumps(ctx or {}),
+        "stuck_sec": stuck_sec,
+    }
+
+
+def _patch_pool(monkeypatch, pool):
+    monkeypatch.setattr("orchestrator.watchdog.db.get_pool", lambda: pool)
+
+
+def _patch_bkd(monkeypatch, issue, follow_up_side_effect=None):
+    fake = AsyncMock()
+    fake.get_issue = AsyncMock(return_value=issue)
+    fake.follow_up_issue = AsyncMock(side_effect=follow_up_side_effect)
+
+    @asynccontextmanager
+    async def _ctx(*a, **kw):
+        yield fake
+
+    monkeypatch.setattr("orchestrator.watchdog.BKDClient", _ctx)
+    return fake
+
+
+def _patch_engine(monkeypatch):
+    calls: list = []
+
+    async def fake_step(pool, *, body, req_id, project_id, tags, cur_state,
+                        ctx, event, depth=0):
+        calls.append({
+            "req_id": req_id,
+            "cur_state": cur_state,
+            "event": event,
+            "body_event": getattr(body, "event", None),
+        })
+        return {}
+
+    monkeypatch.setattr("orchestrator.watchdog.engine.step", fake_step)
+    return calls
+
+
+def _patch_artifact(monkeypatch):
+    calls: list = []
+
+    async def fake_insert(pool, req_id, stage, result):
+        calls.append({"req_id": req_id, "stage": stage, "result": result})
+
+    monkeypatch.setattr(
+        "orchestrator.watchdog.artifact_checks.insert_check", fake_insert,
+    )
+    return calls
+
+
+# ─── SH-S1: session ended + no result tag → self-heal ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_s1_self_heal_no_result_tag(monkeypatch):
+    """SH-S1: CHALLENGER_RUNNING + session=completed + no result tag → follow-up。"""
+    from orchestrator import watchdog
+    from orchestrator.state import ReqState
+
+    pool = _FakePool(rows=[
+        _make_row(
+            ReqState.CHALLENGER_RUNNING.value,
+            req_id="REQ-sh1",
+            ctx={"challenger_issue_id": "ch-sh1"},
+            stuck_sec=400,
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    fake_bkd = _patch_bkd(
+        monkeypatch,
+        _FakeIssue(session_status="completed", id="ch-sh1", tags=["challenger"]),
+    )
+    step_calls = _patch_engine(monkeypatch)
+    art_calls = _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 0}, f"got {result}"
+    fake_bkd.follow_up_issue.assert_awaited_once()
+    assert step_calls == []
+    assert art_calls == []
+
+
+# ─── SH-S2: session ended + has result tag → normal escalate ────────────────
+
+
+@pytest.mark.asyncio
+async def test_s2_has_result_tag_escalates(monkeypatch):
+    """SH-S2: STAGING_TEST_RUNNING + result:fail → escalate，不 follow-up。"""
+    from orchestrator import watchdog
+    from orchestrator.state import Event, ReqState
+
+    pool = _FakePool(rows=[
+        _make_row(
+            ReqState.STAGING_TEST_RUNNING.value,
+            req_id="REQ-sh2",
+            ctx={"staging_test_issue_id": "st-sh2"},
+            stuck_sec=400,
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    fake_bkd = _patch_bkd(
+        monkeypatch,
+        _FakeIssue(session_status="completed", id="st-sh2",
+                   tags=["staging-test", "result:fail"]),
+    )
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    fake_bkd.follow_up_issue.assert_not_called()
+    assert len(step_calls) == 1
+    assert step_calls[0]["event"] == Event.SESSION_FAILED
+
+
+# ─── SH-S3: stage does NOT need result tag → normal escalate ────────────────
+
+
+@pytest.mark.asyncio
+async def test_s3_analyze_no_result_tag_escalates(monkeypatch):
+    """SH-S3: ANALYZING 不在 _STAGES_NEEDING_RESULT_TAG 中，session=completed → escalate。"""
+    from orchestrator import watchdog
+    from orchestrator.state import Event, ReqState
+
+    pool = _FakePool(rows=[
+        _make_row(
+            ReqState.ANALYZING.value,
+            req_id="REQ-sh3",
+            ctx={"intent_issue_id": "intent-sh3"},
+            stuck_sec=400,
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    fake_bkd = _patch_bkd(
+        monkeypatch,
+        _FakeIssue(session_status="completed", id="intent-sh3", tags=["analyze"]),
+    )
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    fake_bkd.follow_up_issue.assert_not_called()
+    assert step_calls[0]["event"] == Event.SESSION_FAILED
+
+
+# ─── SH-S4: follow_up fails → fall through to escalate ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_s4_follow_up_failure_falls_through(monkeypatch):
+    """SH-S4: follow_up_issue 抛异常 → 继续走正常 escalate。"""
+    from orchestrator import watchdog
+    from orchestrator.state import Event, ReqState
+
+    pool = _FakePool(rows=[
+        _make_row(
+            ReqState.FIXER_RUNNING.value,
+            req_id="REQ-sh4",
+            ctx={"fixer_issue_id": "fx-sh4"},
+            stuck_sec=400,
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    fake_bkd = _patch_bkd(
+        monkeypatch,
+        _FakeIssue(session_status="completed", id="fx-sh4", tags=["fixer"]),
+        follow_up_side_effect=RuntimeError("BKD 502"),
+    )
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    fake_bkd.follow_up_issue.assert_awaited_once()
+    assert step_calls[0]["event"] == Event.SESSION_FAILED
+
+
+# ─── SH-S5: pr-ci with pr-ci:timeout tag → escalate ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_s5_pr_ci_with_timeout_tag_escalates(monkeypatch):
+    """SH-S5: PR_CI_RUNNING + pr-ci:timeout → 有 result tag，正常 escalate。"""
+    from orchestrator import watchdog
+    from orchestrator.state import ReqState
+
+    pool = _FakePool(rows=[
+        _make_row(
+            ReqState.PR_CI_RUNNING.value,
+            req_id="REQ-sh5",
+            ctx={"pr_ci_watch_issue_id": "ci-sh5"},
+            stuck_sec=400,
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    fake_bkd = _patch_bkd(
+        monkeypatch,
+        _FakeIssue(session_status="completed", id="ci-sh5",
+                   tags=["pr-ci", "pr-ci:timeout"]),
+    )
+    _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    fake_bkd.follow_up_issue.assert_not_called()
+
+
+# ─── SH-S6: session running → skip regardless ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_s6_running_session_skips(monkeypatch):
+    """SH-S6: session=running → skip，不检查 result tag。"""
+    from orchestrator import watchdog
+    from orchestrator.state import ReqState
+
+    pool = _FakePool(rows=[
+        _make_row(
+            ReqState.CHALLENGER_RUNNING.value,
+            req_id="REQ-sh6",
+            ctx={"challenger_issue_id": "ch-sh6"},
+            stuck_sec=400,
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    fake_bkd = _patch_bkd(
+        monkeypatch,
+        _FakeIssue(session_status="running", id="ch-sh6", tags=["challenger"]),
+    )
+    step_calls = _patch_engine(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 0}
+    fake_bkd.follow_up_issue.assert_not_called()
+    assert step_calls == []
+
+
+# ─── SH-S7: BKD lookup fails → escalate ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_s7_bkd_lookup_fails_escalates(monkeypatch):
+    """SH-S7: BKD get_issue 抛异常 → issue=None → fall through escalate。"""
+    from orchestrator import watchdog
+    from orchestrator.state import Event, ReqState
+
+    pool = _FakePool(rows=[
+        _make_row(
+            ReqState.ACCEPT_RUNNING.value,
+            req_id="REQ-sh7",
+            ctx={"accept_issue_id": "ac-sh7"},
+            stuck_sec=400,
+        ),
+    ])
+    _patch_pool(monkeypatch, pool)
+    fake = AsyncMock()
+    fake.get_issue = AsyncMock(side_effect=RuntimeError("BKD 404"))
+    fake.follow_up_issue = AsyncMock()
+
+    @asynccontextmanager
+    async def _ctx(*a, **kw):
+        yield fake
+
+    monkeypatch.setattr("orchestrator.watchdog.BKDClient", _ctx)
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    fake.follow_up_issue.assert_not_called()
+    assert step_calls[0]["event"] == Event.SESSION_FAILED

--- a/orchestrator/tests/test_watchdog.py
+++ b/orchestrator/tests/test_watchdog.py
@@ -702,3 +702,193 @@ def test_challenger_running_in_state_issue_key():
     """CHALLENGER_RUNNING 必须在 _STATE_ISSUE_KEY 中以便 watchdog 能 reconcile BKD session。"""
     assert ReqState.CHALLENGER_RUNNING in watchdog._STATE_ISSUE_KEY
     assert watchdog._STATE_ISSUE_KEY[ReqState.CHALLENGER_RUNNING] == "challenger_issue_id"
+
+
+# ─── REQ-feat-watchdog-self-heal-1777723955: empty-text 双 retry 后自愈 ──────────
+
+def _patch_bkd_with_follow_up(monkeypatch, issue: FakeIssue | None,
+                              follow_up_side_effect: Exception | None = None):
+    """Mock BKDClient 带 follow_up_issue，返回 (get_issue_mock, follow_up_mock)。"""
+    fake = AsyncMock()
+    fake.get_issue = AsyncMock(return_value=issue)
+    fake_follow_up = AsyncMock(
+        side_effect=follow_up_side_effect,
+    )
+    fake.follow_up_issue = fake_follow_up
+
+    @asynccontextmanager
+    async def _ctx(*a, **kw):
+        yield fake
+
+    monkeypatch.setattr("orchestrator.watchdog.BKDClient", _ctx)
+    return fake, fake_follow_up
+
+
+@pytest.mark.asyncio
+async def test_self_heal_session_ended_without_result_tag(monkeypatch):
+    """SH-S1: CHALLENGER_RUNNING + session=completed + no result tag → follow-up, 不 escalate。"""
+    pool = FakePool(rows=[
+        _row("REQ-SH1", ReqState.CHALLENGER_RUNNING.value,
+             ctx={"challenger_issue_id": "ch-sh1", "intent_issue_id": "intent-sh1"},
+             stuck_sec=400),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _fake, follow_up_mock = _patch_bkd_with_follow_up(
+        monkeypatch, FakeIssue(session_status="completed", id="ch-sh1", tags=["challenger"]),
+    )
+    step_calls = _patch_engine(monkeypatch)
+    art_calls = _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 0}
+    assert step_calls == []
+    assert art_calls == []
+    follow_up_mock.assert_awaited_once()
+    assert "ch-sh1" in follow_up_mock.await_args[0]
+
+
+@pytest.mark.asyncio
+async def test_self_heal_skips_when_result_tag_present(monkeypatch):
+    """SH-S2: CHALLENGER_RUNNING + session=completed + has result:pass → 正常 escalate。"""
+    pool = FakePool(rows=[
+        _row("REQ-SH2", ReqState.CHALLENGER_RUNNING.value,
+             ctx={"challenger_issue_id": "ch-sh2", "intent_issue_id": "intent-sh2"},
+             stuck_sec=400),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _fake, follow_up_mock = _patch_bkd_with_follow_up(
+        monkeypatch,
+        FakeIssue(session_status="completed", id="ch-sh2",
+                  tags=["challenger", "result:pass"]),
+    )
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    assert len(step_calls) == 1
+    follow_up_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_self_heal_skips_for_analyze_stage(monkeypatch):
+    """SH-S3: ANALYZING 不需要 result tag，session=completed → 正常 escalate。"""
+    pool = FakePool(rows=[
+        _row("REQ-SH3", ReqState.ANALYZING.value,
+             ctx={"intent_issue_id": "intent-sh3"},
+             stuck_sec=400),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _fake, follow_up_mock = _patch_bkd_with_follow_up(
+        monkeypatch,
+        FakeIssue(session_status="completed", id="intent-sh3", tags=["analyze"]),
+    )
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    assert len(step_calls) == 1
+    follow_up_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_self_heal_falls_back_to_escalate_on_follow_up_failure(monkeypatch):
+    """SH-S4: follow_up_issue 抛异常 → fall through 到正常 escalate。"""
+    pool = FakePool(rows=[
+        _row("REQ-SH4", ReqState.STAGING_TEST_RUNNING.value,
+             ctx={"staging_test_issue_id": "st-sh4", "intent_issue_id": "intent-sh4"},
+             stuck_sec=400),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _fake, follow_up_mock = _patch_bkd_with_follow_up(
+        monkeypatch,
+        FakeIssue(session_status="completed", id="st-sh4", tags=["staging-test"]),
+        follow_up_side_effect=RuntimeError("BKD 502"),
+    )
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    assert len(step_calls) == 1
+    follow_up_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_self_heal_pr_ci_with_pr_ci_timeout_tag_escalates(monkeypatch):
+    """SH-S5: PR_CI_RUNNING + pr-ci:timeout tag → 有 result tag，正常 escalate。"""
+    pool = FakePool(rows=[
+        _row("REQ-SH5", ReqState.PR_CI_RUNNING.value,
+             ctx={"pr_ci_watch_issue_id": "ci-sh5", "intent_issue_id": "intent-sh5"},
+             stuck_sec=400),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _fake, follow_up_mock = _patch_bkd_with_follow_up(
+        monkeypatch,
+        FakeIssue(session_status="completed", id="ci-sh5",
+                  tags=["pr-ci", "pr-ci:timeout"]),
+    )
+    _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    follow_up_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_self_heal_running_session_not_affected(monkeypatch):
+    """SH-S6: session still running → 原逻辑不变，skip。"""
+    pool = FakePool(rows=[
+        _row("REQ-SH6", ReqState.CHALLENGER_RUNNING.value,
+             ctx={"challenger_issue_id": "ch-sh6", "intent_issue_id": "intent-sh6"},
+             stuck_sec=400),
+    ])
+    _patch_pool(monkeypatch, pool)
+    _fake, follow_up_mock = _patch_bkd_with_follow_up(
+        monkeypatch,
+        FakeIssue(session_status="running", id="ch-sh6", tags=["challenger"]),
+    )
+    step_calls = _patch_engine(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 0}
+    assert step_calls == []
+    follow_up_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_self_heal_bkd_lookup_falls_back_to_escalate(monkeypatch):
+    """SH-S7: BKD get_issue 抛异常（issue=None）+ stage 需要 result tag → fall through escalate。"""
+    pool = FakePool(rows=[
+        _row("REQ-SH7", ReqState.ACCEPT_RUNNING.value,
+             ctx={"accept_issue_id": "ac-sh7", "intent_issue_id": "intent-sh7"},
+             stuck_sec=400),
+    ])
+    _patch_pool(monkeypatch, pool)
+    fake = AsyncMock()
+    fake.get_issue = AsyncMock(side_effect=RuntimeError("BKD 404"))
+    follow_up_mock = AsyncMock()
+    fake.follow_up_issue = follow_up_mock
+
+    @asynccontextmanager
+    async def _ctx(*a, **kw):
+        yield fake
+
+    monkeypatch.setattr("orchestrator.watchdog.BKDClient", _ctx)
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    assert len(step_calls) == 1
+    # issue 查不到时 follow_up 也会失败，所以不会调用
+    follow_up_mock.assert_not_called()


### PR DESCRIPTION
## Summary

BKD agent session 出现 empty-text 双 retry 用尽后，result tag 可能因 race condition 未及时 PATCH，导致 sisyphus 状态卡在 *_RUNNING。watchdog 原有路径只能等 `ended_sec`（5min）后 escalate，且会消耗 `auto_retry_count`。

本 PR 在 watchdog 层新增 **session-ended-without-result 自愈快道**：
- 检测到 BKD `session_status=completed` 但 issue 无 `result:*` / `pr-ci:*` tag 时
- 直接 `follow_up_issue` 唤醒 agent，**不消耗 `auto_retry_count`**
- 不误伤正常 running session，不误杀 session=failed 的真失败场景

## 关键约束

1. **issue 必须能查到**（BKD lookup 失败 → 保守 escalate）
2. **`session_status` 必须是 `completed`**（`failed` → 走原有 escalate）
3. **仅对需要 result tag 的 stage 生效**（analyze / spec_lint / dev_cross_check 排除）

## 测试覆盖

- `test_watchdog.py`：7 个新增单测
- `test_contract_watchdog_self_heal.py`：7 个新增合约测试（SH-S1..S7）
- 全部 69 个 watchdog 相关测试通过，ruff lint 通过

## 关联

- Closes #279