### PR TITLE
feat(orchestrator): hot-reload prompts via ConfigMap (#330)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # accept-env-up/down 不带 ci- 前缀：它们是 accept 阶段 lab 边界，不在 PR-CI 热路径
 # （REQ-rename-accept-targets-1777124774）。
 
-.PHONY: help ci-lint ci-unit-test ci-integration-test accept-env-up accept-env-down test-all test-flutter test-go
+.PHONY: help ci-lint ci-unit-test ci-integration-test accept-env-up accept-env-down test-all test-flutter test-go hotreload-prompts
 
 SCRIPT_DIR := $(shell pwd)
 
@@ -70,6 +70,40 @@ accept-env-down: ## docker compose down -v（幂等；best-effort）
 	@./scripts/sisyphus-accept-down-compose.sh
 
 # ========== 项目级测试聚合（保留） ==========
+
+# ========== Prompt 热更（dogfood only）==========
+#
+# 前置：helm upgrade --set prompts.configMap.enabled=true（只需跑一次）
+# 之后每次改 .j2 只跑本 target，~30s 完成，无需重建镜像。
+#
+# 实现方式：4 个 ConfigMap 对应 prompts/ 下 4 个目录层，每个挂到 pod 对应路径：
+#   sisyphus-prompts          → /etc/sisyphus/prompts/
+#   sisyphus-prompts-verifier → /etc/sisyphus/prompts/verifier/
+#   sisyphus-prompts-shared   → /etc/sisyphus/prompts/_shared/
+#   sisyphus-prompts-shared-hooks → /etc/sisyphus/prompts/_shared/hooks/
+# 不用单 ConfigMap 的原因：k8s ConfigMap key 不允许含 /，无法在一个 CM 里保留目录结构。
+
+PROMPTS_SRC := orchestrator/src/orchestrator/prompts
+ORCH_NS     := sisyphus
+ORCH_DEPLOY := orch-sisyphus-orchestrator
+
+hotreload-prompts: ## dogfood: push .j2 模板到集群并 rolling-restart orchestrator (~30s)
+	@echo "==> [hotreload-prompts] 同步 prompt ConfigMaps..."
+	kubectl create configmap sisyphus-prompts \
+	  $$(find $(PROMPTS_SRC) -maxdepth 1 -name '*.j2' | sort | xargs printf -- '--from-file=%s ') \
+	  --dry-run=client -o yaml | kubectl apply -f -
+	kubectl create configmap sisyphus-prompts-verifier \
+	  $$(find $(PROMPTS_SRC)/verifier -maxdepth 1 -name '*.j2' | sort | xargs printf -- '--from-file=%s ') \
+	  --dry-run=client -o yaml | kubectl apply -f -
+	kubectl create configmap sisyphus-prompts-shared \
+	  $$(find $(PROMPTS_SRC)/_shared -maxdepth 1 -name '*.j2' | sort | xargs printf -- '--from-file=%s ') \
+	  --dry-run=client -o yaml | kubectl apply -f -
+	kubectl create configmap sisyphus-prompts-shared-hooks \
+	  $$(find $(PROMPTS_SRC)/_shared/hooks -maxdepth 1 -name '*.j2' | sort | xargs printf -- '--from-file=%s ') \
+	  --dry-run=client -o yaml | kubectl apply -f -
+	@echo "==> [hotreload-prompts] rolling restart orchestrator..."
+	kubectl -n $(ORCH_NS) rollout restart deploy/$(ORCH_DEPLOY)
+	kubectl -n $(ORCH_NS) rollout status deploy/$(ORCH_DEPLOY)
 
 test-all: test-flutter test-go ## 运行所有项目测试
 

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -197,7 +197,52 @@
 2. 现在做的所有事跟"挡 80% ttpos 需求"距离多远？
 3. 是不是把工具当成了目的？
 
-## 12. 一句话总结
+## 12. Dogfood 期间 prompt 热更
+
+改 `.j2` 模板无需重建镜像。前置一次性配置完成后，每次改模板只需 ~30s。
+
+### 前置（只需做一次）
+
+```bash
+# 1. 建 ConfigMap（内容来自本地 .j2 文件）
+make hotreload-prompts
+
+# 2. helm 开启挂载 flag
+helm -n sisyphus upgrade orch ./orchestrator/helm \
+  -f my-values.yaml \
+  --set prompts.configMap.enabled=true \
+  --set image.tag="<current-sha>" \
+  --set runner.image="<current-runner-sha>"
+```
+
+### 日常热更（改完模板即跑）
+
+```bash
+make hotreload-prompts
+```
+
+这条命令做三件事：
+1. 把 `orchestrator/src/orchestrator/prompts/` 下所有 `.j2`（含 `verifier/`、`_shared/`、`_shared/hooks/`）同步到 4 个 ConfigMap
+2. `kubectl -n sisyphus rollout restart deploy/orch-sisyphus-orchestrator`
+3. 等 rollout 完成（`rollout status`）
+
+全程约 30s，新请求即用新模板。
+
+### 实现原理
+
+- k8s ConfigMap key 不允许含 `/`，故 4 个目录层用 4 个独立 ConfigMap，每个挂载到 pod 对应路径：
+
+  | ConfigMap | mountPath |
+  |---|---|
+  | `sisyphus-prompts` | `/etc/sisyphus/prompts/` |
+  | `sisyphus-prompts-verifier` | `/etc/sisyphus/prompts/verifier/` |
+  | `sisyphus-prompts-shared` | `/etc/sisyphus/prompts/_shared/` |
+  | `sisyphus-prompts-shared-hooks` | `/etc/sisyphus/prompts/_shared/hooks/` |
+
+- `SISYPHUS_PROMPTS_DIR=/etc/sisyphus/prompts` 注入到 pod，`prompts/__init__.py` 读环境变量优先使用该目录；目录为空（ConfigMap 尚未建立）时自动回退 package dir（prod 安全）。
+- `prompts.configMap.enabled=false`（默认）= 完全不挂 ConfigMap，prod 路径不变。
+
+## 13. 一句话总结
 
 **节奏不靠规划，靠 cap。** 设定每周 3-5 REQ / 每月 1 个 sisyphus release / 周末空白 / 不一句话派 REQ。Cap 是 hard limit，超过就 defer。
 

--- a/orchestrator/helm/templates/configmap.yaml
+++ b/orchestrator/helm/templates/configmap.yaml
@@ -54,3 +54,6 @@ data:
   {{- with .Values.env.stage_mcp_requirements }}
   SISYPHUS_STAGE_MCP_REQUIREMENTS: {{ toJson . | quote }}
   {{- end }}
+  {{- if .Values.prompts.configMap.enabled }}
+  SISYPHUS_PROMPTS_DIR: /etc/sisyphus/prompts
+  {{- end }}

--- a/orchestrator/helm/templates/deployment.yaml
+++ b/orchestrator/helm/templates/deployment.yaml
@@ -125,6 +125,36 @@ spec:
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.prompts.configMap.enabled }}
+          volumeMounts:
+            - name: prompts-root
+              mountPath: /etc/sisyphus/prompts
+            - name: prompts-verifier
+              mountPath: /etc/sisyphus/prompts/verifier
+            - name: prompts-shared
+              mountPath: /etc/sisyphus/prompts/_shared
+            - name: prompts-shared-hooks
+              mountPath: /etc/sisyphus/prompts/_shared/hooks
+          {{- end }}
+      {{- if .Values.prompts.configMap.enabled }}
+      volumes:
+        - name: prompts-root
+          configMap:
+            name: sisyphus-prompts
+            optional: true
+        - name: prompts-verifier
+          configMap:
+            name: sisyphus-prompts-verifier
+            optional: true
+        - name: prompts-shared
+          configMap:
+            name: sisyphus-prompts-shared
+            optional: true
+        - name: prompts-shared-hooks
+          configMap:
+            name: sisyphus-prompts-shared-hooks
+            optional: true
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/orchestrator/helm/values.yaml
+++ b/orchestrator/helm/values.yaml
@@ -253,6 +253,16 @@ observability:
   database: sisyphus_obs    # 用 postgres.user/passwordSecret 同账号连
   snapshotIntervalSec: 300  # 0 = 关掉 BKD snapshot 同步循环
 
