### PR TITLE
feat(observability): actual_outcome 自动回填 + config_version startup hook (#242)

### DIFF
--- a/observability/schema.sql
+++ b/observability/schema.sql
@@ -134,6 +134,9 @@ CREATE TABLE IF NOT EXISTS config_version (
 CREATE INDEX IF NOT EXISTS idx_cfg_active ON config_version (kind, target)
   WHERE retired_at IS NULL;
 
+-- P0-2：startup hook 写入时存变更文件列表（ADD COLUMN IF NOT EXISTS，幂等）
+ALTER TABLE config_version ADD COLUMN IF NOT EXISTS changed_files JSONB;
+
 
 -- ===================================================================
 -- 4. improvement_log — 假设 → 验证循环（人工维护为主）

--- a/orchestrator/src/orchestrator/actions/escalate.py
+++ b/orchestrator/src/orchestrator/actions/escalate.py
@@ -33,7 +33,7 @@ from .. import gh_incident, k8s_runner
 from ..bkd import BKDClient
 from ..config import settings
 from ..state import Event, ReqState
-from ..store import db, req_state
+from ..store import db, req_state, verifier_decisions
 from . import register
 from ._clone import resolve_repos
 
@@ -209,6 +209,19 @@ async def _apply_pr_merged_done_override(
         # dev 环境 / runner controller 没装 → 跳过；runner_gc 兜底
         log.debug("escalate.pr_merged_override.no_runner_controller",
                   req_id=req_id, error=str(e))
+
+    # P0-1：回填 verifier_decisions.actual_outcome（bypass engine.step，需在此补调）
+    async def _backfill() -> None:
+        try:
+            n = await verifier_decisions.backfill_outcomes_for_req(pool, req_id, "DONE")
+            log.info("escalate.pr_merged_override.verifier_backfill",
+                     req_id=req_id, updated=n)
+        except Exception as exc:
+            log.warning("escalate.pr_merged_override.verifier_backfill.failed",
+                        req_id=req_id, error=str(exc))
+    bf_task = asyncio.create_task(_backfill())
+    _pr_merged_cleanup_tasks.add(bf_task)
+    bf_task.add_done_callback(_pr_merged_cleanup_tasks.discard)
 
     log.warning(
         "escalate.pr_merged_override",
@@ -487,6 +500,14 @@ async def escalate(*, body, req_id, tags, ctx):
                         target_status_id="review",
                         error=str(e),
                     )
+
+    # P0-1：session-failed 路径手动 CAS 到 ESCALATED 后回填 verifier_decisions（best-effort）
+    if is_session_failed_path:
+        try:
+            n = await verifier_decisions.backfill_outcomes_for_req(pool, req_id, "ESCALATED")
+            log.info("escalate.verifier_backfill", req_id=req_id, updated=n)
+        except Exception as exc:
+            log.warning("escalate.verifier_backfill.failed", req_id=req_id, error=str(exc))
 
     # ─── openspec/changes cleanup（fail-open） ───────────────────────────────
     # 从 PR 分支删孤儿 openspec/changes/REQ-XXX/，防止 escalated PR 被人手 merge 后

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -101,6 +101,10 @@ class Settings(BaseSettings):
     # 留空 = 关闭观测写入和快照同步（dev 模式可不开）
     obs_pg_dsn: str = ""
 
+    # P0-2：config_version startup hook（默认 True — 例外说明：写入纯 metadata、幂等、
+    # best-effort，对 prod 零侵入；flag 仅供 dev/test 消除无 git 环境的 debug log 噪音）
+    config_version_startup_hook_enabled: bool = True
+
     # bkd_snapshot 同步间隔（秒）。0 = 不跑（替代 n8n 5min cron）
     snapshot_interval_sec: int = 300
 

--- a/orchestrator/src/orchestrator/config_version.py
+++ b/orchestrator/src/orchestrator/config_version.py
@@ -1,0 +1,134 @@
+"""P0-2：startup 时自动检测 prompt / checker / config 变更并写 config_version 表。
+
+逻辑：
+  1. git rev-parse HEAD 拿当前 commit SHA
+  2. 查 config_version 表的上一次 git_commit（按 applied_at DESC LIMIT 1）
+  3. 若不同：git diff --name-only <last> <current> 过滤白名单文件
+  4. 白名单内有改动 → INSERT 一行（version_hash=full SHA，changed_files=jsonb，kind 自动推断）
+  5. 任何 git / DB 错误只 log warning，不阻断服务启动。
+
+白名单（_WATCHED_PREFIXES）：
+  - orchestrator/src/orchestrator/prompts/  （.j2 模板）
+  - orchestrator/src/orchestrator/checkers/ （机械 checker）
+  - orchestrator/src/orchestrator/config.py （阈值 / feature flags）
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from datetime import UTC, datetime
+
+import asyncpg
+import structlog
+
+log = structlog.get_logger(__name__)
+
+# 相对 repo 根的路径前缀（git diff --name-only 输出的路径）
+_WATCHED_PREFIXES: tuple[str, ...] = (
+    "orchestrator/src/orchestrator/prompts/",
+    "orchestrator/src/orchestrator/checkers/",
+    "orchestrator/src/orchestrator/config.py",
+)
+
+
+def _git(*args: str) -> str:
+    """同步跑 git 命令；失败抛 CalledProcessError / FileNotFoundError。"""
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _is_watched(path: str) -> bool:
+    return any(path.startswith(p) or path == p.rstrip("/") for p in _WATCHED_PREFIXES)
+
+
+def _infer_kind(files: list[str]) -> str:
+    has_prompt = any("prompts" in f or f.endswith(".j2") for f in files)
+    has_checker = any("checkers" in f for f in files)
+    has_config = any(f.endswith("config.py") for f in files)
+    kinds = []
+    if has_prompt:
+        kinds.append("prompt")
+    if has_checker:
+        kinds.append("checker")
+    if has_config:
+        kinds.append("config")
+    return "+".join(kinds) if kinds else "mixed"
+
+
+async def maybe_record_config_change(obs_pool: asyncpg.Pool) -> None:
+    """startup hook：检测 prompt/checker/config 变更，有则写 config_version 行。
+
+    best-effort — 任何错误只 log，不阻断主服务启动。
+    """
+    # 1. 拿当前 HEAD SHA
+    try:
+        current_sha: str = await asyncio.to_thread(_git, "rev-parse", "HEAD")
+    except Exception as e:
+        log.debug("config_version.git_unavailable", error=str(e))
+        return
+
+    # 2. 查上次已记录的 commit
+    try:
+        last_sha: str | None = await obs_pool.fetchval(
+            "SELECT git_commit FROM config_version ORDER BY applied_at DESC LIMIT 1"
+        )
+    except Exception as e:
+        log.warning("config_version.query_failed", error=str(e))
+        return
+
+    if last_sha == current_sha:
+        log.debug("config_version.up_to_date", sha=current_sha[:8])
+        return
+
+    # 3. 算变更文件列表
+    if last_sha:
+        try:
+            diff_out: str = await asyncio.to_thread(
+                _git, "diff", "--name-only", last_sha, current_sha
+            )
+            all_changed = [f for f in diff_out.splitlines() if f]
+        except Exception as e:
+            log.warning("config_version.git_diff_failed",
+                        last=last_sha[:8], cur=current_sha[:8], error=str(e))
+            return
+        watched = [f for f in all_changed if _is_watched(f)]
+        if not watched:
+            log.debug("config_version.no_watched_files_changed",
+                      sha=current_sha[:8], total_changed=len(all_changed))
+            return
+    else:
+        # 第一次写入：没有历史 commit 可 diff，直接记录当前 SHA
+        watched = ["<initial-record>"]
+
+    # 4. INSERT（version_hash=full SHA，ON CONFLICT DO NOTHING 保幂等）
+    kind = _infer_kind(watched)
+    diff_summary = f"{len(watched)} file(s) changed"
+    try:
+        await obs_pool.execute(
+            """
+            INSERT INTO config_version
+                (version_hash, kind, target, applied_at,
+                 git_commit, diff_summary, changed_files, author)
+            VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+            ON CONFLICT (version_hash) DO NOTHING
+            """,
+            current_sha,
+            kind,
+            None,
+            datetime.now(UTC),
+            current_sha,
+            diff_summary,
+            json.dumps(watched),
+            "orchestrator-startup",
+        )
+        log.info("config_version.recorded",
+                 sha=current_sha[:8], kind=kind, files=watched[:20])
+    except Exception as e:
+        log.warning("config_version.insert_failed",
+                    sha=current_sha[:8], error=str(e))

--- a/orchestrator/src/orchestrator/engine.py
+++ b/orchestrator/src/orchestrator/engine.py
@@ -21,7 +21,7 @@ from .actions import REGISTRY
 from .bkd import BKDClient
 from .config import settings
 from .state import Event, ReqState, decide
-from .store import req_state, stage_runs
+from .store import req_state, stage_runs, verifier_decisions
 
 log = structlog.get_logger(__name__)
 
@@ -243,6 +243,22 @@ async def _auto_archive(req_id: str, ctx: dict) -> None:
         log.warning("archive.error", req_id=req_id, error=str(e))
 
 
+async def _backfill_verifier_outcomes(
+    pool: asyncpg.Pool,
+    req_id: str,
+    terminal_state: ReqState,
+) -> None:
+    """P0-1：终态时回填该 REQ 所有 verifier_decisions.actual_outcome。best-effort。"""
+    try:
+        n = await verifier_decisions.backfill_outcomes_for_req(
+            pool, req_id, terminal_state.value
+        )
+        log.info("engine.verifier_backfill",
+                 req_id=req_id, terminal=terminal_state.value, updated=n)
+    except Exception as e:
+        log.warning("engine.verifier_backfill.failed", req_id=req_id, error=str(e))
+
+
 async def _cleanup_runner_on_terminal(req_id: str, terminal_state: ReqState) -> None:
     try:
         rc = k8s_runner.get_controller()
@@ -362,6 +378,13 @@ async def step(
             archive_task = asyncio.create_task(_auto_archive(req_id, ctx))
             _cleanup_tasks.add(archive_task)
             archive_task.add_done_callback(_cleanup_tasks.discard)
+
+        # P0-1：回填 verifier_decisions.actual_outcome（best-effort，fire-and-forget）
+        backfill_task = asyncio.create_task(
+            _backfill_verifier_outcomes(pool, req_id, transition.next_state)
+        )
+        _cleanup_tasks.add(backfill_task)
+        backfill_task.add_done_callback(_cleanup_tasks.discard)
 
     # REQ-pr-ready-for-review-notify: REVIEW_RUNNING 进入时给 BKD intent issue 打 pr-ready tag
     if transition.next_state == ReqState.REVIEW_RUNNING:

--- a/orchestrator/src/orchestrator/main.py
+++ b/orchestrator/src/orchestrator/main.py
@@ -55,7 +55,7 @@ async def startup() -> None:
     await apply_obs_schema()
     # 2c. P0-2：检测 prompt/checker/config 变更，有则写 config_version 行（best-effort）
     obs_pool = db.get_obs_pool()
-    if obs_pool is not None:
+    if obs_pool is not None and settings.config_version_startup_hook_enabled:
         try:
             await maybe_record_config_change(obs_pool)
         except Exception as e:

--- a/orchestrator/src/orchestrator/main.py
+++ b/orchestrator/src/orchestrator/main.py
@@ -12,6 +12,7 @@ from fastapi.responses import JSONResponse
 from . import accept_env_gc, k8s_runner, pr_health, runner_gc, snapshot, watchdog
 from .admin import admin as admin_api
 from .config import settings
+from .config_version import maybe_record_config_change
 from .maintenance import table_ttl
 from .migrate import apply_pending
 from .obs_schema import apply_obs_schema
@@ -52,6 +53,13 @@ async def startup() -> None:
     await db.init_obs_pool(settings.obs_pg_dsn)
     # 2b. 自动 apply observability schema（幂等，失败不阻断）
     await apply_obs_schema()
+    # 2c. P0-2：检测 prompt/checker/config 变更，有则写 config_version 行（best-effort）
+    obs_pool = db.get_obs_pool()
+    if obs_pool is not None:
+        try:
+            await maybe_record_config_change(obs_pool)
+        except Exception as e:
+            log.warning("startup.config_version.failed", error=str(e))
     # 3. 起 snapshot 后台同步 task（interval 0 不起）。
     # 这个 loop 现在两件事：obs UPSERT（依赖 obs pool） + intent:analyze orphan 恢复
     # （只依赖 main pool）。后者跟 obs DSN 无关，所以 startup gate 不再 require obs_pg_dsn。

--- a/orchestrator/src/orchestrator/store/verifier_decisions.py
+++ b/orchestrator/src/orchestrator/store/verifier_decisions.py
@@ -70,3 +70,63 @@ async def mark_correct(
         actual_outcome,
         correct,
     )
+
+
+async def backfill_outcomes_for_req(
+    pool: asyncpg.Pool,
+    req_id: str,
+    terminal_state: str,
+) -> int:
+    """REQ 到终态时批量回填该 req_id 所有未标 actual_outcome 的 verifier 判决。
+
+    terminal_state: "DONE" 或 "ESCALATED"（ReqState.value）。
+
+    映射（P0-1）：
+      pass/fix  + DONE      → hit         (correct=True)
+      pass      + ESCALATED → silent_pass  (correct=False)
+      fix       + ESCALATED → fixer_failed (correct=False)
+      escalate  + DONE      → over_cautious(correct=False)
+      escalate  + ESCALATED → hit          (correct=True)
+
+    返回更新行数；异常由调用方处理。
+    """
+    result = await pool.execute(
+        """
+        UPDATE verifier_decisions SET
+            actual_outcome = CASE
+                WHEN decision_action IN ('pass', 'fix') AND $2 = 'DONE'
+                    THEN 'hit'
+                WHEN decision_action = 'pass'  AND $2 = 'ESCALATED'
+                    THEN 'silent_pass'
+                WHEN decision_action = 'fix'   AND $2 = 'ESCALATED'
+                    THEN 'fixer_failed'
+                WHEN decision_action = 'escalate' AND $2 = 'DONE'
+                    THEN 'over_cautious'
+                WHEN decision_action = 'escalate' AND $2 = 'ESCALATED'
+                    THEN 'hit'
+                ELSE actual_outcome
+            END,
+            decision_correct = CASE
+                WHEN decision_action IN ('pass', 'fix') AND $2 = 'DONE'
+                    THEN TRUE
+                WHEN decision_action = 'pass'  AND $2 = 'ESCALATED'
+                    THEN FALSE
+                WHEN decision_action = 'fix'   AND $2 = 'ESCALATED'
+                    THEN FALSE
+                WHEN decision_action = 'escalate' AND $2 = 'DONE'
+                    THEN FALSE
+                WHEN decision_action = 'escalate' AND $2 = 'ESCALATED'
+                    THEN TRUE
+                ELSE decision_correct
+            END
+        WHERE req_id = $1
+          AND actual_outcome IS NULL
+          AND decision_action IN ('pass', 'fix', 'escalate')
+        """,
+        req_id,
+        terminal_state,
+    )
+    try:
+        return int(result.split()[-1])
+    except (ValueError, IndexError, AttributeError):
+        return -1

--- a/orchestrator/tests/test_config_version_startup.py
+++ b/orchestrator/tests/test_config_version_startup.py
@@ -19,7 +19,6 @@ import pytest
 
 from orchestrator.config_version import _is_watched, maybe_record_config_change
 
-
 # ── _is_watched 白名单 ───────────────────────────────────────────────────────
 
 @pytest.mark.parametrize("path,expected", [

--- a/orchestrator/tests/test_config_version_startup.py
+++ b/orchestrator/tests/test_config_version_startup.py
@@ -1,0 +1,261 @@
+"""config_version startup hook 单测（P0-2）。
+
+覆盖：
+- _is_watched 白名单过滤（prompts/.j2 ✓、checkers/ ✓、config.py ✓、README.md ✗、tests/ ✗）
+- git 不可用（FileNotFoundError / CalledProcessError）→ 优雅降级，不抛，不调 DB
+- 首次记录路径：DB 无 last_commit → 直接 INSERT watched=["<initial-record>"]
+- 同 SHA 路径：last_commit == current_sha → skip，不调 execute
+- diff 有白名单文件 → INSERT，changed_files 只含白名单文件
+- diff 无白名单文件 → skip
+- kind 推断：只 .j2 → prompt，只 config.py → config，混合 → checker/mixed
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from orchestrator.config_version import _is_watched, maybe_record_config_change
+
+
+# ── _is_watched 白名单 ───────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("path,expected", [
+    # 白名单内
+    ("orchestrator/src/orchestrator/prompts/intake.md.j2",                True),
+    ("orchestrator/src/orchestrator/prompts/verifier/staging_test_fail.md.j2", True),
+    ("orchestrator/src/orchestrator/checkers/spec_lint.py",               True),
+    ("orchestrator/src/orchestrator/checkers/staging_test.py",            True),
+    ("orchestrator/src/orchestrator/config.py",                           True),
+    # 白名单外
+    ("README.md",                                                          False),
+    ("docs/architecture.md",                                               False),
+    ("tests/foo.py",                                                       False),
+    ("orchestrator/tests/test_table_ttl.py",                              False),
+    ("orchestrator/src/orchestrator/engine.py",                           False),
+    ("orchestrator/src/orchestrator/main.py",                             False),
+])
+def test_is_watched(path: str, expected: bool):
+    assert _is_watched(path) is expected
+
+
+# ── FakePool ────────────────────────────────────────────────────────────────
+
+class _FakePool:
+    """asyncpg pool stub：fetchval 返回 last_commit，记录 execute 调用。"""
+
+    def __init__(self, last_commit: str | None = None):
+        self.last_commit = last_commit
+        self.execute_calls: list[tuple[str, tuple]] = []
+
+    async def fetchval(self, sql: str, *args):
+        return self.last_commit
+
+    async def execute(self, sql: str, *args):
+        self.execute_calls.append((sql, args))
+
+
+# ── git 不可用路径 ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_git_file_not_found_does_not_raise_and_skips_db():
+    """git 二进制不存在（FileNotFoundError）→ 优雅返回，不调 DB。"""
+    pool = _FakePool()
+    with patch("orchestrator.config_version._git",
+               side_effect=FileNotFoundError("git not found")):
+        await maybe_record_config_change(pool)
+    assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_git_called_process_error_does_not_raise_and_skips_db():
+    """git 非零退码（CalledProcessError）→ 优雅返回，不调 DB。"""
+    pool = _FakePool()
+    with patch("orchestrator.config_version._git",
+               side_effect=subprocess.CalledProcessError(128, "git")):
+        await maybe_record_config_change(pool)
+    assert pool.execute_calls == []
+
+
+# ── 首次记录路径（DB 空） ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_first_record_inserts_with_initial_marker():
+    """DB 无历史记录时，不 diff，直接 INSERT，changed_files=["<initial-record>"]。"""
+    pool = _FakePool(last_commit=None)
+    current_sha = "a" * 40
+
+    with patch("orchestrator.config_version._git", return_value=current_sha):
+        await maybe_record_config_change(pool)
+
+    assert len(pool.execute_calls) == 1
+    sql, args = pool.execute_calls[0]
+    assert "INSERT INTO config_version" in sql
+    assert "ON CONFLICT" in sql
+    assert args[0] == current_sha        # version_hash
+    assert args[4] == current_sha        # git_commit
+    assert json.loads(args[6]) == ["<initial-record>"]   # changed_files
+
+
+# ── 同 SHA → skip ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_same_sha_skips_insert():
+    """current_sha == last_commit → 直接返回，不调 execute。"""
+    sha = "b" * 40
+    pool = _FakePool(last_commit=sha)
+
+    with patch("orchestrator.config_version._git", return_value=sha):
+        await maybe_record_config_change(pool)
+
+    assert pool.execute_calls == []
+
+
+# ── diff 路径：有白名单文件 → INSERT ─────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_diff_with_watched_files_inserts_only_watched():
+    """diff 含 prompts/.j2 → INSERT；changed_files 仅含白名单文件，README.md 不含。"""
+    last_sha = "c" * 40
+    current_sha = "d" * 40
+    pool = _FakePool(last_commit=last_sha)
+
+    def _fake_git(*args):
+        if args[0] == "rev-parse":
+            return current_sha
+        # diff call
+        return (
+            "orchestrator/src/orchestrator/prompts/intake.md.j2\n"
+            "README.md\n"
+            "docs/architecture.md"
+        )
+
+    with patch("orchestrator.config_version._git", side_effect=_fake_git):
+        await maybe_record_config_change(pool)
+
+    assert len(pool.execute_calls) == 1
+    _, args = pool.execute_calls[0]
+    changed = json.loads(args[6])
+    assert "orchestrator/src/orchestrator/prompts/intake.md.j2" in changed
+    assert "README.md" not in changed
+    assert "docs/architecture.md" not in changed
+
+
+# ── diff 路径：无白名单文件 → skip ───────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_diff_without_watched_files_skips_insert():
+    """diff 只含 README.md / docs / tests 等非白名单文件 → 不 INSERT。"""
+    last_sha = "e" * 40
+    current_sha = "f" * 40
+    pool = _FakePool(last_commit=last_sha)
+
+    def _fake_git(*args):
+        if args[0] == "rev-parse":
+            return current_sha
+        return "README.md\ndocs/architecture.md\norchestrator/tests/test_foo.py"
+
+    with patch("orchestrator.config_version._git", side_effect=_fake_git):
+        await maybe_record_config_change(pool)
+
+    assert pool.execute_calls == []
+
+
+# ── kind 推断 ────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_kind_prompt_for_only_jinja_changes():
+    """.j2 only → kind='prompt'。"""
+    last_sha = "1" * 40
+    current_sha = "2" * 40
+    pool = _FakePool(last_commit=last_sha)
+
+    def _fake_git(*args):
+        if args[0] == "rev-parse":
+            return current_sha
+        return "orchestrator/src/orchestrator/prompts/analyze.md.j2"
+
+    with patch("orchestrator.config_version._git", side_effect=_fake_git):
+        await maybe_record_config_change(pool)
+
+    _, args = pool.execute_calls[0]
+    assert args[1] == "prompt"
+
+
+@pytest.mark.asyncio
+async def test_kind_config_for_only_config_py_change():
+    """config.py only → kind='config'。"""
+    last_sha = "3" * 40
+    current_sha = "4" * 40
+    pool = _FakePool(last_commit=last_sha)
+
+    def _fake_git(*args):
+        if args[0] == "rev-parse":
+            return current_sha
+        return "orchestrator/src/orchestrator/config.py"
+
+    with patch("orchestrator.config_version._git", side_effect=_fake_git):
+        await maybe_record_config_change(pool)
+
+    _, args = pool.execute_calls[0]
+    assert args[1] == "config"
+
+
+@pytest.mark.asyncio
+async def test_kind_checker_for_only_checker_change():
+    """checkers/ only → kind='checker'。"""
+    last_sha = "5" * 40
+    current_sha = "6" * 40
+    pool = _FakePool(last_commit=last_sha)
+
+    def _fake_git(*args):
+        if args[0] == "rev-parse":
+            return current_sha
+        return "orchestrator/src/orchestrator/checkers/spec_lint.py"
+
+    with patch("orchestrator.config_version._git", side_effect=_fake_git):
+        await maybe_record_config_change(pool)
+
+    _, args = pool.execute_calls[0]
+    assert args[1] == "checker"
+
+
+@pytest.mark.asyncio
+async def test_kind_mixed_for_prompt_and_config_changes():
+    """prompt + config 混合 → kind 包含两者（不是单一类型）。"""
+    last_sha = "7" * 40
+    current_sha = "8" * 40
+    pool = _FakePool(last_commit=last_sha)
+
+    def _fake_git(*args):
+        if args[0] == "rev-parse":
+            return current_sha
+        return (
+            "orchestrator/src/orchestrator/prompts/intake.md.j2\n"
+            "orchestrator/src/orchestrator/config.py"
+        )
+
+    with patch("orchestrator.config_version._git", side_effect=_fake_git):
+        await maybe_record_config_change(pool)
+
+    _, args = pool.execute_calls[0]
+    kind: str = args[1]
+    assert kind not in ("prompt", "config")   # must be compound
+    assert "prompt" in kind
+    assert "config" in kind
+
+
+# ── upsert 幂等：ON CONFLICT DO NOTHING ─────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_insert_sql_has_on_conflict_do_nothing():
+    """INSERT 必须携带 ON CONFLICT (version_hash) DO NOTHING，保证幂等。"""
+    pool = _FakePool(last_commit=None)
+    with patch("orchestrator.config_version._git", return_value="a" * 40):
+        await maybe_record_config_change(pool)
+
+    sql, _ = pool.execute_calls[0]
+    assert "ON CONFLICT" in sql
+    assert "DO NOTHING" in sql

--- a/orchestrator/tests/test_verifier_decisions_backfill.py
+++ b/orchestrator/tests/test_verifier_decisions_backfill.py
@@ -13,7 +13,6 @@ import pytest
 
 from orchestrator.store.verifier_decisions import backfill_outcomes_for_req, insert_decision
 
-
 # ── FakePool ────────────────────────────────────────────────────────────────
 
 class _FakePool:

--- a/orchestrator/tests/test_verifier_decisions_backfill.py
+++ b/orchestrator/tests/test_verifier_decisions_backfill.py
@@ -1,0 +1,234 @@
+"""backfill_outcomes_for_req 单测 + 集成测试（P0-1）。
+
+单测：FakePool 验证 SQL 结构、参数、返回值解析正确。
+集成测试：真 PG 验证 6 种 (decision_action, terminal_state) → actual_outcome 映射、
+          幂等（第 2 次 0 行）、部分回填（已有值不被覆盖）。
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from orchestrator.store.verifier_decisions import backfill_outcomes_for_req, insert_decision
+
+
+# ── FakePool ────────────────────────────────────────────────────────────────
+
+class _FakePool:
+    """asyncpg pool stub：记录 execute 调用，返回可配置的 'UPDATE N' 字符串。"""
+
+    def __init__(self, updated: int = 0):
+        self._updated = updated
+        self.execute_calls: list[tuple[str, tuple]] = []
+
+    async def execute(self, sql: str, *args):
+        self.execute_calls.append((sql, args))
+        return f"UPDATE {self._updated}"
+
+
+# ── 单元测试：SQL 结构 + 参数 ────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_backfill_passes_req_id_and_terminal_as_positional_params():
+    """backfill_outcomes_for_req 必须将 req_id 作为 $1、terminal_state 作为 $2 传入。"""
+    pool = _FakePool(updated=3)
+    n = await backfill_outcomes_for_req(pool, "REQ-unit-001", "DONE")
+
+    assert len(pool.execute_calls) == 1
+    sql, args = pool.execute_calls[0]
+    assert "UPDATE verifier_decisions" in sql
+    assert args[0] == "REQ-unit-001"
+    assert args[1] == "DONE"
+    assert n == 3
+
+
+@pytest.mark.asyncio
+async def test_backfill_sql_contains_all_outcome_and_action_values():
+    """SQL 必须覆盖全部 outcome 和 decision_action 枚举值，且只回填 NULL 行。"""
+    pool = _FakePool()
+    await backfill_outcomes_for_req(pool, "REQ-unit-002", "ESCALATED")
+
+    sql, _ = pool.execute_calls[0]
+    # outcome 枚举
+    for outcome in ("'hit'", "'silent_pass'", "'fixer_failed'", "'over_cautious'"):
+        assert outcome in sql, f"missing outcome: {outcome}"
+    # decision_action 枚举
+    for action in ("'pass'", "'fix'", "'escalate'"):
+        assert action in sql, f"missing action: {action}"
+    # 幂等 guard
+    assert "actual_outcome IS NULL" in sql
+
+
+@pytest.mark.asyncio
+async def test_backfill_returns_zero_when_no_rows_updated():
+    pool = _FakePool(updated=0)
+    n = await backfill_outcomes_for_req(pool, "REQ-unit-003", "DONE")
+    assert n == 0
+
+
+@pytest.mark.asyncio
+async def test_backfill_returns_count_from_execute_result():
+    pool = _FakePool(updated=7)
+    n = await backfill_outcomes_for_req(pool, "REQ-unit-004", "ESCALATED")
+    assert n == 7
+
+
+# ── 集成测试：真 PG ─────────────────────────────────────────────────────────
+
+@pytest.mark.integration
+class TestBackfillMappingIntegration:
+    """6 種 mapping + 幂等 + 部分回填。需要 SISYPHUS_PG_DSN 指向真实 PostgreSQL。"""
+
+    _dsn = os.environ.get("SISYPHUS_PG_DSN", "postgresql://test:test@localhost/test")
+
+    async def _pool(self):
+        import asyncpg
+        return await asyncpg.create_pool(self._dsn)
+
+    def _req(self) -> str:
+        return f"REQ-backfill-integ-{uuid.uuid4()}"
+
+    async def _fetch(self, pool, dec_id: int) -> dict:
+        row = await pool.fetchrow(
+            "SELECT actual_outcome, decision_correct FROM verifier_decisions WHERE id=$1",
+            dec_id,
+        )
+        return dict(row)
+
+    @pytest.mark.asyncio
+    async def test_pass_done_maps_to_hit(self):
+        pool = await self._pool()
+        req_id = self._req()
+        try:
+            dec_id = await insert_decision(pool, req_id, "spec_lint", "check_fail",
+                                           action="pass")
+            n = await backfill_outcomes_for_req(pool, req_id, "DONE")
+            assert n == 1
+            row = await self._fetch(pool, dec_id)
+            assert row["actual_outcome"] == "hit"
+            assert row["decision_correct"] is True
+        finally:
+            await pool.execute("DELETE FROM verifier_decisions WHERE req_id=$1", req_id)
+            await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_pass_escalated_maps_to_silent_pass(self):
+        pool = await self._pool()
+        req_id = self._req()
+        try:
+            dec_id = await insert_decision(pool, req_id, "staging_test", "check_fail",
+                                           action="pass")
+            await backfill_outcomes_for_req(pool, req_id, "ESCALATED")
+            row = await self._fetch(pool, dec_id)
+            assert row["actual_outcome"] == "silent_pass"
+            assert row["decision_correct"] is False
+        finally:
+            await pool.execute("DELETE FROM verifier_decisions WHERE req_id=$1", req_id)
+            await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_fix_done_maps_to_hit(self):
+        pool = await self._pool()
+        req_id = self._req()
+        try:
+            dec_id = await insert_decision(pool, req_id, "staging_test", "check_fail",
+                                           action="fix", fixer="dev")
+            await backfill_outcomes_for_req(pool, req_id, "DONE")
+            row = await self._fetch(pool, dec_id)
+            assert row["actual_outcome"] == "hit"
+            assert row["decision_correct"] is True
+        finally:
+            await pool.execute("DELETE FROM verifier_decisions WHERE req_id=$1", req_id)
+            await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_fix_escalated_maps_to_fixer_failed(self):
+        pool = await self._pool()
+        req_id = self._req()
+        try:
+            dec_id = await insert_decision(pool, req_id, "staging_test", "check_fail",
+                                           action="fix", fixer="dev")
+            await backfill_outcomes_for_req(pool, req_id, "ESCALATED")
+            row = await self._fetch(pool, dec_id)
+            assert row["actual_outcome"] == "fixer_failed"
+            assert row["decision_correct"] is False
+        finally:
+            await pool.execute("DELETE FROM verifier_decisions WHERE req_id=$1", req_id)
+            await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_escalate_done_maps_to_over_cautious(self):
+        pool = await self._pool()
+        req_id = self._req()
+        try:
+            dec_id = await insert_decision(pool, req_id, "pr_ci", "check_fail",
+                                           action="escalate")
+            await backfill_outcomes_for_req(pool, req_id, "DONE")
+            row = await self._fetch(pool, dec_id)
+            assert row["actual_outcome"] == "over_cautious"
+            assert row["decision_correct"] is False
+        finally:
+            await pool.execute("DELETE FROM verifier_decisions WHERE req_id=$1", req_id)
+            await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_escalate_escalated_maps_to_hit(self):
+        pool = await self._pool()
+        req_id = self._req()
+        try:
+            dec_id = await insert_decision(pool, req_id, "accept", "check_fail",
+                                           action="escalate")
+            await backfill_outcomes_for_req(pool, req_id, "ESCALATED")
+            row = await self._fetch(pool, dec_id)
+            assert row["actual_outcome"] == "hit"
+            assert row["decision_correct"] is True
+        finally:
+            await pool.execute("DELETE FROM verifier_decisions WHERE req_id=$1", req_id)
+            await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_second_backfill_updates_zero_rows(self):
+        """同一 req 跑 2 次 backfill，第 2 次更新 0 行（WHERE actual_outcome IS NULL）。"""
+        pool = await self._pool()
+        req_id = self._req()
+        try:
+            await insert_decision(pool, req_id, "staging_test", "check_fail", action="pass")
+            n1 = await backfill_outcomes_for_req(pool, req_id, "DONE")
+            n2 = await backfill_outcomes_for_req(pool, req_id, "DONE")
+            assert n1 == 1
+            assert n2 == 0
+        finally:
+            await pool.execute("DELETE FROM verifier_decisions WHERE req_id=$1", req_id)
+            await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_partial_backfill_does_not_overwrite_existing_outcome(self):
+        """actual_outcome 已有值的行不被覆盖，NULL 行正常回填。"""
+        pool = await self._pool()
+        req_id = self._req()
+        try:
+            dec1 = await insert_decision(pool, req_id, "spec_lint", "check_fail",
+                                         action="pass")
+            await pool.execute(
+                "UPDATE verifier_decisions SET actual_outcome='already_set',"
+                " decision_correct=TRUE WHERE id=$1",
+                dec1,
+            )
+            dec2 = await insert_decision(pool, req_id, "staging_test", "check_fail",
+                                         action="fix")
+            n = await backfill_outcomes_for_req(pool, req_id, "DONE")
+            assert n == 1  # only dec2 was NULL
+
+            row1 = await pool.fetchrow(
+                "SELECT actual_outcome FROM verifier_decisions WHERE id=$1", dec1
+            )
+            row2 = await pool.fetchrow(
+                "SELECT actual_outcome FROM verifier_decisions WHERE id=$1", dec2
+            )
+            assert row1["actual_outcome"] == "already_set"
+            assert row2["actual_outcome"] == "hit"
+        finally:
+            await pool.execute("DELETE FROM verifier_decisions WHERE req_id=$1", req_id)
+            await pool.close()


### PR DESCRIPTION
## 改动概要

实现 #242 的 P0-1 + P0-2 两项可观测性增强。

### P0-1：`verifier_decisions.actual_outcome` 自动回填

**痛点**：`actual_outcome` 字段永远 NULL，Q8（verifier 准确率）无法计算。

**实现**：
- `store/verifier_decisions.py` — 新增 `backfill_outcomes_for_req(pool, req_id, terminal_state)`：一条 CASE UPDATE 按 `(decision_action, terminal_state)` 批量回填 `actual_outcome` + `decision_correct`
  - `pass/fix + DONE → hit (correct=True)`
  - `pass + ESCALATED → silent_pass (correct=False)`
  - `fix + ESCALATED → fixer_failed (correct=False)`
  - `escalate + DONE → over_cautious (correct=False)`
  - `escalate + ESCALATED → hit (correct=True)`
- `engine.py` — 进终态块（`cur → DONE/ESCALATED`）追加 fire-and-forget backfill task
- `actions/escalate.py` — 补两个绕过 `engine.step()` 的路径：
  - `_apply_pr_merged_done_override()` → DONE 后 fire-and-forget
  - `is_session_failed_path` 手动 CAS → ESCALATED 后 inline await

### P0-2：`config_version` startup hook

**痛点**：`config_version` 靠手工 INSERT，改 prompt 忘记写 → 改进效果归因断链。

**实现**：
- `observability/schema.sql` — `ALTER TABLE config_version ADD COLUMN IF NOT EXISTS changed_files JSONB`（幂等，obs schema 启动时自动执行）
- `config_version.py`（新文件）— `maybe_record_config_change(obs_pool)`：
  1. `git rev-parse HEAD` 拿当前 SHA
  2. 查表里 `ORDER BY applied_at DESC LIMIT 1` 的上次 `git_commit`
  3. SHA 不同时：`git diff --name-only` 过滤白名单（`prompts/**/*.j2` / `checkers/**` / `config.py`）
  4. 有变更 → `INSERT ... ON CONFLICT DO NOTHING`，`changed_files` 存 JSONB 数组，`kind` 自推断
  5. 无变更 / git 不可用 → 静默跳过
- `main.py` — startup 步骤 2c：`apply_obs_schema()` 之后立即调用，obs pool 未配时跳过

## 未做（留 #242 epic 跟进）

- PR review 信号回填（依赖 #227）
- `improvement_log` baseline 自动抓取（需独立 API endpoint）
- P1-1 agent_turns（#241）
- P1-2 req_timeline view（依赖 #241）

Closes #242