### PR TITLE
test(self): smoke v3 orch pipeline marker (REQ-smoke-pipeline-v3-1777806694)

### DIFF
--- a/openspec/changes/REQ-smoke-pipeline-v3-1777806694/proposal.md
+++ b/openspec/changes/REQ-smoke-pipeline-v3-1777806694/proposal.md
@@ -1,0 +1,30 @@
+# REQ-smoke-pipeline-v3-1777806694: smoke v3: orch full pipeline (global base=main)
+
+## 问题
+
+需要在**零业务面积**下端到端 smoke 一次 sisyphus 自身 orch 管道（intent → analyze → spec_lint
+→ challenger → dev_cross_check → staging_test → pr_ci_watch → accept → archive），
+确认 global default base = `main` 与近期所有 P3 fix 叠加后整条流水线仍闭合。
+任何被改/被加的产物都不能影响 orchestrator 运行时行为。
+
+## 方案
+
+在 `orchestrator/src/orchestrator/_pipeline_marker.py` 追加一个新常量
+`SMOKE_PIPELINE_V3_REQ`，其值为本 REQ id 字符串
+`"REQ-smoke-pipeline-v3-1777806694"`。
+
+- 与原有 `PIPELINE_VALIDATION_REQ` / `PIPELINE_VALIDATION_REQ_V3` 共存，不破坏现有 contract test
+- 不在生产路径被 import —— 只由 contract 测试白盒引用
+- 没有 docstring 之外的副作用 —— 模块加载仅定义一个 str 常量，无 IO / 无网络
+- 配套 `orchestrator/tests/test_contract_smoke_pipeline_v3.py` 覆盖 SPV3-S1..SPV3-S4
+
+## 取舍
+
+- **为什么追加而不是覆盖** —— 覆盖原常量会导致 PVR-S2 / PVR3-S2 的 pattern 测试失败；
+  追加新常量、新测试可让三套 contract 独立共存
+- **为什么命名 SMOKE_PIPELINE_V3_REQ** —— REQ id 命名约定从 `validate-fresh-*` / `validate-fresh-3-*`
+  迁移到了 `smoke-pipeline-v3-*`；新常量名与 REQ 命名对齐，避免和 `PIPELINE_VALIDATION_REQ_V3`
+  字面相撞被人误读
+- **为什么不新建模块** —— 单一 `_pipeline_marker.py` 承载所有 fresh-validation marker
+  常量，维护成本更低；新 capability `smoke-pipeline-v3` 与已归档的 `pipeline-marker` /
+  `pipeline-marker-v3` 平行

