### PR TITLE
fix(runner,thanatos): PATH +pub-cache + MCP schema descriptions (#276 #296)

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -49,8 +49,11 @@ RUN curl -fsSL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
 ARG GO_VERSION=1.23.4
 RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
       | tar -xz -C /usr/local
-ENV PATH="/usr/local/go/bin:/root/go/bin:$PATH" \
+ENV PATH="/usr/local/go/bin:/root/go/bin:/root/.pub-cache/bin:$PATH" \
     GOPATH=/root/go
+# /root/.pub-cache/bin (#276) — `dart pub global activate <pkg>` 装的可执行文件落
+# 在这里（如 melos / flutterfire_cli），下一个 shell 不在 PATH 就 `command not
+# found`。Flutter 业务仓 melos bs 这种步骤都靠这条路径。
 
 # ─── 4. openspec CLI ─────────────────────────────────────────────────────
 # 真包名是 @fission-ai/openspec（旧 Dockerfile 装的 @fission-codes/openspec 不存在，

--- a/thanatos/src/thanatos/server.py
+++ b/thanatos/src/thanatos/server.py
@@ -35,10 +35,37 @@ def _build_server() -> Server:
                     "type": "object",
                     "required": ["skill_path", "spec_path", "scenario_id", "endpoint"],
                     "properties": {
-                        "skill_path": {"type": "string"},
-                        "spec_path": {"type": "string"},
-                        "scenario_id": {"type": "string"},
-                        "endpoint": {"type": "string"},
+                        "skill_path": {
+                            "type": "string",
+                            "description": (
+                                "Absolute path to skill.yaml (FILE, not the .thanatos/ "
+                                "directory). Example: "
+                                "/workspace/source/<repo>/.thanatos/skill.yaml"
+                            ),
+                        },
+                        "spec_path": {
+                            "type": "string",
+                            "description": (
+                                "Absolute path to a spec.md file containing the "
+                                "Scenario block. May live anywhere; common paths: "
+                                "<repo>/.thanatos/spec-fixtures/*.spec.md or "
+                                "<repo>/openspec/changes/<REQ>/specs/.../spec.md"
+                            ),
+                        },
+                        "scenario_id": {
+                            "type": "string",
+                            "description": (
+                                "Identifier in the `#### Scenario: <id> — ...` heading "
+                                "(e.g. ttpos-shop-smoke-001 / REQ-1004-S1). Must match exactly."
+                            ),
+                        },
+                        "endpoint": {
+                            "type": "string",
+                            "description": (
+                                "Driver-specific endpoint. adb: host:port (e.g. "
+                                "localhost:5555). playwright: URL. http: base URL."
+                            ),
+                        },
                     },
                 },
             ),
@@ -52,9 +79,23 @@ def _build_server() -> Server:
                     "type": "object",
                     "required": ["skill_path", "spec_path", "endpoint"],
                     "properties": {
-                        "skill_path": {"type": "string"},
-                        "spec_path": {"type": "string"},
-                        "endpoint": {"type": "string"},
+                        "skill_path": {
+                            "type": "string",
+                            "description": (
+                                "Absolute path to skill.yaml (FILE, not directory). "
+                                "Example: /workspace/source/<repo>/.thanatos/skill.yaml"
+                            ),
+                        },
+                        "spec_path": {
+                            "type": "string",
+                            "description": "Absolute path to spec.md file.",
+                        },
+                        "endpoint": {
+                            "type": "string",
+                            "description": (
+                                "Driver-specific endpoint (adb host:port / playwright URL / http base URL)."
+                            ),
+                        },
                     },
                 },
             ),
@@ -69,12 +110,28 @@ def _build_server() -> Server:
                     "type": "object",
                     "required": ["skill_path", "intent"],
                     "properties": {
-                        "skill_path": {"type": "string"},
-                        "intent": {"type": "string"},
+                        "skill_path": {
+                            "type": "string",
+                            "description": (
+                                "Absolute path to skill.yaml (FILE). recall reads its "
+                                "parent directory to find anchors.md / flows.md / pitfalls.md / etc."
+                            ),
+                        },
+                        "intent": {
+                            "type": "string",
+                            "description": (
+                                "Free-form natural language describing what knowledge to recall, "
+                                "e.g. 'login screen widgets' or 'payment flow pitfalls'."
+                            ),
+                        },
                         "limit": {"type": "integer", "default": 10},
                         "tags": {
                             "type": "array",
                             "items": {"type": "string"},
+                            "description": (
+                                "Optional YAML frontmatter tags to filter by. "
+                                "Files without matching tags are excluded."
+                            ),
                         },
                     },
                 },


### PR DESCRIPTION
## Summary
- runner/Dockerfile (full Flutter): 加 `/root/.pub-cache/bin` 到 PATH
- thanatos server.py: `run_scenario`/`run_all`/`recall` MCP inputSchema 加 description（明示 skill_path 是 file，不是 dir）

详情见 #276 / #296。

## Refs
- closes #276 #296
- 解锁 #248 自驱 acceptance