### PR TITLE
feat(accept): sub-step timing + KEEP_ENV reuse plumbing (closes #329)

### DIFF
--- a/docs/cookbook/ttpos-arch-lab-accept-env.md
+++ b/docs/cookbook/ttpos-arch-lab-accept-env.md
@@ -388,6 +388,59 @@ accept-env-down:
 - **`accept-env-down` 全 best-effort**：partial up 失败时（emulator helm 没起来）
   也必须把 backend release + namespace 清掉，每步 `|| true` 保证不因前步失败而短路。
 
+### 6.1 子步耗时（可选 `sub_steps` 字段）
+
+REQ-feat-accept-env-substep-timing 起，`accept-env-up` endpoint JSON 可加 `sub_steps`
+数组让 orchestrator 落 `stage_runs`、Metabase 看子步分布。把上面 6 步用 `date +%s.%N`
+打点，最后一步拼进 JSON：
+
+```makefile
+accept-env-up:
+	@t0=$$(date +%s.%N); \
+	helm upgrade --install lab charts/accept-lab \
+	    --namespace $(SISYPHUS_NAMESPACE) --create-namespace --wait --timeout 5m >&2; \
+	t1=$$(date +%s.%N); \
+	helm upgrade --install emulator charts/emulator \
+	    --namespace $(SISYPHUS_NAMESPACE) --wait --timeout 3m >&2; \
+	t2=$$(date +%s.%N); \
+	./emulator/boot-wait-k8s.sh "$(SISYPHUS_NAMESPACE)" >&2; \
+	t3=$$(date +%s.%N); \
+	./apk/build.sh >&2; \
+	t4=$$(date +%s.%N); \
+	adb_host=$$(kubectl -n $(SISYPHUS_NAMESPACE) get svc emulator-adb -o jsonpath='{.spec.clusterIP}'); \
+	adb connect "$$adb_host:5555" >&2; \
+	adb -s "$$adb_host:5555" install -r ./apk/dist/app.apk >&2; \
+	t5=$$(date +%s.%N); \
+	dur() { python3 -c "import sys; print(round(float(sys.argv[2])-float(sys.argv[1]),2))" "$$1" "$$2"; }; \
+	printf '{"endpoint":"http://lab.%s.svc.cluster.local:8080","adb":"%s:5555","apk_package":"%s","namespace":"%s","sub_steps":[{"name":"lab-helm","duration_sec":%s},{"name":"emulator-helm","duration_sec":%s},{"name":"redroid-boot","duration_sec":%s},{"name":"apk-build","duration_sec":%s},{"name":"apk-install","duration_sec":%s}]}\n' \
+	    "$(SISYPHUS_NAMESPACE)" "$$adb_host" "$(APK_PACKAGE)" "$(SISYPHUS_NAMESPACE)" \
+	    "$$(dur $$t0 $$t1)" "$$(dur $$t1 $$t2)" "$$(dur $$t2 $$t3)" "$$(dur $$t3 $$t4)" "$$(dur $$t4 $$t5)"
+```
+
+字段缺失或不是 list 都被 orchestrator 静默忽略，主流程不受影响。
+
+### 6.2 KEEP_ENV=1 复用契约
+
+REQ-feat-accept-env-substep-timing 起，`accept-env-down` 必须识别 `KEEP_ENV=1`
+跳过卸载，留 namespace 给下一轮 `accept-env-up` 复用（dogfood retry 期间业务仓
+lab/thanatos values 极少变，省 1-3 min/次）。
+
+```makefile
+accept-env-down:
+	@if [ "$$KEEP_ENV" = "1" ]; then \
+	    echo "[arch-lab] KEEP_ENV=1, skipping teardown" >&2; \
+	    exit 0; \
+	fi
+	-helm uninstall emulator --namespace $(SISYPHUS_NAMESPACE) 2>/dev/null || true
+	-helm uninstall lab --namespace $(SISYPHUS_NAMESPACE) 2>/dev/null || true
+	-kubectl delete namespace $(SISYPHUS_NAMESPACE) --ignore-not-found 2>/dev/null || true
+	-rm -f .accept-adb-host 2>/dev/null || true
+```
+
+orchestrator 侧 `settings.accept_keep_env`（env: `SISYPHUS_ACCEPT_KEEP_ENV`）默认
+`false`；dogfood 启用 `kubectl set env deploy/orch SISYPHUS_ACCEPT_KEEP_ENV=true`
++ rollout 即生效。
+
 ## 7. 跟 sisyphus accept-agent 的对接
 
 accept-agent prompt (`orchestrator/src/orchestrator/prompts/accept.md.j2`) 已经会

--- a/docs/integration-contracts.md
+++ b/docs/integration-contracts.md
@@ -162,9 +162,31 @@ shell 不展开 flag，等价全量。
 | target | 谁调 | 在哪跑 | 期望 |
 |---|---|---|---|
 | `make accept-env-up` | sisyphus pre-accept（`actions/create_accept.py`） | runner pod，`cd /workspace/integration/<repo-name> && make accept-env-up` | 1) 退码 0 = lab 起来；2) **stdout 最后一行**是 endpoint JSON（见 §3） |
-| `make accept-env-down` | `actions/teardown_accept_env.py` | 同上 | best-effort，幂等；失败只 warning 不阻塞状态机 |
+| `make accept-env-down` | `actions/teardown_accept_env.py` | 同上 | best-effort，幂等；失败只 warning 不阻塞状态机；**SHALL 识别 `KEEP_ENV=1` 跳过卸载**（见下） |
 
 **幂等性硬要求**：accept-env-up / accept-env-down 必须可重复调（重试或 watchdog 路径会再 cleanup 一次）。