+# ─── Prompt 热更（dogfood only）─────────────────────────────────────────────
+# 启用后 orchestrator pod 把 4 个 ConfigMap 挂到 /etc/sisyphus/prompts/，
+# 并设 SISYPHUS_PROMPTS_DIR 让 prompts/__init__.py 优先读该目录。
+# prod 默认 false：走 image 内置模板，不依赖集群 ConfigMap。
+# 使用：先 make hotreload-prompts（建 ConfigMap），再 helm upgrade 带此 flag；
+#        后续改模板只跑 make hotreload-prompts 即可（~30s rolling restart）。
+prompts:
+  configMap:
+    enabled: false
+
 probes:
   liveness:
     path: /livez

--- a/orchestrator/src/orchestrator/prompts/__init__.py
+++ b/orchestrator/src/orchestrator/prompts/__init__.py
@@ -1,16 +1,36 @@
 """Jinja2 模板渲染 helper。
 
 模板放本目录 *.md.j2；render() 接 dict 上下文返字符串。
+热更路径：设 SISYPHUS_PROMPTS_DIR 指向 ConfigMap 挂载目录（/etc/sisyphus/prompts），
+          目录含 *.j2 时优先使用；否则回退 package dir（prod 默认路径）。
 """
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from ..config import settings
 
