### PR TITLE
fix(actions/create_accept): clear stale accept_issue_id at entry (#315)

### DIFF
--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -178,6 +178,15 @@ async def create_accept(*, body, req_id, tags, ctx):
     source_issue_id = body.issueId
     namespace = f"accept-{req_id.lower()}"
 
+    # Clear stale accept_issue_id from prior round (#315): create_accept env-up
+    # 阶段 5-15min；watchdog 看 ctx.accept_issue_id 检 stuck，stale id 指向上轮
+    # 早 escalate 关闭的 issue，没新事件 → 误判 watchdog_stuck → 强制 session.failed
+    # 把当前 in-flight create_accept 打断。入口先清 stale id，让 watchdog 知道
+    # 当前没 active acceptance agent，跳过 stuck 检查。
+    pool = db.get_pool()
+    if ctx and ctx.get("accept_issue_id"):
+        await req_state.update_context(pool, req_id, {"accept_issue_id": None})
+
     # Phase 1: env-up via sisyphus (runner exec)
     try:
         rc = k8s_runner.get_controller()


### PR DESCRIPTION
## 问题

create_accept env-up 阶段长达 5-15min（helm install + APK GHA build poll + adb install + verify）。期间 \`ctx.accept_issue_id\` 还指向上轮 acceptance issue（已 escalate 关闭，session ended）。

watchdog 看 ended issue + stuck_sec >= ended_sec(300) → emit \`session.failed\` → 强制 escalate 当前 in-flight create_accept。

REQ-feat-flutter-forgot-password-1777743068 Phase B-final dogfood 撞此 race，escalated_retry_count 2/2 吃满死锁。

## 修法

入口先清 ctx.accept_issue_id：watchdog \`watchdog.py:310\` defense-in-depth (\`issue_id is None and policy.stuck_sec is None\`) return False → 跳过 stuck 检测，给 create_accept 完整 1800s timeout 跑完 + 派出新 acceptance-agent + 写新 id 进 ctx。

## Test plan

- [ ] orchestrator-ci 通过
- [ ] dogfood REQ accept-running 阶段 watchdog 不再误杀 create_accept