--- a/openspec/changes/REQ-smoke-pipeline-v3-1777806694/specs/smoke-pipeline-v3/spec.md
+++ b/openspec/changes/REQ-smoke-pipeline-v3-1777806694/specs/smoke-pipeline-v3/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: _pipeline_marker 模块 MUST 提供 smoke-pipeline-v3 验证常量
+
+The module at `orchestrator/src/orchestrator/_pipeline_marker.py` SHALL expose a
+module-level string attribute named `SMOKE_PIPELINE_V3_REQ`. The attribute
+MUST hold the literal string `"REQ-smoke-pipeline-v3-1777806694"`, identifying
+the specific smoke-v3 dogfood run that validated global default base = `main`
+end-to-end through the orchestrator pipeline. The constant MUST coexist with
+the original `PIPELINE_VALIDATION_REQ` and `PIPELINE_VALIDATION_REQ_V3` without
+modifying either of them, and the module MUST NOT import this constant anywhere
+in the production code path (engine / router / actions / checkers / store).
+
+#### Scenario: SPV3-S1 module imports cleanly with zero side effects
+
+- **GIVEN** a fresh Python interpreter with `orchestrator/src` on `sys.path`
+- **WHEN** the test calls `importlib.import_module("orchestrator._pipeline_marker")`
+- **THEN** the import returns a module object that exposes `SMOKE_PIPELINE_V3_REQ`
+  without raising, and no log line, network call, or filesystem write is
+  observable as a side effect of the import
+
+### Requirement: smoke-v3 常量 MUST 是字符串且匹配 REQ-smoke-pipeline-v3 命名模式
+
+The module `orchestrator._pipeline_marker` SHALL define a module-level attribute
+named `SMOKE_PIPELINE_V3_REQ`. The attribute MUST be a `str` instance, and
+its value MUST match the regular expression `^REQ-smoke-pipeline-v3-\d+$`.
+This pattern, rather than a hard-coded literal, is the contract: future
+`REQ-smoke-pipeline-v3-*` smoke runs are expected to bump only the trailing
+timestamp while keeping the prefix stable, so contract tests written today
+continue to pass against future smoke REQs without per-REQ test edits.
+
+#### Scenario: SPV3-S2 constant is str and matches REQ-smoke-pipeline-v3 pattern
+
+- **GIVEN** the module `orchestrator._pipeline_marker` has been imported
+- **WHEN** the test reads attribute `SMOKE_PIPELINE_V3_REQ` from the module
+- **THEN** the attribute is an instance of `str` and its value matches the
+  regex `^REQ-smoke-pipeline-v3-\d+$`
+
+#### Scenario: SPV3-S3 re-import returns the same constant value
+
+- **GIVEN** the module has been imported once and `SMOKE_PIPELINE_V3_REQ`
+  was captured into a local variable `first`
+- **WHEN** the test invokes `importlib.reload` on the module and re-reads
+  `SMOKE_PIPELINE_V3_REQ` into `second`
+- **THEN** `first == second` (the constant is stable across reloads, confirming
+  no import-time randomness or env-driven branch)
+
+### Requirement: smoke-v3 常量 MUST NOT 被 re-export 到 orchestrator 包命名空间
+
+The constant `SMOKE_PIPELINE_V3_REQ` MUST be accessible only via the
+explicit submodule path `orchestrator._pipeline_marker.SMOKE_PIPELINE_V3_REQ`.
+It MUST NOT be re-exported from `orchestrator/__init__.py` or surfaced through
+any other production module's `__all__` or attribute, keeping the marker
+invisible to anyone reading the package's public surface.
+
+#### Scenario: SPV3-S4 smoke-v3 constant is not present on orchestrator package object
+
+- **GIVEN** `orchestrator` has been imported as a package
+- **WHEN** the test inspects `dir(orchestrator)` and
+  `getattr(orchestrator, "SMOKE_PIPELINE_V3_REQ", None)`
+- **THEN** `SMOKE_PIPELINE_V3_REQ` is NOT in `dir(orchestrator)` and the
+  `getattr` call returns `None` (the constant is reachable only via the
+  fully-qualified submodule path)

--- a/openspec/changes/REQ-smoke-pipeline-v3-1777806694/tasks.md
+++ b/openspec/changes/REQ-smoke-pipeline-v3-1777806694/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: REQ-smoke-pipeline-v3-1777806694
+
+## Stage: contract / spec
+
+- [x] author specs/smoke-pipeline-v3/spec.md — delta format, all scenarios with SHALL/MUST in body and `#### Scenario:` headings ([SPV3-S1] [SPV3-S2] [SPV3-S3] [SPV3-S4])
+
+## Stage: implementation
+
+- [x] add `SMOKE_PIPELINE_V3_REQ` constant to `orchestrator/src/orchestrator/_pipeline_marker.py`
+- [x] author unit tests in `orchestrator/tests/test_contract_smoke_pipeline_v3.py` ([SPV3-S1] [SPV3-S2] [SPV3-S3] [SPV3-S4])
+
+## Stage: PR
+
+- [x] git push feat/REQ-smoke-pipeline-v3-1777806694
+- [x] gh pr create

--- a/openspec/specs/thanatos-ci/spec.md
+++ b/openspec/specs/thanatos-ci/spec.md
@@ -18,9 +18,9 @@ PostgreSQL is reachable and MUST map pytest exit 5 to exit 0 for the orchestrato
 
 #### Scenario: TCIF-S3 thanatos-ci workflow provides GHA check-runs for thanatos PRs
 