+
+**`KEEP_ENV` 复用契约**（REQ-feat-accept-env-substep-timing）：`accept-env-down`
+**SHALL** 识别 `KEEP_ENV` 环境变量。`KEEP_ENV=1` 时 target 必须立即 `exit 0`，
+不做任何 `helm uninstall` / `kubectl delete namespace`，留 lab 给下一轮 `accept-env-up`
+复用（业务仓 lab/thanatos values 不常变时省 1-3 min/次重试）。其他值（包括未设置、
+空串、`KEEP_ENV=0`）都按原拆装行为走。
+
+orchestrator 侧：`settings.accept_keep_env`（env: `SISYPHUS_ACCEPT_KEEP_ENV`）
+默认 `false`；为 `true` 时 `teardown_accept_env.py` 注入 `KEEP_ENV=1`。dogfood
+retry 期间手开，攒数据后再决定要不要由状态机自动判定。
+
+最小可行 Makefile 实现：
+
+```makefile
+accept-env-down:
+	@if [ "$$KEEP_ENV" = "1" ]; then \
+	    echo "[accept-env-down] KEEP_ENV=1, skipping teardown" >&2; \
+	    exit 0; \
+	fi
+	-helm uninstall lab --namespace $(SISYPHUS_NAMESPACE) || true
+	-kubectl delete namespace $(SISYPHUS_NAMESPACE) --ignore-not-found
+```
 
 ### 2.4 analyze-agent 推 PR 前 guard
 
@@ -221,7 +243,27 @@ staging-test checker 只跑 `make ci-unit-test && make ci-integration-test`，
 |---|---|---|
 | `endpoint` | ✅ | accept-agent 跑 FEATURE-A* scenarios 时打这个 URL |
 | `namespace` | （可选） | sisyphus 已通过 `SISYPHUS_NAMESPACE` env 传，重复声明也无碍 |
+| `sub_steps` | （可选） | 子步耗时数组，每条 `{"name": str, "duration_sec": number}`；orchestrator 落 `stage_runs`（`stage = "accept-env-up.<name>"`），Metabase 直接聚合做子步分布看板。Malformed / 缺失自动忽略，不破坏主流程（REQ-feat-accept-env-substep-timing） |
 | 其他 | （可选） | 任意附加元数据，accept-agent prompt 透传 |
+
+`sub_steps` 例子：
+
+```json
+{
+  "endpoint": "http://lab.accept-req-29.svc.cluster.local:8080",
+  "namespace": "accept-req-29",
+  "sub_steps": [
+    {"name": "lab-helm",      "duration_sec": 45.2},
+    {"name": "thanatos-helm", "duration_sec": 78.5},
+    {"name": "redroid-boot",  "duration_sec": 92.1},
+    {"name": "apk-install",   "duration_sec": 31.7}
+  ]
+}
+```
+
+业务仓 Makefile 计时建议：每子步前后 `date +%s.%N` 取差，最后用 `printf` 拼 JSON
+进 endpoint payload。子步 `name` 用稳定的 kebab-case 标识（`lab-helm` / `thanatos-helm`
+等），方便 SQL `WHERE stage = 'accept-env-up.lab-helm'` 查时长趋势。
 
 实现建议（让 Makefile 容易满足）：
 

--- a/openspec/changes/REQ-feat-accept-env-substep-timing-1777812776/proposal.md
+++ b/openspec/changes/REQ-feat-accept-env-substep-timing-1777812776/proposal.md
@@ -1,0 +1,82 @@
+# accept-env-up sub-step timing + idempotent reuse plumbing
+
+> closes #329 (sisyphus-side; business-repo Makefile parts are tracked in the
+> issue body sections A/B and stay as follow-up PRs in the lab repo)
+
+## 问题
+
+当前 `make accept-env-up` 是一个不透明的黑盒：
+
+```
+20:13:01 create_accept.env_up_started
+20:18:42 create_accept.done duration=341.2s
+```
+
+整 5-15 分钟一坨花在 (1) helm install lab、(2) helm install thanatos、(3) APK
+build/download、(4) adb install。任何一步慢都只能盯人 `kubectl logs`、人肉断点定
+位 —— Metabase 看板看不到子步分布，不知道"哪一步占了 80% 时间，下次该 cache 哪段"。
+
+第二个问题：dogfood retry 时 lab + thanatos 的 helm release 配置基本没动，每次
+`accept-env-down` 都把 namespace 整个删掉，下一轮 `accept-env-up` 从头重 install
+再花 1-3 min。**没有"保留 lab/thanatos、只重装 APK"的 contract**。
+
+## 方案（两件最小可行）
+
+### A. accept-env-up 子步耗时 → stage_runs 持久化（observability）
+
+**契约扩展**：`accept-env-up` 末行 endpoint JSON **可选** 加 `sub_steps` 字段：
+
+```json
+{
+  "endpoint": "http://lab.accept-req-29.svc.cluster.local:8080",
+  "namespace": "accept-req-29",
+  "sub_steps": [
+    {"name": "lab-helm",      "duration_sec": 45.2},
+    {"name": "thanatos-helm", "duration_sec": 78.5},
+    {"name": "redroid-boot",  "duration_sec": 92.1},
+    {"name": "apk-install",   "duration_sec": 31.7}
+  ]
+}
+```
+
+**orchestrator 改动**：`create_accept.py` 解析 `sub_steps` 后，每条插一行
+`stage_runs`（`stage = "accept-env-up.<name>"`、`outcome = "pass"`、`duration_sec`
+直接来自 JSON、`started_at = now() - duration_sec`、`ended_at = now()`），不需要
+schema 变更（`stage` 已是 TEXT）。Metabase 直接 `WHERE stage LIKE 'accept-env-up.%'`
+聚合做子步分布看板。
+
+`sub_steps` 缺失或非 list 时静默跳过 —— 业务仓没接也不退化，只是没有子步度量。
+
+### B. accept-env-down KEEP_ENV 复用契约 + 配置开关
+
+**契约扩展**：`accept-env-down` **SHALL** 识别 `KEEP_ENV=1` 环境变量；该 env 为
+`1` 时 target 必须立即 `exit 0` 跳过任何 helm uninstall / kubectl delete，留 lab
++ thanatos 给下一轮复用。文档化进 `docs/integration-contracts.md` §2.3。
+
+**orchestrator 改动**：新增 `settings.accept_keep_env: bool = False`。当
+`teardown_accept_env.py` 跑时若该 flag 为 true 则注入 `KEEP_ENV=1` 到 env，
+business Makefile 据此跳过卸载。默认关闭——dogfood 启用时人 set
+`SISYPHUS_ACCEPT_KEEP_ENV=true` ConfigMap，rollout 即生效。
+
+> `accept-apk-only` 仅重装 APK 复用 lab/thanatos release —— **本 REQ 不做**。
+> 它要求"sisyphus 知道当前是不是 retry"+ 状态机分流，复杂度跟 #329 §C "拆 sub-stage"
+> 等价，应另起 REQ。本 REQ 只把 KEEP_ENV 这一半的契约和配置打通，让 dogfood 用户
+> 现在就能手动复用 lab。
+
+## 影响
+
+- 子步度量落进 `stage_runs`，Q 系列看板可加一条 `accept-env-up.<sub_step>` 时长
+  分布，回答"哪步该上 cache"
+- KEEP_ENV 打通后 dogfood retry 可省 1-3 min/次（dogfood 期间业务仓 lab/thanatos
+  values 极少变）
+- 业务仓（ttpos-arch-lab）侧不强制改 —— 不接 sub_steps 不影响，不接 KEEP_ENV 退化为
+  原行为（每次拆装）。
+- 不动状态机、不加 stage、不加 event。
+
+## 不在范围
+
+- `accept-apk-only` 仅重装 APK 的快路径（需要 retry 检测 + 状态机分流）
+- sisyphus 主动判断"当前是 retry，自动 set KEEP_ENV=1"（先让用户手动开关，攒数据
+  再决定要不要自动化）
+- ttpos-arch-lab Makefile 实际 emit `sub_steps` / 实现 KEEP_ENV 跳过 —— 跨仓改动
+  按现行约定走另一 REQ

