### PR TITLE
fix(actions/create_accept): pass branch into accept.md.j2 render

### DIFF
--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -280,6 +280,7 @@ async def create_accept(*, body, req_id, tags, ctx):
             accept_env=accept_env,
             project_id=proj,
             project_alias=proj,
+            branch=branch_for_links,
             thanatos_pod=thanatos_pod,
             thanatos_namespace=thanatos_namespace,
             thanatos_skill_repo=thanatos_skill_repo,

--- a/orchestrator/src/orchestrator/prompts/accept.md.j2
+++ b/orchestrator/src/orchestrator/prompts/accept.md.j2
@@ -104,7 +104,7 @@ accept-agent 顺手 commit；下次 recall 就能命中，省去重新探索。
 1. 在 BKD Coder workspace（你跑 BKD agent 这边）clone source repo（如果还没）：
    ```bash
    cd /tmp && rm -rf source-{{ thanatos_skill_repo }} && \
-     git clone -b $(echo "{{ ctx.branch }}" || echo "feat/{{ req_id }}") \
+     git clone -b "{{ branch }}" \
        "https://x-access-token:$GITHUB_TOKEN@github.com/<org>/{{ thanatos_skill_repo }}.git" \
        source-{{ thanatos_skill_repo }}
    cd source-{{ thanatos_skill_repo }}


### PR DESCRIPTION
## 问题

\`create_accept\` action 调 \`render(\"accept.md.j2\", ...)\` 没传 \`ctx\` 参数，但 \`accept.md.j2\` line 107 用 \`{{ ctx.branch }}\` → jinja2 \`UndefinedError\` 导致 action 崩 → session.failed 死循环。

\`\`\`
File \"...prompts/accept.md.j2\", line 107
    git clone -b $(echo \"{{ ctx.branch }}\" || echo \"feat/{{ req_id }}\") \\
jinja2.exceptions.UndefinedError: 'ctx' is undefined
\`\`\`

## 修法

最小 surface：
1. \`create_accept.py\`：把已经在 line 260 算好的 \`branch_for_links\` 作为 \`branch\` 传给 render
2. \`accept.md.j2\`：直接用 \`{{ branch }}\`（callsite 永远算好，包含 \`feat/{req_id}\` fallback）；去掉模板里的 \`echo || echo\` shell fallback（重复且 jinja 已经死了）

## 实证

REQ-feat-flutter-forgot-password-1777743068 (Phase B-final dogfood) accept-env-up 跑通后撞此 bug，stuck loop until escalate cap.

## Test plan

- [ ] orchestrator-ci 通过
- [ ] redeploy 后验：dogfood REQ accept stage 走过 create_accept 进 BKD acceptance-agent