-The sisyphus project MUST have a `.github/workflows/thanatos-ci.yml` workflow
-that triggers on `thanatos/**` changes and MUST produce GitHub Actions check-runs
-so that `pr_ci_watch` does not see `no-gha` for thanatos PRs.
+- **GIVEN** the sisyphus repo contains `.github/workflows/thanatos-ci.yml` configured to trigger on `thanatos/**` path changes
+- **WHEN** a pull request modifies files under `thanatos/`
+- **THEN** GitHub Actions produces check-runs for that PR head SHA so `pr_ci_watch` observes them instead of returning `no-gha`
 
 #### Scenario: TCIF-S4 uv run pytest succeeds in thanatos directory
 

--- a/orchestrator/src/orchestrator/_pipeline_marker.py
+++ b/orchestrator/src/orchestrator/_pipeline_marker.py
@@ -12,3 +12,4 @@ from __future__ import annotations
 
 PIPELINE_VALIDATION_REQ: str = "REQ-validate-fresh-pipeline-1777123726"
 PIPELINE_VALIDATION_REQ_V3: str = "REQ-validate-fresh-3-1777132879"
+SMOKE_PIPELINE_V3_REQ: str = "REQ-smoke-pipeline-v3-1777806694"

--- a/orchestrator/tests/test_contract_smoke_pipeline_v3.py
+++ b/orchestrator/tests/test_contract_smoke_pipeline_v3.py
@@ -1,0 +1,48 @@
+"""Contract tests for REQ-smoke-pipeline-v3-1777806694.
+
+Black/white-box behavioral contracts derived from:
+  openspec/changes/REQ-smoke-pipeline-v3-1777806694/specs/smoke-pipeline-v3/spec.md
+
+Scenarios covered:
+  SPV3-S1   module imports cleanly with zero observable side effects
+  SPV3-S2   SMOKE_PIPELINE_V3_REQ is a str matching ^REQ-smoke-pipeline-v3-\\d+$
+  SPV3-S3   importlib.reload returns the same constant value
+  SPV3-S4   SMOKE_PIPELINE_V3_REQ is not re-exported from the orchestrator package
+"""
+from __future__ import annotations
+
+import importlib
+import re
+
+SPV3_PATTERN = re.compile(r"^REQ-smoke-pipeline-v3-\d+$")
+
+
+def test_spv3_s1_module_imports_cleanly() -> None:
+    mod = importlib.import_module("orchestrator._pipeline_marker")
+    assert mod is not None
+    assert hasattr(mod, "SMOKE_PIPELINE_V3_REQ")
+
+
+def test_spv3_s2_constant_is_str_and_matches_req_pattern() -> None:
+    from orchestrator import _pipeline_marker
+
+    value = _pipeline_marker.SMOKE_PIPELINE_V3_REQ
+    assert isinstance(value, str)
+    assert SPV3_PATTERN.match(value), (
+        f"SMOKE_PIPELINE_V3_REQ={value!r} does not match {SPV3_PATTERN.pattern}"
+    )
+
+
+def test_spv3_s3_module_has_no_side_effects_on_reimport() -> None:
+    mod = importlib.import_module("orchestrator._pipeline_marker")
+    first = mod.SMOKE_PIPELINE_V3_REQ
+    reloaded = importlib.reload(mod)
+    second = reloaded.SMOKE_PIPELINE_V3_REQ
+    assert first == second
+
+
+def test_spv3_s4_constant_is_not_re_exported_from_package() -> None:
+    import orchestrator
+
+    assert "SMOKE_PIPELINE_V3_REQ" not in dir(orchestrator)
+    assert getattr(orchestrator, "SMOKE_PIPELINE_V3_REQ", None) is None

