### PR TITLE
fix(deploy): DB migration 多副本安全锁

### DIFF
--- a/orchestrator/helm/templates/deployment.yaml
+++ b/orchestrator/helm/templates/deployment.yaml
@@ -28,6 +28,35 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.migrations.enabled }}
+      initContainers:
+        - name: migrations
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            - sh
+            - -c
+            - |
+              python -c "
+              from orchestrator.migrate import apply_pending
+              import os
+              apply_pending(
+                  os.environ['SISYPHUS_PG_DSN'],
+                  lock_timeout=int(os.environ.get('SISYPHUS_MIGRATION_LOCK_TIMEOUT', '300'))
+              )
+              "
+          envFrom:
+            - configMapRef:
+                name: {{ include "orchestrator.fullname" . }}
+          env:
+            {{- include "orchestrator.pgDsnEnv" . | nindent 12 }}
+            - name: SISYPHUS_MIGRATION_LOCK_TIMEOUT
+              value: {{ .Values.migrations.timeout | quote }}
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+      {{- end }}
       containers:
         - name: orchestrator
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -77,6 +106,11 @@ spec:
               value: {{ .Values.runner.kvmEnabled | default false | quote }}
             - name: SISYPHUS_K8S_IN_CLUSTER
               value: "true"
+            # init-container 已跑 migration 时主容器跳过，避免重复竞争锁
+            - name: SISYPHUS_SKIP_MIGRATION_ON_STARTUP
+              value: {{ .Values.migrations.enabled | quote }}
+            - name: SISYPHUS_MIGRATION_LOCK_TIMEOUT
+              value: {{ .Values.migrations.timeout | quote }}
           livenessProbe:
             httpGet:
               path: {{ .Values.probes.liveness.path }}

--- a/orchestrator/helm/values.yaml
+++ b/orchestrator/helm/values.yaml
@@ -65,6 +65,14 @@ resources:
 # 跑 yoyo apply 用的初始化 init-container（同样的镜像）
 migrations:
   enabled: true
+  timeout: 300
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
 
 # ─── 业务配置（注入 SISYPHUS_* env）──────────────────────────────────────
 env:

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -90,6 +90,13 @@ class Settings(BaseSettings):
     # Postgres
     pg_dsn: str = Field(..., description="postgresql://user:pass@host:5432/sisyphus")
 
+    # ─── DB migration 控制 ─────────────────────────────────────────────────
+    # True = startup 跳过 yoyo migration（helm init-container 已跑完）
+    skip_migration_on_startup: bool = False
+    # yoyo 分布式锁等待超时（秒）。默认 300s，防止 K8s 多副本同时启动时
+    # 排队 Pod 因 yoyo 默认 10s 超时 crashloop。
+    migration_lock_timeout: int = 300
+
     # 可观测性 DB（schema 见 observability/schema.sql，独立 db sisyphus_obs）
     # 留空 = 关闭观测写入和快照同步（dev 模式可不开）
     obs_pg_dsn: str = ""

--- a/orchestrator/src/orchestrator/main.py
+++ b/orchestrator/src/orchestrator/main.py
@@ -42,7 +42,9 @@ _bg_tasks: list[asyncio.Task] = []
 @app.on_event("startup")
 async def startup() -> None:
     # 1. 跑 schema 迁移（同步，启动时一次性）
-    apply_pending(settings.pg_dsn)
+    #    helm init-container 负责时跳过，避免与 init-container 重复竞争锁
+    if not settings.skip_migration_on_startup:
+        apply_pending(settings.pg_dsn, lock_timeout=settings.migration_lock_timeout)
     # 2. 起业务 pool + observability pool（obs DSN 空就跳过）
     await db.init_pool(settings.pg_dsn)
     await db.init_obs_pool(settings.obs_pg_dsn)

--- a/orchestrator/src/orchestrator/migrate.py
+++ b/orchestrator/src/orchestrator/migrate.py
@@ -41,11 +41,19 @@ def _resolve_default_dir() -> Path:
 _DEFAULT_MIGRATIONS_DIR = _resolve_default_dir()
 
 
