### PR TITLE
feat(ci): 镜像 tag 改为 immutable git-sha

### DIFF
--- a/.github/workflows/orchestrator-ci.yml
+++ b/.github/workflows/orchestrator-ci.yml
@@ -55,10 +55,11 @@ jobs:
           version: 'v3.16.3'
 
       - name: helm lint (defaults)
-        # 默认 values 缺 secret.bkd_token 会 fail-by-design，是预期行为
+        # 默认 values 缺 image.tag / secret.bkd_token 会 fail-by-design，是预期行为
         run: |
           set +e
           helm lint helm/ 2>&1 | tee /tmp/lint.txt
+          grep -q 'values.image.tag is required' /tmp/lint.txt || exit 1
           grep -q 'values.secret.bkd_token is required' /tmp/lint.txt || exit 1
 
       - name: helm lint (with dev values)

--- a/.github/workflows/orchestrator-image.yml
+++ b/.github/workflows/orchestrator-image.yml
@@ -1,5 +1,14 @@
 name: orchestrator-image
 
+# build & push sisyphus-orchestrator image to GHCR.
+#
+# 触发：
+#   - push main：build + push（branch tag :main 也由 metadata-action 兜底产出，但
+#     部署侧禁止再用——helm values 一律 pin 到 sha-<short>，见 deploy/README.md）
+#   - 打 orchestrator-v* tag：build + push semver + :latest
+#
+# 输出 tag：sha-<short> + branch tag (:main 仅留作 debug，不让 deployment 引用)
+
 on:
   push:
     branches: [main]
@@ -31,18 +40,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract short SHA
-        id: vars
-        run: echo "sha_short=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-
+            type=match,pattern=orchestrator-v(.*),group=1
+            type=match,pattern=orchestrator-v(\d+\.\d+),group=1
+            type=match,pattern=orchestrator-v(\d+),group=1
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/orchestrator-v') }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./orchestrator
           file: ./orchestrator/Dockerfile
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ steps.vars.outputs.sha_short }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/thanatos-image.yml
+++ b/.github/workflows/thanatos-image.yml
@@ -4,7 +4,8 @@ name: thanatos-image
 # 触发：
 #   - pull_request: build but don't push（验证 Dockerfile 改动能 build）
 #   - push main / 打 thanatos-v* tag: build + push
-# 输出 tag：sha-<short> + dev（main 滚动）+ tag 版本号（push tag 时）
+# 输出 tag：sha-<short> + branch tag (:main，仅 debug；deployment 一律 pin sha)
+#         + 打 thanatos-v* 时 semver + :latest
 
 on:
   pull_request:
@@ -42,18 +43,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract short SHA
-        id: vars
-        run: echo "sha_short=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-
+            type=match,pattern=thanatos-v(.*),group=1
+            type=match,pattern=thanatos-v(\d+\.\d+),group=1
+            type=match,pattern=thanatos-v(\d+),group=1
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/thanatos-v') }}
 
       - name: Build (push only on push events; PR 阶段只验 Dockerfile 能 build)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./thanatos
           file: ./thanatos/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ steps.vars.outputs.sha_short }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/deploy/charts/thanatos/templates/deployment.yaml
+++ b/deploy/charts/thanatos/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             {{- toYaml .Values.redroid.resources | nindent 12 }}
         {{- end }}
         - name: thanatos
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ required "values.image.tag is required: must pin to immutable git-sha (e.g. sha-abc1234), see issue #267" .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           # MCP stdio server — accept-agent talks to it via `kubectl exec`,
           # so we don't expose any TCP listener from the container itself.

--- a/deploy/charts/thanatos/values.yaml
+++ b/deploy/charts/thanatos/values.yaml
@@ -10,7 +10,10 @@ driver: playwright
 
 image:
   repository: ghcr.io/phona/thanatos
-  tag: dev
+  # tag 必填且必须 immutable git-sha（issue #267）。
+  # 部署时 helm upgrade --set image.tag=sha-<short> 注入；
+  # mutable :dev / :latest 已禁止——节点缓存 + IfNotPresent 永远跑老镜像。
+  tag: ""
   pullPolicy: IfNotPresent
 
 resources:
