### PR TITLE
feat(orchestrator): PR base drift cron + 看板 (#246)

### DIFF
--- a/observability/queries/sisyphus/19-pr-drift.sql
+++ b/observability/queries/sisyphus/19-pr-drift.sql
@@ -1,0 +1,34 @@
+-- Q19: PR base drift 最新快照
+-- REQ-fix-pr-queue-health-monitoring-1777789759
+--
+-- 展示每个 OPEN PR 最近一次扫描时的 drift 状态：落后 commit 数 + 是否预测冲突。
+-- 只看 behind_count > 5 的（低于阈值的 PR 不写 pr_drift_log）。
+-- 按 drift_kind / behind_count DESC 排序：语义冲突优先，纯 lint drift 其次。
+--
+-- 建议 Visualization：Table，条件格式 conflict_predicted=true 标红
+
+WITH latest AS (
+    SELECT DISTINCT ON (repo, pr_number)
+        repo,
+        pr_number,
+        base_sha,
+        behind_count,
+        conflict_predicted,
+        drift_kind,
+        checked_at
+    FROM pr_drift_log
+    ORDER BY repo, pr_number, checked_at DESC
+)
+SELECT
+    repo,
+    pr_number,
+    behind_count,
+    drift_kind,
+    conflict_predicted,
+    checked_at
+FROM latest
+WHERE behind_count > 5
+ORDER BY
+    conflict_predicted DESC,
+    drift_kind,
+    behind_count DESC;

--- a/observability/queries/sisyphus/20-pr-aging.sql
+++ b/observability/queries/sisyphus/20-pr-aging.sql
@@ -1,0 +1,50 @@
+-- Q20: PR queue 年龄 + dirty rate 分桶统计
+-- REQ-fix-pr-queue-health-monitoring-1777789759
+--
+-- 统计 pr_drift_log 里各 PR 的首次发现时间（首次 checked_at）作为 proxy 年龄，
+-- 按 <1d / 1-3d / 3-7d / >7d 分桶，输出 dirty rate（drift_kind != NULL）和平均 behind_count。
+--
+-- NOTE: pr_drift_log 只记录 behind > threshold 的 PR；newly-opened fresh PR（threshold 内）
+-- 不在此表，年龄统计不含 fresh PR。若需完整 PR 生命周期统计，需扩展 pr_links 表（TODO）。
+-- 建议 Visualization：Bar chart，X = age_bucket，Y = pr_count，颜色按 dirty_rate 渐变
+
+WITH first_seen AS (
+    SELECT
+        repo,
+        pr_number,
+        MIN(checked_at)                                    AS first_seen_at,
+        MAX(behind_count)                                  AS max_behind,
+        BOOL_OR(drift_kind IS NOT NULL)                    AS is_dirty
+    FROM pr_drift_log
+    GROUP BY repo, pr_number
+),
+bucketed AS (
+    SELECT
+        repo,
+        pr_number,
+        max_behind,
+        is_dirty,
+        NOW() - first_seen_at                              AS age,
+        CASE
+            WHEN NOW() - first_seen_at < INTERVAL '1 day'  THEN '<1d'
+            WHEN NOW() - first_seen_at < INTERVAL '3 days' THEN '1-3d'
+            WHEN NOW() - first_seen_at < INTERVAL '7 days' THEN '3-7d'
+            ELSE '>7d'
+        END                                                AS age_bucket
+    FROM first_seen
+)
+SELECT
+    repo,
+    age_bucket,
+    COUNT(*)                                               AS pr_count,
+    ROUND(AVG(max_behind), 1)                              AS avg_behind_count,
+    ROUND(100.0 * SUM(CASE WHEN is_dirty THEN 1 ELSE 0 END) / COUNT(*), 1)
+                                                           AS dirty_rate_pct
+FROM bucketed
+GROUP BY repo, age_bucket
+ORDER BY repo, CASE age_bucket
+    WHEN '<1d'  THEN 1
+    WHEN '1-3d' THEN 2
+    WHEN '3-7d' THEN 3
+    ELSE 4
+END;

--- a/observability/sisyphus-dashboard.md
+++ b/observability/sisyphus-dashboard.md
@@ -280,6 +280,32 @@ Q12/Q13 是"此刻在出事吗"，放最上；Q6/Q8 是周度趋势；Q9/Q11 是
 └─────────────────────────────────────────────────────────────┘
 ```
 
+## PR queue health 看板（Q19–Q20，REQ-fix-pr-queue-health-monitoring-1777789759）
+
+pr_health cron（30min 周期）把 behind > 5 commit 的 OPEN PR 写入 `pr_drift_log`，供以下两条 Question 查询。
+
+### Q19. PR base drift 最新快照
+
+- **SQL**：[queries/sisyphus/19-pr-drift.sql](queries/sisyphus/19-pr-drift.sql)
+- **Visualization**：Table（列：`repo, pr_number, behind_count, drift_kind, conflict_predicted, checked_at`）
+- **条件格式**：`conflict_predicted = true` 行标红
+- **人工介入阈值**：`drift_kind = 'semantic-drift'` 行 > 0 应检查受影响 PR 是否需要人工 rebase
+
+### Q20. PR queue 年龄 + dirty rate 分桶
+
+- **SQL**：[queries/sisyphus/20-pr-aging.sql](queries/sisyphus/20-pr-aging.sql)
+- **Visualization**：Bar chart（X = `age_bucket`，Y = `pr_count`，颜色表示 `dirty_rate_pct`）
+- **注意**：仅含 behind > threshold 的 PR（fresh PR 不写 pr_drift_log）；完整 PR 生命周期统计需 pr_links 扩展（TODO followup）
+
+**PR queue health 看板布局（建议挂 M7 看板底部）**：
+
+```
+┌──────────────────────────────┬──────────────────────────────┐
+│  Q19. PR drift 最新快照       │  Q20. PR 年龄 + dirty rate   │
+│  (table，冲突行标红)          │  (bar chart，按年龄分桶)      │
+└──────────────────────────────┴──────────────────────────────┘
+```
+
 ## 刷新频率
 
 M7 看板：
@@ -297,6 +323,9 @@ M14e 质量看板：
 
 Webhook dedup 看板：
 - Q17：每 5 分钟（pending_or_crashed > 0 通常意味 webhook handler 崩了，越早发现越好）
+
+PR queue health 看板：
+- Q19 / Q20：每 30 分钟（和 pr_health cron 同步，数据不比 cron 更新）
 
 Metabase Question 设置 `Results cache TTL`：Q5/Q1 设 30s，Q2/Q3/Q4/Q12/Q13/Q17/Q18 设 120s，其余设 1800s。
 

--- a/orchestrator/migrations/0013_pr_drift_log.rollback.sql
+++ b/orchestrator/migrations/0013_pr_drift_log.rollback.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_pr_drift_log_latest;
+DROP TABLE IF EXISTS pr_drift_log;

--- a/orchestrator/migrations/0013_pr_drift_log.sql
+++ b/orchestrator/migrations/0013_pr_drift_log.sql
@@ -1,0 +1,19 @@
+-- REQ-fix-pr-queue-health-monitoring-1777789759: PR base drift 检测表
+--
+-- 每 30min cron 扫 OPEN PR，记录落后 main 的 commit 数 + 冲突预测。
+-- 供 Metabase Q19-pr-drift / Q20-pr-aging 看板查询。
+-- PRIMARY KEY 含 checked_at：允许同一 PR 多次记录（历史趋势）。
+
+CREATE TABLE pr_drift_log (
+    pr_number       INTEGER     NOT NULL,
+    repo            TEXT        NOT NULL,  -- 'phona/sisyphus' / 'phona/ttpos-flutter' 等
+    base_sha        TEXT        NOT NULL,  -- 检测时 target branch HEAD SHA
+    behind_count    INTEGER     NOT NULL,  -- PR head 落后 base branch 的 commit 数
+    conflict_predicted BOOLEAN  NOT NULL,  -- GitHub mergeable=false / mergeable_state=dirty
+    drift_kind      TEXT,                  -- 'pure-lint-drift' / 'semantic-drift' / NULL(<= threshold)
+    checked_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (repo, pr_number, checked_at)
+);
+
+CREATE INDEX idx_pr_drift_log_latest
+    ON pr_drift_log (repo, pr_number, checked_at DESC);

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -296,6 +296,15 @@ class Settings(BaseSettings):
     checker_infra_flake_retry_max: int = 1            # 0 = no retry, 1 = 1 retry (2 attempts)
     checker_infra_flake_retry_backoff_sec: int = 15
 
+    # ─── REQ-fix-pr-queue-health-monitoring-1777789759：PR drift cron ────────
+    # 每 interval 秒扫 repos 列表的 OPEN PR，把落后 > threshold commit 的记入
+    # pr_drift_log 供 Metabase Q19/Q20 看板。False = 不跑（默认；无 github_token 时
+    # 自动跳过）。repos 格式：["phona/sisyphus"]（owner/name）。
+    pr_health_enabled: bool = False
+    pr_health_interval_sec: int = 1800          # 30min
+    pr_health_repos: list[str] = Field(default_factory=list)
+    pr_health_behind_threshold: int = 5         # <= 此数视为 fresh，跳过不记录
+
     # ─── 周期 TTL 清理（增长表防膨胀） ───────────────────────────────────
     # event_seen / dispatch_slugs / verifier_decisions / stage_runs(closed) 只增不减；
     # 后台任务按 interval 周期删过期行。False = 关闭（dev / 单测可不跑）。

--- a/orchestrator/src/orchestrator/main.py
+++ b/orchestrator/src/orchestrator/main.py
@@ -7,7 +7,7 @@ import logging
 import structlog
 from fastapi import FastAPI, HTTPException
 
-from . import accept_env_gc, k8s_runner, runner_gc, snapshot, watchdog
+from . import accept_env_gc, k8s_runner, pr_health, runner_gc, snapshot, watchdog
 from .admin import admin as admin_api
 from .config import settings
 from .maintenance import table_ttl
@@ -87,6 +87,9 @@ async def startup() -> None:
     # 7. 起 TTL 清理后台任务（event_seen / dispatch_slugs / verifier_decisions / stage_runs）
     if settings.ttl_cleanup_enabled and settings.ttl_cleanup_interval_sec > 0:
         _bg_tasks.append(asyncio.create_task(table_ttl.run_loop(), name="table_ttl"))
+    # 8. 起 PR drift cron（REQ-fix-pr-queue-health-monitoring-1777789759）
+    if settings.pr_health_enabled and settings.pr_health_interval_sec > 0:
+        _bg_tasks.append(asyncio.create_task(pr_health.run_loop(), name="pr_health"))
     log.info(
         "startup.ok",
         port=settings.port,

--- a/orchestrator/src/orchestrator/pr_health.py
+++ b/orchestrator/src/orchestrator/pr_health.py
@@ -1,0 +1,156 @@
+"""PR queue health cron — 检测 OPEN PR base drift，写入 pr_drift_log。
+
+每 pr_health_interval_sec（默认 1800s = 30min）扫一次配置的 repos：
+- 列出所有 OPEN PR（GitHub REST API，自动分页）
+- compare/{base.ref}...{head.sha} 算 behind_count
+- 用 PR.mergeable / mergeable_state 预测冲突
+- behind_count > pr_health_behind_threshold 才写 pr_drift_log
+
+drift_kind 分类：
+  'semantic-drift'  = behind > threshold 且 conflict_predicted = True
+  'pure-lint-drift' = behind > threshold 且无冲突（main 修了 lint 等，PR 只需 rebase）
+
+不做飞书 alert / 跨 PR 传染检测 / 业务仓扩展（留 followup issue）。
+"""
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import structlog
+
+from .config import settings
+from .store import db
+
+log = structlog.get_logger(__name__)
+
+_GH_API = "https://api.github.com"
+
+
+async def _gh_get(client: httpx.AsyncClient, path: str) -> dict | list:
+    r = await client.get(f"{_GH_API}{path}")
+    r.raise_for_status()
+    return r.json()
+
+
+async def _list_open_prs(client: httpx.AsyncClient, repo: str) -> list[dict]:
+    """列出 repo 全部 OPEN PR，自动分页（最多 10 页 / 1000 条）。"""
+    prs: list[dict] = []
+    page = 1
+    while page <= 10:
+        batch: list = await _gh_get(  # type: ignore[assignment]
+            client, f"/repos/{repo}/pulls?state=open&per_page=100&page={page}"
+        )
+        if not batch:
+            break
+        prs.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return prs
+
+
+async def _behind_count(
+    client: httpx.AsyncClient, repo: str, head_sha: str, base_ref: str
+) -> int:
+    """用 GitHub compare API 算 PR head 落后 base branch 的 commit 数。
+
+    compare/{base_ref}...{head_sha} 的 behind_by 即 main 比 PR head 多的 commit 数。
+    """
+    data: dict = await _gh_get(  # type: ignore[assignment]
+        client, f"/repos/{repo}/compare/{base_ref}...{head_sha}"
+    )
+    return int(data.get("behind_by", 0))
+
+
+def _predict_conflict(pr: dict) -> bool:
+    """根据 PR.mergeable / mergeable_state 预测是否存在合并冲突。
+
+    GitHub 异步计算 mergeable，null 表示还没算完，保守返 False（宁漏不误报）。
+    """
+    if pr.get("mergeable") is False:
+        return True
+    if pr.get("mergeable_state") == "dirty":
+        return True
+    return False
+
+
+async def check_pr_drift_once(repos: list[str]) -> dict:
+    """单次扫描：遍历所有 repo 的 OPEN PR，把 drift 写入 pr_drift_log。"""
+    if not settings.github_token:
+        log.warning("pr_health.skip", reason="github_token not configured")
+        return {"skipped": "no_github_token"}
+
+    headers = {
+        "Authorization": f"Bearer {settings.github_token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    threshold = settings.pr_health_behind_threshold
+    pool = db.get_pool()
+    total_inserted = 0
+
+    async with httpx.AsyncClient(headers=headers, timeout=30) as client:
+        for repo in repos:
+            try:
+                prs = await _list_open_prs(client, repo)
+                log.debug("pr_health.repo_scanned", repo=repo, pr_count=len(prs))
+
+                for pr in prs:
+                    pr_number: int = pr["number"]
+                    head_sha: str = pr["head"]["sha"]
+                    base_ref: str = pr["base"]["ref"]
+                    base_sha: str = pr["base"]["sha"]
+
+                    try:
+                        behind = await _behind_count(client, repo, head_sha, base_ref)
+                    except Exception as e:
+                        log.warning(
+                            "pr_health.compare_failed",
+                            repo=repo, pr=pr_number, error=str(e),
+                        )
+                        continue
+
+                    if behind <= threshold:
+                        continue
+
+                    has_conflict = _predict_conflict(pr)
+                    drift_kind = "semantic-drift" if has_conflict else "pure-lint-drift"
+
+                    await pool.execute(
+                        """
+                        INSERT INTO pr_drift_log
+                            (pr_number, repo, base_sha, behind_count,
+                             conflict_predicted, drift_kind)
+                        VALUES ($1, $2, $3, $4, $5, $6)
+                        """,
+                        pr_number, repo, base_sha, behind, has_conflict, drift_kind,
+                    )
+                    total_inserted += 1
+                    log.info(
+                        "pr_health.drift_detected",
+                        repo=repo, pr=pr_number, behind=behind,
+                        drift_kind=drift_kind, conflict=has_conflict,
+                    )
+
+            except Exception as e:
+                log.exception("pr_health.repo_failed", repo=repo, error=str(e))
+
+    return {"inserted": total_inserted, "repos_scanned": repos}
+
+
+async def run_loop() -> None:
+    """orchestrator 启动起的后台任务，周期性扫 PR drift。"""
+    interval = settings.pr_health_interval_sec
+    repos = settings.pr_health_repos
+    log.info("pr_health.loop.started", interval_sec=interval, repos=repos)
+    while True:
+        try:
+            result = await check_pr_drift_once(repos)
+            log.debug("pr_health.tick", result=result)
+        except asyncio.CancelledError:
+            log.info("pr_health.loop.stopped")
+            raise
+        except Exception as e:
+            log.exception("pr_health.loop.error", error=str(e))
+        await asyncio.sleep(interval)

--- a/orchestrator/tests/test_contract_docs_drift_audit.py
+++ b/orchestrator/tests/test_contract_docs_drift_audit.py
@@ -203,10 +203,10 @@ def test_docs_s4_architecture_mentions_challenger():
 # ──────────────────────────────────────────────────────────────────────────
 
 def test_docs_s5_sql_file_count_is_18():
-    """DOCS-S5: observability/queries/sisyphus/ contains exactly 18 SQL files."""
+    """DOCS-S5: observability/queries/sisyphus/ contains exactly 20 SQL files."""
     sql_files = list(OBS_QUERIES_DIR.glob("*.sql"))
-    assert len(sql_files) == 18, (
-        f"observability/queries/sisyphus/ has {len(sql_files)} SQL files, expected 18"
+    assert len(sql_files) == 20, (
+        f"observability/queries/sisyphus/ has {len(sql_files)} SQL files, expected 20"
     )
 
 
@@ -270,11 +270,11 @@ def test_docs_s6_tag_spec_not_apifox_content():
 # ──────────────────────────────────────────────────────────────────────────
 
 def test_docs_s7_forward_migration_count_is_11():
-    """DOCS-S7: orchestrator/migrations/ has exactly 10 forward migration files
-    (0001..0010 contiguous; 0009 = artifact_checks_flake, 0010 = dispatch_slugs)."""
+    """DOCS-S7: orchestrator/migrations/ has exactly 12 forward migration files
+    (0001..0013 contiguous; 0012 = baseline_results, 0013 = pr_drift_log)."""
     forward = [f for f in MIGRATIONS_DIR.glob("*.sql") if ".rollback." not in f.name]
-    assert len(forward) == 11, (
-        f"orchestrator/migrations/ has {len(forward)} forward migration(s), expected 11: "
+    assert len(forward) == 12, (
+        f"orchestrator/migrations/ has {len(forward)} forward migration(s), expected 12: "
         f"{sorted(f.name for f in forward)}"
     )
 

--- a/orchestrator/tests/test_pr_health.py
+++ b/orchestrator/tests/test_pr_health.py
@@ -1,0 +1,253 @@
+"""pr_health.check_pr_drift_once 单测：mock httpx + PG pool。"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from orchestrator import pr_health
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 共用 fixtures / helpers
+# ──────────────────────────────────────────────────────────────────────
+
+def _make_pr(
+    number: int = 1,
+    head_sha: str = "abc123",
+    base_ref: str = "main",
+    base_sha: str = "def456",
+    mergeable: bool | None = True,
+    mergeable_state: str = "clean",
+) -> dict:
+    return {
+        "number": number,
+        "head": {"sha": head_sha},
+        "base": {"ref": base_ref, "sha": base_sha},
+        "mergeable": mergeable,
+        "mergeable_state": mergeable_state,
+    }
+
+
+class _FakePool:
+    def __init__(self):
+        self.executed: list[tuple] = []
+
+    async def execute(self, sql, *args):
+        self.executed.append((sql, args))
+
+
+@pytest.fixture
+def fake_pool():
+    return _FakePool()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _predict_conflict
+# ──────────────────────────────────────────────────────────────────────
+
+def test_predict_conflict_false_when_mergeable_true():
+    pr = _make_pr(mergeable=True, mergeable_state="clean")
+    assert pr_health._predict_conflict(pr) is False
+
+
+def test_predict_conflict_true_when_mergeable_false():
+    pr = _make_pr(mergeable=False, mergeable_state="dirty")
+    assert pr_health._predict_conflict(pr) is True
+
+
+def test_predict_conflict_true_when_dirty_state():
+    pr = _make_pr(mergeable=None, mergeable_state="dirty")
+    assert pr_health._predict_conflict(pr) is True
+
+
+def test_predict_conflict_false_when_mergeable_null():
+    """null = GitHub 还没算完，保守返 False（宁漏不误报）。"""
+    pr = _make_pr(mergeable=None, mergeable_state="unknown")
+    assert pr_health._predict_conflict(pr) is False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# check_pr_drift_once — skip conditions
+# ──────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_skip_when_no_github_token(monkeypatch):
+    monkeypatch.setattr("orchestrator.pr_health.settings.github_token", "")
+    result = await pr_health.check_pr_drift_once(["phona/sisyphus"])
+    assert result.get("skipped") == "no_github_token"
+
+
+@pytest.mark.asyncio
+async def test_skip_pr_within_threshold(monkeypatch, fake_pool):
+    """behind_count <= threshold 时不写 pr_drift_log。"""
+    monkeypatch.setattr("orchestrator.pr_health.settings.github_token", "tok")
+    monkeypatch.setattr("orchestrator.pr_health.settings.pr_health_behind_threshold", 5)
+    monkeypatch.setattr("orchestrator.pr_health.db.get_pool", lambda: fake_pool)
+
+    pr = _make_pr(number=42)
+
+    async def fake_list_open_prs(client, repo):
+        return [pr]
+
+    async def fake_behind_count(client, repo, head_sha, base_ref):
+        return 3  # <= threshold=5 → should skip
+
+    monkeypatch.setattr(pr_health, "_list_open_prs", fake_list_open_prs)
+    monkeypatch.setattr(pr_health, "_behind_count", fake_behind_count)
+
+    result = await pr_health.check_pr_drift_once(["phona/sisyphus"])
+
+    assert result["inserted"] == 0
+    assert fake_pool.executed == []
+
+
+# ──────────────────────────────────────────────────────────────────────
+# check_pr_drift_once — drift detection
+# ──────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_detects_pure_lint_drift(monkeypatch, fake_pool):
+    """behind > threshold 且 mergeable=True → pure-lint-drift 写入 DB。"""
+    monkeypatch.setattr("orchestrator.pr_health.settings.github_token", "tok")
+    monkeypatch.setattr("orchestrator.pr_health.settings.pr_health_behind_threshold", 5)
+    monkeypatch.setattr("orchestrator.pr_health.db.get_pool", lambda: fake_pool)
+
+    pr = _make_pr(number=10, head_sha="head1", base_sha="base1",
+                  mergeable=True, mergeable_state="clean")
+
+    async def fake_list_open_prs(client, repo):
+        return [pr]
+
+    async def fake_behind_count(client, repo, head_sha, base_ref):
+        return 12
+
+    monkeypatch.setattr(pr_health, "_list_open_prs", fake_list_open_prs)
+    monkeypatch.setattr(pr_health, "_behind_count", fake_behind_count)
+
+    result = await pr_health.check_pr_drift_once(["phona/sisyphus"])
+
+    assert result["inserted"] == 1
+    assert len(fake_pool.executed) == 1
+    _, args = fake_pool.executed[0]
+    pr_number, repo, base_sha, behind, has_conflict, drift_kind = args
+    assert pr_number == 10
+    assert repo == "phona/sisyphus"
+    assert base_sha == "base1"
+    assert behind == 12
+    assert has_conflict is False
+    assert drift_kind == "pure-lint-drift"
+
+
+@pytest.mark.asyncio
+async def test_detects_semantic_drift(monkeypatch, fake_pool):
+    """behind > threshold 且 mergeable=False → semantic-drift 写入 DB。"""
+    monkeypatch.setattr("orchestrator.pr_health.settings.github_token", "tok")
+    monkeypatch.setattr("orchestrator.pr_health.settings.pr_health_behind_threshold", 5)
+    monkeypatch.setattr("orchestrator.pr_health.db.get_pool", lambda: fake_pool)
+
+    pr = _make_pr(number=7, mergeable=False, mergeable_state="dirty")
+
+    async def fake_list_open_prs(client, repo):
+        return [pr]
+
+    async def fake_behind_count(client, repo, head_sha, base_ref):
+        return 20
+
+    monkeypatch.setattr(pr_health, "_list_open_prs", fake_list_open_prs)
+    monkeypatch.setattr(pr_health, "_behind_count", fake_behind_count)
+
+    result = await pr_health.check_pr_drift_once(["phona/sisyphus"])
+
+    assert result["inserted"] == 1
+    _, args = fake_pool.executed[0]
+    has_conflict, drift_kind = args[4], args[5]
+    assert has_conflict is True
+    assert drift_kind == "semantic-drift"
+
+
+@pytest.mark.asyncio
+async def test_multiple_prs_only_drifted_inserted(monkeypatch, fake_pool):
+    """多 PR 中只有 behind > threshold 的被记录。"""
+    monkeypatch.setattr("orchestrator.pr_health.settings.github_token", "tok")
+    monkeypatch.setattr("orchestrator.pr_health.settings.pr_health_behind_threshold", 5)
+    monkeypatch.setattr("orchestrator.pr_health.db.get_pool", lambda: fake_pool)
+
+    prs = [
+        _make_pr(number=1, head_sha="sha1"),
+        _make_pr(number=2, head_sha="sha2"),
+        _make_pr(number=3, head_sha="sha3"),
+    ]
+    behinds = {"sha1": 3, "sha2": 10, "sha3": 1}
+
+    async def fake_list_open_prs(client, repo):
+        return prs
+
+    async def fake_behind_count(client, repo, head_sha, base_ref):
+        return behinds[head_sha]
+
+    monkeypatch.setattr(pr_health, "_list_open_prs", fake_list_open_prs)
+    monkeypatch.setattr(pr_health, "_behind_count", fake_behind_count)
+
+    result = await pr_health.check_pr_drift_once(["phona/sisyphus"])
+
+    assert result["inserted"] == 1  # only PR#2 (behind=10)
+    _, args = fake_pool.executed[0]
+    assert args[0] == 2  # pr_number
+
+
+@pytest.mark.asyncio
+async def test_compare_error_skips_pr_continues(monkeypatch, fake_pool):
+    """compare API 失败 → 该 PR 跳过，后续 PR 继续处理。"""
+    monkeypatch.setattr("orchestrator.pr_health.settings.github_token", "tok")
+    monkeypatch.setattr("orchestrator.pr_health.settings.pr_health_behind_threshold", 5)
+    monkeypatch.setattr("orchestrator.pr_health.db.get_pool", lambda: fake_pool)
+
+    prs = [_make_pr(number=1, head_sha="sha1"), _make_pr(number=2, head_sha="sha2")]
+    call_count = 0
+
+    async def fake_list_open_prs(client, repo):
+        return prs
+
+    async def fake_behind_count(client, repo, head_sha, base_ref):
+        nonlocal call_count
+        call_count += 1
+        if head_sha == "sha1":
+            raise RuntimeError("network error")
+        return 15
+
+    monkeypatch.setattr(pr_health, "_list_open_prs", fake_list_open_prs)
+    monkeypatch.setattr(pr_health, "_behind_count", fake_behind_count)
+
+    result = await pr_health.check_pr_drift_once(["phona/sisyphus"])
+
+    assert result["inserted"] == 1  # PR#2 succeeds despite PR#1 failing
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_repo_error_continues_other_repos(monkeypatch, fake_pool):
+    """整个 repo 调用失败 → 跳过该 repo，继续其他 repo。"""
+    monkeypatch.setattr("orchestrator.pr_health.settings.github_token", "tok")
+    monkeypatch.setattr("orchestrator.pr_health.settings.pr_health_behind_threshold", 5)
+    monkeypatch.setattr("orchestrator.pr_health.db.get_pool", lambda: fake_pool)
+
+    call_order: list[str] = []
+
+    async def fake_list_open_prs(client, repo):
+        call_order.append(repo)
+        if repo == "owner/bad-repo":
+            raise RuntimeError("403 Forbidden")
+        return [_make_pr(number=1)]
+
+    async def fake_behind_count(client, repo, head_sha, base_ref):
+        return 10
+
+    monkeypatch.setattr(pr_health, "_list_open_prs", fake_list_open_prs)
+    monkeypatch.setattr(pr_health, "_behind_count", fake_behind_count)
+
+    result = await pr_health.check_pr_drift_once(["owner/bad-repo", "owner/good-repo"])
+
+    assert "owner/bad-repo" in call_order
+    assert "owner/good-repo" in call_order
+    assert result["inserted"] == 1  # good-repo の PR が記録される

--- a/orchestrator/tests/test_pr_health.py
+++ b/orchestrator/tests/test_pr_health.py
@@ -1,12 +1,9 @@
 """pr_health.check_pr_drift_once 单测：mock httpx + PG pool。"""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
-
 import pytest
 
 from orchestrator import pr_health
-
 
 # ──────────────────────────────────────────────────────────────────────
 # 共用 fixtures / helpers


### PR DESCRIPTION
## Summary

- **migration `0013_pr_drift_log`**：新表 `pr_drift_log`（`repo, pr_number, base_sha, behind_count, conflict_predicted, drift_kind, checked_at` PK），带 `idx_pr_drift_log_latest` 索引 + rollback
- **`pr_health.py`**：30min cron，GitHub REST API 扫全量 OPEN PR，`behind_count > threshold`（默认 5）写 `pr_drift_log`；`drift_kind = 'semantic-drift'`（mergeable=false）/ `'pure-lint-drift'`（behind but clean）
- **`config.py`**：新增 `pr_health_enabled`（默认 False）/ `pr_health_interval_sec`（1800s）/ `pr_health_repos`（空列表，生产配 `["phona/sisyphus"]`）/ `pr_health_behind_threshold`（5）
- **`main.py`**：第 8 个 bg task，`pr_health_enabled=True` 时启动
- **Q19 `19-pr-drift.sql`**：最新 drift 快照，`conflict_predicted=true` 行标红
- **Q20 `20-pr-aging.sql`**：PR 年龄分桶（<1d/1-3d/3-7d/>7d）+ dirty rate 统计

> SQL 编号用 19/20 而不是任务描述的 13/14，因为 observability/queries/sisyphus/ 目录下 13/14 已被 watchdog-escalate-frequency / fixer-audit-verdict-trend 占用

## Followup（本 PR 不做）

- ❌ 飞书 / Slack alert（通知通道另起 issue）
- ❌ 跨 PR 传染检测（#2 信号留 followup）
- ❌ 扩展到业务仓（先 sisyphus 自闭环；接入时 `pr_health_repos` 追加 `phona/ttpos-flutter` 等）
- ❌ pr_links 表完整 PR 生命周期（Q20 当前只统计 behind > threshold 的 PR）

## Test plan

- [x] `pytest tests/test_pr_health.py` 11/11 通过（mock httpx + pool，不需 PG）
- [x] migration forward SQL 语法正确
- [x] rollback SQL 干净（DROP INDEX + DROP TABLE）
- [x] `pr_health_enabled=False`（默认）→ main.py 不启动 bg task，零侵入

References #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)