### PR TITLE
fix(bkd_rest): truncate title/tags > 50 char before sending to BKD (#306)

### DIFF
--- a/orchestrator/src/orchestrator/bkd_rest.py
+++ b/orchestrator/src/orchestrator/bkd_rest.py
@@ -60,11 +60,18 @@ class BKDRestClient:
         engine_type: str | None = None,
         model: str | None = None,
     ) -> Issue:
+        # BKD 限制 title ≤ 50 char (#306) — REQ-id 43 char + `[stage-name]` prefix
+        # 直接撑爆。dispatch 层 callers 只关心可读性，不该全部去算字节。在 client
+        # 这层一刀切截断给 BKD：超 50 留 49 char + `…`，BKD UI 上仍能辨识 REQ。
+        # 同样防御 tags（虽然单个 tag 一般 < 50，但 PR-link tag 历史撞过）。
+        if len(title) > 50:
+            title = title[:49] + "…"
+        sanitized_tags = [t if len(t) <= 50 else (t[:49] + "…") for t in tags]
         body: dict = {
             "title": title,
             "statusId": status_id,
             "useWorktree": use_worktree,
-            "tags": _ensure_sisyphus_tag(tags),
+            "tags": _ensure_sisyphus_tag(sanitized_tags),
         }
         if engine_type:
             body["engineType"] = engine_type


### PR DESCRIPTION
## Summary
- bkd_rest.create_issue truncate title 和 tag 超 50 char 到 49+`…`
- 单点修，所有 create_* dispatch 都受益（staging_test / pr_ci_watch / accept / verifier / fixer）

详情见 #306。

## 实证
REQ-feat-flutter-forgot-password-1777743068 (slug 43 char) 跑通 analyze→spec_lint→challenger→dev_cross_check 后，create_staging_test 撞 `Too big: expected string to have <=50 characters` 卡死。

## Test plan
- [x] uv run pytest tests/ -m "not integration" -k "bkd or rest" → 119 passed
- [ ] CI 绿
- [ ] 部署后 admin/escalate + admin/resume 推 REQ 进 staging_test 看是否通过 dispatch

## Refs
closes #306, 解锁 #248 自驱 dogfood

🤖 Generated with [Claude Code](https://claude.com/claude-code)