@@ -32,7 +35,7 @@ redroid:
   # `redroid/redroid:11.0.0-latest` / `:13.0.0_64only-latest` 都炸）。
   # build 流水：sisyphus repo `redroid-fixed/` + `.github/workflows/redroid-fixed-image.yml`。
   image: ghcr.io/phona/redroid-fixed:13.0.0
-  # pullPolicy 跟 image.pullPolicy 解耦：thanatos 镜像走 dev tag 滚动可能 Always；
+  # pullPolicy 跟 image.pullPolicy 解耦：thanatos 镜像走 immutable sha tag IfNotPresent；
   # redroid 走稳定 13.0.0 tag IfNotPresent 即可。空值则 fallback 到 image.pullPolicy。
   pullPolicy: ""
   port: 5555

--- a/orchestrator/deploy/README.md
+++ b/orchestrator/deploy/README.md
@@ -69,16 +69,27 @@ git commit + push。部署方拉最新版再跑 helm。
 ### 步骤 5：部署方 helm upgrade + verify
 
 ```bash
+# 获取最近一次 CI build 的 orchestrator sha tag（或本地 git sha）
+SHA="sha-$(git rev-parse --short HEAD)"
+
 # 部署方通过 aissh 跑（两个 values file：非敏感 my-values + 敏感 secrets-values）
 helm -n sisyphus upgrade --install orch ./orchestrator/helm \
   -f orchestrator/deploy/my-values.yaml \
-  -f /tmp/secrets-values.yaml
+  -f /tmp/secrets-values.yaml \
+  --set image.tag="$SHA" \
+  --set runner.image="ghcr.io/phona/sisyphus-runner:$SHA"
 rm -f /tmp/secrets-values.yaml            # 敏感文件用完立即清
 
 kubectl -n sisyphus rollout status deploy/orch-sisyphus-orchestrator
 curl -sSH 'Authorization: Bearer <webhook_token>' \
   http://sisyphus.43.239.84.24.nip.io/admin/metrics | jq .state_distribution
 ```
+
+> **image.tag / runner.image 必须 pin immutable sha**（issue #267）。
+> 部署时忘传 `--set image.tag` 会让 helm template 报错
+> `values.image.tag is required`，fail-loud 而不是渲染出损坏的 image ref。
+> `:main` / `:latest` / `:dev` 等 mutable tag 已禁止——它们看不出对应哪个
+> commit，且 `IfNotPresent` 时节点缓存的旧镜像永远不会被刷新。
 
 ### 步骤 6：BKD webhook 注册（一次性）
 

--- a/orchestrator/deploy/my-values.yaml
+++ b/orchestrator/deploy/my-values.yaml
@@ -9,7 +9,11 @@
 # ── orchestrator image ────────────────────────────────────────────
 image:
   repository: ghcr.io/phona/sisyphus-orchestrator
-  tag: main                       # 实际跑的 tag；CI 自动覆盖到最新 sha
+  # tag 必填且必须 immutable git-sha（issue #267）。
+  # 部署时 helm upgrade --set image.tag=sha-<short> 注入；
+  # 这里留空字符串占位，让"忘记 --set"时 helm 报 "values.image.tag is required"
+  # 而不是渲染出 `:` 这种损坏的 image ref。
+  tag: ""
   pullPolicy: IfNotPresent
 
 replicaCount: 1                    # 多副本对状态机 dedup 无帮助
@@ -76,7 +80,7 @@ runner:
   createRbac: true               # 建 SA/Role/RoleBinding
   serviceAccountName: sisyphus-runner-sa
 
-  image: ghcr.io/phona/sisyphus-runner-go:main
+  image: ""                      # 必填且必须 immutable sha；部署时 --set runner.image=ghcr.io/phona/sisyphus-runner-go:sha-<short>
   storageClass: local-path       # K3s 默认
   workspaceSize: 10Gi
   readyTimeoutSec: 120