-def apply_pending(dsn: str, migrations_dir: Path | None = None) -> int:
+def apply_pending(
+    dsn: str,
+    migrations_dir: Path | None = None,
+    *,
+    lock_timeout: int = 300,
+) -> int:
     """同步跑所有未 apply 的迁移。返回新 apply 的迁移数。
 
     yoyo 用 psycopg2 同步 driver；因为只在启动时跑一次，没必要 async。
     DSN 必须是 yoyo 支持的形式，`postgresql://...` 直接可用。
+
+    :param lock_timeout: yoyo 分布式锁等待超时（秒）。默认 300s，防止多副本
+        K8s Deployment 同时启动时排队 Pod 因 10s 默认超时 crashloop。
     """
     path = migrations_dir or _DEFAULT_MIGRATIONS_DIR
     if not path.is_dir():
@@ -53,7 +61,7 @@ def apply_pending(dsn: str, migrations_dir: Path | None = None) -> int:
         return 0
 
     backend = get_backend(dsn)
-    with backend.lock():
+    with backend.lock(timeout=lock_timeout):
         migrations = backend.to_apply(read_migrations(str(path)))
         if not migrations:
             log.info("migrate.up_to_date", dir=str(path))

--- a/orchestrator/tests/test_contract_accept_env_gc.py
+++ b/orchestrator/tests/test_contract_accept_env_gc.py
@@ -614,7 +614,7 @@ async def test_aegc_s13_startup_starts_loop_when_controller_ok_and_interval_posi
     from orchestrator import k8s_runner
 
     monkeypatch.setattr(main_mod, "_bg_tasks", [])
-    monkeypatch.setattr("orchestrator.main.apply_pending", lambda dsn: None)
+    monkeypatch.setattr("orchestrator.main.apply_pending", lambda *a, **kw: None)
     monkeypatch.setattr("orchestrator.main.db.init_pool", AsyncMock())
     monkeypatch.setattr("orchestrator.main.db.init_obs_pool", AsyncMock())
     monkeypatch.setattr("orchestrator.main.settings.accept_env_gc_interval_sec", 900)
@@ -665,7 +665,7 @@ async def test_aegc_s14_startup_skips_loop_when_controller_fails(monkeypatch):
     import orchestrator.main as main_mod
 
     monkeypatch.setattr(main_mod, "_bg_tasks", [])
-    monkeypatch.setattr("orchestrator.main.apply_pending", lambda dsn: None)
+    monkeypatch.setattr("orchestrator.main.apply_pending", lambda *a, **kw: None)
     monkeypatch.setattr("orchestrator.main.db.init_pool", AsyncMock())
     monkeypatch.setattr("orchestrator.main.db.init_obs_pool", AsyncMock())
     monkeypatch.setattr("orchestrator.main.settings.accept_env_gc_interval_sec", 900)


### PR DESCRIPTION
## Summary
- closes #257
- 修复 sisyphus orchestrator 多副本启动时 DB migration 冲突问题。

## 改动
- **migrate.py**: `apply_pending` 增加 `lock_timeout` 参数（默认 300s），覆盖 yoyo 默认 10s 超时，防止多副本排队时 crashloop。
- **config.py**: 新增 `skip_migration_on_startup` / `migration_lock_timeout`。
- **main.py**: startup 支持跳过 migration（init-container 已跑完时）。
- **helm/deployment.yaml**: 加 init container 跑 migration，主容器通过 `SISYPHUS_SKIP_MIGRATION_ON_STARTUP` 避免重复竞争锁。
- **helm/values.yaml**: `migrations` 段补充 `timeout` / `resources`。
- 更新 accept_env_gc mock 以适配新签名。

## 验证
- 单测通过: `pytest -m 'not integration'` 1991 passed
- ruff lint: all passed
- helm template 渲染正常，`initContainers` 段在 `.Values.migrations.enabled=true` 时出现

🤖 Generated with [Claude Code](https://claude.com/claude-code)