### PR TITLE
fix(orchestrator): create_accept ensure runner pod 幂等防 admin/resume 跳过 staging_test 崩 (#308)

### DIFF
--- a/orchestrator/src/orchestrator/actions/_clone.py
+++ b/orchestrator/src/orchestrator/actions/_clone.py
@@ -103,6 +103,35 @@ def resolve_repos(
     return [], "none"
 
 
+async def ensure_runner_with_clone(
+    req_id: str,
+    ctx: dict | None,
+    *,
+    tags: Iterable[str] | None = None,
+    default_repos: Iterable[str] | None = None,
+    branch: str | None = None,
+) -> tuple[list[str] | None, int | None]:
+    """Ensure runner pod exists then clone repos into it.
+
+    Used by create_accept when the runner pod never existed (e.g. admin/resume
+    skipped staging_test).  Returns same (repos, exit_code) as
+    clone_involved_repos_into_runner.
+    """
+    try:
+        rc = k8s_runner.get_controller()
+    except RuntimeError as e:
+        log.warning("ensure_runner_with_clone.no_controller", req_id=req_id, error=str(e))
+        return None, None
+
+    await rc.ensure_runner(req_id, wait_ready=True)
+    return await clone_involved_repos_into_runner(
+        req_id, ctx,
+        tags=tags,
+        default_repos=default_repos,
+        default_base=branch,
+    )
+
+
 async def clone_involved_repos_into_runner(
     req_id: str,
     ctx: dict | None,

--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -19,6 +19,7 @@ from ..prompts import render
 from ..state import Event
 from ..store import db, req_state
 from . import register, short_title
+from ._clone import ensure_runner_with_clone
 from ._integration_resolver import resolve_integration_dir
 from ._skip import skip_if_enabled
 
@@ -184,6 +185,32 @@ async def create_accept(*, body, req_id, tags, ctx):
     except RuntimeError as e:
         log.warning("create_accept.no_runner_controller", req_id=req_id, error=str(e))
         return {"emit": Event.ACCEPT_PASS.value, "note": "no runner controller, skipped env-up"}
+
+    # Ensure runner pod exists: admin/resume may have skipped staging_test,
+    # leaving the pod never created.  ensure_runner is idempotent (409 = skip).
+    status = await rc.get_runner_status(req_id)
+    if status is None or status.pod_phase == "NotFound":
+        log.info("create_accept.runner_pod_missing", req_id=req_id,
+                 pod_phase=status.pod_phase if status else "NotFound")
+        branch = (ctx or {}).get("branch") or f"feat/{req_id}"
+        _cloned, clone_exit = await ensure_runner_with_clone(
+            req_id, ctx,
+            tags=tags,
+            default_repos=settings.default_involved_repos or [],
+            branch=branch,
+        )
+        if clone_exit is not None:
+            log.error("create_accept.ensure_runner_clone_failed",
+                      req_id=req_id, exit_code=clone_exit)
+            pool = db.get_pool()
+            await req_state.update_context(pool, req_id, {
+                "accept_result": "fail",
+                "accept_error": f"ensure runner+clone failed: exit_code={clone_exit}",
+            })
+            return {
+                "emit": Event.ACCEPT_ENV_UP_FAIL.value,
+                "reason": f"runner pod clone failed: exit_code={clone_exit}",
+            }
 
     resolved = await resolve_integration_dir(rc, req_id)
     if resolved.dir is None:

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -370,6 +370,14 @@ async def test_create_accept(monkeypatch):
     monkeypatch.setattr("orchestrator.actions.create_accept.settings.accept_smoke_delay_sec", 0)
 
     class FakeRC:
+        async def get_runner_status(self, req_id):
+            from orchestrator.k8s_runner import RunnerStatus
+            return RunnerStatus(
+                req_id=req_id, pod_name=f"runner-{req_id.lower()}",
+                pvc_name=f"workspace-{req_id.lower()}",
+                pod_phase="Running", pvc_phase="Bound", created_at=None,
+            )
+
         async def exec_in_runner(self, req_id, command, env=None, timeout_sec=None):
             if "make accept-env-up" in command:
                 return ExecResult(
@@ -416,6 +424,14 @@ async def test_create_accept_env_up_fail(monkeypatch):
     monkeypatch.setattr("orchestrator.actions.create_accept.settings.accept_smoke_delay_sec", 0)
 
     class FakeRC:
+        async def get_runner_status(self, req_id):
+            from orchestrator.k8s_runner import RunnerStatus
+            return RunnerStatus(
+                req_id=req_id, pod_name=f"runner-{req_id.lower()}",
+                pvc_name=f"workspace-{req_id.lower()}",
+                pod_phase="Running", pvc_phase="Bound", created_at=None,
+            )
+
         async def exec_in_runner(self, req_id, command, env=None, timeout_sec=None):
             if "make accept-env-up" in command:
                 return ExecResult(
@@ -464,6 +480,9 @@ async def test_create_accept_skipped(monkeypatch):
     monkeypatch.setattr("orchestrator.actions.create_accept.settings.test_mode", False)
 
     class FakeRC:
+        async def get_runner_status(self, req_id):
+            raise AssertionError("get_runner_status must NOT be called when skipped")
+
         async def exec_in_runner(self, *a, **kw):
             raise AssertionError("exec_in_runner must NOT be called when skipped")
 

--- a/orchestrator/tests/test_contract_thanatos_m1_accept.py
+++ b/orchestrator/tests/test_contract_thanatos_m1_accept.py
@@ -37,6 +37,14 @@ class _FakeRC:
         self.calls: list[dict] = []
         self._idx = 0
 
+    async def get_runner_status(self, req_id):
+        from orchestrator.k8s_runner import RunnerStatus
+        return RunnerStatus(
+            req_id=req_id, pod_name=f"runner-{req_id.lower()}",
+            pvc_name=f"workspace-{req_id.lower()}",
+            pod_phase="Running", pvc_phase="Bound", created_at=None,
+        )
+
     async def exec_in_runner(self, req_id, command, env=None, timeout_sec=None):
         self.calls.append({"req_id": req_id, "command": command, "env": env})
         result = self.results[self._idx] if self._idx < len(self.results) else _FakeExecResult()

--- a/orchestrator/tests/test_create_accept_ensure_runner.py
+++ b/orchestrator/tests/test_create_accept_ensure_runner.py
@@ -1,0 +1,206 @@
+"""Tests for create_accept runner-pod ensure logic (#308).
+
+Two scenarios:
+  - ERS-S1: runner pod NotFound → ensure_runner_with_clone called → proceeds
+  - ERS-S2: runner pod already Running → ensure skipped → proceeds normally
+"""
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.actions import create_accept as mod
+from orchestrator.actions._integration_resolver import ResolveResult
+from orchestrator.k8s_runner import ExecResult, RunnerStatus
+from orchestrator.state import Event
+
+
+# ─── Fakes ────────────────────────────────────────────────────────────────
+
+
+class _FakeRC:
+    def __init__(self, pod_phase: str = "Running"):
+        self._pod_phase = pod_phase
+        self.ensure_runner_calls: list[str] = []
+        self.exec_calls: list[dict] = []
+
+    async def get_runner_status(self, req_id: str) -> RunnerStatus | None:
+        if self._pod_phase == "NotFound":
+            return None
+        return RunnerStatus(
+            req_id=req_id,
+            pod_name=f"runner-{req_id.lower()}",
+            pvc_name=f"workspace-{req_id.lower()}",
+            pod_phase=self._pod_phase,
+            pvc_phase="Bound",
+            created_at=None,
+        )
+
+    async def ensure_runner(self, req_id: str, *, wait_ready: bool = True,
+                            timeout_sec=None, attempts=None) -> str:
+        self.ensure_runner_calls.append(req_id)
+        return f"runner-{req_id.lower()}"
+
+    async def exec_in_runner(self, req_id, command, env=None, timeout_sec=None):
+        self.exec_calls.append({"req_id": req_id, "command": command})
+        if "make accept-env-up" in command:
+            return ExecResult(
+                exit_code=0,
+                stdout='{"endpoint": "http://localhost"}\n',
+                stderr="",
+                duration_sec=0.5,
+            )
+        # lite fallback
+        return ExecResult(exit_code=0, stdout="PASS\n", stderr="", duration_sec=0.5)
+
+
+class _FakePool:
+    def __init__(self):
+        self.ctx_updates: list[dict] = []
+
+    async def execute(self, sql, *args):
+        pass
+
+    async def fetchrow(self, sql, *args):
+        return None
+
+
+def _body():
+    return type("B", (), {
+        "issueId": "src-1", "projectId": "proj",
+        "event": "pr-ci.pass", "title": "T",
+        "tags": [], "issueNumber": None,
+    })()
+
+
+def _patch(monkeypatch, rc: _FakeRC, pool: _FakePool,
+           clone_exit: int | None = None,
+           cloned_repos: list[str] | None = None):
+    monkeypatch.setattr("orchestrator.actions.create_accept.k8s_runner.get_controller", lambda: rc)
+    monkeypatch.setattr("orchestrator.actions.create_accept.db.get_pool", lambda: pool)
+    monkeypatch.setattr("orchestrator.actions.create_accept.settings.skip_accept", False)
+    monkeypatch.setattr("orchestrator.actions.create_accept.settings.test_mode", False)
+    monkeypatch.setattr("orchestrator.actions.create_accept.settings.accept_smoke_delay_sec", 0)
+    monkeypatch.setattr(
+        "orchestrator.actions.create_accept.settings.default_involved_repos", []
+    )
+
+    async def fake_ensure_runner_with_clone(req_id, ctx, *, tags, default_repos, branch):
+        return (cloned_repos or [], clone_exit)
+
+    monkeypatch.setattr(
+        "orchestrator.actions.create_accept.ensure_runner_with_clone",
+        fake_ensure_runner_with_clone,
+    )
+
+    async def fake_resolve_integration_dir(rc, req_id):
+        return ResolveResult(dir="/workspace/source/test")
+
+    monkeypatch.setattr(
+        "orchestrator.actions.create_accept.resolve_integration_dir",
+        fake_resolve_integration_dir,
+    )
+
+    async def fake_update_ctx(p, req_id, updates):
+        pool.ctx_updates.append(updates)
+
+    monkeypatch.setattr(
+        "orchestrator.actions.create_accept.req_state.update_context",
+        fake_update_ctx,
+    )
+
+
+# ─── ERS-S1: pod NotFound → ensure called → proceeds ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ers_s1_pod_missing_ensures_and_proceeds(monkeypatch):
+    """Pod NotFound → ensure_runner_with_clone → continues to env-up → ACCEPT_PASS."""
+    rc = _FakeRC(pod_phase="NotFound")
+    pool = _FakePool()
+    _patch(monkeypatch, rc, pool, clone_exit=None, cloned_repos=["org/repo"])
+
+    out = await mod.create_accept(
+        body=_body(),
+        req_id="REQ-test-123",
+        tags=[],
+        ctx={"branch": "feat/REQ-test-123", "cloned_repos": ["org/repo"]},
+    )
+
+    assert out.get("emit") == Event.ACCEPT_PASS.value, f"expected ACCEPT_PASS, got {out}"
+    # exec_in_runner called for env-up + lite fallback
+    assert len(rc.exec_calls) >= 1
+
+
+@pytest.mark.asyncio
+async def test_ers_s1_clone_fail_emits_env_up_fail(monkeypatch):
+    """Pod NotFound + clone fails → ACCEPT_ENV_UP_FAIL, ctx records error."""
+    rc = _FakeRC(pod_phase="NotFound")
+    pool = _FakePool()
+    _patch(monkeypatch, rc, pool, clone_exit=1, cloned_repos=["org/repo"])
+
+    out = await mod.create_accept(
+        body=_body(),
+        req_id="REQ-test-456",
+        tags=[],
+        ctx={"branch": "feat/REQ-test-456"},
+    )
+
+    assert out.get("emit") == Event.ACCEPT_ENV_UP_FAIL.value
+    assert "clone failed" in out.get("reason", "")
+    fail_ctx = next((u for u in pool.ctx_updates if u.get("accept_result") == "fail"), None)
+    assert fail_ctx is not None, "accept_result=fail must be stored in ctx"
+
+
+# ─── ERS-S2: pod already Running → ensure skipped → proceeds ─────────────
+
+
+@pytest.mark.asyncio
+async def test_ers_s2_pod_running_skips_ensure(monkeypatch):
+    """Pod already Running → ensure_runner_with_clone NOT called → proceeds normally."""
+    rc = _FakeRC(pod_phase="Running")
+    pool = _FakePool()
+
+    ensure_called = []
+
+    async def fake_ensure_runner_with_clone(req_id, ctx, *, tags, default_repos, branch):
+        ensure_called.append(req_id)
+        return ([], None)
+
+    monkeypatch.setattr("orchestrator.actions.create_accept.k8s_runner.get_controller", lambda: rc)
+    monkeypatch.setattr("orchestrator.actions.create_accept.db.get_pool", lambda: pool)
+    monkeypatch.setattr("orchestrator.actions.create_accept.settings.skip_accept", False)
+    monkeypatch.setattr("orchestrator.actions.create_accept.settings.test_mode", False)
+    monkeypatch.setattr("orchestrator.actions.create_accept.settings.accept_smoke_delay_sec", 0)
+    monkeypatch.setattr(
+        "orchestrator.actions.create_accept.settings.default_involved_repos", []
+    )
+    monkeypatch.setattr(
+        "orchestrator.actions.create_accept.ensure_runner_with_clone",
+        fake_ensure_runner_with_clone,
+    )
+
+    async def fake_resolve_integration_dir(rc, req_id):
+        return ResolveResult(dir="/workspace/source/test")
+
+    monkeypatch.setattr(
+        "orchestrator.actions.create_accept.resolve_integration_dir",
+        fake_resolve_integration_dir,
+    )
+
+    async def fake_update_ctx(p, req_id, updates):
+        pool.ctx_updates.append(updates)
+
+    monkeypatch.setattr(
+        "orchestrator.actions.create_accept.req_state.update_context",
+        fake_update_ctx,
+    )
+
+    out = await mod.create_accept(
+        body=_body(),
+        req_id="REQ-test-789",
+        tags=[],
+        ctx={"branch": "feat/REQ-test-789", "cloned_repos": ["org/repo"]},
+    )
+
+    assert len(ensure_called) == 0, "ensure_runner_with_clone must NOT be called when pod exists"
+    assert out.get("emit") == Event.ACCEPT_PASS.value

--- a/orchestrator/tests/test_create_accept_ensure_runner.py
+++ b/orchestrator/tests/test_create_accept_ensure_runner.py
@@ -13,7 +13,6 @@ from orchestrator.actions._integration_resolver import ResolveResult
 from orchestrator.k8s_runner import ExecResult, RunnerStatus
 from orchestrator.state import Event
 
-
 # ─── Fakes ────────────────────────────────────────────────────────────────
 
 

--- a/orchestrator/tests/test_create_accept_minimal.py
+++ b/orchestrator/tests/test_create_accept_minimal.py
@@ -26,6 +26,14 @@ class _FakeRC:
         self.lite_stderr = lite_stderr
         self.calls: list[dict] = []
 
+    async def get_runner_status(self, req_id):
+        from orchestrator.k8s_runner import RunnerStatus
+        return RunnerStatus(
+            req_id=req_id, pod_name=f"runner-{req_id.lower()}",
+            pvc_name=f"workspace-{req_id.lower()}",
+            pod_phase="Running", pvc_phase="Bound", created_at=None,
+        )
+
     async def exec_in_runner(self, req_id, command, env=None, timeout_sec=None):
         self.calls.append({"req_id": req_id, "command": command, "env": env})
         # env-up call


### PR DESCRIPTION
## Summary

- **根因**：admin/resume `action=pass` 跳过 staging_test 时 runner pod 从未创建，`create_accept` 直接调 `resolve_integration_dir` → `exec_in_runner` → K8s 404 崩溃（closes #308）
- **修法**：`create_accept` 入口新增 `get_runner_status` 检查，pod 缺失时调 `_clone.py` 新增的 `ensure_runner_with_clone` helper（`ensure_runner` 幂等建 pod + clone repos + checkout `feat/<REQ>`），clone 失败 emit `ACCEPT_ENV_UP_FAIL` 并写 ctx error
- **测试**：新增 `test_create_accept_ensure_runner.py`（ERS-S1 pod 缺失走通、ERS-S1 clone 失败报错、ERS-S2 pod 已在跳过 ensure）；修 3 处存量 FakeRC 补 `get_runner_status` stub

## 实证日志（#308）

```
{"event": "engine.action_failed", "action": "create_accept", ...}
WebSocketBadStatusException: Handshake status 404 Not Found ...
pods "runner-req-feat-flutter-forgot-password-1777743068" not found
```

## Test plan

- [x] `pytest tests/test_create_accept_ensure_runner.py` — 3 passed
- [x] `pytest tests/ -m "not integration"` — 2033 passed（ruff 环境缺失的 2 条 skip）
- [ ] 生产验证：下次 admin/resume 跳 staging_test 后 create_accept 成功建 pod + clone + env-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)