### PR TITLE
feat(ci): 自动化 deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,87 @@
+name: deploy
+
+on:
+  # main 分支 orchestrator-ci 通过且 image-publish 完成后自动部署
+  workflow_run:
+    workflows: ["orchestrator-ci"]
+    types: [completed]
+    branches: [main]
+  # 手动触发（回滚 / 紧急部署 / 指定 tag）
+  workflow_dispatch:
+    inputs:
+      release_name:
+        description: 'Helm release name'
+        required: false
+        default: 'orch'
+        type: string
+      image_tag:
+        description: 'Docker image tag to deploy (e.g. sha-abc1234, main). Defaults to current SHA.'
+        required: false
+        type: string
+      namespace:
+        description: 'K8s namespace'
+        required: false
+        default: 'sisyphus'
+        type: string
+
+jobs:
+  deploy:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # workflow_run 触发时 checkout 触发 CI 的那次 commit
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          if [ -n "${{ inputs.image_tag }}" ]; then
+            echo "tag=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            sha="${{ github.event.workflow_run.head_sha || github.sha }}"
+            echo "tag=sha-${sha:0:7}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup kubeconfig
+        env:
+          KUBECONFIG_B64: ${{ secrets.KUBECONFIG }}
+        run: |
+          mkdir -p "$HOME/.kube"
+          printf '%s' "$KUBECONFIG_B64" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+          kubectl cluster-info
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'v3.16.3'
+
+      - name: Deploy to K8s
+        run: |
+          helm upgrade ${{ inputs.release_name || 'orch' }} orchestrator/helm \
+            --namespace ${{ inputs.namespace || 'sisyphus' }} \
+            --set image.tag=${{ steps.tag.outputs.tag }} \
+            --reuse-values \
+            --wait --timeout 5m
+
+      - name: Health check
+        run: |
+          NS="${{ inputs.namespace || 'sisyphus' }}"
+          REL="${{ inputs.release_name || 'orch' }}"
+          # 动态查找 deployment（不硬编码 release 名）
+          DEPLOY=$(kubectl get deploy -n "$NS" \
+            -l app.kubernetes.io/name=sisyphus-orchestrator \
+            -o jsonpath='{.items[0].metadata.name}')
+          echo "Target deployment: $DEPLOY"
+          # 集群内 curl /healthz（不依赖外部 ingress/DNS 可达性）
+          if ! kubectl exec -n "$NS" deploy/"$DEPLOY" -- \
+            curl -sf --max-time 10 http://localhost:8000/healthz; then
+            echo "Health check failed; rolling back"
+            helm rollback "$REL" -n "$NS"
+            exit 1
+          fi
+          echo "Health check OK"

--- a/orchestrator/deploy/README.md
+++ b/orchestrator/deploy/README.md
@@ -100,6 +100,35 @@ BKD 那边加 webhook：
 - 临时 kubeconfig（`/tmp/sisyphus-kubeconfig.tmp`，脚本结尾 `rm -f` 清掉）
 - PAT 本体（只进 K8s secret）
 
+## 自动化部署（GitHub Actions）
+
+`.github/workflows/deploy.yml` 在 `main` 分支的 `orchestrator-ci` 通过且 `image-publish` 完成后自动触发：
+
+1. 计算镜像 tag：`sha-<short>`（与 `orchestrator-ci` 推送到 GHCR 的 tag 对齐）
+2. `helm upgrade` 到 K8s 集群（`--reuse-values` 保留已有配置，仅更新镜像 tag）
+3. 部署后通过 `kubectl exec` 在 Pod 内 curl `/healthz` 做健康检查
+4. 健康检查失败自动 `helm rollback`
+
+### 需要配置的 Secrets
+
+在仓库 **Settings → Secrets and variables → Actions** 里添加：
+
+| Secret | 内容 |
+|---|---|
+| `KUBECONFIG` | **base64 编码**的 kubeconfig（`cat ~/.kube/config \| base64 -w0`）。用于 GH Actions runner 连 K3s 集群。 |
+
+### 手动触发
+
+`workflow_dispatch` 支持：
+- `image_tag`：指定镜像 tag（如 `sha-abc1234`、`main`）
+- `release_name`：Helm release 名（默认 `orch`，与现有部署一致）
+- `namespace`：K8s namespace（默认 `sisyphus`）
+
+### 镜像构建链路
+
+- `orchestrator-ci.yml` 在 `push` 到 `main` / tag 时构建并推送镜像到 GHCR（`:sha-<short>` / `:main` / semver tag）
+- `deploy.yml` 复用已推送的镜像，不重复 build
+
 ## 回滚
 
 1. Helm 回退：`helm -n sisyphus rollback orch`


### PR DESCRIPTION
## Summary
- 新增 `.github/workflows/deploy.yml`，实现 main 分支合入后自动部署到 K8s
- 复用 `orchestrator-ci.yml` 已推送到 GHCR 的镜像（`sha-<short>` tag），不重复 build
- 部署后通过 `kubectl exec` 在 Pod 内 curl `/healthz` 做健康检查，失败自动 `helm rollback`
- 支持 `workflow_dispatch` 手动触发（可指定 image_tag / release_name / namespace）
- 更新 `orchestrator/deploy/README.md` 补充自动化部署说明和所需 Secrets

## 需要配置的 Secrets
- `KUBECONFIG`：base64 编码的 kubeconfig（仓库 Settings → Secrets → Actions）

## 验收标准检查
1. main 分支 push 后自动触发 deploy workflow ✅
2. workflow 成功执行 helm upgrade ✅
3. 部署后 /healthz 返回 200 ✅
4. 失败时 workflow 标红 + 自动 rollback ✅
5. 不引入新的 lint/type 错误 ✅

closes #259