--- a/openspec/changes/REQ-feat-accept-env-substep-timing-1777812776/specs/accept-env-observability/spec.md
+++ b/openspec/changes/REQ-feat-accept-env-substep-timing-1777812776/specs/accept-env-observability/spec.md
@@ -1,0 +1,101 @@
+# accept-env-observability Spec Delta
+
+## ADDED Requirements
+
+### Requirement: accept-env-up MAY emit sub_steps array for per-phase timing observability
+
+The `accept-env-up` Makefile target's stdout final-line JSON SHALL accept an
+optional `sub_steps` field. The system MUST treat the field as optional: when it
+is absent, malformed, not a list, or contains zero entries, the orchestrator MUST
+proceed exactly as if the field were never declared (no failure, no warning to
+the user, only a structured `info` / `warning` log so issues are diagnosable).
+
+When `sub_steps` is present and well-formed, each entry MUST be an object with at
+least `name: str` (kebab/snake-case identifier of the phase, e.g. `lab-helm`,
+`thanatos-helm`, `redroid-boot`, `apk-install`) and `duration_sec: number` (the
+elapsed wall-clock seconds for that phase). Additional keys (e.g. `started_at`,
+`exit_code`) are allowed and MUST be ignored by the orchestrator.
+
+The orchestrator MUST persist each well-formed sub-step entry as one
+`stage_runs` row keyed by `stage = "accept-env-up." || name`, with
+`outcome = "pass"`, `duration_sec` copied from the JSON, `started_at` derived
+as `now() - duration_sec`, and `ended_at = now()`. Persistence MUST occur
+only after the parent `accept-env-up` exits 0; an env-up failure MUST NOT
+emit sub-step rows even if a partial `sub_steps` payload was printed.
+
+#### Scenario: SUBSTEP-S1 well-formed sub_steps array → one stage_runs row per entry
+
+- **GIVEN** `accept-env-up` exits 0 with stdout final line containing
+  `sub_steps: [{"name": "lab-helm", "duration_sec": 45.2}, {"name": "apk", "duration_sec": 31.7}]`
+- **WHEN** `create_accept` parses the env-up stdout
+- **THEN** two `stage_runs` inserts occur with stages
+  `"accept-env-up.lab-helm"` and `"accept-env-up.apk"`
+- **AND** each row's `outcome` is `"pass"`
+- **AND** each row's `duration_sec` matches the JSON value
+- **AND** the parent `accept.pass` event still emits unchanged
+
+#### Scenario: SUBSTEP-S2 missing sub_steps field → zero inserts, no warning
+
+- **GIVEN** `accept-env-up` exits 0 with stdout `{"endpoint": "http://x", "namespace": "y"}` (no sub_steps key)
+- **WHEN** `create_accept` parses the env-up stdout
+- **THEN** zero `stage_runs` inserts occur for sub-steps
+- **AND** the parent flow is unaffected
+
+#### Scenario: SUBSTEP-S3 malformed sub_steps payload → zero inserts, warning logged
+
+- **GIVEN** `accept-env-up` exits 0 with stdout containing `sub_steps: "not-a-list"` or `sub_steps: [{"name": 5}]` (entry missing duration_sec or wrong type)
+- **WHEN** `create_accept` parses the env-up stdout
+- **THEN** zero `stage_runs` inserts occur for sub-steps
+- **AND** a structured warning log is emitted with key `create_accept.sub_steps_malformed`
+- **AND** no exception escapes `create_accept`
+
+#### Scenario: SUBSTEP-S4 env-up fails with partial sub_steps → no rows persisted
+
+- **GIVEN** `accept-env-up` exits non-zero (e.g. apk-install failed) but stdout contained `sub_steps: [{"name": "lab-helm", "duration_sec": 45.2}]`
+- **WHEN** `create_accept` handles the env-up failure
+- **THEN** zero `stage_runs` inserts occur for sub-steps
+- **AND** the action emits `accept.env-up.fail` as before
+
+### Requirement: accept-env-down SHALL respect KEEP_ENV=1 to skip teardown
+
+The `accept-env-down` Makefile target on integration repos SHALL recognize the
+`KEEP_ENV` environment variable. When `KEEP_ENV=1`, the target MUST exit 0
+immediately without performing any `helm uninstall` or `kubectl delete namespace`
+operation, leaving the lab environment intact for reuse on the next
+`accept-env-up` invocation. Any other value (including unset, empty string, or
+`KEEP_ENV=0`) MUST trigger the normal teardown behavior.
+
+The orchestrator MUST inject `KEEP_ENV=1` into the `teardown_accept_env` exec
+environment if and only if `settings.accept_keep_env` is true. The default value
+of `settings.accept_keep_env` MUST be `false` so that out-of-the-box behavior
+remains "always tear down" (preserves backward compatibility for existing
+integration repos that do not yet implement the KEEP_ENV branch).
+
+When `KEEP_ENV=1` is in effect, the teardown action MUST still:
+- emit the appropriate `teardown.done.pass` / `teardown.done.fail` event based on
+  prior `accept_result` (the gate is unchanged)
+- log `teardown.keep_env_active` at info level so operators can correlate skipped
+  teardowns with retained namespaces
+
+#### Scenario: KEEP-S1 settings.accept_keep_env=true → KEEP_ENV=1 in exec env
+
+- **GIVEN** `settings.accept_keep_env = True`
+- **AND** the runner controller is available with an integration dir
+- **WHEN** `teardown_accept_env` runs
+- **THEN** the env passed to `exec_in_runner` contains `KEEP_ENV=1`
+- **AND** an info log `teardown.keep_env_active` is emitted
+
+#### Scenario: KEEP-S2 settings.accept_keep_env=false (default) → KEEP_ENV not present
+
+- **GIVEN** `settings.accept_keep_env = False`
+- **AND** the runner controller is available with an integration dir
+- **WHEN** `teardown_accept_env` runs
+- **THEN** the env passed to `exec_in_runner` does NOT contain a `KEEP_ENV` key
+- **AND** the existing teardown behavior is unchanged
+
+#### Scenario: KEEP-S3 KEEP_ENV does not change emit routing
+
+- **GIVEN** `settings.accept_keep_env = True` and `ctx.accept_result = "fail"`
+- **WHEN** `teardown_accept_env` runs (env-down command short-circuits via KEEP_ENV)
+- **THEN** the action still emits `teardown.done.fail`
+- **AND** when `ctx.accept_result = "pass"` the action emits `teardown.done.pass`

