### PR TITLE
refactor(state): apply_verify_pass 自循环拆显式 transition

### DIFF
--- a/orchestrator/src/orchestrator/actions/_verifier.py
+++ b/orchestrator/src/orchestrator/actions/_verifier.py
@@ -5,11 +5,9 @@ issue，让它做主观判断 —— 3 路决策：**pass / fix / escalate**。v
 webhook.py 解析 decision JSON，映射成 Event 推状态机。
 
 本模块只管"起 issue + 挂 prompt"：同步返回 verifier_issue_id，不等决策
-（异步走 session.completed webhook）。决策 → Event 映射在 webhook.py。
+（异步走 session.completed webhook）。决策 → Event 映射在 router.py。
 
 同时提供 action handler：
-- `apply_verify_pass`：decision=pass → 手工 CAS 回 stage_running + 链式 emit
-   对应 stage 的 done/pass 事件（走原主链 transition）
 - `start_fixer`：decision=fix → 起 fixer agent（dev / spec）
 - `invoke_verifier_after_fix`：fixer 完 → 再调 verifier 复查
 - `invoke_verifier_for_staging_test_fail` / `_pr_ci_fail` / `_accept_fail`：
@@ -21,6 +19,10 @@ webhook.py 解析 decision JSON，映射成 Event 推状态机。
 兜 retry —— 避免假阳性 retry 死循环 + 跟"薄编排，不抢 AI 决定权"哲学一致。
 
 M14c：verifier_enabled 默认 True，旧 fail_kind / bugfix 子链已砍。
+
+REQ-refactor-verify-pass-transition-1777727230：
+apply_verify_pass 已删，decision=pass 由 router 译成对应主链 pass 事件
+（如 STAGING_TEST_PASS），transition 表显式写死 REVIEW_RUNNING → next_state。
 """
 from __future__ import annotations
 
@@ -28,7 +30,7 @@ from typing import Literal
 
 import structlog
 
-from .. import k8s_runner, pr_links
+from .. import pr_links
 from ..bkd import BKDClient
 from ..config import settings
 from ..prompts import render
@@ -58,21 +60,6 @@ _RETRY_ROUTING: dict[str, tuple[ReqState, str]] = {
     "pr_ci":           (ReqState.PR_CI_RUNNING,           "create_pr_ci_watch"),
 }
 
-# stage → decision=pass 时要 emit 的原主链 event + 目标 stage_running state
-# 用于 apply_verify_pass 手工把 state 从 REVIEW_RUNNING 回推到对应 stage_running，
-# 随后链式 emit 该 stage 的 done/pass 事件走原 transition。
-_PASS_ROUTING: dict[str, tuple[ReqState, Event]] = {
-    "analyze":                 (ReqState.ANALYZING,                Event.ANALYZE_DONE),
-    "analyze_artifact_check":  (ReqState.ANALYZE_ARTIFACT_CHECKING,
-                                Event.ANALYZE_ARTIFACT_CHECK_PASS),
-    "spec_lint":               (ReqState.SPEC_LINT_RUNNING,        Event.SPEC_LINT_PASS),
-    "challenger":              (ReqState.CHALLENGER_RUNNING,       Event.CHALLENGER_PASS),
-    "dev_cross_check":         (ReqState.DEV_CROSS_CHECK_RUNNING,  Event.DEV_CROSS_CHECK_PASS),
-    "staging_test":            (ReqState.STAGING_TEST_RUNNING,     Event.STAGING_TEST_PASS),
-    "pr_ci":                   (ReqState.PR_CI_RUNNING,            Event.PR_CI_PASS),
-    "accept":                  (ReqState.ACCEPT_RUNNING,           Event.ACCEPT_PASS),
-}
-
 # prompt template stage 名 → artifact_checks.stage DB 值
 _STAGE_TO_DB: dict[str, str] = {
     "spec_lint":              "spec-lint",
@@ -93,7 +80,6 @@ def _tail_lines(text: str | None, n: int = _CHECKER_TAIL_LINES) -> str:
     if len(lines) <= n:
         return text
     return "\n".join(lines[-n:])
-
 # ─── invoke_verifier：起 BKD verifier issue ──────────────────────────────
 
 async def invoke_verifier(
@@ -225,69 +211,6 @@ def _stage_from_tags_or_ctx(tags: list[str] | None, ctx: dict | None) -> str | N
         if t.startswith("verify:"):
             return t.removeprefix("verify:")
     return (ctx or {}).get("verifier_stage")
-
-
-@register("apply_verify_pass", idempotent=True)
-async def apply_verify_pass(*, body, req_id, tags, ctx):
-    """decision=pass：读 verifier issue 的 verify:<stage> tag，手工 CAS REVIEW_RUNNING
-    → stage_running，链式 emit 该 stage 的 done/pass 事件（走原主链 transition）。
-    """
-    stage = _stage_from_tags_or_ctx(tags, ctx)
-    route = _PASS_ROUTING.get(stage) if stage else None
-    if route is None:
-        log.error("apply_verify_pass.unknown_stage", req_id=req_id, stage=stage)
-        return {"emit": Event.VERIFY_ESCALATE.value,
-                "reason": f"unknown verifier_stage: {stage!r}"}
-
-    target_state, next_event = route
-    pool = db.get_pool()
-    # CAS 接 REVIEW_RUNNING（正常 verifier 完成）+ ESCALATED（人续 escalate 的 verifier）
-    src_state = None
-    for src in (ReqState.REVIEW_RUNNING, ReqState.ESCALATED):
-        if await req_state.cas_transition(
-            pool, req_id, src, target_state,
-            Event.VERIFY_PASS, "apply_verify_pass",
-        ):
-            src_state = src
-            break
-    if src_state is None:
-        log.warning("apply_verify_pass.cas_failed", req_id=req_id, stage=stage)
-        return {"cas_failed": True}
-
-    # 收尾 stage_runs.verifier 行（best-effort）。
-    # transition (REVIEW_RUNNING, VERIFY_PASS) -> REVIEW_RUNNING 是 self-loop —
-    # engine._record_stage_transitions 看到 cur==next 直接 return，**不写**
-    # stage_runs；这里手 CAS 推到 target_state 也绕过 engine 的钩子。结果是
-    # verifier 行 insert 后没人 close（DB 实证：18 条 outcome=NULL，污染
-    # Metabase 的 stage_stats / agent_quality 看板）。
-    # 仅 src=REVIEW_RUNNING 路径需要 close（ESCALATED 续是 self-loop 重入，
-    # 上一轮 verifier 行已被前次 escalate 路径关掉，不会有新的 open verifier 行）。
-    if src_state == ReqState.REVIEW_RUNNING:
-        try:
-            await stage_runs.close_latest_stage_run(
-                pool, req_id, "verifier", outcome="pass",
-            )
-        except Exception as e:
-            log.warning("apply_verify_pass.stage_runs.close_failed",
-                        req_id=req_id, error=str(e))
-
-    # 推下一 stage 前 ensure_runner（idempotent，pod 在则秒返）。
-    # 关键场景：从 ESCALATED 续 → escalate 时 runner pod 被删了；fixer 跑完续也可能没 pod。
-    # PVC 因 #40 retain，workspace 状态不丢。
-    try:
-        rc = k8s_runner.get_controller()
-    except RuntimeError:
-        log.warning("apply_verify_pass.no_runner_controller", req_id=req_id)
-    else:
-        pod = await rc.ensure_runner(req_id, wait_ready=True)
-        log.info("apply_verify_pass.runner_ready",
-                 req_id=req_id, stage=stage, pod=pod, src_state=src_state.value)
-
-    log.info("apply_verify_pass.done",
-             req_id=req_id, stage=stage,
-             src_state=src_state.value, target_state=target_state.value,
-             emit=next_event.value)
-    return {"emit": next_event.value, "stage": stage}
 
 
 @register("start_fixer", idempotent=False)
@@ -604,7 +527,7 @@ async def apply_verify_infra_retry(*, body, req_id, tags, ctx):
         log.warning("apply_verify_infra_retry.cas_failed", req_id=req_id, stage=stage)
         return {"cas_failed": True}
 
-    # close verifier stage_run（同 apply_verify_pass 的模式）
+    # close verifier stage_run（离开 REVIEW_RUNNING 时收尾）
     try:
         await stage_runs.close_latest_stage_run(
             pool, req_id, "verifier", outcome="infra-retry",

--- a/orchestrator/src/orchestrator/admin.py
+++ b/orchestrator/src/orchestrator/admin.py
@@ -37,6 +37,7 @@ from fastapi import APIRouter, Header, HTTPException
 from pydantic import BaseModel
 
 from . import accept_env_gc, engine, k8s_runner, runner_gc
+from . import router as router_lib
 from .bkd import BKDClient
 from .config import settings
 from .state import Event, ReqState
@@ -314,7 +315,7 @@ async def resume_req(
     """从 ESCALATED 派 verifier 决策 Event，走合法 transition 推进状态机。
 
     跟 BKD verifier follow-up 路径并行：两条路径都最终命中
-    `(ESCALATED, VERIFY_PASS) → REVIEW_RUNNING (apply_verify_pass)` 或
+    `(ESCALATED, <stage>_PASS) → <next_stage>_RUNNING`（显式 transition）或
     `(ESCALATED, VERIFY_FIX_NEEDED) → FIXER_RUNNING (start_fixer)`，
     区别仅在事件来源（BKD verifier 路径有 verifier_decisions 行；admin
     路径靠 ctx.resumed_by_admin 标识）。
@@ -341,8 +342,8 @@ async def resume_req(
             ),
         )
 
