### PR TITLE
fix(runner): bake kubectl + auto-rewrite kubeconfig server URL (#292 #293)

### DIFF
--- a/orchestrator/src/orchestrator/k8s_runner.py
+++ b/orchestrator/src/orchestrator/k8s_runner.py
@@ -200,6 +200,12 @@ class RunnerController:
             client.V1EnvVar(name="GOCACHE", value="/workspace/.cache/go/build"),
             client.V1EnvVar(name="npm_config_cache", value="/workspace/.cache/npm"),
             client.V1EnvVar(name="UV_CACHE_DIR", value="/workspace/.cache/uv"),
+            # 指向 entrypoint.sh 重写过 in-cluster URL 的 kubeconfig (#292)。文件
+            # 不存在时 helm/kubectl 自动降级到 ~/.kube/config 或 in-cluster sa，无害。
+            # 这条让 `kubectl exec runner-pod -- bash -c "kubectl get ns"` 这类
+            # 非交互 exec 也能读到正确 server URL —— /etc/profile.d 在
+            # `bash -c` 下不会 source，必须 pod env 注入。
+            client.V1EnvVar(name="KUBECONFIG", value="/workspace/.kubeconfig"),
         ]
         # 从 runner-secrets 注入 GitHub 凭证（optional，secret 缺了 pod 还能起）
         for env_name, secret_key in (

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -45,6 +45,17 @@ RUN curl -fsSL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
       | tar -xz --strip-components=1 -C /usr/local/bin linux-amd64/helm \
     && helm version
 
+# ─── 2b. kubectl (#293) ──────────────────────────────────────────────────
+# 业务仓 accept-env-up Makefile 大量用 `kubectl exec deploy/xxx`、`kubectl get
+# pods` 等 cluster API 操作。helm 自带 k8s client 但 kubectl 是独立 binary，
+# image 里没装会直接 `kubectl: command not found` 让 accept-env-up 无下文。
+# Pin 到 v1.31.x 跟 K3s 默认 server version 兼容（client/server skew ±1 minor）。
+ARG KUBECTL_VERSION=v1.31.4
+RUN curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+      -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && kubectl version --client --output=yaml | head -5
+
 # ─── 3. Go 1.23 ─────────────────────────────────────────────────────────
 ARG GO_VERSION=1.23.4
 RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \

--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -60,6 +60,29 @@ else
   echo "[sisyphus-entrypoint] GH_TOKEN missing — git private-repo clone will fail" >&2
 fi
 
+# ── Kubeconfig in-cluster URL rewrite (#292) ──────────────────────────
+# helm values 让用户填 runner.secret.kubeconfig，期望 "runner pod 跑 accept 阶
+# 段 helm install 用"。典型用法是把 host 的 ~/.kube/config 直接复制进来 ——
+# 内容是 `server: https://127.0.0.1:6443`（k3s 默认）。这个 URL 从 runner
+# pod 内**不可达**——pod 的 127.0.0.1 = pod 自己。
+#
+# entrypoint 扫描 secret-mounted kubeconfig (read-only at /root/.kube/config)，
+# 发现 host loopback 时 sed 改成 in-cluster service URL `kubernetes.default.svc:443`
+# 写到 /workspace/.kubeconfig（PVC 上，writable + cross-restart persist），
+# 同时 export KUBECONFIG 让 helm/kubectl 优先读改写后的版本。
+# kubernetes.default.svc 在 pod DNS 内永远 resolves 到 cluster API 的 ClusterIP，
+# 跨 cloud / on-prem / k3s / kind 全通用。
+if [[ -f /root/.kube/config ]] && grep -q "127.0.0.1:6443" /root/.kube/config; then
+  mkdir -p /workspace
+  sed "s|server: https://127.0.0.1:6443|server: https://kubernetes.default.svc.cluster.local:443|" \
+      /root/.kube/config > /workspace/.kubeconfig
+  chmod 600 /workspace/.kubeconfig
+  export KUBECONFIG=/workspace/.kubeconfig
+  echo "[sisyphus-entrypoint] kubeconfig server URL rewritten to in-cluster service (KUBECONFIG=/workspace/.kubeconfig)"
+elif [[ -f /root/.kube/config ]]; then
+  echo "[sisyphus-entrypoint] kubeconfig present, server URL not localhost (passing through)"
+fi
+
 # ── Workspace 目录契约 + restart 恢复 ──────────────────────────────────
 # Pod restart（restartPolicy=Always）时，entrypoint.sh 会重新跑。
 # 用 /.sisyphus-runner-init 标记检测 restart：标记存在 → 清掉 /workspace/* 从零开始。

--- a/runner/go.Dockerfile
+++ b/runner/go.Dockerfile
@@ -43,6 +43,16 @@ RUN curl -fsSL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
       | tar -xz --strip-components=1 -C /usr/local/bin linux-amd64/helm \
     && helm version
 
+# ─── 2b. kubectl (#293) ──────────────────────────────────────────────────
+# 业务仓 accept-env-up Makefile / staging_test 偶用 `kubectl exec/get/...` 直接
+# 跟 cluster API 打交道。helm 自带 k8s client 但 kubectl 是独立 binary，没装就
+# `kubectl: command not found`。Pin 到 v1.31.x 跟 K3s 默认 server version 兼容。
+ARG KUBECTL_VERSION=v1.31.4
+RUN curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+      -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && kubectl version --client --output=yaml | head -5
+
 # ─── 3. openspec CLI ─────────────────────────────────────────────────────
 # 真包名是 @fission-ai/openspec（旧版本误装 npm 上的占位 openspec@0.0.0 是空的，导致
 # REQ-997 analyze 报 "openspec: command not found"）


### PR DESCRIPTION
## Summary

- `runner/Dockerfile` + `runner/go.Dockerfile`: install kubectl v1.31.4 (#293)
- `runner/entrypoint.sh`: detect kubeconfig 127.0.0.1:6443 → sed rewrite → `/workspace/.kubeconfig` (#292)
- `k8s_runner.build_pod`: add `KUBECONFIG=/workspace/.kubeconfig` env so non-interactive `kubectl exec` 继承

详细 root cause 分别见 #292 / #293。

## 实证

REQ-657 Phase C dogfood 期间 manual smoke：
- `which kubectl` → 空 (需要手 curl 安装到 /workspace 兜)
- `helm list` → "Kubernetes cluster unreachable: 127.0.0.1:6443: connection refused" (需要手 sed 改 URL + KUBECONFIG override)

修后 runner pod 起来即 cluster-ready，accept-env-up Makefile 直接跑 `kubectl exec` / `helm install` 无 hack。

## Test plan
- [x] `uv run pytest tests/test_k8s_runner.py -q` → 41 passed
- [ ] runner-image CI 绿
- [ ] orchestrator-ci 绿（k8s_runner spec 改了一行）
- [ ] 部署后 fresh REQ accept stage 直接通过，不需要任何 manual netrc/kubeconfig/kubectl 兜底

## Refs
- closes #292 #293
- 解锁 #248 Phase C 自动跑通

🤖 Generated with [Claude Code](https://claude.com/claude-code)