### PR TITLE
fix(bkd-cli): inject SISYPHUS_BKD_TOKEN auth + custom User-Agent

### DIFF
--- a/scripts/bkd-cli.py
+++ b/scripts/bkd-cli.py
@@ -60,6 +60,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import time
 import urllib.error
@@ -71,19 +72,40 @@ DEFAULT_PROJECT = "nnvxh8wj"
 DEFAULT_MODEL = "claude-sonnet-4-6"
 DEFAULT_ENGINE_TYPE = "claude-code"
 SLUG_TS_LIMIT = 46  # tag 整体 ≤ 50；REQ-<slug> 后 4 字 prefix
+# Cloudflare 在 BKD ingress 前装了 WAF，默认 `Python-urllib/3.x` UA 直接 1010。
+# 任何具名 UA 都通过；这里跟 orchestrator/bkd_rest.py 的 httpx default 风格对齐。
+USER_AGENT = "sisyphus-bkd-cli/1.0"
 
 
 # ─── BKD REST helpers ──────────────────────────────────────────────────────
 
 
+def _bkd_token() -> str | None:
+    """从 env 读 Coder-Session-Token。
+
+    优先 SISYPHUS_BKD_TOKEN（跟 orchestrator helm values 对齐），fallback CODER_SESSION_TOKEN
+    （Coder workspace 内置 env，bkd-cli 在 workspace 里跑时直接复用）。
+    本地 BKD（base_url=http://localhost:3000/api）无 auth，返 None。
+    """
+    return os.environ.get("SISYPHUS_BKD_TOKEN") or os.environ.get("CODER_SESSION_TOKEN")
+
+
 def _req(method: str, url: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
-    """发 HTTP 到 BKD，返回解析后 dict。"""
+    """发 HTTP 到 BKD，返回解析后 dict。
+
+    自动注入：
+      - User-Agent: 绕过 cloudflare WAF 默认拦 Python-urllib UA
+      - Coder-Session-Token: 远端 BKD（gated by Coder）必须；从 env 读
+    """
     data = json.dumps(body, ensure_ascii=False).encode("utf-8") if body else None
-    r = urllib.request.Request(
-        url, data=data,
-        headers={"Content-Type": "application/json"},
-        method=method,
-    )
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
+    }
+    tok = _bkd_token()
+    if tok:
+        headers["Coder-Session-Token"] = tok
+    r = urllib.request.Request(url, data=data, headers=headers, method=method)
     try:
         with urllib.request.urlopen(r, timeout=30) as resp:
             return json.loads(resp.read().decode("utf-8"))


### PR DESCRIPTION
## Summary

`bkd-cli.py` 跑远端 BKD 撞两层墙：
1. Cloudflare WAF 拦默认 `Python-urllib/3.x` UA → \`error code: 1010\`
2. 即使 UA 通了，没 \`Coder-Session-Token\` header → 403

修：自动注入 custom UA + 从 env 读 token (\`SISYPHUS_BKD_TOKEN\` / \`CODER_SESSION_TOKEN\`)。本地 BKD 不影响（env 缺时不注入 auth header）。

## 实证

派 #248 Phase C 业务仓 fix 时撞过，本地 monkey-patch \`_req\` 才能下下去。

## Test plan
- [x] localhost BKD：env 缺，照样 work（no-auth 模式）
- [x] 远端 BKD: \`SISYPHUS_BKD_TOKEN=...\` 设了之后 inline / list / patch 都 200

## Refs
phona/sisyphus#248

🤖 Generated with [Claude Code](https://claude.com/claude-code)