--- a/orchestrator/helm/templates/deployment.yaml
+++ b/orchestrator/helm/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: orchestrator
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ required "values.image.tag is required: must pin to immutable git-sha (e.g. sha-abc1234), see issue #267" .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -58,7 +58,7 @@ spec:
             - name: SISYPHUS_RUNNER_NAMESPACE
               value: {{ .Values.runner.namespace | quote }}
             - name: SISYPHUS_RUNNER_IMAGE
-              value: {{ .Values.runner.image | quote }}
+              value: {{ required "values.runner.image is required: must pin to immutable git-sha (e.g. ghcr.io/phona/sisyphus-runner:sha-abc1234), see issue #267" .Values.runner.image | quote }}
             - name: SISYPHUS_RUNNER_SERVICE_ACCOUNT
               value: {{ .Values.runner.serviceAccountName | quote }}
             - name: SISYPHUS_RUNNER_STORAGE_CLASS

--- a/orchestrator/helm/values.dev.yaml
+++ b/orchestrator/helm/values.dev.yaml
@@ -1,9 +1,16 @@
 # dev override：本地 K3s 用，开发自填密钥
 # helm -n sisyphus install orch ./helm -f helm/values.dev.yaml --create-namespace
+#
+# 部署时必须 --set image.tag=sha-<short> 和 --set runner.image=...:sha-<short>
+# 覆盖下面的占位 sha-DEV-PLACEHOLDER（issue #267：部署侧禁止 mutable tag）。
 
 image:
-  pullPolicy: Always
-  tag: "main"   # CI 推到 main 分支会更新这个 tag
+  pullPolicy: IfNotPresent
+  tag: "sha-DEV-PLACEHOLDER"   # 部署时 --set image.tag=sha-<short> 覆盖
+
+runner:
+  # 部署时 --set runner.image=ghcr.io/phona/sisyphus-runner:sha-<short> 覆盖
+  image: "ghcr.io/phona/sisyphus-runner:sha-DEV-PLACEHOLDER"
 
 ingress:
   hosts:

--- a/orchestrator/helm/values.yaml
+++ b/orchestrator/helm/values.yaml
@@ -6,9 +6,15 @@ replicaCount: 1   # 状态机靠 PG CAS 串行，多副本无害但 dedup 无意
 
 image:
   # GHCR：CI 推到 ghcr.io/<github-owner>/sisyphus-orchestrator
-  # tag 推送规则见 .github/workflows/orchestrator-ci.yml
+  # tag 推送规则见 .github/workflows/orchestrator-image.yml
   repository: ghcr.io/phona/sisyphus-orchestrator
-  tag: ""                     # 留空 → 用 Chart.appVersion；用 main 镜像填 "main"
+  # tag 必填，且必须是 immutable git-sha（如 "sha-abc1234"）。**禁止用 mutable tag**
+  # （:main / :latest）—— mutable tag 看不出对应哪个 commit，且 IfNotPresent 时
+  # 节点缓存的旧镜像永远不会刷新（issue #267）。
+  # 部署：helm upgrade --set image.tag="sha-${GITHUB_SHA::7}" ...
+  # tag 留空时 deployment.yaml 的 required 校验会让 helm template / install 报错。
+  tag: ""
+  # immutable tag 下 IfNotPresent 是正解（同 tag = 同镜像，节点缓存反而是好事）
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -128,15 +134,16 @@ runner:
   createRbac: true            # 自动建 Role/RoleBinding 给 orchestrator SA 管 ns
   serviceAccountName: sisyphus-runner-sa   # runner Pod 跑的 SA
 
-  # 默认 full flavor（Flutter SDK + Android SDK + Java + Go + Node + Docker DinD）。
-  # 之前默认 sisyphus-runner-go 是 Go-only 轻量（~1GB），但 Flutter REQ
-  # （如 ttpos-flutter）跑 ci-setup `dart pub global activate melos` 会撞
-  # `dart: No such file or directory`。
+  # runner image **必填且必须是 immutable git-sha** —— 见上方 image.tag 注释。
+  # 之前默认 sisyphus-runner-go:main 是 Go-only 轻量（~1GB），现在切 full flavor
+  # （Flutter SDK + Android SDK + Java + Go + Node + Docker DinD），但 mutable
+  # `:main` tag 已不再允许（issue #267）。
   # full image ~5GB，cold pull 慢一点（~30s vs ~5s），但镜像 cache 命中后所有