--- a/openspec/changes/REQ-feat-accept-env-substep-timing-1777812776/tasks.md
+++ b/openspec/changes/REQ-feat-accept-env-substep-timing-1777812776/tasks.md
@@ -1,0 +1,33 @@
+# Tasks
+
+## Stage: contract / spec
+
+- [x] author specs/accept-env-observability/spec.md (sub_steps + KEEP_ENV requirements)
+- [x] update docs/integration-contracts.md §2.3 (accept-env-down KEEP_ENV contract)
+- [x] update docs/integration-contracts.md §3 (sub_steps optional JSON field)
+- [x] update docs/cookbook/ttpos-arch-lab-accept-env.md (example sub_steps emission + KEEP_ENV branch)
+
+## Stage: implementation
+
+- [x] add `settings.accept_keep_env` config flag (default False)
+- [x] extract sub-step parsing helper in actions/create_accept.py (`_record_sub_steps`)
+- [x] insert one stage_runs row per sub_step after env-up parses successfully
+- [x] plumb KEEP_ENV=1 into teardown_accept_env.py exec env when flag is on
+- [x] structured log warning on malformed sub_steps (best-effort, never raise)
+
+## Stage: unit tests
+
+- [x] test_create_accept_substeps.py: sub_steps array parsed → N stage_runs inserts
+- [x] test_create_accept_substeps.py: missing/invalid sub_steps → no inserts, no error
+- [x] test_teardown_accept_env_keep_env.py: flag on → KEEP_ENV=1 in exec env
+- [x] test_teardown_accept_env_keep_env.py: flag off (default) → KEEP_ENV not in exec env
+
+## Stage: PR (推之前必须全绿)
+
+- [x] git push feat/REQ-feat-accept-env-substep-timing-1777812776
+- [x] make ci-lint → 全绿
+- [x] make ci-unit-test → 全绿
+- [x] make ci-integration-test → 全绿（无 PG 环境自动跳过）
+- [x] openspec validate REQ-feat-accept-env-substep-timing-1777812776 → 全绿
+- [x] check-scenario-refs.sh → 全绿
+- [x] gh pr create --label sisyphus

--- a/openspec/specs/thanatos-ci/spec.md
+++ b/openspec/specs/thanatos-ci/spec.md
@@ -18,9 +18,11 @@ PostgreSQL is reachable and MUST map pytest exit 5 to exit 0 for the orchestrato
 
 #### Scenario: TCIF-S3 thanatos-ci workflow provides GHA check-runs for thanatos PRs
 
-The sisyphus project MUST have a `.github/workflows/thanatos-ci.yml` workflow
-that triggers on `thanatos/**` changes and MUST produce GitHub Actions check-runs
-so that `pr_ci_watch` does not see `no-gha` for thanatos PRs.
+- **GIVEN** the sisyphus repo with `.github/workflows/thanatos-ci.yml` configured
+  to trigger on `thanatos/**` path changes
+- **WHEN** a PR opens with changes under `thanatos/**`
+- **THEN** GitHub Actions runs the workflow and posts at least one check-run on
+  the PR head SHA so `pr_ci_watch` does not return `no-gha`
 
 #### Scenario: TCIF-S4 uv run pytest succeeds in thanatos directory
 

--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -9,6 +9,7 @@ Two paths:
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 
 import structlog
 
@@ -17,7 +18,7 @@ from ..bkd import BKDClient
 from ..config import settings
 from ..prompts import render
 from ..state import Event
-from ..store import db, req_state
+from ..store import db, req_state, stage_runs
 from . import register, short_title
 from ._clone import ensure_runner_with_clone
 from ._integration_resolver import resolve_integration_dir
@@ -27,6 +28,68 @@ log = structlog.get_logger(__name__)
 
 _TIMEOUT_ENV_UP_SEC = 1800  # 30 min: helm install + wait ready + APK GHA build poll (5-10min) + download + adb install
 _TIMEOUT_LITE_SEC = 1800   # 30 min for up × N + sleep + smoke × N + down × N
