### PR TITLE
fix(watchdog): liveness check + no tag pollution (closes #352 #353)

### DIFF
--- a/openspec/changes/REQ-fix-watchdog-liveness-1777809646/proposal.md
+++ b/openspec/changes/REQ-fix-watchdog-liveness-1777809646/proposal.md
@@ -1,0 +1,67 @@
+# REQ-fix-watchdog-liveness-1777809646
+
+fix(watchdog): liveness check + no tag pollution (closes #352 #353)
+
+## Why
+
+Watchdog 当前唯一的活体信号是 BKD `sessionStatus == "running"`。在 5/3 大 REQ
+analyze 实测：analyze-agent 单 turn ~5min 写大量代码，watchdog 1min 一 tick，
+检测到 `sessionStatus != "running"`（BKD 在 turn 边界、sub-issue 等待等场景会
+短暂离开 `running`）+ stuck >= ended 阈值（300s）→ emit `SESSION_FAILED` →
+escalate.py auto_resume 救回；连续两次 stuck → retry 用尽 → 真 escalate，给
+**父 intent issue** 加 `[escalated, reason:<X>]` tag。Agent 实际还在干活，retry
+是误救，escalated tag 是误污染。
+
+后果：
+- 每个长 analyze REQ 都被误标 escalated，UI / 用户误以为崩了
+- `verifier_decisions.actual_outcome` 自动回填（PR #337）把"agent 实际跑通但
+  父 issue 留着 escalated tag"算成 escalate / silent_pass，污染 Q8 verifier
+  准确率
+- auto_resume 的"⚠️ Session was interrupted"follow-up 打断 agent 自然节奏，
+  agent 被迫从 chat history 重读现场重新规划
+
+根因不是阈值不够长（拉长阈值只是把误判推后），而是**watchdog 用错信号**。BKD
+`sessionStatus` 是 session 生命周期标，不是 agent 工作活体；真正能反映"agent
+本秒还在产出"的是 BKD `/issues/{id}/logs` 里最新 log entry 的 `createdAt`
+（assistant-message / tool-result 都会创建新 entry）。
+
+## What Changes
+
+### 1. 给 BKD client 加 `last_log_activity_at()`（轻量活体探针）
+
+`BKDRestClient.last_log_activity_at(project_id, issue_id) -> datetime | None`
+拉 `/issues/{id}/logs?limit=10` 取最新一条 log entry 的 `createdAt`。失败 / 空
+日志返回 None。BKDClient (factory) 同步暴露同名方法。
+
+### 2. watchdog 在 escalate 决策前先看活动
+
+`watchdog._check_and_escalate` 拿到 issue 后，**不论 sessionStatus 是什么**，
+先调 `last_log_activity_at`。如果距今 < `watchdog_liveness_grace_sec`（默认 120s）
+→ 记 debug log 并 `return False`，不进入任何 escalate 路径（既不快车 / 也不
+慢车 / 也不 self-heal）。本检查在 `_STAGES_NEEDING_RESULT_TAG` 自愈逻辑、
+`fixer-round-cap` 硬终止之外（fixer-round-cap 仍然短路活体检查继续走 escalate，
+因为是确定性硬封顶不依赖 agent 是否活着）。
+
+### 3. 新配置 `watchdog_liveness_grace_sec`
+
+`config.py` 加 `watchdog_liveness_grace_sec: int = 120`。120s 给单 turn 写大量
+代码留出节奏空间；用户可调。SQL 预过滤阈值 `_sql_prefilter_threshold()` 同步
+把它纳入 min 取值，避免活体检查根本拦不到（grace > ended/stuck 的极端配置）。
+
+### 4. 测试钉牢 auto_resume 路径不污染 tag
+
+#353 的核心保证："auto_resume 路径不在父 issue 加 escalated tag"。当前代码已经
+是这样（escalate.py auto_resume 早返回，不调 `merge_tags_and_update`），但缺
+显式契约测试。新增 contract test 验证：transient + retry < 2 → escalate 返
+`auto_resumed=True` + BKD client 没收到 `merge_tags_and_update` add `escalated`
+的调用。
+
+## Out of Scope
+
+- 不改 `_STAGE_POLICY` 各 stage 的 ended_sec / stuck_sec 默认值。活体检查是更
+  上层的过滤，policy 数值仍然作为硬上限兜底。
+- 不做"escalated 后用户手工 resume 成功 → 自动撤 tag"。属于 M14b 后续扩展，
+  本 REQ 先把误污染源头堵住。
+- 不引入 `agent_turns` 表查询。`agent_turns_collector` 是 5min 批量 + 仅扫
+  `ended_at IS NOT NULL` 的 stage_runs，不适合实时活体；直接调 BKD `/logs`
+  更轻量、零额外耦合。

--- a/openspec/changes/REQ-fix-watchdog-liveness-1777809646/proposal.md
+++ b/openspec/changes/REQ-fix-watchdog-liveness-1777809646/proposal.md
@@ -45,8 +45,8 @@ escalate.py auto_resume 救回；连续两次 stuck → retry 用尽 → 真 esc
 ### 3. 新配置 `watchdog_liveness_grace_sec`
 
 `config.py` 加 `watchdog_liveness_grace_sec: int = 120`。120s 给单 turn 写大量
-代码留出节奏空间；用户可调。SQL 预过滤阈值 `_sql_prefilter_threshold()` 同步
-把它纳入 min 取值，避免活体检查根本拦不到（grace > ended/stuck 的极端配置）。
+代码留出节奏空间；用户可调。SQL 预过滤阈值不动——row 仍按现有 ended_sec /
+stuck_sec min 入选，活体检查只是在选中的 row 上多加一道豁免门。
 
 ### 4. 测试钉牢 auto_resume 路径不污染 tag
 

--- a/openspec/changes/REQ-fix-watchdog-liveness-1777809646/specs/watchdog-liveness/spec.md
+++ b/openspec/changes/REQ-fix-watchdog-liveness-1777809646/specs/watchdog-liveness/spec.md
@@ -1,0 +1,72 @@
+# Spec Delta — watchdog liveness check
+
+## ADDED Requirements
+
+### Requirement: Watchdog suppresses escalate when BKD logs show recent activity
+
+The orchestrator watchdog SHALL probe the BKD `/issues/{id}/logs` endpoint for
+the latest log entry timestamp before deciding to escalate a stuck stage. If
+that timestamp is within `watchdog_liveness_grace_sec` (default 120 seconds),
+the watchdog MUST treat the stage as live and return without firing
+`SESSION_FAILED`, regardless of the BKD `sessionStatus` value. This applies to
+both the ended-session fast lane and the long-tail slow lane in
+`_check_and_escalate`. The check MUST NOT bypass the explicit
+`fixer-round-cap` hard-stop branch, because that branch is a deterministic
+upper bound that does not depend on agent liveness.
+
+#### Scenario: WLC-S1 fresh activity within grace skips escalate
+- **GIVEN** a REQ in `ANALYZING` whose BKD intent issue has `sessionStatus="completed"` and the latest log entry `createdAt` is 30 seconds before now
+- **WHEN** `watchdog._check_and_escalate` runs against that row with `stuck_sec=400` (above the stage `ended_sec=300`)
+- **THEN** the function returns `False`, no `SESSION_FAILED` event is emitted, and a `watchdog.live_activity_skip` debug log is recorded
+
+#### Scenario: WLC-S2 stale activity falls through to escalate
+- **GIVEN** a REQ in `SPEC_LINT_RUNNING` whose BKD issue has `sessionStatus="completed"` and the latest log entry `createdAt` is 600 seconds before now
+- **WHEN** `watchdog._check_and_escalate` runs with `stuck_sec=400` (above `ended_sec=300`)
+- **THEN** the function proceeds to `engine.step` with `Event.SESSION_FAILED` exactly as before the activity check existed
+
+#### Scenario: WLC-S3 fixer-round-cap still escalates regardless of activity
+- **GIVEN** a REQ in `FIXER_RUNNING` with `ctx.fixer_round` >= `settings.fixer_round_cap` and the latest log entry `createdAt` 5 seconds before now
+- **WHEN** `watchdog._check_and_escalate` runs
+- **THEN** the function still emits `SESSION_FAILED` with `escalated_reason="fixer-round-cap"` (activity check MUST NOT short-circuit the hard cap)
+
+### Requirement: BKD client exposes a lightweight last-activity probe
+
+`BKDRestClient` SHALL expose `async def last_log_activity_at(project_id, issue_id) -> datetime | None`
+that performs a single `GET /projects/{pid}/issues/{iid}/logs?limit=10`,
+parses the maximum `createdAt` timestamp across the returned entries, and
+returns it as a timezone-aware `datetime` in UTC. The method MUST return
+`None` when the response has no `logs`, when an entry's `createdAt` is missing
+or unparseable, or when the HTTP call raises. The method SHALL NOT raise; all
+errors MUST be swallowed and logged at warning level so the watchdog caller
+can fall back to existing behaviour.
+
+#### Scenario: WLC-S4 returns max createdAt across log entries
+- **GIVEN** BKD `/logs?limit=10` returns three entries with `createdAt` timestamps `T-300s`, `T-30s`, `T-90s`
+- **WHEN** `last_log_activity_at` is called
+- **THEN** the returned `datetime` equals `T-30s` parsed in UTC
+
+#### Scenario: WLC-S5 returns None on empty logs
+- **GIVEN** BKD `/logs?limit=10` returns `{"logs": []}`
+- **WHEN** `last_log_activity_at` is called
+- **THEN** the function returns `None`
+
+#### Scenario: WLC-S6 swallows HTTP errors and returns None
+- **GIVEN** the BKD `/logs` call raises an exception
+- **WHEN** `last_log_activity_at` is called
+- **THEN** the function returns `None` and logs `bkd.last_log_activity_at.failed` at warning level
+
+### Requirement: Auto-resume path leaves parent intent issue tags untouched
+
+When `escalate` action runs the auto-resume branch (transient signal +
+`auto_retry_count < _MAX_AUTO_RETRY`), it MUST NOT add the `escalated` or any
+`reason:*` tag to the BKD intent issue. The action SHALL only invoke
+`bkd.follow_up_issue` on the failed issue and update `req_state.context` with
+the new `auto_retry_count` and `last_retry_reason`. This invariant lets long
+analyze sessions that are auto-resumed remain visually clean in BKD UI and
+keeps `verifier_decisions.actual_outcome` backfill from incorrectly classifying
+recovered REQs as escalated.
+
+#### Scenario: WLC-S7 transient escalate with retry slack does not tag intent issue
+- **GIVEN** a `body.event="watchdog.stuck"` escalate call with `ctx.auto_retry_count=0` and `_MAX_AUTO_RETRY=2`
+- **WHEN** the `escalate` action is invoked
+- **THEN** `BKDClient.merge_tags_and_update` is NOT called for the intent issue with `escalated` in the `add` list, and the action returns `{"auto_resumed": True, "retry": 1, ...}`

--- a/openspec/changes/REQ-fix-watchdog-liveness-1777809646/specs/watchdog-liveness/spec.md
+++ b/openspec/changes/REQ-fix-watchdog-liveness-1777809646/specs/watchdog-liveness/spec.md
@@ -57,13 +57,13 @@ can fall back to existing behaviour.
 
 ### Requirement: Auto-resume path leaves parent intent issue tags untouched
 
-When `escalate` action runs the auto-resume branch (transient signal +
-`auto_retry_count < _MAX_AUTO_RETRY`), it MUST NOT add the `escalated` or any
-`reason:*` tag to the BKD intent issue. The action SHALL only invoke
-`bkd.follow_up_issue` on the failed issue and update `req_state.context` with
-the new `auto_retry_count` and `last_retry_reason`. This invariant lets long
-analyze sessions that are auto-resumed remain visually clean in BKD UI and
-keeps `verifier_decisions.actual_outcome` backfill from incorrectly classifying
+The `escalate` action SHALL keep the BKD intent issue tag set unchanged when
+it takes the auto-resume branch (transient signal plus `auto_retry_count <
+_MAX_AUTO_RETRY`). The action MUST only invoke `bkd.follow_up_issue` on the
+failed issue and update `req_state.context` with the new `auto_retry_count`
+and `last_retry_reason`. This invariant lets long analyze sessions that are
+auto-resumed remain visually clean in BKD UI and keeps
+`verifier_decisions.actual_outcome` backfill from incorrectly classifying
 recovered REQs as escalated.
 
 #### Scenario: WLC-S7 transient escalate with retry slack does not tag intent issue

--- a/openspec/changes/REQ-fix-watchdog-liveness-1777809646/tasks.md
+++ b/openspec/changes/REQ-fix-watchdog-liveness-1777809646/tasks.md
@@ -10,7 +10,6 @@
 - [ ] add `BKDRestClient.last_log_activity_at(project_id, issue_id)` returning latest log entry `createdAt` or `None`
 - [ ] add `watchdog_liveness_grace_sec: int = 120` to `config.Settings`
 - [ ] in `watchdog._check_and_escalate`, after BKD `get_issue`, call `last_log_activity_at`; if recent activity within grace window → log skip + return False
-- [ ] include `watchdog_liveness_grace_sec` in `_sql_prefilter_threshold()` candidates so the SQL filter window admits rows the activity check needs to evaluate
 
 ## Stage: tests
 

--- a/openspec/changes/REQ-fix-watchdog-liveness-1777809646/tasks.md
+++ b/openspec/changes/REQ-fix-watchdog-liveness-1777809646/tasks.md
@@ -1,0 +1,28 @@
+# Tasks — REQ-fix-watchdog-liveness-1777809646
+
+## Stage: spec
+
+- [ ] author proposal.md (this REQ)
+- [ ] author specs/watchdog-liveness/spec.md (delta format, ADDED Requirements)
+
+## Stage: implementation
+
+- [ ] add `BKDRestClient.last_log_activity_at(project_id, issue_id)` returning latest log entry `createdAt` or `None`
+- [ ] add `watchdog_liveness_grace_sec: int = 120` to `config.Settings`
+- [ ] in `watchdog._check_and_escalate`, after BKD `get_issue`, call `last_log_activity_at`; if recent activity within grace window → log skip + return False
+- [ ] include `watchdog_liveness_grace_sec` in `_sql_prefilter_threshold()` candidates so the SQL filter window admits rows the activity check needs to evaluate
+
+## Stage: tests
+
+- [ ] unit test: `BKDRestClient.last_log_activity_at` parses `createdAt` from latest log; returns None on empty/error
+- [ ] unit test: `watchdog._check_and_escalate` returns False (no escalate) when last activity within grace, even if `session_status != "running"`
+- [ ] unit test: `watchdog._check_and_escalate` still escalates when last activity is stale (> grace) and session not running, preserving original behaviour
+- [ ] contract test: `escalate` action with transient body (`watchdog.stuck`, retry < cap) does NOT call `merge_tags_and_update` adding `escalated` (locks down #353 invariant)
+
+## Stage: PR (推之前必须全绿)
+
+- [ ] git push feat/REQ-fix-watchdog-liveness-1777809646
+- [ ] `make ci-lint` 全绿
+- [ ] `make ci-unit-test` 全绿
+- [ ] `make ci-integration-test` 全绿（无 PG 环境跳过视为 pass）
+- [ ] gh pr create --label sisyphus

--- a/openspec/changes/REQ-fix-watchdog-liveness-1777809646/tasks.md
+++ b/openspec/changes/REQ-fix-watchdog-liveness-1777809646/tasks.md
@@ -2,26 +2,26 @@
 
 ## Stage: spec
 
-- [ ] author proposal.md (this REQ)
-- [ ] author specs/watchdog-liveness/spec.md (delta format, ADDED Requirements)
+- [x] author proposal.md (this REQ)
+- [x] author specs/watchdog-liveness/spec.md (delta format, ADDED Requirements)
 
 ## Stage: implementation
 
-- [ ] add `BKDRestClient.last_log_activity_at(project_id, issue_id)` returning latest log entry `createdAt` or `None`
-- [ ] add `watchdog_liveness_grace_sec: int = 120` to `config.Settings`
-- [ ] in `watchdog._check_and_escalate`, after BKD `get_issue`, call `last_log_activity_at`; if recent activity within grace window → log skip + return False
+- [x] add `BKDRestClient.last_log_activity_at(project_id, issue_id)` returning latest log entry `createdAt` or `None`
+- [x] add `watchdog_liveness_grace_sec: int = 120` to `config.Settings`
+- [x] in `watchdog._check_and_escalate`, after BKD `get_issue`, call `last_log_activity_at`; if recent activity within grace window → log skip + return False
 
 ## Stage: tests
 
-- [ ] unit test: `BKDRestClient.last_log_activity_at` parses `createdAt` from latest log; returns None on empty/error
-- [ ] unit test: `watchdog._check_and_escalate` returns False (no escalate) when last activity within grace, even if `session_status != "running"`
-- [ ] unit test: `watchdog._check_and_escalate` still escalates when last activity is stale (> grace) and session not running, preserving original behaviour
-- [ ] contract test: `escalate` action with transient body (`watchdog.stuck`, retry < cap) does NOT call `merge_tags_and_update` adding `escalated` (locks down #353 invariant)
+- [x] unit test: `BKDRestClient.last_log_activity_at` parses `createdAt` from latest log; returns None on empty/error
+- [x] unit test: `watchdog._check_and_escalate` returns False (no escalate) when last activity within grace, even if `session_status != "running"`
+- [x] unit test: `watchdog._check_and_escalate` still escalates when last activity is stale (> grace) and session not running, preserving original behaviour
+- [x] contract test: `escalate` action with transient body (`watchdog.stuck`, retry < cap) does NOT call `merge_tags_and_update` adding `escalated` (locks down #353 invariant)
 
 ## Stage: PR (推之前必须全绿)
 
-- [ ] git push feat/REQ-fix-watchdog-liveness-1777809646
-- [ ] `make ci-lint` 全绿
-- [ ] `make ci-unit-test` 全绿
-- [ ] `make ci-integration-test` 全绿（无 PG 环境跳过视为 pass）
+- [x] git push feat/REQ-fix-watchdog-liveness-1777809646
+- [x] `make ci-lint` 全绿
+- [x] `make ci-unit-test` 全绿（2134 + 44 passed）
+- [x] `make ci-integration-test` 全绿（无 PG 环境 exit 5 → pass）
 - [ ] gh pr create --label sisyphus

--- a/orchestrator/src/orchestrator/bkd_rest.py
+++ b/orchestrator/src/orchestrator/bkd_rest.py
@@ -180,6 +180,48 @@ class BKDRestClient:
         ]
         return "\n\n---\n\n".join(msgs) if msgs else None
 
+    async def last_log_activity_at(
+        self,
+        project_id: str,
+        issue_id: str,
+    ) -> datetime | None:
+        """最近一条 BKD log entry 的 createdAt（UTC）；watchdog 用作活体探针。
+
+        实现：GET /logs?limit=10 取所有 entry 的 createdAt 最大值。
+        失败 / 空 / 无 createdAt 一律返回 None；调用方按"未知活动"处理。
+        """
+        try:
+            data = await self._get(
+                f"/projects/{project_id}/issues/{issue_id}/logs?limit=10"
+            )
+        except Exception as e:
+            log.warning(
+                "bkd.last_log_activity_at.failed",
+                issue_id=issue_id, error=str(e),
+            )
+            return None
+        if not isinstance(data, dict):
+            return None
+        logs = data.get("logs") or []
+        latest: datetime | None = None
+        for entry in logs:
+            if not isinstance(entry, dict):
+                continue
+            ts_raw = entry.get("createdAt")
+            if not ts_raw:
+                continue
+            try:
+                ts = datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+            except (TypeError, ValueError):
+                continue
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=UTC)
+            else:
+                ts = ts.astimezone(UTC)
+            if latest is None or ts > latest:
+                latest = ts
+        return latest
+
     async def fetch_turns(self, project_id: str, issue_id: str) -> list[Turn]:
         """拉 BKD issue logs，折叠成 turn 维度（role × token × duration × tool_calls）。
 

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -273,6 +273,11 @@ class Settings(BaseSettings):
     # 立即 escalate；session_status == "running" 仍由 in-loop 跳过（不受影响）。
     # 把 "BKD agent 死了但没发 session.failed webhook" 的兜底从 60min 缩到 5min。
     watchdog_session_ended_threshold_sec: int = 300
+    # REQ-fix-watchdog-liveness-1777809646: 活体探针。watchdog 在 escalate 决策前
+    # 拉 BKD /logs 看最新 entry createdAt。距今 < 该值 → 视 agent 仍活，跳过 escalate。
+    # 默认 120s 给单 turn 写大量代码留空间；BKD 仅返回 entry 后才会更新 createdAt，
+    # 所以中间没 tool-result/assistant-message 的"思考期"也算静默——120s 是经验折中。
+    watchdog_liveness_grace_sec: int = 120
 
     # ─── 防 verifier↔fixer 死循环：硬封顶 fixer round 数 ─────────────────
     # 每次 verifier decision=fix 都会 start_fixer 起新一轮 fixer agent，跑完回 verifier

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import asyncio
 import json
 from dataclasses import dataclass
+from datetime import UTC, datetime
 
 import structlog
 
@@ -310,6 +311,40 @@ async def _check_and_escalate(row) -> bool:
     if issue_id is None and policy.stuck_sec is None and ctx.get("escalated_reason") != "fixer-round-cap":
         log.warning("watchdog.missing_issue_id", req_id=req_id, state=state.value)
         return False
+
+    # 3b. REQ-fix-watchdog-liveness-1777809646: 活体探针。BKD sessionStatus 是
+    # session 生命周期标，不是 agent 活体；BKD 在 turn 边界 / 等待 sub-issue 时
+    # 短暂离开 "running" 会被误判 ended。改用 BKD /logs 看最新 entry createdAt：
+    # 距今 < watchdog_liveness_grace_sec → agent 实际还在产出，不论 session_status
+    # 都跳过 escalate。fixer-round-cap 路径保持例外（确定性硬封顶不依赖活体）。
+    skip_for_liveness = (
+        issue_id is not None
+        and ctx.get("escalated_reason") != "fixer-round-cap"
+    )
+    if skip_for_liveness:
+        last_activity: datetime | None = None
+        try:
+            async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+                last_activity = await bkd.last_log_activity_at(project_id, issue_id)
+        except Exception as e:
+            # BKD 挂 / transport 不支持 → 静默回到原行为，下面继续按 policy 判
+            log.warning(
+                "watchdog.last_activity_probe_failed",
+                req_id=req_id, issue_id=issue_id, error=str(e),
+            )
+        if isinstance(last_activity, datetime):
+            grace = settings.watchdog_liveness_grace_sec
+            now = datetime.now(UTC)
+            inactive_sec = (now - last_activity).total_seconds()
+            if inactive_sec < grace:
+                log.debug(
+                    "watchdog.live_activity_skip",
+                    req_id=req_id, state=state_str,
+                    issue_id=issue_id,
+                    inactive_sec=int(inactive_sec),
+                    grace_sec=grace,
+                )
+                return False
 
     # 4. 按 policy 决定是否 escalate
     if still_running:

--- a/orchestrator/tests/test_actions_smoke.py
+++ b/orchestrator/tests/test_actions_smoke.py
@@ -698,3 +698,25 @@ async def test_bkd_merge_tags_preserves(monkeypatch):
     )
     assert set(captured["tags"]) == {"REQ-9", "ci-passed"}
     assert captured["status_id"] == "done"
+
+
+# ─── REQ-fix-watchdog-liveness-1777809646 (#353): auto-resume must not pollute tags
+@pytest.mark.asyncio
+async def test_escalate_auto_resume_never_tags_intent_issue(monkeypatch):
+    """WLC-S7: transient escalate within retry slack must NOT add `escalated`
+    or `reason:*` tag to BKD intent issue. Lock-down for #353."""
+    from orchestrator.actions import escalate as mod
+    fake = make_fake_bkd()
+    patch_bkd(monkeypatch, "escalate", fake)
+    patch_db(monkeypatch, "escalate")
+    body = make_body(issue_id="src-1", event="watchdog.stuck")
+    out = await mod.escalate(
+        body=body, req_id="REQ-WLC-S7", tags=["analyze"],
+        ctx={"intent_issue_id": "intent-1", "auto_retry_count": 0},
+    )
+    assert out["auto_resumed"] is True
+    assert out["retry"] == 1
+    # 关键不变量：BKD merge_tags_and_update 不应被 await
+    fake.merge_tags_and_update.assert_not_awaited()
+    # follow-up 是允许的（auto-resume 唤醒 agent）
+    fake.follow_up_issue.assert_awaited_once()

--- a/orchestrator/tests/test_bkd_rest.py
+++ b/orchestrator/tests/test_bkd_rest.py
@@ -411,3 +411,106 @@ async def test_get_issue_returns_external_session_id_via_rest():
     client._http = FakeHttp()  # type: ignore[assignment]
     issue = await client.get_issue("p", "i1")
     assert issue.external_session_id == "sess-abc"
+
+
+# ─── REQ-fix-watchdog-liveness-1777809646: last_log_activity_at ─────────────
+
+
+@pytest.mark.asyncio
+async def test_last_log_activity_at_returns_max_created_at():
+    """WLC-S4: 多 entry 取最新 createdAt（不是顺序最后一条）。"""
+    from datetime import UTC, datetime
+    captured_url = {}
+
+    class FakeHttp:
+        async def get(self, url, headers=None):
+            captured_url["url"] = url
+            payload = {
+                "success": True,
+                "data": {
+                    "logs": [
+                        {"entryType": "assistant-message",
+                         "createdAt": "2026-05-03T10:00:00Z"},
+                        {"entryType": "tool-result",
+                         "createdAt": "2026-05-03T10:05:00Z"},
+                        {"entryType": "user-message",
+                         "createdAt": "2026-05-03T10:02:00Z"},
+                    ]
+                },
+            }
+            return httpx.Response(200, text=json.dumps(payload))
+
+        async def aclose(self):
+            pass
+
+    client = BKDRestClient("https://bkd.example/api", "tok")
+    client._http = FakeHttp()  # type: ignore[assignment]
+
+    ts = await client.last_log_activity_at("p", "i1")
+    assert ts == datetime(2026, 5, 3, 10, 5, 0, tzinfo=UTC)
+    assert "/projects/p/issues/i1/logs?limit=10" in captured_url["url"]
+
+
+@pytest.mark.asyncio
+async def test_last_log_activity_at_returns_none_for_empty_logs():
+    """WLC-S5: 空 logs 数组 → None。"""
+
+    class FakeHttp:
+        async def get(self, url, headers=None):
+            return httpx.Response(200, text='{"success":true,"data":{"logs":[]}}')
+
+        async def aclose(self):
+            pass
+
+    client = BKDRestClient("https://bkd.example/api", "tok")
+    client._http = FakeHttp()  # type: ignore[assignment]
+
+    assert await client.last_log_activity_at("p", "i1") is None
+
+
+@pytest.mark.asyncio
+async def test_last_log_activity_at_swallows_http_errors():
+    """WLC-S6: HTTP 抛 → 不抛出，返 None。"""
+
+    class FakeHttp:
+        async def get(self, url, headers=None):
+            raise httpx.ConnectError("boom")
+
+        async def aclose(self):
+            pass
+
+    client = BKDRestClient("https://bkd.example/api", "tok")
+    client._http = FakeHttp()  # type: ignore[assignment]
+
+    assert await client.last_log_activity_at("p", "i1") is None
+
+
+@pytest.mark.asyncio
+async def test_last_log_activity_at_skips_unparseable_timestamps():
+    """malformed createdAt entries are skipped, max of valid ones returned."""
+    from datetime import UTC, datetime
+
+    class FakeHttp:
+        async def get(self, url, headers=None):
+            payload = {
+                "success": True,
+                "data": {
+                    "logs": [
+                        {"entryType": "assistant-message",
+                         "createdAt": "not-a-date"},
+                        {"entryType": "tool-result",
+                         "createdAt": "2026-05-03T10:05:00Z"},
+                        {"entryType": "user-message"},
+                    ]
+                },
+            }
+            return httpx.Response(200, text=json.dumps(payload))
+
+        async def aclose(self):
+            pass
+
+    client = BKDRestClient("https://bkd.example/api", "tok")
+    client._http = FakeHttp()  # type: ignore[assignment]
+    ts = await client.last_log_activity_at("p", "i1")
+    assert ts == datetime(2026, 5, 3, 10, 5, 0, tzinfo=UTC)
+

--- a/orchestrator/tests/test_watchdog.py
+++ b/orchestrator/tests/test_watchdog.py
@@ -981,11 +981,14 @@ async def test_fixer_round_cap_escalates_regardless_of_recent_activity(monkeypat
     ])
     _patch_pool(monkeypatch, pool)
     fresh = datetime.now(UTC) - timedelta(seconds=5)  # very fresh
+    # session_status="failed" matches the real fixer-cap incident: fixer agent
+    # died but stuck > ended_sec; round count alone determines escalate.
     _patch_bkd(
         monkeypatch,
-        FakeIssue(session_status="running", id="fx-wlc-3"),
+        FakeIssue(session_status="failed", id="fx-wlc-3"),
         last_activity_at=fresh,
     )
+    monkeypatch.setattr("orchestrator.watchdog.settings.fixer_round_cap", 5)
     step_calls = _patch_engine(monkeypatch)
     _patch_artifact(monkeypatch)
 

--- a/orchestrator/tests/test_watchdog.py
+++ b/orchestrator/tests/test_watchdog.py
@@ -48,12 +48,20 @@ class FakeIssue:
     tags: list = field(default_factory=list)
 
 
-def _patch_bkd(monkeypatch, issue: FakeIssue | None, side_effect: Exception | None = None):
+def _patch_bkd(
+    monkeypatch,
+    issue: FakeIssue | None,
+    side_effect: Exception | None = None,
+    last_activity_at=None,
+):
+    """Patch BKDClient context manager. last_activity_at defaults to None so
+    REQ-fix-watchdog-liveness probe is a noop (existing tests preserve behavior)."""
     fake = AsyncMock()
     if side_effect:
         fake.get_issue = AsyncMock(side_effect=side_effect)
     else:
         fake.get_issue = AsyncMock(return_value=issue)
+    fake.last_log_activity_at = AsyncMock(return_value=last_activity_at)
 
     @asynccontextmanager
     async def _ctx(*a, **kw):
@@ -892,3 +900,104 @@ async def test_self_heal_bkd_lookup_falls_back_to_escalate(monkeypatch):
     assert len(step_calls) == 1
     # issue 查不到时 follow_up 也会失败，所以不会调用
     follow_up_mock.assert_not_called()
+
+
+# ─── REQ-fix-watchdog-liveness-1777809646 ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_recent_log_activity_skips_escalate_even_if_session_not_running(monkeypatch):
+    """WLC-S1: BKD /logs 最新 entry createdAt 在 grace 窗口内 → 跳过，
+    不论 sessionStatus 是 completed / failed。"""
+    from datetime import UTC, datetime, timedelta
+
+    pool = FakePool(rows=[
+        _row("REQ-WLC-1", ReqState.ANALYZING.value,
+             ctx={"intent_issue_id": "intent-wlc-1"}, stuck_sec=400),
+    ])
+    _patch_pool(monkeypatch, pool)
+    fresh = datetime.now(UTC) - timedelta(seconds=30)
+    _patch_bkd(
+        monkeypatch,
+        FakeIssue(session_status="completed", id="intent-wlc-1"),
+        last_activity_at=fresh,
+    )
+    monkeypatch.setattr(
+        "orchestrator.watchdog.settings.watchdog_liveness_grace_sec", 120,
+    )
+    step_calls = _patch_engine(monkeypatch)
+    art_calls = _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 0}
+    assert step_calls == []
+    assert art_calls == []
+
+
+@pytest.mark.asyncio
+async def test_stale_log_activity_falls_through_to_escalate(monkeypatch):
+    """WLC-S2: 最新 log entry 在 grace 窗口外 → 落回原 escalate 路径。
+    使用 ANALYZING + intent_issue_id（有 issue_key 映射，活体探针会 fire）。"""
+    from datetime import UTC, datetime, timedelta
+
+    pool = FakePool(rows=[
+        _row("REQ-WLC-2", ReqState.ANALYZING.value,
+             ctx={"intent_issue_id": "intent-wlc-2"}, stuck_sec=400),
+    ])
+    _patch_pool(monkeypatch, pool)
+    stale = datetime.now(UTC) - timedelta(seconds=600)
+    _patch_bkd(
+        monkeypatch,
+        FakeIssue(session_status="completed", id="intent-wlc-2"),
+        last_activity_at=stale,
+    )
+    monkeypatch.setattr(
+        "orchestrator.watchdog.settings.watchdog_liveness_grace_sec", 120,
+    )
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    assert len(step_calls) == 1
+    assert step_calls[0]["event"] == Event.SESSION_FAILED
+
+
+@pytest.mark.asyncio
+async def test_fixer_round_cap_escalates_regardless_of_recent_activity(monkeypatch):
+    """WLC-S3: fixer-round-cap 是确定性硬封顶，活体探针 MUST NOT 短路它。"""
+    from datetime import UTC, datetime, timedelta
+
+    pool = FakePool(rows=[
+        _row("REQ-WLC-3", ReqState.FIXER_RUNNING.value,
+             ctx={
+                 "fixer_issue_id": "fx-wlc-3",
+                 "intent_issue_id": "intent-wlc-3",
+                 "fixer_round": 99,  # >> default cap (5)
+             },
+             stuck_sec=400),
+    ])
+    _patch_pool(monkeypatch, pool)
+    fresh = datetime.now(UTC) - timedelta(seconds=5)  # very fresh
+    _patch_bkd(
+        monkeypatch,
+        FakeIssue(session_status="running", id="fx-wlc-3"),
+        last_activity_at=fresh,
+    )
+    step_calls = _patch_engine(monkeypatch)
+    _patch_artifact(monkeypatch)
+
+    # update_context shim — watchdog calls it for fixer-round-cap branch
+    async def fake_update_context(pool_, req_id_, patch):
+        return None
+    monkeypatch.setattr(
+        "orchestrator.watchdog.req_state.update_context", fake_update_context,
+    )
+
+    result = await watchdog._tick()
+
+    assert result == {"checked": 1, "escalated": 1}
+    assert len(step_calls) == 1
+    assert step_calls[0]["ctx"].get("escalated_reason") == "fixer-round-cap"


### PR DESCRIPTION
## Summary

Watchdog 当前唯一的活体信号是 BKD `sessionStatus == "running"`。在 5/3 大 REQ
analyze 实测：analyze-agent 单 turn ~5min 写大量代码，BKD 在 turn 边界 / 等
sub-issue 时短暂离开 `running`，watchdog 误判 ended → 连续 escalate → 父 intent
issue 被打 `[escalated, reason:*]` tag，污染 UI + Q8 verifier 准确率。

根因不是阈值不够长，而是**信号用错**。改用 BKD `/issues/{id}/logs` 最新 entry 的
`createdAt` 作为真活体探针。

## Changes

- `BKDRestClient.last_log_activity_at(project_id, issue_id) -> datetime | None`
  —— 拉 `/logs?limit=10` 取最大 `createdAt`；失败 / 空返回 None。
- `config.watchdog_liveness_grace_sec: int = 120` —— 活体窗口（120s 给单 turn
  写大量代码留空间）。
- `watchdog._check_and_escalate` 在 escalate 决策前调活体探针：距今 <
  grace → return False，不论 sessionStatus 是什么。`fixer-round-cap` 路径仍硬
  封顶（不依赖活体）。
- 测试：`BKDRestClient.last_log_activity_at` × 4，watchdog 活体跳过 / 落回 / fixer-cap
  例外 × 3，escalate auto-resume 不污染 tag 不变量 × 1（锁 #353）。

## OpenSpec

`openspec/changes/REQ-fix-watchdog-liveness-1777809646/` 含 proposal + tasks +
`specs/watchdog-liveness/spec.md`（3 Requirements，7 Scenarios WLC-S1..S7）。

## Test plan

- [x] make ci-lint
- [x] make ci-unit-test (2134 + 44 passed)
- [x] make ci-integration-test (PG 不可达 → exit 5 → pass)
- [x] openspec validate REQ-fix-watchdog-liveness-1777809646 → valid
- [ ] dogfood: 跑长 analyze REQ 观察是否还会误 escalate（M14e dashboard Q4 / Q8）

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-fix-watchdog-liveness-1777809646\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/cr8o9va5)