-  # REQ 复用，跟 Go-only 实际差不多。换 image 工作量 = 改这一行。
+  # REQ 复用，跟 Go-only 实际差不多。
   # `sisyphus-runner-go` 仍保留 build（runner-image.yml matrix 不动），有需要
-  # 可手动 --set runner.image=ghcr.io/phona/sisyphus-runner-go:main 切回。
-  image: ghcr.io/phona/sisyphus-runner:main
+  # 可换成 `ghcr.io/phona/sisyphus-runner-go:sha-<short>` 切回。
+  # 部署：helm upgrade --set runner.image="ghcr.io/phona/sisyphus-runner:sha-..." ...
+  image: ""
   storageClass: local-path    # K3s 默认；多节点场景换 longhorn / NFS
   workspaceSize: 10Gi         # PVC 大小（runner 峰值 ~5GB + 余量）
   readyTimeoutSec: 120        # ensure_runner 等 Pod Ready 的超时

--- a/orchestrator/src/orchestrator/k8s_runner.py
+++ b/orchestrator/src/orchestrator/k8s_runner.py
@@ -269,11 +269,13 @@ class RunnerController:
         container = client.V1Container(
             name="runner",
             image=self.runner_image,
-            # Always pull —— runner image 是 :main 浮动 tag，IfNotPresent 时节点
-            # 缓存的旧 image 永远不会被刷新（实测：PR #34 加 sisyphus-clone-repos.sh
-            # + check-scenario-refs --specs-search-path 后，runner pod 仍跑老 script
-            # 报 'cd: --: invalid option'，因为节点缓存没更新）。
-            image_pull_policy="Always",
+            # IfNotPresent —— runner image 现在强制 immutable git-sha
+            # （issue #267：helm values runner.image 必填且必须 sha-<short>）。
+            # 同 sha = 同镜像，节点缓存反而是好事；deploy 升级 = bump sha 触发新 pull。
+            # 历史背景：之前是 Always 兜 mutable :main tag（PR #34 加 sisyphus-clone-repos.sh
+            # 后 IfNotPresent + :main 节点缓存没刷新报 'cd: --: invalid option'）；
+            # 切 sha tag 后这个 workaround 不再需要。
+            image_pull_policy="IfNotPresent",
             command=["/usr/local/bin/sisyphus-entrypoint.sh"],
             args=["sleep", "infinity"],
             # privileged: DinD 必须；fuse-overlayfs 要 /dev/fuse + CAP_SYS_ADMIN


### PR DESCRIPTION
## 改动

关闭 #267

- **CI workflow 统一**：`orchestrator-image.yml`、`thanatos-image.yml` 改用 `docker/metadata-action@v5`，产出一致的 sha-<short> / semver / latest tag 策略
- **删 mutable tag**：`:dev`（thanatos）、`:main`（dev values / deploy values）全部移除；部署侧禁止引用 mutable tag
- **helm required 校验**：`image.tag` 和 `runner.image` 留空 → `helm template` / `helm install` 报 `required: must pin to immutable git-sha`，fail-loudly
- **k8s_runner**：`image_pull_policy="Always"` → `"IfNotPresent"`，sha tag 唯一确定镜像，不需要 Always 兜 mutable tag
- **部署文档**：`deploy/README.md` 更新 helm upgrade 注入 `--set image.tag=sha-$SHA`

## 测试

- `helm lint helm/` 默认 values 正确报 `image.tag is required` 和 `secret.bkd_token is required`
- `helm lint helm/ -f helm/values.dev.yaml` pass
- `helm template orch helm/ -f helm/values.dev.yaml` pass
- `helm template orch helm/ -f deploy/my-values.yaml --set image.tag=sha-1234567 --set runner.image=...` 渲染出正确 image ref
- `pytest -m "not integration"` 1991 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)