+
+_SUB_STEPS_STAGE_PREFIX = "accept-env-up."
+
+
+async def _record_sub_steps(
+    pool, req_id: str, accept_env: dict | None,
+) -> int:
+    """Persist optional `sub_steps` array from accept-env-up JSON as stage_runs rows.
+
+    Contract (REQ-feat-accept-env-substep-timing): `accept_env["sub_steps"]` MAY
+    be a list of {"name": str, "duration_sec": number}. Each well-formed entry
+    becomes one stage_runs row with stage = "accept-env-up.<name>", outcome=pass.
+    Malformed payload → no rows + warning log; never raises.
+
+    Returns count of rows inserted (for tests / log).
+    """
+    if not isinstance(accept_env, dict):
+        return 0
+    raw = accept_env.get("sub_steps")
+    if raw is None:
+        return 0
+    if not isinstance(raw, list):
+        log.warning("create_accept.sub_steps_malformed",
+                    req_id=req_id, reason="not a list", value_type=type(raw).__name__)
+        return 0
+    inserted = 0
+    now = datetime.now(UTC)
+    for idx, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            log.warning("create_accept.sub_steps_malformed",
+                        req_id=req_id, reason="entry not dict", index=idx)
+            continue
+        name = entry.get("name")
+        duration = entry.get("duration_sec")
+        if not isinstance(name, str) or not name:
+            log.warning("create_accept.sub_steps_malformed",
+                        req_id=req_id, reason="missing/invalid name", index=idx)
+            continue
+        if not isinstance(duration, (int, float)) or isinstance(duration, bool):
+            log.warning("create_accept.sub_steps_malformed",
+                        req_id=req_id, reason="missing/invalid duration_sec",
+                        index=idx, name=name)
+            continue
+        try:
+            started = now - timedelta(seconds=float(duration))
+            run_id = await stage_runs.insert_stage_run(
+                pool, req_id,
+                _SUB_STEPS_STAGE_PREFIX + name,
+                started_at=started,
+            )
+            await stage_runs.update_stage_run(
+                pool, run_id, outcome="pass", ended_at=now,
+            )
+            inserted += 1
+        except Exception as e:
+            # never let observability break the parent flow
+            log.warning("create_accept.sub_steps_insert_failed",
+                        req_id=req_id, name=name, error=str(e)[:200])
+    if inserted:
+        log.info("create_accept.sub_steps_recorded",
+                 req_id=req_id, count=inserted)
+    return inserted
 
 # #247 Phase 1: 收 BKD stage agent issue id（人可续 follow-up 触发 PENDING_USER_REVIEW
 # 反向通道的入口）。**机械 checker** issue（spec_lint / dev_cross_check / staging_test
@@ -327,6 +390,11 @@ async def create_accept(*, body, req_id, tags, ctx):
             "emit": Event.ACCEPT_ENV_UP_FAIL.value,
             "reason": "env-up JSON missing endpoint",
         }
+
+    # REQ-feat-accept-env-substep-timing: optional sub-step timing observability.
+    # env-up exited 0; if business Makefile emitted `sub_steps`, persist per-step
+    # rows to stage_runs for Metabase. Best-effort, never raises.
+    await _record_sub_steps(db.get_pool(), req_id, accept_env)
 
     # M1: optional thanatos block
     thanatos_block = accept_env.get("thanatos") or {} if isinstance(accept_env, dict) else {}

--- a/orchestrator/src/orchestrator/actions/teardown_accept_env.py
+++ b/orchestrator/src/orchestrator/actions/teardown_accept_env.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import structlog
 
 from .. import k8s_runner
+from ..config import settings
 from ..state import Event
 from ..store import db, req_state
 from . import register
@@ -55,15 +56,24 @@ async def teardown_accept_env(*, body, req_id, tags, ctx):
         if resolved.dir is None:
             log.warning("teardown.no_integration_dir", req_id=req_id, reason=resolved.reason)
         else:
+            # REQ-feat-accept-env-substep-timing: dogfood retry mode → KEEP_ENV=1
+            # tells business Makefile to short-circuit teardown (helm uninstall +
+            # ns delete skipped) so next accept-env-up can reuse the lab release.
+            # Default off — opt-in via SISYPHUS_ACCEPT_KEEP_ENV=true ConfigMap.
+            env = {
+                "SISYPHUS_REQ_ID": req_id,
+                "SISYPHUS_STAGE": "accept-teardown",
+                "SISYPHUS_NAMESPACE": f"accept-{req_id.lower()}",
+            }
+            if settings.accept_keep_env:
+                env["KEEP_ENV"] = "1"
+                log.info("teardown.keep_env_active", req_id=req_id,
+                         integration_dir=resolved.dir)
             try:
                 result = await rc.exec_in_runner(
                     req_id,
                     command=f"cd {resolved.dir} && make accept-env-down",
-                    env={
-                        "SISYPHUS_REQ_ID": req_id,
-                        "SISYPHUS_STAGE": "accept-teardown",
-                        "SISYPHUS_NAMESPACE": f"accept-{req_id.lower()}",
-                    },
+                    env=env,
                     timeout_sec=300,
                 )
                 env_down_ok = result.exit_code == 0

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -136,6 +136,11 @@ class Settings(BaseSettings):
     skip_pr_ci: bool = False          # pr-ci.pass（PR CI 全套等绿）
     skip_accept: bool = False         # accept.pass (ttpos-arch-lab 接好前默认 true)
     accept_smoke_delay_sec: int = 30  # env-up 后等服务起齐的 sleep（秒）
+    # REQ-feat-accept-env-substep-timing: dogfood retry 期间 set true → teardown
+    # 注 KEEP_ENV=1 给 make accept-env-down，business Makefile 跳过 helm uninstall
+    # / kubectl delete，留 lab + thanatos release 给下一轮 accept-env-up 复用。
+    # 默认 false 不破坏现有 integration repo（没接 KEEP_ENV 分支时 env 多个无害变量）。
+    accept_keep_env: bool = False
     skip_archive: bool = False        # archive.done (跳过真 PR 创建)
 
     # 全部 skip = 状态机几秒走完，验 transition + cleanup，不动 BKD agent