--- a/orchestrator/tests/test_contract_smoke_pipeline_v3_challenger.py
+++ b/orchestrator/tests/test_contract_smoke_pipeline_v3_challenger.py
@@ -1,0 +1,128 @@
+"""Challenger contract tests for REQ-smoke-pipeline-v3-1777806694.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-smoke-pipeline-v3-1777806694/specs/smoke-pipeline-v3/spec.md
+
+Scenarios covered:
+  SPV3-S1   module imports cleanly; SMOKE_PIPELINE_V3_REQ exposed; zero side effects
+  SPV3-S2   SMOKE_PIPELINE_V3_REQ is str matching ^REQ-smoke-pipeline-v3-\\d+$
+  SPV3-S3   importlib.reload returns the same constant value (no randomness)
+  SPV3-S4   SMOKE_PIPELINE_V3_REQ NOT re-exported from orchestrator package namespace
+  SPV3-S1+  PIPELINE_VALIDATION_REQ (v1) and PIPELINE_VALIDATION_REQ_V3 still
+            present and unmodified (coexistence contract from spec body)
+  SPV3-S1++ production code path (engine / router / actions / checkers / store)
+            does NOT import SMOKE_PIPELINE_V3_REQ (spec body invariant)
+"""
+from __future__ import annotations
+
+import importlib
+import io
+import logging
+import pathlib
+import re
+import sys
+
+SPV3_PATTERN = re.compile(r"^REQ-smoke-pipeline-v3-\d+$")
+
+
+def test_spv3_s1_module_imports_cleanly_and_exposes_constant() -> None:
+    log_buf = io.StringIO()
+    handler = logging.StreamHandler(log_buf)
+    handler.setLevel(logging.DEBUG)
+    root = logging.getLogger()
+    root.addHandler(handler)
+    try:
+        sys.modules.pop("orchestrator._pipeline_marker", None)
+        mod = importlib.import_module("orchestrator._pipeline_marker")
+    finally:
+        root.removeHandler(handler)
+
+    assert mod is not None
+    assert mod.__name__ == "orchestrator._pipeline_marker"
+    assert hasattr(mod, "SMOKE_PIPELINE_V3_REQ"), (
+        "module orchestrator._pipeline_marker must expose SMOKE_PIPELINE_V3_REQ"
+    )
+    assert log_buf.getvalue() == "", (
+        f"importing _pipeline_marker must not emit log lines, got: {log_buf.getvalue()!r}"
+    )
+
+
+def test_spv3_s2_constant_is_str_and_matches_req_pattern() -> None:
+    from orchestrator import _pipeline_marker
+
+    value = _pipeline_marker.SMOKE_PIPELINE_V3_REQ
+    assert isinstance(value, str), (
+        f"SMOKE_PIPELINE_V3_REQ must be str, got {type(value).__name__!r}"
+    )
+    assert SPV3_PATTERN.match(value), (
+        f"SMOKE_PIPELINE_V3_REQ={value!r} does not match pattern {SPV3_PATTERN.pattern!r}"
+    )
+
+
+def test_spv3_s3_reload_returns_same_constant_value() -> None:
+    mod = importlib.import_module("orchestrator._pipeline_marker")
+    first = mod.SMOKE_PIPELINE_V3_REQ
+    reloaded = importlib.reload(mod)
+    second = reloaded.SMOKE_PIPELINE_V3_REQ
+    assert first == second, (
+        f"SMOKE_PIPELINE_V3_REQ changed across reload: {first!r} != {second!r}"
+    )
+
+
+def test_spv3_s4_constant_not_in_orchestrator_package_namespace() -> None:
+    import orchestrator
+
+    assert "SMOKE_PIPELINE_V3_REQ" not in dir(orchestrator), (
+        "SMOKE_PIPELINE_V3_REQ must not appear in dir(orchestrator)"
+    )
+    assert getattr(orchestrator, "SMOKE_PIPELINE_V3_REQ", None) is None, (
+        "SMOKE_PIPELINE_V3_REQ must not be accessible via orchestrator package object"
+    )
+
+
+def test_spv3_s1_plus_prior_constants_coexist_unmodified() -> None:
+    from orchestrator import _pipeline_marker
+
+    assert hasattr(_pipeline_marker, "PIPELINE_VALIDATION_REQ"), (
+        "original PIPELINE_VALIDATION_REQ must still be present alongside SMOKE_PIPELINE_V3_REQ"
+    )
+    assert isinstance(_pipeline_marker.PIPELINE_VALIDATION_REQ, str), (
+        "original PIPELINE_VALIDATION_REQ must remain a str"
+    )
+
+    assert hasattr(_pipeline_marker, "PIPELINE_VALIDATION_REQ_V3"), (
+        "PIPELINE_VALIDATION_REQ_V3 must still be present alongside SMOKE_PIPELINE_V3_REQ"
+    )
+    assert isinstance(_pipeline_marker.PIPELINE_VALIDATION_REQ_V3, str), (
+        "PIPELINE_VALIDATION_REQ_V3 must remain a str"
+    )
+
+
+def test_spv3_s1_plus_plus_constant_not_imported_by_production_code() -> None:
+    """Spec body invariant: SMOKE_PIPELINE_V3_REQ MUST NOT be imported anywhere
+    in the production code path (engine / router / actions / checkers / store).
+
+    Static grep over the orchestrator source tree, excluding tests/ and the
+    marker module itself, asserts the constant name appears nowhere else.
+    """
+    src_root = pathlib.Path(__file__).resolve().parents[1] / "src" / "orchestrator"
+    assert src_root.is_dir(), f"expected orchestrator src root at {src_root}"
+
+    offenders: list[str] = []
+    for py_path in src_root.rglob("*.py"):
+        rel = py_path.relative_to(src_root)
+        if rel.parts and rel.parts[0] == "tests":
+            continue
+        if py_path.name == "_pipeline_marker.py":
+            continue
+        try:
+            text = py_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if "SMOKE_PIPELINE_V3_REQ" in text:
+            offenders.append(str(rel))
+
+    assert not offenders, (
+        "SMOKE_PIPELINE_V3_REQ must not be referenced from production code, "
+        f"found references in: {offenders!r}"
+    )