-    # action=pass 必须有可路由的 verifier_stage（apply_verify_pass 拿不到会
-    # emit VERIFY_ESCALATE 走自循环，对调用方静默 —— 早 fail 给清晰错误）。
+    # action=pass 必须有可路由的 verifier_stage（pass_event_for_stage 拿不到 stage
+    # 会回退 VERIFY_PASS，而 transition 表已无 VERIFY_PASS → 引擎 skip；早 fail 给清晰错误）。
     effective_stage = body.stage or (row.context or {}).get("verifier_stage")
     if body.action == "pass" and not effective_stage:
         raise HTTPException(
@@ -371,9 +372,18 @@ async def resume_req(
     if row is None:  # 极小概率：admin 调用前并发删 row
         raise HTTPException(status_code=404, detail=f"req {req_id} not found")
 
-    event = (
-        Event.VERIFY_PASS if body.action == "pass" else Event.VERIFY_FIX_NEEDED
-    )
+    if body.action == "pass":
+        event = router_lib.pass_event_for_stage(effective_stage)
+        if event is None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"unknown verifier stage {effective_stage!r} for action=pass; "
+                    f"known stages: {list(router_lib._VERIFY_PASS_ROUTING.keys())}"
+                ),
+            )
+    else:
+        event = Event.VERIFY_FIX_NEEDED
     fake = _FakeBody(req_id, row.project_id)
     log.warning(
         "admin.resume",

--- a/orchestrator/src/orchestrator/engine.py
+++ b/orchestrator/src/orchestrator/engine.py
@@ -100,23 +100,9 @@ async def _record_stage_transitions(
 
     - 离开 *_RUNNING（cur ≠ next）→ close 上条 run（按事件映射 outcome）
     - 进入 *_RUNNING（cur ≠ next）→ open 新一条 run
-    - 自循环（mark_*_reviewed_and_check / apply_verify_pass 等）不动
+    - 自循环不动
     任何错误只 log 不抛，避免拖垮主流程。
-
-    例外：(REVIEW_RUNNING, VERIFY_PASS) 是 transition 表声明的 self-loop，但
-    apply_verify_pass action 内部手工 CAS 把 state 推到 target stage_running，那条手工
-    CAS 绕过本函数。如果不在这里显式 close verifier 那条 run，stage_runs 会留 orphan
-    （ended_at IS NULL），Q12/Q13 verifier 看板漏掉 PASS 决策。
     """
-    if cur_state == ReqState.REVIEW_RUNNING and event == Event.VERIFY_PASS:
-        try:
-            await stage_runs.close_latest_stage_run(
-                pool, req_id, "verifier", outcome="pass",
-            )
-        except Exception as e:
-            log.warning("engine.stage_runs.write_failed",
-                        req_id=req_id, cur=cur_state.value, nxt=next_state.value,
-                        evt=event.value, error=str(e))
     if cur_state == next_state:
         return
     try:
@@ -348,9 +334,8 @@ async def step(
     )
 
     # M10：转 terminal state 时立即清 runner（fire-and-forget）。
-    # 但跳过 terminal self-loop（cur 已是 terminal）—— 出现在 ESCALATED 接 verifier 续 follow-up
-    # 的场景：engine 表面 self-loop，apply_verify_pass 内部把 state CAS 推到下游 stage_running
-    # 并 ensure_runner；这时再清 pod 会误删 resume 路径刚拉起的 pod。
+    # 但跳过 terminal self-loop（cur 已是 terminal）—— ESCALATED + VERIFY_ESCALATE
+    # 是 no-op 自循环，不应重复清 runner（首次进 ESCALATED 时已清过）。
     if (transition.next_state in _TERMINAL_STATES
             and cur_state not in _TERMINAL_STATES):
         task = asyncio.create_task(

--- a/orchestrator/src/orchestrator/router.py
+++ b/orchestrator/src/orchestrator/router.py
@@ -78,11 +78,38 @@ def validate_audit_soft(audit: dict | None) -> str | None:
     return None
 
 
-def decision_to_event(decision: dict) -> Event:
-    """合规 decision → Event。调用前必须先跑 validate_decision。"""
+# verifier decision=pass 时 stage → 对应主链 pass 事件
+#（REQ-refactor-verify-pass-transition-1777727230：把 apply_verify_pass 自循环拆成
+# 显式 transition，router 负责在 decision 解析层做事件映射）。
+_VERIFY_PASS_ROUTING: dict[str, Event] = {
+    "analyze":                Event.ANALYZE_DONE,
+    "analyze_artifact_check": Event.ANALYZE_ARTIFACT_CHECK_PASS,
+    "spec_lint":              Event.SPEC_LINT_PASS,
+    "challenger":             Event.CHALLENGER_PASS,
+    "dev_cross_check":        Event.DEV_CROSS_CHECK_PASS,
+    "staging_test":           Event.STAGING_TEST_PASS,
+    "pr_ci":                  Event.PR_CI_PASS,
+    "accept":                 Event.ACCEPT_PASS,
+}
+
+
+def pass_event_for_stage(stage: str | None) -> Event | None:
+    """verifier decision=pass 时，按 stage 返回对应主链 pass 事件。
+
+    None 表示 stage 不在已知路由表（应 escalate）。
+    """
+    return _VERIFY_PASS_ROUTING.get(stage) if stage else None
+
+
+def decision_to_event(decision: dict, stage: str | None = None) -> Event:
+    """合规 decision → Event。调用前必须先跑 validate_decision。
+
+    stage 只在 action=pass 时使用；缺省或未知 stage 时回退 VERIFY_PASS
+   （调用方应检查 None 并 escalate）。
+    """
     action = decision["action"]
     if action == "pass":
-        return Event.VERIFY_PASS
+        return pass_event_for_stage(stage) or Event.VERIFY_PASS
     if action == "fix":
         return Event.VERIFY_FIX_NEEDED
     if action == "retry":
@@ -102,6 +129,13 @@ def derive_verifier_event(
     """
     event, decision, reason, _ = derive_verifier_event_with_retry_info(description, tags)
     return event, decision, reason
+
+
+def _stage_from_tags(tags: Iterable[str] | None) -> str | None:
+    for t in (tags or []):
+        if t.startswith("verify:"):
+            return t.removeprefix("verify:")
+    return None
 
 
 def derive_verifier_event_with_retry_info(
@@ -128,7 +162,11 @@ def derive_verifier_event_with_retry_info(
     ok, why = validate_decision(decision)
     if not ok:
         return Event.VERIFY_ESCALATE, decision, f"invalid decision: {why}", True
-    return decision_to_event(decision), decision, "", False
+    stage = _stage_from_tags(tags)
+    event = decision_to_event(decision, stage=stage)
+    if event == Event.VERIFY_PASS:
+        return Event.VERIFY_ESCALATE, decision, f"unknown verifier stage: {stage!r}", False
+    return event, decision, "", False
 
 
 def extract_decision_from_issue(

--- a/orchestrator/src/orchestrator/state.py
+++ b/orchestrator/src/orchestrator/state.py
@@ -232,13 +232,35 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
 
     # ─── verifier 子链 ─────────────────────────────────────────────────
     # verifier-agent 完成 → webhook 解 decision JSON → emit 对应事件。
-    # 注意：VERIFY_PASS 的目标 stage 由 ctx.verifier_stage 决定 —— transition 表无法静态表达
-    # next_state 随 stage 变化，所以 apply_verify_pass action 内部手工 CAS 到对应 stage_running
-    # 再链式 emit 该 stage 的 done/pass 事件（走原主链 transition）。
+    # VERIFY_PASS 拆成 N 条显式 transition（REQ-refactor-verify-pass-transition-1777727230）：
+    # router/webhook 根据 ctx.verifier_stage 把 decision=pass 映射成该 stage 的主链
+    # pass 事件（如 verify:staging_test → STAGING_TEST_PASS），transition 表直接写死
+    # REVIEW_RUNNING → 对应 next_state，不再靠 apply_verify_pass 内部手工 CAS。
     # 4 路决策：pass / fix / escalate / retry（infra-flake 有界重跑，超 cap → escalate）
-    (ReqState.REVIEW_RUNNING, Event.VERIFY_PASS):
-        Transition(ReqState.REVIEW_RUNNING, "apply_verify_pass",
-                   "decision=pass → action 读 stage 手动推进"),
+    (ReqState.REVIEW_RUNNING, Event.ANALYZE_DONE):
+        Transition(ReqState.ANALYZE_ARTIFACT_CHECKING, "create_analyze_artifact_check",
+                   "verifier decision=pass (analyze) → 走 analyze done 后 artifact check"),
+    (ReqState.REVIEW_RUNNING, Event.ANALYZE_ARTIFACT_CHECK_PASS):
+        Transition(ReqState.SPEC_LINT_RUNNING, "create_spec_lint",
+                   "verifier decision=pass (analyze_artifact_check) → spec lint"),
+    (ReqState.REVIEW_RUNNING, Event.SPEC_LINT_PASS):
+        Transition(ReqState.CHALLENGER_RUNNING, "start_challenger",
+                   "verifier decision=pass (spec_lint) → challenger"),
+    (ReqState.REVIEW_RUNNING, Event.CHALLENGER_PASS):
+        Transition(ReqState.DEV_CROSS_CHECK_RUNNING, "create_dev_cross_check",
+                   "verifier decision=pass (challenger) → dev cross check"),
+    (ReqState.REVIEW_RUNNING, Event.DEV_CROSS_CHECK_PASS):
+        Transition(ReqState.STAGING_TEST_RUNNING, "create_staging_test",
+                   "verifier decision=pass (dev_cross_check) → staging test"),
+    (ReqState.REVIEW_RUNNING, Event.STAGING_TEST_PASS):
+        Transition(ReqState.PR_CI_RUNNING, "create_pr_ci_watch",
+                   "verifier decision=pass (staging_test) → PR CI watch"),
+    (ReqState.REVIEW_RUNNING, Event.PR_CI_PASS):
+        Transition(ReqState.ACCEPT_RUNNING, "create_accept",
+                   "verifier decision=pass (pr_ci) → accept"),
+    (ReqState.REVIEW_RUNNING, Event.ACCEPT_PASS):
+        Transition(ReqState.ACCEPT_TEARING_DOWN, "teardown_accept_env",
+                   "verifier decision=pass (accept) → teardown"),
     (ReqState.REVIEW_RUNNING, Event.VERIFY_FIX_NEEDED):
         Transition(ReqState.FIXER_RUNNING, "start_fixer",
                    "decision=fix → 起对应 fixer（dev/spec）"),
@@ -262,13 +284,10 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
 
     # ─── 人工恢复（escalate ≠ 死终态）─────────────────────────────────────
     # 用户在 BKD UI follow-up 那个 escalate 的 verifier issue → BKD wake agent →
-    # 写新 decision JSON → session.completed 走原来 verifier 同一套链路 → 命中下面 3 条。
-    # 复用 apply_verify_pass / start_fixer，它们的 CAS source 同时接 REVIEW_RUNNING + ESCALATED。
-    # 配套：webhook.py 把 verifier-decision=escalate 的 issue PATCH 到 BKD statusId="review"
-    # （而非 done），用户在 BKD 看板"待审查"列就能定位到该 follow-up 哪条。
-    (ReqState.ESCALATED, Event.VERIFY_PASS):
-        Transition(ReqState.ESCALATED, "apply_verify_pass",
-                   "用户续 escalate 的 verifier issue → 新 decision=pass → action 推下一 stage"),
+    # 写新 decision JSON → session.completed 走原来 verifier 同一套链路。
+    # decision=pass 时 router/webhook 把 VERIFY_PASS 翻译成该 stage 的主链 pass 事件
+    #（如 STAGING_TEST_PASS），命中 ESCALATED 反激活 transition（_ESCALATED_RESUME_EVENT_SOURCES）。
+    # decision=fix / escalate 仍走下面 2 条。
     (ReqState.ESCALATED, Event.VERIFY_FIX_NEEDED):
         Transition(ReqState.FIXER_RUNNING, "start_fixer",
                    "用户续 escalate 的 verifier issue → 新 decision=fix → 起 fixer"),
@@ -298,8 +317,10 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
 
 
 # ─── ESCALATED 主链反激活：stage-issue 续写 follow-up ─────────────────────
-# 已有：(ESCALATED, VERIFY_*) 让用户续 escalate 的 verifier issue 走原 verifier 链。
+# 已有：(ESCALATED, VERIFY_FIX_NEEDED / VERIFY_ESCALATE) 让用户续 escalate 的
+# verifier issue 走 fixer / no-op 路径。
 # 这里补：用户在 stage agent issue（intake / analyze / challenger / accept / fixer）
+# 或 verifier issue（decision=pass 时 router 译成对应主链 pass 事件）
 # 续 follow-up → BKD wake agent → agent 重跑并贴 result tag → router 派出对应主链
 # 事件 → ESCALATED 复用主链 transition（next_state / action 跟主链同一份）。
 #
@@ -312,7 +333,8 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
 #   - 直接进 ESCALATED 的事件：INTAKE_FAIL / PR_CI_TIMEOUT / ACCEPT_ENV_UP_FAIL
 #     / VERIFY_ESCALATE / USER_REVIEW_FIX —— 这些不是"恢复信号"
 #   - PR_MERGED：escalate.py 入口的 PR-merged shortcut 已处理
-#   - VERIFY_PASS / VERIFY_FIX_NEEDED / VERIFY_INFRA_RETRY：已在上面 verifier 反激活段
+#   - VERIFY_FIX_NEEDED：已在上面 verifier 反激活段
+#   - VERIFY_INFRA_RETRY：不在 ESCALATED 恢复语义（infra retry 只在 REVIEW_RUNNING）
 _ESCALATED_RESUME_EVENT_SOURCES: list[tuple[Event, ReqState]] = [
     (Event.INTAKE_PASS,                  ReqState.INTAKING),
     (Event.ANALYZE_DONE,                 ReqState.ANALYZING),

--- a/orchestrator/tests/test_admin.py
+++ b/orchestrator/tests/test_admin.py
@@ -605,7 +605,7 @@ async def test_resume_400_when_pass_missing_stage(monkeypatch):
 @pytest.mark.asyncio
 async def test_resume_pass_dispatches_verify_pass_event(monkeypatch):
     """ARE-S1: state=escalated, ctx.verifier_stage=staging_test, action=pass →
-    engine.step 被调一次 with event=VERIFY_PASS."""
+    engine.step 被调一次 with event=STAGING_TEST_PASS（pass_event_for_stage 翻译）."""
     pool = _FakePool()
     row = _FakeRow(
         req_id="REQ-X", project_id="p", state=ReqState.ESCALATED,
@@ -627,11 +627,11 @@ async def test_resume_pass_dispatches_verify_pass_event(monkeypatch):
 
     assert result["action"] == "resumed"
     assert result["from_state"] == "escalated"
-    assert result["event"] == "verify.pass"
+    assert result["event"] == "staging-test.pass"
     assert "chained" in result
-    # engine.step 被调一次，event 是 VERIFY_PASS
+    # engine.step 被调一次，event 是 STAGING_TEST_PASS（pass_event_for_stage 翻译）
     assert len(step_calls) == 1
-    assert step_calls[0]["event"] == Event.VERIFY_PASS
+    assert step_calls[0]["event"] == Event.STAGING_TEST_PASS
     assert step_calls[0]["cur_state"] == ReqState.ESCALATED
     assert step_calls[0]["req_id"] == "REQ-X"
     # ctx 被 patch（resumed_by_admin + resume_action）

--- a/orchestrator/tests/test_contract_engine_escalated_resume_challenger.py
+++ b/orchestrator/tests/test_contract_engine_escalated_resume_challenger.py
@@ -13,7 +13,7 @@ Scenarios covered:
   ERT-S4  (INTAKING, VERIFY_ESCALATE) → ESCALATED + escalate + cleanup_runner(retain_pvc=True)
   ERT-S5  (ANALYZING, VERIFY_ESCALATE) → ESCALATED + escalate + cleanup_runner(retain_pvc=True)
   ERT-S6  (PR_CI_RUNNING, PR_CI_TIMEOUT) → ESCALATED + escalate + cleanup_runner(retain_pvc=True)
-  ERT-S7  ESCALATED + VERIFY_PASS → apply_verify_pass chains to create_pr_ci_watch, final PR_CI_RUNNING
+  ERT-S7  ESCALATED + PR_CI_PASS → ACCEPT_RUNNING + create_accept (explicit transition, no chaining)
   ERT-S8  ESCALATED + VERIFY_FIX_NEEDED → FIXER_RUNNING, start_fixer receives verify:staging_test tag + ctx
   ERT-S9  47/47 TRANSITIONS sweep — every declared transition round-trips through engine.step
 
@@ -257,63 +257,45 @@ async def test_ert_s3_to_s6_non_terminal_escalate_triggers_cleanup(
     )
 
 
-# ─── ERT-S7: ESCALATED + VERIFY_PASS chains end-to-end to PR_CI_RUNNING ──────
+# ─── ERT-S7: ESCALATED + stage pass → direct resume via explicit transition ────
 
 
-async def test_ert_s7_escalated_verify_pass_chains_to_pr_ci_running(monkeypatch) -> None:
-    """ERT-S7: ESCALATED + VERIFY_PASS → apply_verify_pass chains to create_pr_ci_watch.
-    apply_verify_pass internally CAS-advances to STAGING_TEST_RUNNING and emits
-    staging-test.pass; engine MUST chain-dispatch create_pr_ci_watch; final state = PR_CI_RUNNING.
-    This is the sole human-driven path to resume a stranded REQ end-to-end."""
+async def test_ert_s7_escalated_stage_pass_resumes_directly(monkeypatch) -> None:
+    """ERT-S7: ESCALATED + PR_CI_PASS → ACCEPT_RUNNING + create_accept.
+    REQ-refactor-verify-pass-transition-1777727230: VERIFY_PASS removed;
+    router translates decision=pass to stage-specific pass event.
+    ESCALATED reuses main-chain transition directly — no apply_verify_pass chaining."""
     from orchestrator.actions import REGISTRY
     from orchestrator.state import Event, ReqState
 
-    _patch_io(
-        monkeypatch,
-        get_side_effects=[_FakeRow(ReqState.STAGING_TEST_RUNNING)],
-    )
+    cas, _ = _patch_io(monkeypatch)
+    calls: list[str] = []
 
-    avp_calls: list[int] = []
-    cpcw_calls: list[int] = []
-
-    async def _apply_verify_pass(**_kw):
-        avp_calls.append(1)
-        return {"emit": "staging-test.pass"}
-
-    async def _create_pr_ci_watch(**_kw):
-        cpcw_calls.append(1)
+    async def _create_accept(**_kw):
+        calls.append("create_accept")
         return {}
 
-    REGISTRY["apply_verify_pass"] = _apply_verify_pass
-    REGISTRY["create_pr_ci_watch"] = _create_pr_ci_watch
+    REGISTRY["create_accept"] = _create_accept
 
     result = await _step(
         cur_state=ReqState.ESCALATED,
-        event=Event.VERIFY_PASS,
-        tags=["verifier", _REQ_ID, "verify:staging_test"],
-        ctx={"verifier_stage": "staging_test"},
+        event=Event.PR_CI_PASS,
+        tags=["verifier", _REQ_ID, "verify:pr_ci"],
+        ctx={"verifier_stage": "pr_ci"},
     )
 
-    assert result.get("action") == "apply_verify_pass", (
-        f"ERT-S7: action MUST be 'apply_verify_pass'; got {result!r}"
+    assert result.get("action") == "create_accept", (
+        f"ERT-S7: action MUST be 'create_accept'; got {result!r}"
     )
-    assert len(avp_calls) == 1, (
-        f"ERT-S7: apply_verify_pass MUST be awaited exactly once; got {len(avp_calls)}"
+    assert result.get("next_state") == ReqState.ACCEPT_RUNNING.value, (
+        f"ERT-S7: next_state MUST be {ReqState.ACCEPT_RUNNING.value!r}; got {result!r}"
     )
-    assert len(cpcw_calls) == 1, (
-        f"ERT-S7: create_pr_ci_watch MUST be awaited exactly once (chained); got {len(cpcw_calls)}"
+    assert len(calls) == 1, (
+        f"ERT-S7: create_accept MUST be awaited exactly once; got {len(calls)}"
     )
-
-    chained = result.get("chained")
-    assert chained is not None, (
-        f"ERT-S7: result MUST contain 'chained' sub-result; got {result!r}"
-    )
-    assert chained.get("action") == "create_pr_ci_watch", (
-        f"ERT-S7: chained.action MUST be 'create_pr_ci_watch'; got chained={chained!r}"
-    )
-    assert chained.get("next_state") == ReqState.PR_CI_RUNNING.value, (
-        f"ERT-S7: chained.next_state MUST be {ReqState.PR_CI_RUNNING.value!r}; "
-        f"got chained={chained!r}"
+    cas_next = cas.call_args.args[3]
+    assert cas_next == ReqState.ACCEPT_RUNNING, (
+        f"ERT-S7: CAS MUST advance to ACCEPT_RUNNING; got {cas_next!r}"
     )
 
 

--- a/orchestrator/tests/test_contract_engine_verifier_loop_challenger.py
+++ b/orchestrator/tests/test_contract_engine_verifier_loop_challenger.py
@@ -18,7 +18,7 @@ Scenarios covered:
   VLT-S9   (REVIEW_RUNNING, VERIFY_ESCALATE) → ESCALATED + cleanup_runner fire-and-forget
   VLT-S10  (FIXER_RUNNING, FIXER_DONE) → REVIEW_RUNNING, stage_runs: close fixer/pass + insert verifier
   VLT-S11  (FIXER_RUNNING, VERIFY_ESCALATE) → ESCALATED + escalate dispatched
-  VLT-S12  (ESCALATED, VERIFY_PASS) → ESCALATED self-loop + apply_verify_pass dispatched, no cleanup
+  VLT-S12  (ESCALATED, PR_CI_PASS) → ACCEPT_RUNNING + create_accept (explicit transition resume), no cleanup
   VLT-S13  (ESCALATED, VERIFY_FIX_NEEDED) → FIXER_RUNNING + start_fixer dispatched
   VLT-S14  (ESCALATED, VERIFY_ESCALATE) → ESCALATED no-op self-loop, no cleanup_runner
   VLT-S15  13× (*_RUNNING, SESSION_FAILED) → self-loop + escalate dispatch, no cleanup
@@ -427,14 +427,17 @@ async def test_vlt_s11_fixer_round_cap_escapes_to_escalated(monkeypatch) -> None
     )
 
 
-# ─── VLT-S12: ESCALATED + VERIFY_PASS → self-loop, apply_verify_pass ─────────
+# ─── VLT-S12: ESCALATED + stage pass → resume via explicit transition ─────────
 
 
 @pytest.mark.asyncio
-async def test_vlt_s12_escalated_verify_pass_dispatches_apply_verify_pass(
+async def test_vlt_s12_escalated_stage_pass_resumes_via_explicit_transition(
     monkeypatch,
 ) -> None:
-    """VLT-S12: (ESCALATED, VERIFY_PASS) → ESCALATED self-loop + apply_verify_pass.
+    """VLT-S12: (ESCALATED, PR_CI_PASS) → ACCEPT_RUNNING + create_accept.
+    REQ-refactor-verify-pass-transition-1777727230: VERIFY_PASS removed;
+    router translates decision=pass to stage-specific pass event.
+    ESCALATED uses _ESCALATED_RESUME_EVENT_SOURCES to reuse main-chain transition.
     cur_state is terminal → engine MUST NOT trigger cleanup_runner."""
     from orchestrator import engine
     from orchestrator.actions import REGISTRY
@@ -453,28 +456,30 @@ async def test_vlt_s12_escalated_verify_pass_dispatches_apply_verify_pass(
     calls: list[str] = []
 
     async def _stub(**_kw):
-        calls.append("apply_verify_pass")
+        calls.append("create_accept")
         return {}
 
-    REGISTRY["apply_verify_pass"] = _stub
+    REGISTRY["create_accept"] = _stub
 
     result = await _step(
         cur_state=ReqState.ESCALATED,
-        event=Event.VERIFY_PASS,
+        event=Event.PR_CI_PASS,
         tags=["verifier", _REQ_ID, "verify:pr_ci"],
         ctx={"verifier_stage": "pr_ci"},
     )
     await asyncio.sleep(0)
 
-    assert result.get("action") == "apply_verify_pass", (
-        f"VLT-S12: action MUST be 'apply_verify_pass'; got {result!r}"
+    assert result.get("action") == "create_accept", (
+        f"VLT-S12: action MUST be 'create_accept'; got {result!r}"
     )
-    # self-loop: CAS next_state == ESCALATED
+    assert result.get("next_state") == ReqState.ACCEPT_RUNNING.value, (
+        f"VLT-S12: next_state MUST be 'accept-running'; got {result!r}"
+    )
     cas_next = cas.call_args.args[3]
-    assert cas_next == ReqState.ESCALATED, (
-        f"VLT-S12: CAS MUST be self-loop to ESCALATED; got {cas_next!r}"
+    assert cas_next == ReqState.ACCEPT_RUNNING, (
+        f"VLT-S12: CAS MUST advance to ACCEPT_RUNNING; got {cas_next!r}"
     )
-    assert len(calls) == 1, "VLT-S12: apply_verify_pass MUST be awaited exactly once"
+    assert len(calls) == 1, "VLT-S12: create_accept MUST be awaited exactly once"
     assert cleanup_calls == [], (
         f"VLT-S12: cleanup_runner MUST NOT be triggered (cur is terminal); "
         f"got {cleanup_calls!r}"

--- a/orchestrator/tests/test_contract_verifier_stagerun_close.py
+++ b/orchestrator/tests/test_contract_verifier_stagerun_close.py
@@ -1,6 +1,6 @@
 """
 Contract tests for REQ-verifier-stagerun-close-1777105576:
-fix(verifier): close orphan verifier stage_run on VERIFY_PASS path
+fix(verifier): close orphan verifier stage_run on pass transition from REVIEW_RUNNING
 
 Black-box behavioral contracts derived from:
   openspec/changes/REQ-verifier-stagerun-close-1777105576/specs/verifier-stagerun-close/spec.md
@@ -10,7 +10,7 @@ Dev MUST NOT modify these tests to make them pass — fix the implementation ins
 If a test is wrong, escalate to spec_fixer to correct the spec, not the test.
 
 Scenarios covered:
-  VSC-S1  VERIFY_PASS self-loop closes verifier stage_run with outcome=pass
+  VSC-S1  Explicit pass transition leaving REVIEW_RUNNING closes verifier stage_run with outcome=pass
   VSC-S2  close 是 best-effort，失败只 log 不抛
   VSC-S3  VERIFY_FIX_NEEDED 仍走原 close+open 路径
   VSC-S4  REVIEW_RUNNING + SESSION_FAILED self-loop 不触发 verifier close
@@ -83,16 +83,17 @@ def _make_fake_stage_runs(close_side_effect=None) -> _FakeStageRuns:
     return _FakeStageRuns(close_side_effect=close_side_effect)
 
 
-# ─── VSC-S1: VERIFY_PASS self-loop MUST close verifier stage_run ─────────────
+# ─── VSC-S1: explicit pass transition from REVIEW_RUNNING MUST close verifier stage_run ─
 
 
-async def test_vsc_s1_verify_pass_closes_verifier_stage_run(monkeypatch):
+async def test_vsc_s1_explicit_pass_closes_verifier_stage_run(monkeypatch):
     """
     VSC-S1: _record_stage_transitions MUST call close_latest_stage_run(pool, req_id,
-    "verifier", outcome="pass") exactly once when cur_state=REVIEW_RUNNING and
-    event=VERIFY_PASS, even though next_state == cur_state (self-loop in transition table).
+    "verifier", outcome="pass") exactly once when leaving REVIEW_RUNNING via an explicit
+    pass transition (e.g., STAGING_TEST_PASS → PR_CI_RUNNING).
 
-    Invariant: close MUST happen regardless of cur_state == next_state equality.
+    REQ-refactor-verify-pass-transition-1777727230: VERIFY_PASS self-loop removed;
+    pass transitions are now explicit (cur ≠ next) and the generic leave path closes verifier.
     """
     import orchestrator.engine as engine_mod
     from orchestrator.state import Event, ReqState
@@ -107,16 +108,15 @@ async def test_vsc_s1_verify_pass_closes_verifier_stage_run(monkeypatch):
         pool,
         req_id=req_id,
         cur_state=ReqState.REVIEW_RUNNING,
-        next_state=ReqState.REVIEW_RUNNING,  # self-loop
-        event=Event.VERIFY_PASS,
+        next_state=ReqState.CHALLENGER_RUNNING,
+        event=Event.SPEC_LINT_PASS,
     )
 
     verifier_closes = [c for c in fake_sr._close_calls if c["stage"] == "verifier"]
 
     assert len(verifier_closes) == 1, (
         f"VSC-S1: close_latest_stage_run MUST be called exactly once for stage='verifier' "
-        f"on (REVIEW_RUNNING, VERIFY_PASS) self-loop; "
-        f"got {len(verifier_closes)} call(s): {verifier_closes}"
+        f"when leaving REVIEW_RUNNING; got {len(verifier_closes)} call(s): {verifier_closes}"
     )
     assert verifier_closes[0]["outcome"] == "pass", (
         f"VSC-S1: outcome MUST be 'pass'; got {verifier_closes[0]['outcome']!r}. "
@@ -127,10 +127,10 @@ async def test_vsc_s1_verify_pass_closes_verifier_stage_run(monkeypatch):
         f"got {verifier_closes[0]['req_id']!r}"
     )
 
-    # Invariant: self-loop means no new stage_run should be inserted
+    # CHALLENGER_RUNNING has no entry in STATE_TO_STAGE → no insert
     assert fake_sr._open_calls == [], (
-        f"VSC-S1: on (REVIEW_RUNNING→REVIEW_RUNNING) self-loop, insert_stage_run MUST NOT "
-        f"be called (no new stage is entered); got: {fake_sr._open_calls}"
+        f"VSC-S1: on REVIEW_RUNNING → CHALLENGER_RUNNING, insert_stage_run MUST NOT "
+        f"be called (CHALLENGER_RUNNING has no mapped stage); got: {fake_sr._open_calls}"
     )
 
 
@@ -158,8 +158,8 @@ async def test_vsc_s2_close_error_logged_not_raised(monkeypatch):
                 pool,
                 req_id="REQ-vsc-test-002",
                 cur_state=ReqState.REVIEW_RUNNING,
-                next_state=ReqState.REVIEW_RUNNING,
-                event=Event.VERIFY_PASS,
+                next_state=ReqState.CHALLENGER_RUNNING,
+                event=Event.SPEC_LINT_PASS,
             )
         except Exception as exc:
             pytest.fail(
@@ -193,7 +193,7 @@ async def test_vsc_s3_verify_fix_needed_normal_close_open(monkeypatch):
     - open a fixer stage_run via the generic open-on-enter path
 
     This verifies the existing behavior is preserved and not accidentally broken by the
-    VERIFY_PASS fix — the explicit close branch MUST only trigger on VERIFY_PASS.
+    refactor — verifier close only happens when leaving REVIEW_RUNNING (generic path).
     """
     import orchestrator.engine as engine_mod
     from orchestrator.state import Event, ReqState
@@ -236,8 +236,8 @@ async def test_vsc_s4_session_failed_self_loop_no_verifier_close(monkeypatch):
     """
     VSC-S4: (REVIEW_RUNNING, SESSION_FAILED) is a self-loop (next_state == cur_state).
     _record_stage_transitions MUST NOT call close_latest_stage_run for stage='verifier'.
-    Only event == VERIFY_PASS triggers the explicit verifier close; other self-loop
-    events (e.g. SESSION_FAILED dispatched by the watchdog) must not.
+    Self-loop events (e.g. SESSION_FAILED dispatched by the watchdog) do not leave
+    REVIEW_RUNNING, so the generic leave path must not trigger.
     """
     import orchestrator.engine as engine_mod
     from orchestrator.state import Event, ReqState
@@ -258,6 +258,6 @@ async def test_vsc_s4_session_failed_self_loop_no_verifier_close(monkeypatch):
     verifier_closes = [c for c in fake_sr._close_calls if c["stage"] == "verifier"]
     assert verifier_closes == [], (
         f"VSC-S4: close_latest_stage_run MUST NOT be called for stage='verifier' "
-        f"on (REVIEW_RUNNING, SESSION_FAILED) self-loop — only VERIFY_PASS triggers "
-        f"the explicit verifier close; got {len(verifier_closes)} call(s): {verifier_closes}"
+        f"on (REVIEW_RUNNING, SESSION_FAILED) self-loop — self-loop does not leave "
+        f"REVIEW_RUNNING; got {len(verifier_closes)} call(s): {verifier_closes}"
     )

--- a/orchestrator/tests/test_engine.py
+++ b/orchestrator/tests/test_engine.py
@@ -554,37 +554,37 @@ async def test_recursion_depth_guard(stub_actions, monkeypatch):
 
 
 # ═══════════════════════════════════════════════════════════════════════
-# REQ-verifier-stagerun-close: VERIFY_PASS self-loop must close verifier stage_run
+# REQ-verifier-stagerun-close: 显式 transition 离开 REVIEW_RUNNING 时自动 close verifier
 # ═══════════════════════════════════════════════════════════════════════
 
 
 @pytest.mark.asyncio
-async def test_verify_pass_closes_orphan_verifier_stage_run(stub_actions):
-    """(REVIEW_RUNNING, VERIFY_PASS) 是 transition 表的 self-loop，但
-    apply_verify_pass 内部手 CAS，绕过 _record_stage_transitions。fix 后 engine 必须
-    显式 close verifier 那条 stage_run（outcome='pass'），否则 ended_at 永远 NULL。
+async def test_verify_pass_explicit_transition_closes_verifier_and_opens_next_stage(stub_actions):
+    """REQ-refactor-verify-pass-transition-1777727230：(REVIEW_RUNNING, DEV_CROSS_CHECK_PASS) 是
+    显式 transition → STAGING_TEST_RUNNING + create_staging_test。engine._record_stage_transitions
+    看到 cur≠next，自动 close verifier（outcome='pass'）+ open staging_test。
     """
     calls, reg = stub_actions
 
-    async def apply_verify_pass(*, body, req_id, tags, ctx):
-        calls.append(("apply_verify_pass", {"req_id": req_id}))
+    async def create_staging_test(*, body, req_id, tags, ctx):
+        calls.append(("create_staging_test", {"req_id": req_id}))
         return {"ok": True}
 
-    reg["apply_verify_pass"] = apply_verify_pass
+    reg["create_staging_test"] = create_staging_test
 
     pool = FakePool({"REQ-1": FakeReq(state=ReqState.REVIEW_RUNNING.value)})
     body = type("B", (), {"issueId": "v-1", "projectId": "p", "event": "session.completed"})()
     await engine.step(
         pool, body=body, req_id="REQ-1", project_id="p",
-        tags=["verifier", "REQ-1", "verify:spec_lint"],
+        tags=["verifier", "REQ-1", "verify:dev_cross_check"],
         cur_state=ReqState.REVIEW_RUNNING,
-        ctx={"verifier_stage": "spec_lint"}, event=Event.VERIFY_PASS,
+        ctx={"verifier_stage": "dev_cross_check"}, event=Event.DEV_CROSS_CHECK_PASS,
     )
 
-    # transition 表声明的 self-loop：state 不变
-    assert pool.rows["REQ-1"].state == ReqState.REVIEW_RUNNING.value
+    # 显式 transition：state 推进到 STAGING_TEST_RUNNING
+    assert pool.rows["REQ-1"].state == ReqState.STAGING_TEST_RUNNING.value
 
-    # close_latest_stage_run 必须被调一次：req_id, stage='verifier', outcome='pass', fail_reason=None
+    # close verifier（outcome='pass'）
     closes = [c for c in pool.stage_runs_calls if c[0] == "close"]
     assert len(closes) == 1, f"expected exactly 1 close, got {pool.stage_runs_calls!r}"
     _, _, args = closes[0]
@@ -593,9 +593,11 @@ async def test_verify_pass_closes_orphan_verifier_stage_run(stub_actions):
     assert args[2] == "pass"
     assert args[3] is None
 
-    # 不应该 open 任何新 stage_run（self-loop 不进入新 *_RUNNING）
+    # open staging_test
     inserts = [c for c in pool.stage_runs_calls if c[0] == "insert"]
-    assert inserts == []
+    assert len(inserts) == 1
+    _, _, insert_args = inserts[0]
+    assert insert_args[1] == "staging_test"
 
 
 @pytest.mark.asyncio
@@ -637,8 +639,8 @@ async def test_verify_fix_needed_still_closes_verifier_via_normal_path(stub_acti
 
 @pytest.mark.asyncio
 async def test_review_running_self_loop_other_event_does_not_close_verifier(stub_actions):
-    """fix 必须只在 event == VERIFY_PASS 触发；其他 REVIEW_RUNNING self-loop 事件
-    （如 SESSION_FAILED 经状态机 self-loop 给 escalate action 自决）不动 verifier stage_run。
+    """SESSION_FAILED 等 REVIEW_RUNNING self-loop 事件不动 verifier stage_run。
+    verifier stage_run 只在离开 REVIEW_RUNNING（如显式 pass transition）时由通用 leave 路径关闭。
     """
     calls, reg = stub_actions
 

--- a/orchestrator/tests/test_engine_adversarial.py
+++ b/orchestrator/tests/test_engine_adversarial.py
@@ -373,7 +373,7 @@ async def test_eat_s12_done_skips_every_event(stub_actions):
         "create_analyze_artifact_check", "create_spec_lint", "start_challenger",
         "create_dev_cross_check", "create_staging_test", "create_pr_ci_watch",
         "create_accept", "teardown_accept_env", "escalate",
-        "apply_verify_pass", "start_fixer", "invoke_verifier_after_fix",
+        "start_fixer", "invoke_verifier_after_fix",
         "invoke_verifier_for_analyze_artifact_check_fail",
         "invoke_verifier_for_spec_lint_fail",
         "invoke_verifier_for_challenger_fail",

--- a/orchestrator/tests/test_engine_escalated_resume.py
+++ b/orchestrator/tests/test_engine_escalated_resume.py
@@ -260,7 +260,7 @@ async def test_ert_s6_pr_ci_timeout_escalates_with_cleanup(
 
 
 # ───────────────────────────────────────────────────────────────────────
-# ERT-S7: ESCALATED + VERIFY_PASS — end-to-end resume to next stage via chain emit
+# ERT-S7: ESCALATED + STAGING_TEST_PASS — end-to-end resume to next stage
 # ───────────────────────────────────────────────────────────────────────
 
 
@@ -269,34 +269,19 @@ async def test_ert_s7_escalated_verify_pass_chains_to_next_stage(
     stub_actions, mock_runner_controller,
 ):
     """Spec ERT-S7: 人工 resume from ESCALATED 端到端。
-    apply_verify_pass stub 模拟生产 action 行为：内部 CAS ESCALATED→STAGING_TEST_RUNNING
-    + emit STAGING_TEST_PASS。engine 必须 chain-dispatch create_pr_ci_watch，最终
-    pool row state = PR_CI_RUNNING。
+    router 把 verifier decision=pass 译成 STAGING_TEST_PASS；transition 表显式推进
+    ESCALATED → PR_CI_RUNNING + create_pr_ci_watch。无需 chain emit，一步到位。
 
-    这是 sisyphus 唯一让人手把"卡死"REQ 续起来的路径，dispatch-level 测（VLT-S12）
-    没法证明 chain emit 真把 REQ 推过 ESCALATED 边界 —— 必须有专门的端到端断言。
+    REQ-refactor-verify-pass-transition-1777727230：apply_verify_pass 自循环已拆，
+    所有 pass 路径都是显式 transition。
     """
-    apply_calls: list = []
     pr_ci_calls: list = []
-
-    async def apply_verify_pass(*, body, req_id, tags, ctx):
-        # 模拟生产 apply_verify_pass：手 CAS ESCALATED → 下游 stage_running。
-        # FakePool.fetchrow 在 UPDATE req_state 分支按 expected==actual 做 CAS。
-        from orchestrator.store import req_state as rs
-        ok = await rs.cas_transition(
-            pool, req_id, ReqState.ESCALATED, ReqState.STAGING_TEST_RUNNING,
-            Event.VERIFY_PASS, "apply_verify_pass",
-        )
-        assert ok, "stub apply_verify_pass: ESCALATED→STAGING_TEST_RUNNING CAS must succeed"
-        apply_calls.append({"tags": list(tags or []), "ctx": dict(ctx or {})})
-        return {"emit": Event.STAGING_TEST_PASS.value}
 
     async def create_pr_ci_watch(*, body, req_id, tags, ctx):
         pr_ci_calls.append({"tags": list(tags or [])})
         return {"ok": True}
 
     pool = FakePool({"REQ-1": FakeReq(state=ReqState.ESCALATED.value)})
-    stub_actions["apply_verify_pass"] = apply_verify_pass
     stub_actions["create_pr_ci_watch"] = create_pr_ci_watch
 
     body = _body(issueId="vfy-resume", projectId="p", event="session.completed")
@@ -306,22 +291,16 @@ async def test_ert_s7_escalated_verify_pass_chains_to_next_stage(
         tags=["verifier", "REQ-1", "verify:staging_test"],
         cur_state=ReqState.ESCALATED,
         ctx={"verifier_stage": "staging_test"},
-        event=Event.VERIFY_PASS,
+        event=Event.STAGING_TEST_PASS,
     )
     await _drain_tasks()
 
-    # 顶层 step：apply_verify_pass dispatched, transition 表声明 self-loop
-    assert result["action"] == "apply_verify_pass"
-    assert result["next_state"] == ReqState.ESCALATED.value
-
-    # chain：staging-test.pass → create_pr_ci_watch → PR_CI_RUNNING
-    assert "chained" in result, f"chain emit lost: {result!r}"
-    assert result["chained"]["action"] == "create_pr_ci_watch"
-    assert result["chained"]["next_state"] == ReqState.PR_CI_RUNNING.value
+    # 显式 transition：ESCALATED → PR_CI_RUNNING
+    assert result["action"] == "create_pr_ci_watch"
+    assert result["next_state"] == ReqState.PR_CI_RUNNING.value
 
     # 端到端：行真被推到 PR_CI_RUNNING
     assert pool.rows["REQ-1"].state == ReqState.PR_CI_RUNNING.value
-    assert len(apply_calls) == 1
     assert len(pr_ci_calls) == 1
 
     # cur 已是 terminal (ESCALATED) → engine 跳过 cleanup（防误删 resume 路径拉的 pod）
@@ -442,14 +421,15 @@ async def test_ert_s9_full_transition_sweep(
     )
 
 
-def test_ert_s9_sweep_covers_exactly_70():
-    """Sanity: TRANSITIONS 必须正好 70 条 —— 加 / 减 transition 时这条 fail 提醒
+def test_ert_s9_sweep_covers_exactly_76():
+    """Sanity: TRANSITIONS 必须正好 76 条 —— 加 / 减 transition 时这条 fail 提醒
     review 是否同步加 spec scenario / 文档（state-machine.md / dump_transitions）。
 
     历史：47 → 49（PENDING_USER_REVIEW 入/出）→ 51（再 +1）→ 70（REQ-escalated-stage-resume：
-    + 19 条 ESCALATED 主链反激活，让 stage-issue 续 follow-up 也能恢复）。"""
-    assert len(state_mod.TRANSITIONS) == 70, (
-        f"expected 70 transitions, got {len(state_mod.TRANSITIONS)}; "
+    + 19 条 ESCALATED 主链反激活）→ 76（REQ-refactor-verify-pass-transition-1777727230：
+    apply_verify_pass 自循环拆 8 条显式 transition，drop 2 条 VERIFY_PASS）="""
+    assert len(state_mod.TRANSITIONS) == 76, (
+        f"expected 76 transitions, got {len(state_mod.TRANSITIONS)}; "
         "if you intentionally added/removed a transition, update this assertion "
         "AND add granular ERT/MCT/APT/VLT scenario coverage for it."
     )

--- a/orchestrator/tests/test_engine_verifier_loop.py
+++ b/orchestrator/tests/test_engine_verifier_loop.py
@@ -284,20 +284,20 @@ async def test_vlt_s11_fixer_round_cap_escapes_to_escalated(
 
 
 # ───────────────────────────────────────────────────────────────────────
-# VLT-S12: ESCALATED + VERIFY_PASS resume (apply_verify_pass self-loop)
+# VLT-S12: ESCALATED + PR_CI_PASS resume (router 译 decision=pass → 主链 pass 事件)
 # ───────────────────────────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_vlt_s12_escalated_verify_pass_dispatches_apply(
+async def test_vlt_s12_escalated_verify_pass_dispatches_create_accept(
     stub_actions, mock_runner_controller,
 ):
-    """Spec VLT-S12: ESCALATED + VERIFY_PASS → ESCALATED self-loop, action=apply_verify_pass。
+    """Spec VLT-S12: ESCALATED + PR_CI_PASS → ACCEPT_RUNNING + create_accept。
     用户在 BKD UI follow-up escalate 的 verifier issue 写新 decision=pass 触发；
-    engine 仅 dispatch action（实际 CAS 推下游 state 是 action 内部职责）。
-    自循环且 cur 已 terminal → engine 不应再触发 cleanup。"""
+    router 按 verify:pr_ci tag 译成 PR_CI_PASS，transition 表显式推进到 ACCEPT_RUNNING。
+    cur 已 terminal → engine 不应再触发 cleanup。"""
     calls: list = []
-    stub_actions["apply_verify_pass"] = _make_recorder("apply_verify_pass", calls)
+    stub_actions["create_accept"] = _make_recorder("create_accept", calls)
 
     pool = FakePool({"REQ-1": FakeReq(state=ReqState.ESCALATED.value)})
     body = _body(issueId="vfy-resume", projectId="p", event="session.completed")
@@ -306,13 +306,13 @@ async def test_vlt_s12_escalated_verify_pass_dispatches_apply(
         pool, body=body, req_id="REQ-1", project_id="p",
         tags=["verifier", "REQ-1", "verify:pr_ci"],
         cur_state=ReqState.ESCALATED, ctx={"verifier_stage": "pr_ci"},
-        event=Event.VERIFY_PASS,
+        event=Event.PR_CI_PASS,
     )
     await _drain_tasks()
 
-    assert result["action"] == "apply_verify_pass"
-    # transition 表声明的 self-loop：state 不动（stub 不内部 CAS）
-    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+    assert result["action"] == "create_accept"
+    assert result["next_state"] == ReqState.ACCEPT_RUNNING.value
+    assert pool.rows["REQ-1"].state == ReqState.ACCEPT_RUNNING.value
     assert len(calls) == 1
     # cur 已 terminal → engine 跳过 cleanup
     mock_runner_controller.cleanup_runner.assert_not_awaited()

--- a/orchestrator/tests/test_state.py
+++ b/orchestrator/tests/test_state.py
@@ -42,8 +42,15 @@ EXPECTED = [
     (ReqState.PENDING_USER_REVIEW,  Event.USER_REVIEW_PASS,    ReqState.DONE,                None),
     (ReqState.PENDING_USER_REVIEW,  Event.USER_REVIEW_FIX,     ReqState.ESCALATED,           "escalate"),
     (ReqState.ACCEPT_TEARING_DOWN,  Event.TEARDOWN_DONE_FAIL,  ReqState.REVIEW_RUNNING,      "invoke_verifier_for_accept_fail"),
-    # M14b verifier 子链（3 路：pass / fix / escalate）
-    (ReqState.REVIEW_RUNNING,       Event.VERIFY_PASS,         ReqState.REVIEW_RUNNING,      "apply_verify_pass"),
+    # verifier 子链（pass 拆成 N 条显式 transition，REQ-refactor-verify-pass-transition-1777727230）
+    (ReqState.REVIEW_RUNNING,       Event.ANALYZE_DONE,                 ReqState.ANALYZE_ARTIFACT_CHECKING, "create_analyze_artifact_check"),
+    (ReqState.REVIEW_RUNNING,       Event.ANALYZE_ARTIFACT_CHECK_PASS,  ReqState.SPEC_LINT_RUNNING,         "create_spec_lint"),
+    (ReqState.REVIEW_RUNNING,       Event.SPEC_LINT_PASS,               ReqState.CHALLENGER_RUNNING,        "start_challenger"),
+    (ReqState.REVIEW_RUNNING,       Event.CHALLENGER_PASS,              ReqState.DEV_CROSS_CHECK_RUNNING,   "create_dev_cross_check"),
+    (ReqState.REVIEW_RUNNING,       Event.DEV_CROSS_CHECK_PASS,         ReqState.STAGING_TEST_RUNNING,      "create_staging_test"),
+    (ReqState.REVIEW_RUNNING,       Event.STAGING_TEST_PASS,            ReqState.PR_CI_RUNNING,             "create_pr_ci_watch"),
+    (ReqState.REVIEW_RUNNING,       Event.PR_CI_PASS,                   ReqState.ACCEPT_RUNNING,            "create_accept"),
+    (ReqState.REVIEW_RUNNING,       Event.ACCEPT_PASS,                  ReqState.ACCEPT_TEARING_DOWN,       "teardown_accept_env"),
     (ReqState.REVIEW_RUNNING,       Event.VERIFY_FIX_NEEDED,   ReqState.FIXER_RUNNING,       "start_fixer"),
     (ReqState.REVIEW_RUNNING,       Event.VERIFY_ESCALATE,     ReqState.ESCALATED,           "escalate"),
     (ReqState.FIXER_RUNNING,        Event.FIXER_DONE,          ReqState.REVIEW_RUNNING,      "invoke_verifier_after_fix"),
@@ -143,8 +150,12 @@ def test_done_terminal_has_no_outgoing():
 
 
 def test_escalated_resumable_via_verifier_followup():
-    """ESCALATED 不是死终态：用户续 verifier issue → BKD 新 decision → 走原 verifier 同链。"""
-    for ev in (Event.VERIFY_PASS, Event.VERIFY_FIX_NEEDED, Event.VERIFY_ESCALATE):
+    """ESCALATED 不是死终态：用户续 verifier issue → BKD 新 decision → 走原 verifier 同链。
+
+    decision=pass 时 router 译成对应主链 pass 事件（如 STAGING_TEST_PASS），
+    ESCALATED 反激活 transition 处理；VERIFY_FIX_NEEDED / VERIFY_ESCALATE 仍走 verifier 子链。
+    """
+    for ev in (Event.STAGING_TEST_PASS, Event.VERIFY_FIX_NEEDED, Event.VERIFY_ESCALATE):
         assert decide(ReqState.ESCALATED, ev) is not None, ev
 
 

--- a/orchestrator/tests/test_state_transitions_gap.py
+++ b/orchestrator/tests/test_state_transitions_gap.py
@@ -71,7 +71,6 @@ def test_verify_infra_retry_only_from_review_running():
 # ── 缺口 3：ESCALATED 恢复态 transition 实际值（此前只测了 existence）──────────────────
 
 ESCALATED_RESUME_CASES = [
-    (Event.VERIFY_PASS, ReqState.ESCALATED, "apply_verify_pass"),
     (Event.VERIFY_FIX_NEEDED, ReqState.FIXER_RUNNING, "start_fixer"),
 ]
 
@@ -250,9 +249,13 @@ def test_pending_user_review_illegal_events():
 
 
 def test_review_running_illegal_events():
-    """REVIEW_RUNNING 接受 verifier 4 路决策 + merged + SESSION_FAILED。"""
+    """REVIEW_RUNNING 接受 verifier pass（8 条 stage 显式）+ fix/escalate/retry + merged + SESSION_FAILED。"""
     legal = {
-        Event.VERIFY_PASS, Event.VERIFY_FIX_NEEDED, Event.VERIFY_ESCALATE,
+        Event.ANALYZE_DONE, Event.ANALYZE_ARTIFACT_CHECK_PASS,
+        Event.SPEC_LINT_PASS, Event.CHALLENGER_PASS,
+        Event.DEV_CROSS_CHECK_PASS, Event.STAGING_TEST_PASS,
+        Event.PR_CI_PASS, Event.ACCEPT_PASS,
+        Event.VERIFY_FIX_NEEDED, Event.VERIFY_ESCALATE,
         Event.VERIFY_INFRA_RETRY, Event.PR_MERGED, Event.SESSION_FAILED,
     }
     for ev in Event:
@@ -298,12 +301,12 @@ def test_all_transitions_reason_is_str_or_none():
 def test_transition_count_sanity():
     """transition 总数 sanity check：防止未来重构误删/误增。
 
-    当前总数 = 39 显式 + 12 SESSION_FAILED self-loop + 19 ESCALATED stage-resume 反激活
-    （REQ-escalated-stage-resume）= 70。
+    当前总数 = 45 显式 + 12 SESSION_FAILED self-loop + 19 ESCALATED stage-resume 反激活
+    （REQ-escalated-stage-resume）= 76。
     如果数字变了，说明有人增删 transition，本测试会 fail 提醒同步测试。
     """
-    assert len(TRANSITIONS) == 70, (
-        f"Expected 70 transitions, got {len(TRANSITIONS)}. "
+    assert len(TRANSITIONS) == 76, (
+        f"Expected 76 transitions, got {len(TRANSITIONS)}. "
         "If this is intentional, update this assertion and add corresponding tests."
     )
 
@@ -311,12 +314,12 @@ def test_transition_count_sanity():
 def test_explicit_transition_count():
     """非 SESSION_FAILED 的显式 + ESCALATED 反激活 transition 数量 sanity check。
 
-    包含 39 主链显式 + 19 ESCALATED 主链反激活（复用主链 transition 对象，但 key 是
-    (ESCALATED, ev) 独立计数）= 58 条非 SESSION_FAILED transition。
+    包含 45 主链显式 + 19 ESCALATED 主链反激活（复用主链 transition 对象，但 key 是
+    (ESCALATED, ev) 独立计数）= 64 条非 SESSION_FAILED transition。
     """
     explicit = [k for k in TRANSITIONS if k[1] != Event.SESSION_FAILED]
-    assert len(explicit) == 58, (
-        f"Expected 58 explicit transitions, got {len(explicit)}"
+    assert len(explicit) == 64, (
+        f"Expected 64 explicit transitions, got {len(explicit)}"
     )
 
 
@@ -331,15 +334,16 @@ def test_session_failed_transition_count():
 # ── 缺口 7：竞态路径 —— CAS 场景下的 transition 行为────────────────────────────────────
 
 
-def test_verify_pass_from_review_running_is_self_loop():
-    """VERIFY_PASS 从 REVIEW_RUNNING 出发是 self-loop：action 内部手动 CAS 推进。
+def test_verify_pass_from_review_running_is_explicit_transition():
+    """decision=pass 从 REVIEW_RUNNING 出发是显式 transition（非 self-loop）。
 
-    这是 M14b 设计要点：next_state 不动，action 自己决定跳到哪个 stage_running。
+    REQ-refactor-verify-pass-transition-1777727230：router 按 stage 译成主链 pass 事件，
+    transition 表直接写死 next_state，不再靠 action 内部 CAS。
     """
-    t = decide(ReqState.REVIEW_RUNNING, Event.VERIFY_PASS)
+    t = decide(ReqState.REVIEW_RUNNING, Event.STAGING_TEST_PASS)
     assert t is not None
-    assert t.next_state == ReqState.REVIEW_RUNNING
-    assert t.action == "apply_verify_pass"
+    assert t.next_state == ReqState.PR_CI_RUNNING
+    assert t.action == "create_pr_ci_watch"
 
 
 def test_verify_infra_retry_from_review_running_is_self_loop():
@@ -362,15 +366,16 @@ def test_done_no_transitions_at_all():
 def test_escalated_non_resume_events_all_none():
     """ESCALATED 接受 3 类恢复事件，其余非法：
 
-    1. verifier 决策续 follow-up：VERIFY_PASS / VERIFY_FIX_NEEDED / VERIFY_ESCALATE
+    1. verifier 决策续 follow-up：VERIFY_FIX_NEEDED / VERIFY_ESCALATE；
+       decision=pass 时 router 译成对应主链 pass 事件，走 stage-issue 反激活路径。
     2. stage-issue 续 follow-up（REQ-escalated-stage-resume）：19 条主链事件
        —— intake/analyze/spec_lint/challenger/dev_cross_check/staging_test/pr_ci/
        accept/teardown/fixer 各 pass+fail（无 timeout/env-up-fail/intake-fail/
        user-review-fix/PR_MERGED 这类直接进 ESCALATED 或不属于"恢复"语义的事件）
     """
     resume_events = {
-        # verifier 决策反激活
-        Event.VERIFY_PASS, Event.VERIFY_FIX_NEEDED, Event.VERIFY_ESCALATE,
+        # verifier 决策反激活（pass 由主链 pass 事件代理）
+        Event.VERIFY_FIX_NEEDED, Event.VERIFY_ESCALATE,
         # stage-issue 反激活
         Event.INTAKE_PASS,
         Event.ANALYZE_DONE,

--- a/orchestrator/tests/test_verifier.py
+++ b/orchestrator/tests/test_verifier.py
@@ -60,7 +60,11 @@ def test_validate_decision(decision, ok):
 
 
 def test_decision_to_event_mapping():
+    # 无 stage → 回退 VERIFY_PASS（调用方应 escalate）
     assert decision_to_event({"action": "pass"}) == Event.VERIFY_PASS
+    # 有 stage → 主链 pass 事件
+    assert decision_to_event({"action": "pass"}, stage="staging_test") == Event.STAGING_TEST_PASS
+    assert decision_to_event({"action": "pass"}, stage="pr_ci") == Event.PR_CI_PASS
     assert decision_to_event({"action": "fix"}) == Event.VERIFY_FIX_NEEDED
     assert decision_to_event({"action": "escalate"}) == Event.VERIFY_ESCALATE
     # REQ-428 VFR-S6: retry maps to VERIFY_INFRA_RETRY
@@ -123,8 +127,9 @@ def test_extract_none_when_empty():
 def test_derive_verifier_event_pass():
     d = {"action": "pass", "fixer": None, "scope": None, "reason": "ok", "confidence": "high"}
     b64 = base64.urlsafe_b64encode(json.dumps(d).encode()).decode().rstrip("=")
-    ev, decision, why = derive_verifier_event(None, [f"decision:{b64}"])
-    assert ev == Event.VERIFY_PASS
+    # verify:staging_test tag 驱动 router 译成 STAGING_TEST_PASS
+    ev, decision, why = derive_verifier_event(None, [f"decision:{b64}", "verify:staging_test"])
+    assert ev == Event.STAGING_TEST_PASS
     assert decision == d
     assert why == ""
 
@@ -166,10 +171,24 @@ def test_derive_verifier_event_no_decision_escalates():
 
 def test_derive_with_retry_info_valid_decision():
     d = {"action": "pass", "fixer": None, "scope": None, "reason": "ok", "confidence": "high"}
-    ev, decision, why, retry = derive_verifier_event_with_retry_info(None, [f"decision:{_b64(d)}"])
-    assert ev == Event.VERIFY_PASS
+    ev, decision, why, retry = derive_verifier_event_with_retry_info(
+        None, [f"decision:{_b64(d)}", "verify:staging_test"],
+    )
+    assert ev == Event.STAGING_TEST_PASS
     assert decision == d
     assert why == ""
+    assert retry is False
+
+
+def test_derive_pass_without_verify_tag_escalates():
+    """无 verify:<stage> tag → router 译不出 stage → escalate（不 retry，不是解析问题）。"""
+    d = {"action": "pass", "fixer": None, "scope": None, "reason": "ok", "confidence": "high"}
+    ev, decision, why, retry = derive_verifier_event_with_retry_info(
+        None, [f"decision:{_b64(d)}"],
+    )
+    assert ev == Event.VERIFY_ESCALATE
+    assert decision == d
+    assert "unknown verifier stage" in why
     assert retry is False
 
 
@@ -491,166 +510,6 @@ def make_body(issue_id="src-1", project_id="p", event="session.completed"):
         "issueId": issue_id, "projectId": project_id,
         "event": event, "title": "", "tags": [], "issueNumber": None,
     })()
-
-
-@pytest.mark.asyncio
-async def test_apply_verify_pass_chains_staging_test_pass(monkeypatch):
-    """verifier_stage=staging_test + VERIFY_PASS → CAS REVIEW_RUNNING→STAGING_TEST_RUNNING
-    + emit STAGING_TEST_PASS（走原主链）。"""
-    from orchestrator.actions import _verifier as v
-
-    cas_calls: list = []
-
-    async def fake_cas(pool, req_id, expected, nxt, event, action, context_patch=None):
-        cas_calls.append((req_id, expected, nxt, event, action))
-        return True
-
-    monkeypatch.setattr("orchestrator.actions._verifier.req_state.cas_transition", fake_cas)
-    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
-
-    out = await v.apply_verify_pass(
-        body=make_body(), req_id="REQ-9", tags=[],
-        ctx={"verifier_stage": "staging_test"},
-    )
-    assert out["emit"] == Event.STAGING_TEST_PASS.value
-    assert out["stage"] == "staging_test"
-    assert len(cas_calls) == 1
-    (_, expected, nxt, event, _) = cas_calls[0]
-    assert expected.value == "review-running"
-    assert nxt.value == "staging-test-running"
-    assert event == Event.VERIFY_PASS
-
-
-@pytest.mark.asyncio
-async def test_apply_verify_pass_unknown_stage_escalates(monkeypatch):
-    from orchestrator.actions import _verifier as v
-    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
-    out = await v.apply_verify_pass(
-        body=make_body(), req_id="REQ-9", tags=[],
-        ctx={"verifier_stage": None},
-    )
-    assert out["emit"] == Event.VERIFY_ESCALATE.value
-
-
-@pytest.mark.asyncio
-async def test_apply_verify_pass_cas_fail_returns_skip(monkeypatch):
-    """并发导致 REVIEW_RUNNING 已被别的事件改走 → action 不抛，返 cas_failed。"""
-    from orchestrator.actions import _verifier as v
-
-    async def fake_cas(*a, **kw):
-        return False
-    monkeypatch.setattr("orchestrator.actions._verifier.req_state.cas_transition", fake_cas)
-    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
-
-    out = await v.apply_verify_pass(
-        body=make_body(), req_id="REQ-9", tags=[],
-        ctx={"verifier_stage": "dev_cross_check"},
-    )
-    assert out == {"cas_failed": True}
-
-
-@pytest.mark.asyncio
-async def test_apply_verify_pass_closes_orphan_verifier_stage_run(monkeypatch):
-    """REGRESSION: (REVIEW_RUNNING, VERIFY_PASS) 是 self-loop transition →
-    engine._record_stage_transitions 跳过 close → verifier 行 outcome 永远为 None。
-
-    DB 实证：18 条 verifier outcome=NULL（占 verifier 总数 29%）污染 stage_stats /
-    agent_quality / failure_mode 三张 Metabase 看板。修：apply_verify_pass 在
-    REVIEW_RUNNING → target_state CAS 成功后，手动 close_latest_stage_run("verifier",
-    outcome="pass")。
-    """
-    from orchestrator.actions import _verifier as v
-
-    close_calls: list = []
-
-    async def fake_cas(*a, **kw):
-        return True
-
-    async def fake_close(pool, req_id, stage, *, outcome, fail_reason=None):
-        close_calls.append({"req_id": req_id, "stage": stage, "outcome": outcome})
-        return 42  # any non-None id
-
-    monkeypatch.setattr(
-        "orchestrator.actions._verifier.req_state.cas_transition", fake_cas,
-    )
-    monkeypatch.setattr(
-        "orchestrator.actions._verifier.stage_runs.close_latest_stage_run",
-        fake_close,
-    )
-    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
-
-    out = await v.apply_verify_pass(
-        body=make_body(), req_id="REQ-9", tags=[],
-        ctx={"verifier_stage": "pr_ci"},
-    )
-
-    assert out["emit"] == Event.PR_CI_PASS.value
-    assert close_calls == [
-        {"req_id": "REQ-9", "stage": "verifier", "outcome": "pass"},
-    ], "verifier orphan stage_run must be closed with outcome=pass when CAS from REVIEW_RUNNING"
-
-
-@pytest.mark.asyncio
-async def test_apply_verify_pass_skips_close_on_escalated_resume(monkeypatch):
-    """resume from ESCALATED：上一轮 verifier 行已被前次 escalate 路径关掉
-    （outcome=escalate）；此时不应再 close 一次，避免改写 outcome 或关错行。"""
-    from orchestrator.actions import _verifier as v
-
-    close_calls: list = []
-
-    async def fake_cas(pool, req_id, expected, nxt, event, action, context_patch=None):
-        # 模拟 REQ 在 ESCALATED：CAS REVIEW_RUNNING 失败，CAS ESCALATED 成功
-        return expected.value == "escalated"
-
-    async def fake_close(pool, req_id, stage, *, outcome, fail_reason=None):
-        close_calls.append({"req_id": req_id, "stage": stage, "outcome": outcome})
-        return 42
-
-    monkeypatch.setattr(
-        "orchestrator.actions._verifier.req_state.cas_transition", fake_cas,
-    )
-    monkeypatch.setattr(
-        "orchestrator.actions._verifier.stage_runs.close_latest_stage_run",
-        fake_close,
-    )
-    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
-
-    out = await v.apply_verify_pass(
-        body=make_body(), req_id="REQ-9", tags=[],
-        ctx={"verifier_stage": "pr_ci"},
-    )
-
-    assert out["emit"] == Event.PR_CI_PASS.value
-    assert close_calls == [], (
-        "ESCALATED-resume 路径不应 close verifier stage_run "
-        "（前次 escalate 已 close，重复 close 会改写 outcome）"
-    )
-
-
-@pytest.mark.asyncio
-async def test_apply_verify_pass_resumes_from_escalated(monkeypatch):
-    """resume 路径：用户 follow-up escalate 的 verifier issue → 新 decision=pass →
-    apply_verify_pass 第一次 CAS REVIEW_RUNNING 失败（state 是 ESCALATED），
-    第二次 CAS ESCALATED → STAGE_RUNNING 成功 + chain emit 上游 pass event。"""
-    from orchestrator.actions import _verifier as v
-
-    cas_calls: list = []
-
-    async def fake_cas(pool, req_id, expected, nxt, event, action, context_patch=None):
-        cas_calls.append(expected.value)
-        # 模拟"REQ 当前在 ESCALATED"——CAS REVIEW_RUNNING 失败，CAS ESCALATED 成功
-        return expected.value == "escalated"
-
-    monkeypatch.setattr("orchestrator.actions._verifier.req_state.cas_transition", fake_cas)
-    monkeypatch.setattr("orchestrator.actions._verifier.db.get_pool", lambda: None)
-
-    out = await v.apply_verify_pass(
-        body=make_body(), req_id="REQ-9", tags=[],
-        ctx={"verifier_stage": "pr_ci"},
-    )
-    assert cas_calls == ["review-running", "escalated"]
-    assert out["emit"] == Event.PR_CI_PASS.value
-    assert out["stage"] == "pr_ci"
 
 
 @pytest.mark.asyncio

--- a/orchestrator/tests/test_webhook_verifier_retry.py
+++ b/orchestrator/tests/test_webhook_verifier_retry.py
@@ -261,6 +261,6 @@ async def test_no_retry_when_valid_decision(fake_bkd, fake_req_state, fake_obs, 
     )
     result = await _call_webhook(body, monkeypatch)
 
-    assert result["event"] == Event.VERIFY_PASS
+    assert result["event"] == Event.STAGING_TEST_PASS
     assert result["retry_worthy"] is False
     assert len(fake_bkd.captured_follow_up) == 0


### PR DESCRIPTION
closes #255

## Summary
- 删除 `(REVIEW_RUNNING, VERIFY_PASS)` 和 `(ESCALATED, VERIFY_PASS)` 自循环 transition
- 新增 8 条 REVIEW_RUNNING + stage pass 显式 transition，覆盖 analyze → artifact_check → spec_lint → challenger → dev_cross_check → staging_test → pr_ci → accept → teardown 全链路
- router 新增 `_VERIFY_PASS_ROUTING` + `pass_event_for_stage()`，webhook 解析 verifier decision=pass 时按 `verify:<stage>` tag 翻译成对应主链 pass 事件
- admin `/resume` 复用 router 翻译，不再硬编码 `VERIFY_PASS`
- engine 删除 `_record_stage_transitions` 中 `VERIFY_PASS` 特殊分支（通用 leave 路径已自然覆盖）
- 删除 `actions/_verifier.py` 中 `apply_verify_pass` action（~60 行）
- 同步更新 14 个测试文件，transition 总数 70 → 76

## Test plan
- [x] `test_state_transitions_gap.py` — transition 计数 + 负向断言 + PR_MERGED 竞态
- [x] `test_contract_engine_verifier_loop_challenger.py` — VLT-S12 改为 ESCALATED + PR_CI_PASS → ACCEPT_RUNNING
- [x] `test_contract_engine_escalated_resume_challenger.py` — ERT-S7 改为直接显式 transition（无 chaining）
- [x] `test_contract_verifier_stagerun_close.py` — VSC-S1/S2 改为测显式 pass transition 离开 REVIEW_RUNNING
- [x] `test_webhook_verifier_retry.py` — valid decision 预期 stage-specific pass 事件
- [x] `test_admin.py` — resume pass 预期 `STAGING_TEST_PASS`
- [x] `test_engine.py` / `test_verifier.py` / `test_engine_escalated_resume.py` / `test_engine_verifier_loop.py` / `test_engine_adversarial.py` — 同步更新
- [x] ruff check 全绿
- [x] 核心 pytest 270+ 条全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)