-_PROMPT_DIR = Path(__file__).parent
+_PACKAGE_DIR = Path(__file__).parent
+
+
+def _get_prompt_dir() -> Path:
+    """返回 Jinja2 模板根目录。
+
+    SISYPHUS_PROMPTS_DIR 存在且含 *.j2 文件时返回该目录（ConfigMap 热更路径）；
+    否则回退到 package dir（prod 默认，image 内置模板）。
+    """
+    env_dir = os.environ.get("SISYPHUS_PROMPTS_DIR")
+    if env_dir:
+        candidate = Path(env_dir)
+        if candidate.is_dir() and any(candidate.glob("*.j2")):
+            return candidate
+    return _PACKAGE_DIR
+
+
+_PROMPT_DIR = _get_prompt_dir()
 _env = Environment(
     loader=FileSystemLoader(str(_PROMPT_DIR)),
     autoescape=select_autoescape(disabled_extensions=("md", "j2", "txt"), default=False),

--- a/orchestrator/tests/test_contract_prompts_hot_reload.py
+++ b/orchestrator/tests/test_contract_prompts_hot_reload.py
@@ -1,0 +1,34 @@
+"""Contract: SISYPHUS_PROMPTS_DIR env var 优先级 + 缺省回退 package dir。
+
+验收条件（issue #330 §A）：
+  1. 设了 SISYPHUS_PROMPTS_DIR 且目录含 *.j2 → 返回该目录
+  2. 设了 SISYPHUS_PROMPTS_DIR 但目录为空  → 回退 package dir
+  3. 未设 SISYPHUS_PROMPTS_DIR             → 回退 package dir
+"""
+from orchestrator.prompts import _PACKAGE_DIR, _get_prompt_dir
+
+
+def test_env_dir_with_j2_files_is_preferred(monkeypatch, tmp_path):
+    (tmp_path / "example.md.j2").write_text("{{ var }}")
+    monkeypatch.setenv("SISYPHUS_PROMPTS_DIR", str(tmp_path))
+    assert _get_prompt_dir() == tmp_path
+
+
+def test_env_dir_empty_falls_back_to_package_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("SISYPHUS_PROMPTS_DIR", str(tmp_path))
+    assert _get_prompt_dir() == _PACKAGE_DIR
+
+
+def test_no_env_uses_package_dir(monkeypatch):
+    monkeypatch.delenv("SISYPHUS_PROMPTS_DIR", raising=False)
+    assert _get_prompt_dir() == _PACKAGE_DIR
+
+
+def test_package_dir_contains_j2_files():
+    """回归：package dir 自身必须含 *.j2，否则 prod 路径全挂。"""
+    assert any(_PACKAGE_DIR.glob("*.j2")), f"no *.j2 in {_PACKAGE_DIR}"
+
+
+def test_env_dir_nonexistent_path_falls_back(monkeypatch):
+    monkeypatch.setenv("SISYPHUS_PROMPTS_DIR", "/nonexistent/path/prompts")
+    assert _get_prompt_dir() == _PACKAGE_DIR


### PR DESCRIPTION
## 背景

dogfood 期间改 `.j2` 模板走完整 CI + image build + rollout 约 5-6min/次，严重拖慢迭代速度（issue #330）。

## 方案：4 个 ConfigMap + SISYPHUS_PROMPTS_DIR 回退

**目录结构 → ConfigMap 映射**（k8s ConfigMap key 不允许含 `/`，无法单 CM 保留目录结构，故 4 个分开挂）：

| ConfigMap | mountPath |
|---|---|
| `sisyphus-prompts` | `/etc/sisyphus/prompts/` |
| `sisyphus-prompts-verifier` | `/etc/sisyphus/prompts/verifier/` |
| `sisyphus-prompts-shared` | `/etc/sisyphus/prompts/_shared/` |
| `sisyphus-prompts-shared-hooks` | `/etc/sisyphus/prompts/_shared/hooks/` |

## 改动

- **`prompts/__init__.py`**：新增 `_get_prompt_dir()` — 检查 `SISYPHUS_PROMPTS_DIR` 是否存在且含 `*.j2`；满足则用之，否则回退 package dir
- **`helm/values.yaml`**：加 `prompts.configMap.enabled: false`（默认关闭，prod 路径不变）
- **`helm/templates/configmap.yaml`**：enabled 时注入 `SISYPHUS_PROMPTS_DIR=/etc/sisyphus/prompts`
- **`helm/templates/deployment.yaml`**：enabled 时加 4 个 volumeMounts + volumes（`optional: true`，CM 不存在时 pod 正常启动并回退 package dir）
- **`Makefile`**：`hotreload-prompts` target，用 `find … -name '*.j2'` 精确排除 `.py`，4 条 `kubectl apply` + rollout restart/status
- **`tests/test_contract_prompts_hot_reload.py`**：5 个 contract test（env 有文件用 env dir / env 目录空回退 / 未设回退 / package dir 含 .j2 回归 / 路径不存在回退）
- **`docs/playbook.md`**：§12「Dogfood 期间 prompt 热更」含前置步骤和日常用法

## 日常用法（前置 helm 开启后）

```bash
make hotreload-prompts   # ~30s，改完即跑
```

## 测试结果

```
5 passed in 0.33s  (test_contract_prompts_hot_reload.py)
2082 passed, 1 skipped  (完整单测套件，无回归)
```

Closes #330