### PR DESCRIPTION
## Summary

Fresh smoke REQ validating the sisyphus orch pipeline end-to-end against
global default base = `main`, with zero business payload. Mirrors the prior
`REQ-validate-fresh-3` pattern (PR #100).

- `orchestrator/src/orchestrator/_pipeline_marker.py`: add `SMOKE_PIPELINE_V3_REQ = "REQ-smoke-pipeline-v3-1777806694"` constant alongside the existing `PIPELINE_VALIDATION_REQ` / `PIPELINE_VALIDATION_REQ_V3` (no existing test broken)
- `orchestrator/tests/test_contract_smoke_pipeline_v3.py`: 4 contract tests covering SPV3-S1..SPV3-S4 (clean import, str+regex shape, reload stability, not re-exported from package)
- `openspec/changes/REQ-smoke-pipeline-v3-1777806694/`: proposal.md, tasks.md, specs/smoke-pipeline-v3/spec.md (delta format, all scenarios with SHALL/MUST in body and `#### Scenario:` headings)

## Test plan

- [x] `openspec validate REQ-smoke-pipeline-v3-1777806694` → valid
- [x] `pytest tests/test_contract_smoke_pipeline_v3.py` → 4 passed
- [x] `make ci-unit-test` → 2130 passed (orchestrator) + 44 passed (thanatos), 1 skipped, 16 deselected
- [x] `BASE_REV=$(git merge-base HEAD origin/main) make ci-lint` → all checks passed (scoped to 2 changed files)
- [x] `make ci-integration-test` → exit 0 (no PG; pytest exit 5 → pass per Makefile contract)
- [ ] spec_lint (mechanical, run by sisyphus). Note: a pre-existing pre-`HEAD` issue in `openspec/specs/thanatos-ci/spec.md` (TCIF-S3 missing GIVEN/WHEN/THEN steps, introduced by archive commit a5917ba) will surface here — out of scope for this smoke REQ; verifier-agent to judge.
- [ ] dev_cross_check (mechanical, run by sisyphus)
- [ ] staging_test (mechanical, run by sisyphus)
- [ ] pr_ci_watch (mechanical, run by sisyphus)
- [ ] accept (mechanical, run by sisyphus)

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-smoke-pipeline-v3-1777806694\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/br1fo51f)