### PR TITLE
feat(prompts): exec_run output 大小约束防 stream stall (#304)

### DIFF
--- a/orchestrator/src/orchestrator/prompts/_shared/runner_container.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/runner_container.md.j2
@@ -32,6 +32,35 @@ POD=runner-{{ req_id | lower }}
 NS=sisyphus-runners
 ```
 
+### ⚠️ exec_run 输出大小约束（**防 stream stall，必读**）
+
+`mcp__{{ mcp_capability_providers['ssh_exec'] }}__exec_run` 的单次输出**不得超过 50 KB（约 1 万行）**。
+超限时 BKD 会把 output 截断落盘并给你一个 stub 错误——agent 无法读到完整内容，且极易触发 3 min+ stream stall。
+
+**危险写法 → 安全写法对照表：**
+
+| 危险写法（输出无上限） | 安全替代 |
+|---|---|
+| `kubectl logs <pod>` | `kubectl logs --tail=200 <pod>` |
+| `git log -p` | `git log --oneline -20` 或 `git log -p -1 -- <path>` |
+| `find /` 或 `ls -R` | `find . -name '*.py' \| head -50` |
+| `cat <bigfile>` | `head -200 <bigfile>` 或 `sed -n '100,200p' <bigfile>` |
+| `ps aux`（全量） | `ps aux \| grep <name>` |
+
+**不确定 output 多大时，先探后拉：**
+
+```bash
+# 先量再决定
+wc -l /some/file
+du -h /some/dir
+kubectl logs --tail=1 <pod> | wc -c   # 估每行大小
+
+# 真需要看长 output：先落盘，再取关键段
+kubectl logs <pod> > /tmp/pod.log
+tail -n 200 /tmp/pod.log
+grep -n 'ERROR\|FATAL' /tmp/pod.log | head -50
+```
+
 ### workspace 约定结构（**sisyphus 强约定**）
 
 每个 source repo **必须** clone 到 `/workspace/source/<repo-basename>/`——

--- a/orchestrator/src/orchestrator/prompts/_shared/tools_whitelist.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/tools_whitelist.md.j2
@@ -5,6 +5,7 @@
 - `mcp__{{ mcp_capability_providers['ssh_exec'] }}__*` —— vm-node04 上 exec_run 命令、file_deploy 文件
   （`ssh_exec` capability 对应的 provider 由 `mcp_capability_providers` 决定，
   当前默认 = `{{ mcp_capability_providers['ssh_exec'] }}`；helm values 可改 provider）
+  ⚠️ exec_run 单次输出必须 ≤ 50 KB，危险写法和安全替代见 runner_container.md.j2 §exec_run 输出大小约束
 - `Bash` —— 跑 curl 调 BKD REST API（见下方）、跑本地 git/gh CLI 命令、跑本地 openspec 等
 - `Read` / `Write` / `Edit` / `Glob` / `Grep` —— agent 自己 cwd 的文件操作
 


### PR DESCRIPTION
## 背景

closes #304

REQ-feat-flutter-forgot-password analyze stage 撞过：

```
Error: result (233,663 characters) exceeds maximum allowed tokens.
[BKD] Stream stall detected — waiting for CLI recovery (silent 3min, pid=2303795)
```

agent 调 `mcp__aissh-tao__exec_run` 时跑 `kubectl logs`（无 --tail）/ `git log -p` 等 raw dump，单次输出超 Claude API max tokens → BKD 截断落盘 + agent 无法 recover → stream stall。

## 改动

- `_shared/runner_container.md.j2`：在 exec_run 用法说明之后插入 ⚠️ 章节，含 50 KB 上限声明、危险→安全写法对照表、先探后拉的落盘技巧
- `_shared/tools_whitelist.md.j2`：在 `exec_run` 工具条目末加一行 cross-ref，指向新章节

不改任何 .py 代码；两份 _shared partial 被所有 stage prompt include，自动生效。

## 关联

- closes #304
- 相关：#290 (BKD watchdog self-heal 只覆盖 empty text，不覆盖大 output 截断)