### PR TITLE
fix(actions/create_accept): bump env-up timeout 600→1800s

### DIFF
--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -24,7 +24,7 @@ from ._skip import skip_if_enabled
 
 log = structlog.get_logger(__name__)
 
-_TIMEOUT_ENV_UP_SEC = 600  # 10 min for helm install + wait ready
+_TIMEOUT_ENV_UP_SEC = 1800  # 30 min: helm install + wait ready + APK GHA build poll (5-10min) + download + adb install
 _TIMEOUT_LITE_SEC = 1800   # 30 min for up × N + sleep + smoke × N + down × N
 
 


### PR DESCRIPTION
## 问题

原 \`_TIMEOUT_ENV_UP_SEC = 600\`（10min）是历史预算（helm install + wait ready）。Phase B-final dogfood (REQ-feat-flutter-forgot-password-1777743068) 撞到：

业务仓 \`make accept-env-up\` 现在还包含：
- helm install lab + thanatos：1-3min
- redroid boot wait：0-2min
- **dispatch APK GHA build + poll：5-10min**
- download artifact：~30s
- kubectl cp + adb install：~10s

整体 12-15min，10min 不够，subprocess 被 orch 杀掉，exit_code=-1，stderr 截在 \"downloading artifact\"。

## 修法

bump 1800s (30min) 留 margin。

## 后续 backlog

- \`ttpos-flutter scripts/trigger_apk_build.sh\` 加 sha-based artifact cache 复用，省 5-10min/次重跑
- 拆 accept-env-up 为多步骤（lab/thanatos/apk）让 orch 能各自计时 + 各自 retry

## Test plan

- [ ] orchestrator-ci 通过
- [ ] dogfood REQ accept-env-up 跑完整 ≤30min 不再 timeout