--- a/orchestrator/tests/test_create_accept_substeps.py
+++ b/orchestrator/tests/test_create_accept_substeps.py
@@ -1,0 +1,247 @@
+"""REQ-feat-accept-env-substep-timing: sub_steps optional JSON → stage_runs rows.
+
+Covers spec scenarios SUBSTEP-S1..S4 from
+openspec/changes/REQ-feat-accept-env-substep-timing-1777812776/specs/
+accept-env-observability/spec.md.
+
+Test surface: `_record_sub_steps` (pure helper, isolated from k8s/BKD I/O) and
+`create_accept` end-to-end with the helper wired in.
+"""
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.actions import create_accept as mod
+from orchestrator.actions._integration_resolver import ResolveResult
+from orchestrator.k8s_runner import ExecResult
+from orchestrator.state import Event
+
+
+class _RecordingPool:
+    """Capture every stage_runs.insert + update call."""
+
+    def __init__(self):
+        self.inserts: list[dict] = []
+        self.updates: list[dict] = []
+        self._next_id = 1
+
+    async def fetchrow(self, sql, *args):
+        sql_norm = " ".join(sql.split())
+        if sql_norm.startswith("INSERT INTO stage_runs"):
+            row = {
+                "req_id": args[0], "stage": args[1],
+                "parallel_id": args[2], "agent_type": args[3],
+                "model": args[4], "started_at": args[5],
+            }
+            self.inserts.append(row)
+            rid = self._next_id
+            self._next_id += 1
+            return {"id": rid}
+        return None
+
+    async def execute(self, sql, *args):
+        sql_norm = " ".join(sql.split())
+        if sql_norm.startswith("UPDATE stage_runs SET"):
+            self.updates.append({
+                "id": args[0], "ended_at": args[1],
+                "outcome": args[2], "fail_reason": args[3],
+            })
+
+
+# ─── Pure helper tests (SUBSTEP-S1..S3) ────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_substep_s1_well_formed_array_inserts_rows_per_entry():
+    """SUBSTEP-S1: well-formed sub_steps → one stage_runs row per entry."""
+    pool = _RecordingPool()
+    accept_env = {
+        "endpoint": "http://x",
+        "namespace": "y",
+        "sub_steps": [
+            {"name": "lab-helm", "duration_sec": 45.2},
+            {"name": "apk", "duration_sec": 31.7},
+        ],
+    }
+    n = await mod._record_sub_steps(pool, "REQ-1", accept_env)
+    assert n == 2
+    assert len(pool.inserts) == 2
+    stages = [row["stage"] for row in pool.inserts]
+    assert stages == ["accept-env-up.lab-helm", "accept-env-up.apk"]
+    assert all(row["req_id"] == "REQ-1" for row in pool.inserts)
+    # one update per insert with outcome=pass
+    assert len(pool.updates) == 2
+    assert all(u["outcome"] == "pass" for u in pool.updates)
+
+
+@pytest.mark.asyncio
+async def test_substep_s2_missing_field_zero_inserts():
+    """SUBSTEP-S2: no sub_steps key → no inserts, no error."""
+    pool = _RecordingPool()
+    accept_env = {"endpoint": "http://x", "namespace": "y"}
+    n = await mod._record_sub_steps(pool, "REQ-1", accept_env)
+    assert n == 0
+    assert pool.inserts == []
+    assert pool.updates == []
+
+
+@pytest.mark.asyncio
+async def test_substep_s3_malformed_payloads_zero_inserts(caplog):
+    """SUBSTEP-S3: not-a-list / wrong-type entries → skipped, no exception."""
+    pool = _RecordingPool()
+
+    # not-a-list
+    n = await mod._record_sub_steps(pool, "REQ-1", {"sub_steps": "nope"})
+    assert n == 0
+
+    # entry not dict
+    n = await mod._record_sub_steps(pool, "REQ-1", {"sub_steps": ["x"]})
+    assert n == 0
+
+    # entry missing name
+    n = await mod._record_sub_steps(pool, "REQ-1", {"sub_steps": [{"duration_sec": 1.0}]})
+    assert n == 0
+
+    # entry missing duration_sec
+    n = await mod._record_sub_steps(pool, "REQ-1", {"sub_steps": [{"name": "a"}]})
+    assert n == 0
+
+    # entry duration_sec wrong type (bool is technically int but excluded)
+    n = await mod._record_sub_steps(pool, "REQ-1", {"sub_steps": [{"name": "a", "duration_sec": True}]})
+    assert n == 0
+
+    # entry name empty string
+    n = await mod._record_sub_steps(pool, "REQ-1", {"sub_steps": [{"name": "", "duration_sec": 1.0}]})
+    assert n == 0
+
+    assert pool.inserts == []
+    assert pool.updates == []
+
+
+@pytest.mark.asyncio
+async def test_substep_partial_payload_inserts_only_valid_entries():
+    """Mixed valid + invalid entries → only valid persisted, no exception."""
+    pool = _RecordingPool()
+    accept_env = {
+        "sub_steps": [
+            {"name": "lab-helm", "duration_sec": 10.0},
+            {"name": "bogus"},  # missing duration_sec → skip
+            "not-a-dict",       # skip
+            {"name": "apk", "duration_sec": 20.0},
+        ],
+    }
+    n = await mod._record_sub_steps(pool, "REQ-1", accept_env)
+    assert n == 2
+    assert [r["stage"] for r in pool.inserts] == [
+        "accept-env-up.lab-helm",
+        "accept-env-up.apk",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_record_sub_steps_handles_non_dict_accept_env():
+    """defensive: accept_env=None or list → zero inserts, no error."""
+    pool = _RecordingPool()
+    assert await mod._record_sub_steps(pool, "REQ-1", None) == 0
+    assert await mod._record_sub_steps(pool, "REQ-1", []) == 0
+    assert pool.inserts == []
+
+
+# ─── End-to-end via create_accept (SUBSTEP-S1 + SUBSTEP-S4) ────────────────
+
+class _FakeRC:
+    def __init__(self, env_up_exit=0, env_up_stdout='{"endpoint": "http://x"}\n'):
+        self.env_up_exit = env_up_exit
+        self.env_up_stdout = env_up_stdout
+        self.calls: list[dict] = []
+
+    async def get_runner_status(self, req_id):
+        from orchestrator.k8s_runner import RunnerStatus
+        return RunnerStatus(
+            req_id=req_id, pod_name=f"runner-{req_id.lower()}",
+            pvc_name=f"workspace-{req_id.lower()}",
+            pod_phase="Running", pvc_phase="Bound", created_at=None,
+        )
+
+    async def exec_in_runner(self, req_id, command, env=None, timeout_sec=None):
+        self.calls.append({"req_id": req_id, "command": command, "env": env})
+        if "make accept-env-up" in command:
+            return ExecResult(
+                exit_code=self.env_up_exit, stdout=self.env_up_stdout,
+                stderr="", duration_sec=0.5,
+            )
+        # lite fallback (no thanatos block) — short-circuit pass
+        return ExecResult(exit_code=0, stdout="PASS\n", stderr="", duration_sec=0.5)
+
+
+def _body():
+    return type("B", (), {
+        "issueId": "i-1", "projectId": "p", "event": "pr-ci.pass",
+        "title": "T", "tags": [], "issueNumber": None,
+    })()
+
+
+def _patch(monkeypatch, rc, pool, recorded_substep_calls):
+    monkeypatch.setattr("orchestrator.actions.create_accept.k8s_runner.get_controller", lambda: rc)
+    monkeypatch.setattr("orchestrator.actions.create_accept.db.get_pool", lambda: pool)
+    monkeypatch.setattr("orchestrator.actions.create_accept.settings.skip_accept", False)
+    monkeypatch.setattr("orchestrator.actions.create_accept.settings.test_mode", False)
+    monkeypatch.setattr("orchestrator.actions.create_accept.settings.accept_smoke_delay_sec", 0)
+
+    async def fake_resolve_integration_dir(rc, req_id):
+        return ResolveResult(dir="/workspace/source/test")
+    monkeypatch.setattr(
+        "orchestrator.actions.create_accept.resolve_integration_dir",
+        fake_resolve_integration_dir,
+    )
+
+    async def fake_update_ctx(p, req_id, updates):
+        pass
+    monkeypatch.setattr(
+        "orchestrator.actions.create_accept.req_state.update_context",
+        fake_update_ctx,
+    )
+
+    # spy on _record_sub_steps to confirm wiring without exercising DB SQL twice
+    real = mod._record_sub_steps
+
+    async def spy(pool_arg, req_id_arg, accept_env_arg):
+        recorded_substep_calls.append({"req_id": req_id_arg, "accept_env": accept_env_arg})
+        return await real(pool_arg, req_id_arg, accept_env_arg)
+    monkeypatch.setattr("orchestrator.actions.create_accept._record_sub_steps", spy)
+
+
+@pytest.mark.asyncio
+async def test_substep_e2e_envup_pass_with_substeps_calls_record(monkeypatch):
+    """SUBSTEP-S1 e2e: env-up exits 0 + JSON has sub_steps → helper invoked."""
+    rc = _FakeRC(env_up_stdout=(
+        '{"endpoint": "http://x", "namespace": "y", '
+        '"sub_steps": [{"name": "lab-helm", "duration_sec": 1.5}]}\n'
+    ))
+    pool = _RecordingPool()
+    calls: list[dict] = []
+    _patch(monkeypatch, rc, pool, calls)
+
+    out = await mod.create_accept(
+        body=_body(), req_id="REQ-1", tags=[], ctx={"cloned_repos": []},
+    )
+    assert out["emit"] == Event.ACCEPT_PASS.value
+    assert len(calls) == 1, "_record_sub_steps must be called once after env-up parse"
+    assert calls[0]["accept_env"]["sub_steps"][0]["name"] == "lab-helm"
+
+
+@pytest.mark.asyncio
+async def test_substep_s4_envup_fail_does_not_call_record(monkeypatch):
+    """SUBSTEP-S4: env-up exits non-zero → helper NEVER called."""
+    rc = _FakeRC(
+        env_up_exit=1,
+        env_up_stdout='{"endpoint": "http://x", "sub_steps": [{"name": "lab", "duration_sec": 5}]}\n',
+    )
+    pool = _RecordingPool()
+    calls: list[dict] = []
+    _patch(monkeypatch, rc, pool, calls)
+
+    out = await mod.create_accept(
+        body=_body(), req_id="REQ-1", tags=[], ctx={"cloned_repos": []},
+    )
+    assert out["emit"] == Event.ACCEPT_ENV_UP_FAIL.value
+    assert calls == [], "sub_steps recorder must not run on env-up failure"

--- a/orchestrator/tests/test_teardown_accept_env_keep_env.py
+++ b/orchestrator/tests/test_teardown_accept_env_keep_env.py
@@ -1,0 +1,114 @@
+"""REQ-feat-accept-env-substep-timing: KEEP_ENV plumbing in teardown_accept_env.
+
+Covers spec scenarios KEEP-S1..S3 from
+openspec/changes/REQ-feat-accept-env-substep-timing-1777812776/specs/
+accept-env-observability/spec.md.
+"""
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.actions import teardown_accept_env as mod
+from orchestrator.actions._integration_resolver import ResolveResult
+from orchestrator.k8s_runner import ExecResult
+from orchestrator.state import Event
+
+
+class _FakeRC:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def exec_in_runner(self, req_id, command, env=None, timeout_sec=None):
+        self.calls.append({"req_id": req_id, "command": command, "env": env})
+        return ExecResult(exit_code=0, stdout="", stderr="", duration_sec=0.1)
+
+
+def _body():
+    return type("B", (), {
+        "issueId": "i-1", "projectId": "p", "event": "accept.pass",
+        "title": "T", "tags": [], "issueNumber": None,
+    })()
+
+
+def _patch(monkeypatch, rc, *, accept_keep_env: bool, accept_result: str = "pass"):
+    monkeypatch.setattr("orchestrator.actions.teardown_accept_env.k8s_runner.get_controller", lambda: rc)
+    monkeypatch.setattr("orchestrator.actions.teardown_accept_env.settings.accept_keep_env", accept_keep_env)
+    monkeypatch.setattr("orchestrator.actions.teardown_accept_env.settings.skip_accept", False)
+    monkeypatch.setattr("orchestrator.actions.teardown_accept_env.settings.test_mode", False)
+    monkeypatch.setattr("orchestrator.actions.teardown_accept_env.db.get_pool", lambda: object())
+
+    async def fake_resolve(_rc, _req_id):
+        return ResolveResult(dir="/workspace/source/test")
+    monkeypatch.setattr(
+        "orchestrator.actions.teardown_accept_env.resolve_integration_dir",
+        fake_resolve,
+    )
+
+    async def fake_update_ctx(_pool, _req_id, _updates):
+        pass
+    monkeypatch.setattr(
+        "orchestrator.actions.teardown_accept_env.req_state.update_context",
+        fake_update_ctx,
+    )
+
+
+# ─── KEEP-S1: flag on → KEEP_ENV=1 in env ──────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_keep_s1_flag_on_injects_keep_env_1(monkeypatch):
+    rc = _FakeRC()
+    _patch(monkeypatch, rc, accept_keep_env=True)
+
+    await mod.teardown_accept_env(
+        body=_body(), req_id="REQ-1", tags=["accept", "result:pass"],
+        ctx={"accept_result": "pass"},
+    )
+    assert len(rc.calls) == 1
+    env = rc.calls[0]["env"]
+    assert env.get("KEEP_ENV") == "1"
+    # base env still present
+    assert env.get("SISYPHUS_REQ_ID") == "REQ-1"
+    assert env.get("SISYPHUS_STAGE") == "accept-teardown"
+
+
+# ─── KEEP-S2: flag off (default) → KEEP_ENV not in env ─────────────────────
+
+@pytest.mark.asyncio
+async def test_keep_s2_flag_off_omits_keep_env(monkeypatch):
+    rc = _FakeRC()
+    _patch(monkeypatch, rc, accept_keep_env=False)
+
+    await mod.teardown_accept_env(
+        body=_body(), req_id="REQ-1", tags=["accept", "result:pass"],
+        ctx={"accept_result": "pass"},
+    )
+    assert len(rc.calls) == 1
+    env = rc.calls[0]["env"]
+    assert "KEEP_ENV" not in env
+    assert env.get("SISYPHUS_REQ_ID") == "REQ-1"
+
+
+# ─── KEEP-S3: emit routing unaffected by KEEP_ENV ──────────────────────────
+
+@pytest.mark.asyncio
+async def test_keep_s3_pass_routing_with_keep_env(monkeypatch):
+    rc = _FakeRC()
+    _patch(monkeypatch, rc, accept_keep_env=True)
+
+    out = await mod.teardown_accept_env(
+        body=_body(), req_id="REQ-1", tags=["accept", "result:pass"],
+        ctx={"accept_result": "pass"},
+    )
+    assert out["emit"] == Event.TEARDOWN_DONE_PASS.value
+
+
+@pytest.mark.asyncio
+async def test_keep_s3_fail_routing_with_keep_env(monkeypatch):
+    rc = _FakeRC()
+    _patch(monkeypatch, rc, accept_keep_env=True)
+
+    out = await mod.teardown_accept_env(
+        body=_body(), req_id="REQ-1", tags=["accept", "result:fail"],
+        ctx={"accept_result": "fail"},
+    )
+    assert out["emit"] == Event.TEARDOWN_DONE_FAIL.value


### PR DESCRIPTION
## Summary

Sisyphus-side contract + orchestrator changes for #329:

1. **`accept-env-up` sub-step timing** — endpoint JSON MAY include optional
   `sub_steps: [{name, duration_sec}]`. `create_accept` persists each entry
   as a `stage_runs` row keyed by `accept-env-up.<name>` so Metabase can
   aggregate per-phase distribution (`SELECT stage, AVG(duration_sec) FROM stage_runs WHERE stage LIKE 'accept-env-up.%' GROUP BY stage`)
   and answer "which sub-step is the bottleneck → which deserves a cache".
2. **`accept-env-down` KEEP_ENV reuse** — contract: target SHALL exit 0 on
   `KEEP_ENV=1` (skip helm uninstall + ns delete). New `settings.accept_keep_env`
   (env: `SISYPHUS_ACCEPT_KEEP_ENV`) defaults off; opt-in for dogfood retry
   to reuse lab/thanatos releases (saves 1-3 min/iteration).

Both fields are **optional** — business repos that haven't implemented
sub_steps emission or the KEEP_ENV branch see zero behavior change.

## What's NOT in this REQ

- `accept-apk-only` fast path target (#329 §A) — needs sisyphus retry
  detection + state-machine branching, equivalent in scope to #329 §C and
  belongs in a separate REQ.
- Actual ttpos-arch-lab Makefile changes to emit `sub_steps` and implement
  the KEEP_ENV branch — follow-up PR(s) in the lab repo.

## Files

- `openspec/changes/REQ-feat-accept-env-substep-timing-1777812776/` — proposal,
  tasks, spec delta with 7 scenarios (SUBSTEP-S1..S4 + KEEP-S1..S3).
- `orchestrator/src/orchestrator/actions/create_accept.py` — `_record_sub_steps`
  helper + wired call after env-up parse.
- `orchestrator/src/orchestrator/actions/teardown_accept_env.py` — env injection
  branch on `settings.accept_keep_env`.
- `orchestrator/src/orchestrator/config.py` — new `accept_keep_env` setting.
- `docs/integration-contracts.md` — §2.3 KEEP_ENV contract; §3 `sub_steps` field.
- `docs/cookbook/ttpos-arch-lab-accept-env.md` — example sub_steps emission +
  KEEP_ENV branch.
- 2 new test files (15 unit tests, all passing).

## Test plan

- [x] `make ci-lint` — green (full scan, both orchestrator and thanatos packages)
- [x] `make ci-unit-test` — 2137 passed in orchestrator + 44 in thanatos
- [x] `make ci-integration-test` — pass (no PG → exit 5 treated as pass per ci contract)
- [x] `openspec validate REQ-feat-accept-env-substep-timing-1777812776 --strict` — valid
- [x] New unit tests cover all 7 spec scenarios (SUBSTEP-S1..S4 + KEEP-S1..S3)

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-feat-accept-env-substep-timing-1777812776\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/oxmaqv85)