### PR TITLE
spec(cross-repo-env): endpoint pattern contract amendment (refs #342 #359)

### DIFF
--- a/openspec/changes/REQ-spec-pattern-contract-amendment-1777818469/proposal.md
+++ b/openspec/changes/REQ-spec-pattern-contract-amendment-1777818469/proposal.md
@@ -1,0 +1,109 @@
+# Proposal — endpoint pattern contract amendment
+
+> **Type**: spec-only amendment to capability `feat-cross-repo-env-orchestration` (originally
+> landed via PR #354 / spec #342). No implementation in this REQ; downstream impl REQ派 after
+> merge per Phase B/C in the GitHub issue #359.
+>
+> **Refs**: #342 (origin spec), #359 (amendment driver), #311 #326 #327 #333 (root pain).
+> Does **not** `Closes #` —— this is a spec PR, downstream impl REQ closes.
+
+## Why
+
+The current `feat-cross-repo-env-orchestration` spec (R1–R10 + Readiness Gate) ships a
+**runtime endpoint passthrough** model:
+
+1. Each layer emits real endpoint values inside its `make accept-env-up` JSON output (R4 + R5).
+2. The orchestrator parses output, builds the bundle, injects vars to the next layer.
+3. APK build / mobile-env-up / accept-agent receive values **after** the upstream layer is up.
+
+Implementation experiment (`ZonEaseTech/ttpos-flutter#167`,
+`ZonEaseTech/ttpos-arch-lab#16`) exposed three load-bearing problems with this runtime model:
+
+- **Speed**: APK build cannot wait for backend `accept-env-up` to finish (5–10 min serial).
+  Either we pre-build APK with a guess and risk drift, or we serialize and pay the latency.
+- **Single source of truth**: consumers (APK, accept-agent) end up coding the backend's
+  endpoint shape (`ttpos-flutter-lab.{ns}` virtual hostname + `ExternalName` shim across 5
+  call-sites), so a backend rename / port change requires patching every consumer.
+- **Security**: runtime config injection of `BASE_URL` into a built APK is a known footgun
+  (recipient can be tricked into pointing the binary at a hostile origin).
+
+The pre-existing R5 "opaque JSON passthrough" framing is **not wrong, just not enough**:
+it described how values flow once they exist. It did not address **when** they exist or
+**who** is the source of truth for their *shape*.
+
+## What this amendment changes
+
+Three surgical edits to the existing capability spec — enough to declare the architecture,
+not enough to implement it. Implementation is a follow-up REQ.
+
+### 1. R1 Manifest schema — add `emits[].pattern` + `emits[].vars`
+
+`emits` entries gain a second admissible form: a single-key object whose value is a
+**pattern contract** (a template string with `{VAR}` placeholders) plus a `vars` map
+binding placeholders to either literal strings or `${SISYPHUS_*}` references to
+orchestrator-provided REQ context variables (namespace, REQ id, source SHA…).
+
+The legacy bare-string form (`emits: [endpoint]`) is **retained verbatim** so that
+un-migrated repositories continue to validate. Migration is opt-in per repo.
+
+### 2. R5 Endpoint value semantics — pattern contract resolver replaces "opaque passthrough only"
+
+R5 previously committed only to "treat all emitted values as opaque JSON; pass through
+unchanged." This still holds **after** values are resolved. The amended R5 names the
+**source** of values:
+
+- For **pattern-form emits**, the orchestrator pre-resolves the pattern using the layer's
+  declared `vars` and the REQ context **before** the runner pod starts. The resolved
+  string IS the emit value. No `accept-env-up` JSON parsing for these fields.
+- For **bare-string emits**, the orchestrator parses `accept-env-up` JSON output at layer
+  runtime exactly as before (R4 unchanged for this path).
+
+Either source produces the same `endpoint_bundle` shape. Consumers see no difference.
+
+### 3. ADD R12 Pre-resolve phase
+
+A new requirement formalising the pre-resolve step: read every manifest in the topology,
+substitute every pattern-form emit, fail-loud on unresolved placeholders, and have the
+bundle ready **before** the runner pod is created. This is the requirement that lets APK
+build run in parallel with `accept-env-up`, and that makes the manifest the single source
+of truth for endpoint shape.
+
+## What this amendment does **not** change
+
+- **R2** topology resolution: identical algorithm, identical scenarios.
+- **R3** workspace layout: unchanged.
+- **R6** branch resolution: unchanged.
+- **R7** teardown: unchanged.
+- **R8** backward compat for repos without manifest: unchanged. Bare-string emits remain
+  a first-class legacy path so today's deployments keep working without manifest edits.
+- **R9** thanatos `.sisyphus/scenarios/` fallback: unchanged.
+- **R10** failure layer attribution: unchanged. Pre-resolve failures are recorded under
+  the same `stage_runs.context.failed_layer` shape, with `failed_phase: pre_resolve`.
+
+## Out-of-scope (will not be in any impl REQ for this amendment)
+
+- Cross-repo PR merge ordering automation
+- Pattern syntax beyond `{VAR_NAME}` (no expressions, no defaults, no conditionals)
+- Variable namespaces other than `${SISYPHUS_*}` (no `${ENV_*}`, no `${SECRET_*}`)
+- Pre-resolve for non-emit fields (e.g. resolving `inputs` patterns)
+- Migration tooling for legacy bare-string emits
+
+## Roll-out
+
+1. Merge this spec amendment PR (no code change).
+2. Open impl REQ "sisyphus orch pattern resolver" (Phase B in #359):
+   add manifest reader for new schema; add pre-resolve action; unit + integration tests
+   per R12 readiness gate.
+3. Open business-repo manifest REQs (Phase C): `ttpos-server-go` + `ttpos-flutter` adopt
+   pattern form. The flutter `#167` PR is superseded by this path; close it once the new
+   impl REQ lands.
+
+## Side effects
+
+| Issue | How resolved |
+|-------|--------------|
+| #311 backend not installed in mobile accept-env-up | reaffirmed by R12 + R4: mobile layer receives backend endpoint pre-resolved, never tries to deploy backend itself |
+| #326 endpoint format mismatch (HTTP URL vs ADB host:port) | R5 amended: each layer's pattern declares its own format; no normalization, no surprise |
+| #327 chart sub-chart assumption | unchanged — already addressed by R3+R4 |
+| #333 three-party contract missing | strengthened: pattern contract is the machine-readable contract |
+| #248 P0 thanatos M3 dogfood | unblocked: APK build can proceed in parallel with backend `accept-env-up`, removing the 5–10 min serial floor |

--- a/openspec/changes/REQ-spec-pattern-contract-amendment-1777818469/specs/feat-cross-repo-env-orchestration/spec.md
+++ b/openspec/changes/REQ-spec-pattern-contract-amendment-1777818469/specs/feat-cross-repo-env-orchestration/spec.md
@@ -1,0 +1,202 @@
+# feat-cross-repo-env-orchestration: endpoint pattern contract amendment
+
+> Amendment to capability `feat-cross-repo-env-orchestration` (originally landed via
+> spec PR #342, impl PR #354). Replaces the runtime-only "layer emit真值" semantics with
+> a pre-resolved pattern contract; preserves the bare-string emit form for backward
+> compatibility. Implementation is deferred to a follow-up REQ; this PR is spec-only.
+
+## MODIFIED Requirements
+
+### Requirement: R1 .sisyphus/env.yaml manifest schema validation
+
+Each repository that participates in cross-repo env orchestration SHALL declare a `.sisyphus/env.yaml` file at its root. The orchestrator MUST validate this file against the following schema before any topology resolution:
+
+- `emits` (optional, list): each entry MUST be one of two admissible forms.
+  - **Bare-string form** (legacy, retained for backward compatibility): a non-empty string field name. Values for these fields are sourced at layer runtime from the JSON output of `make accept-env-up` (R4).
+  - **Pattern form** (new): a single-key object where the key is the field name and the value is a map with two required sub-keys:
+    - `pattern` (string, required): a template string containing zero or more `{VAR_NAME}` placeholders. `VAR_NAME` MUST match `[A-Z_][A-Z0-9_]*`.
+    - `vars` (map, required): each placeholder used in `pattern` MUST be a key of `vars`. Values MUST be one of: a literal string, or a reference of the form `${SISYPHUS_*}` (an orchestrator-provided REQ-context variable; see R12). Unresolved or undeclared placeholders MUST be rejected at validation time.
+  Mixing bare-string and pattern entries in the same `emits` list MUST be permitted.
+- `needs` (optional, list of strings): upstream repository full names (`OWNER/REPO`) that must be brought up before this layer. Each entry MUST match the pattern `[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+`.
+- `inputs` (optional, map string→string): env var name to `OWNER/REPO.field` reference. The left-hand side MUST be a valid shell variable name; the right-hand side MUST reference a repo listed in `needs` and a field that repo lists in its `emits` (in either form).
+- `branches` (optional, map string→string): base-branch name aliases. If omitted, defaults to `{develop: develop, release: release}`. Keys and values MUST be non-empty strings.
+
+A manifest with `inputs` referencing a field from a repo not listed in `needs` MUST be rejected. A manifest with both `emits` and `needs` absent is valid (emit-only or consume-only layering). A pattern-form `emits` entry whose `pattern` references a placeholder not declared in its `vars` MUST be rejected.
+
+#### Scenario: CREO-S1 valid manifest with emits and needs passes validation
+- **GIVEN** `.sisyphus/env.yaml` containing `emits: [endpoint, namespace]`, `needs: [ZonEaseTech/ttpos-server-go]`, and `inputs: {BACKEND_ENDPOINT: "ZonEaseTech/ttpos-server-go.endpoint"}`
+- **WHEN** the manifest validator runs
+- **THEN** validation passes with no errors
+
+#### Scenario: CREO-S2 manifest with inputs referencing undeclared needs is rejected
+- **GIVEN** `.sisyphus/env.yaml` containing `inputs: {FOO: "some-org/some-repo.field"}` but `needs` is absent
+- **WHEN** the manifest validator runs
+- **THEN** validation fails with an error identifying `some-org/some-repo` as undeclared in `needs`
+
+#### Scenario: CREO-S3 manifest with invalid repo name format is rejected
+- **GIVEN** `.sisyphus/env.yaml` containing `needs: ["not-a-valid/repo/name"]`
+- **WHEN** the manifest validator runs
+- **THEN** validation fails with an error identifying the malformed entry
+
+#### Scenario: CREO-S4 manifest with invalid shell var name in inputs is rejected
+- **GIVEN** `.sisyphus/env.yaml` containing `inputs: {"123INVALID": "org/repo.field"}` and `needs: [org/repo]`
+- **WHEN** the manifest validator runs
+- **THEN** validation fails with an error identifying the invalid env var name
+
+#### Scenario: CREO-S5 manifest with emits only is valid
+- **GIVEN** `.sisyphus/env.yaml` containing only `emits: [endpoint]`
+- **WHEN** the manifest validator runs
+- **THEN** validation passes with no errors
+
+#### Scenario: EPCA-S1 pattern-form emit with literal and SISYPHUS var passes validation
+- **GIVEN** `.sisyphus/env.yaml` containing
+  ```yaml
+  emits:
+    - endpoint:
+        pattern: "ttpos-server-go.{NAMESPACE}.svc.cluster.local:{PORT}"
+        vars:
+          NAMESPACE: "${SISYPHUS_NAMESPACE}"
+          PORT: "8080"
+  ```
+- **WHEN** the manifest validator runs
+- **THEN** validation passes with no errors and the entry is recorded as a pattern-form emit with field name `endpoint`
+
+#### Scenario: EPCA-S2 mixed bare-string and pattern emits in one list is valid
+- **GIVEN** `.sisyphus/env.yaml` containing `emits: [namespace, {endpoint: {pattern: "svc.{NS}:8080", vars: {NS: "${SISYPHUS_NAMESPACE}"}}}]`
+- **WHEN** the manifest validator runs
+- **THEN** validation passes; the validator MUST record `namespace` as a bare-string emit and `endpoint` as a pattern-form emit
+
+#### Scenario: EPCA-S3 pattern referencing undeclared placeholder is rejected
+- **GIVEN** `.sisyphus/env.yaml` containing
+  ```yaml
+  emits:
+    - endpoint:
+        pattern: "svc.{NS}.local:{PORT}"
+        vars:
+          NS: "${SISYPHUS_NAMESPACE}"
+  ```
+  (`PORT` is used in `pattern` but absent from `vars`)
+- **WHEN** the manifest validator runs
+- **THEN** validation fails with an error identifying `PORT` as an undeclared placeholder in the `endpoint` pattern
+
+---
+
+### Requirement: R4 Sequential accept-env-up with env var injection
+
+The orchestrator SHALL run `make accept-env-up` for each repository in topological order (leaves first). Before invoking each layer's `make`, it MUST inject the env vars declared in that layer's `inputs` map, resolved from the **endpoint bundle** (see below). After the layer's `accept-env-up` completes, the orchestrator MUST update the bundle with values for that layer's emits using the source rules:
+
+- For **pattern-form emits** (R1): the field's value is taken from the pre-resolved bundle assembled in R12 **before** the layer ran. The orchestrator MUST NOT re-resolve from the layer's runtime output.
+- For **bare-string emits** (legacy): the orchestrator MUST parse the JSON output of the layer's `accept-env-up`, extract each declared field, and merge it into the bundle keyed by `OWNER/REPO`. Fields not listed in `emits` MUST be discarded.
+
+The accumulated bundle MUST be passed in full to the accept-agent at the end. When a layer's `inputs` reference an upstream pattern-form emit, the value is already in the bundle from R12 and is injected immediately — including before the upstream layer's own `accept-env-up` has run, when consumers (e.g. APK build) need the value early.
+
+#### Scenario: CREO-S14 backend layer runs first and its endpoint is passed to mobile layer
+- **GIVEN** topology [ttpos-server-go, ttpos-flutter]; server-go emits `endpoint` (bare-string); flutter needs `BACKEND_ENDPOINT=ttpos-server-go.endpoint`
+- **WHEN** sequential accept-env-up runs
+- **THEN** `make accept-env-up` for ttpos-server-go runs first without injected vars; its `endpoint` value parsed from `accept-env-up` JSON output is injected as `BACKEND_ENDPOINT` when running ttpos-flutter's `make accept-env-up`
+
+#### Scenario: CREO-S15 bare-string emits fields are extracted from accept-env-up JSON output
+- **GIVEN** ttpos-server-go's `accept-env-up` outputs `{"endpoint": "http://svc:8080", "namespace": "ns-abc", "extra": "ignored"}`; manifest emits: `[endpoint, namespace]` (both bare-string)
+- **WHEN** the orchestrator processes the output
+- **THEN** the endpoint bundle contains `{"ZonEaseTech/ttpos-server-go": {"endpoint": "http://svc:8080", "namespace": "ns-abc"}}` and `extra` is discarded
+
+#### Scenario: CREO-S16 missing bare-string emit field in accept-env-up JSON causes fail
+- **GIVEN** manifest declares `emits: [endpoint]` (bare-string); `accept-env-up` JSON output does not contain key `endpoint`
+- **WHEN** the orchestrator parses the output
+- **THEN** the accept stage fails with an error identifying the missing field and the layer name
+
+#### Scenario: CREO-S17 accept-agent receives full accumulated endpoint bundle
+- **GIVEN** topology [server-go, flutter]; both layers succeed and emit their fields (in any mix of bare-string and pattern form)
+- **WHEN** accept-env-up completes for all layers
+- **THEN** the BKD accept-agent issue is created with an endpoint bundle containing fields from all layers merged into a single JSON object
+
+#### Scenario: EPCA-S4 pattern-form emit value is injected to consumer without parsing layer output
+- **GIVEN** topology [server-go, flutter]; server-go emits `endpoint` in pattern form (R12 has pre-resolved it to `"ttpos-server-go.req-7-abc.svc.cluster.local:8080"`); flutter needs `BACKEND_ENDPOINT=ZonEaseTech/ttpos-server-go.endpoint`
+- **WHEN** the orchestrator prepares to run flutter's `make accept-env-up`
+- **THEN** `BACKEND_ENDPOINT="ttpos-server-go.req-7-abc.svc.cluster.local:8080"` is injected; the orchestrator MUST NOT parse server-go's `accept-env-up` JSON output to obtain this value (it is already in the pre-resolved bundle from R12)
+
+---
+
+### Requirement: R5 Endpoint value resolution and passthrough
+
+Endpoint field values in the bundle SHALL come from one of two sources, determined by the `emits` form declared in the layer's manifest (R1):
+
+1. **Pattern-form emits** — the orchestrator MUST resolve the `pattern` template by substituting every `{VAR_NAME}` placeholder using the layer's declared `vars` map. Literal values are taken verbatim. `${SISYPHUS_*}` references MUST be expanded against the orchestrator's REQ context (see R12 for the supported variable namespace). The resolved value is a string and is the canonical emit value; no `accept-env-up` JSON output parsing is performed for this field.
+2. **Bare-string emits** — the orchestrator MUST extract the field value from the JSON output of the layer's `accept-env-up` invocation and pass it through unchanged. JSON type information (string, number, boolean, null, array, object) MUST be preserved.
+
+Once a value is in the bundle (from either source), the orchestrator MUST treat it as opaque and pass it through to consumers and the accept-agent unchanged. The orchestrator MUST NOT impose any schema or format constraints on the values themselves — format interpretation (HTTP URL vs ADB host:port vs other) is the contract between provider and consumer. The orchestrator MUST NOT parse, normalize, or validate field values beyond the type-preservation rule above.
+
+#### Scenario: CREO-S18 HTTP URL bare-string endpoint is passed unchanged
+- **GIVEN** server-go emits `endpoint` (bare-string) and `accept-env-up` outputs `{"endpoint": "http://ttpos-server-go.ns-abc.svc.cluster.local:8080"}`
+- **WHEN** the endpoint bundle is assembled
+- **THEN** the accept-agent receives the field value `"http://ttpos-server-go.ns-abc.svc.cluster.local:8080"` byte-for-byte
+
+#### Scenario: CREO-S19 ADB host:port bare-string endpoint is passed unchanged
+- **GIVEN** mobile layer emits `device` (bare-string) and `accept-env-up` outputs `{"device": "redroid-pod-x:5554"}`
+- **WHEN** the endpoint bundle is assembled
+- **THEN** the accept-agent receives `"redroid-pod-x:5554"` unchanged, without conversion to a URL form
+
+#### Scenario: CREO-S20 numeric and boolean JSON field values are preserved for bare-string emits
+- **GIVEN** a layer emits `port` and `tls` (both bare-string) and `accept-env-up` outputs `{"port": 8080, "tls": false}`
+- **WHEN** the endpoint bundle is assembled
+- **THEN** the accept-agent receives `port` as JSON number `8080` and `tls` as JSON boolean `false`, not as strings
+
+#### Scenario: EPCA-S5 pattern-form emit resolves to a string value
+- **GIVEN** a layer manifest declares
+  ```yaml
+  emits:
+    - endpoint:
+        pattern: "ttpos-server-go.{NS}.svc.cluster.local:{PORT}"
+        vars:
+          NS: "${SISYPHUS_NAMESPACE}"
+          PORT: "8080"
+  ```
+  and the REQ context provides `SISYPHUS_NAMESPACE=req-7-abc`
+- **WHEN** R12 pre-resolve executes for this layer
+- **THEN** the bundle contains `{"<repo>": {"endpoint": "ttpos-server-go.req-7-abc.svc.cluster.local:8080"}}` — a JSON string with the placeholders fully substituted
+
+#### Scenario: EPCA-S6 pattern-form emit value is passed through opaquely after resolution
+- **GIVEN** a pattern resolves to `"redroid.req-7-abc.svc.cluster.local:5554"`
+- **WHEN** the consumer layer (or accept-agent) reads the value via `inputs`
+- **THEN** the orchestrator MUST NOT reformat the string (no URL prefixing, no port-stripping, no host-only extraction); the consumer receives the byte-identical string from the bundle
+
+---
+
+## ADDED Requirements
+
+### Requirement: R12 Pre-resolve phase before runner pod startup
+
+The orchestrator SHALL execute a **pre-resolve phase** between source-REQ admission and runner-pod creation. In this phase, after R2 topology resolution but before any `kubectl apply` for the runner pod, the orchestrator MUST:
+
+1. For every repository in the topology, fetch the pinned `.sisyphus/env.yaml` content (using the branch resolved by R6).
+2. For every pattern-form entry in each manifest's `emits`, substitute `{VAR_NAME}` placeholders using the entry's `vars` map. `${SISYPHUS_*}` references MUST be expanded against the **REQ context**, which MUST include at minimum:
+   - `SISYPHUS_NAMESPACE` — the kubernetes namespace assigned to this REQ (typically derived from `req-{N}-{slug}`)
+   - `SISYPHUS_REQ_ID` — the REQ identifier
+   - `SISYPHUS_REQ_BRANCH` — the source REQ branch name
+   - `SISYPHUS_SOURCE_REPO_SHA` — the source REQ commit SHA at admission time
+3. Assemble the resolved values into a partial `endpoint_bundle` keyed by `OWNER/REPO`. Bare-string emits are left unresolved at this phase (their values are filled in at layer runtime by R4).
+4. Persist the partial bundle in `stage_runs.context.endpoint_bundle_pre_resolved` (a `dict[str, dict[str, str]]`) so it is observable in Metabase and survives runner pod restarts.
+
+The pre-resolved bundle MUST be available to all consumers — including out-of-band consumers such as APK build dispatch and the mobile-env-up layer — at the moment the runner pod (or any consumer side-channel) starts, **without** waiting for any layer's `accept-env-up` to run.
+
+The orchestrator MUST fail-loud on any pre-resolve error: an unresolved `${SISYPHUS_*}` reference (variable not in the REQ context), a `pattern` referencing a placeholder not declared in `vars` (already rejected by R1, but re-checked here for defence in depth), or a manifest fetch failure for a repo in the topology. Failure MUST cause the REQ to escalate **before** the runner pod is created; `stage_runs.context.failed_layer` MUST identify the offending repo and `stage_runs.context.failed_phase` MUST be `"pre_resolve"` (a new sentinel value distinct from R10's runtime layer-attribution).
+
+#### Scenario: EPCA-S7 pre-resolve assembles bundle before runner pod creation
+- **GIVEN** topology [ttpos-server-go, ttpos-flutter] resolved by R2; ttpos-server-go's manifest declares `emits: [{endpoint: {pattern: "ttpos-server-go.{NS}.svc.cluster.local:{PORT}", vars: {NS: "${SISYPHUS_NAMESPACE}", PORT: "8080"}}}]`; REQ context includes `SISYPHUS_NAMESPACE=req-7-foo`
+- **WHEN** the pre-resolve phase runs
+- **THEN** `stage_runs.context.endpoint_bundle_pre_resolved` equals `{"ZonEaseTech/ttpos-server-go": {"endpoint": "ttpos-server-go.req-7-foo.svc.cluster.local:8080"}}` and the runner pod for this REQ is created **after** this write completes
+
+#### Scenario: EPCA-S8 unresolved SISYPHUS context variable causes pre-resolve fail-loud
+- **GIVEN** a manifest pattern references `${SISYPHUS_NONEXISTENT_VAR}` which is not in the orchestrator's REQ-context allow-list
+- **WHEN** the pre-resolve phase runs
+- **THEN** the REQ MUST escalate before the runner pod is created; `stage_runs.context.failed_phase` equals `"pre_resolve"`; `stage_runs.context.failed_layer` equals the offending repo's full name; the error message MUST name `SISYPHUS_NONEXISTENT_VAR` as the unresolved reference
+
+#### Scenario: EPCA-S9 pre-resolved value is available to APK build dispatch in parallel with accept-env-up
+- **GIVEN** an APK build dispatch consumer needs `BACKEND_ENDPOINT` from `ZonEaseTech/ttpos-server-go.endpoint` (pattern form); pre-resolve completed
+- **WHEN** the orchestrator triggers both APK build dispatch and `make accept-env-up` for ttpos-server-go
+- **THEN** the APK build job receives `BACKEND_ENDPOINT` from the pre-resolved bundle at dispatch time, without waiting for ttpos-server-go's `accept-env-up` to start or complete
+
+#### Scenario: EPCA-S10 manifest fetch failure during pre-resolve fails the REQ before runner pod starts
+- **GIVEN** topology resolution lists `org/some-repo` and that repo's manifest fetch returns HTTP 5xx
+- **WHEN** pre-resolve attempts to read the manifest
+- **THEN** the REQ MUST escalate before runner pod creation; `stage_runs.context.failed_phase` equals `"pre_resolve"`; `stage_runs.context.failed_layer` equals `"org/some-repo"`; the error MUST distinguish the manifest-fetch failure from a placeholder-resolution failure

--- a/openspec/changes/REQ-spec-pattern-contract-amendment-1777818469/tasks.md
+++ b/openspec/changes/REQ-spec-pattern-contract-amendment-1777818469/tasks.md
@@ -1,0 +1,32 @@
+# Tasks — REQ-spec-pattern-contract-amendment-1777818469
+
+> spec-only amendment. No business code. No tests. Sisyphus checkers (`spec_lint` +
+> `dev_cross_check` + `staging_test`) only enforce that the openspec delta validates and
+> that the repo's lint/test baselines stay green.
+
+## Stage: contract / spec
+- [x] author proposal.md — motivation, scope, non-goals, roll-out plan
+- [x] author tasks.md — this file
+- [x] author specs/feat-cross-repo-env-orchestration/spec.md delta:
+  - [x] MODIFIED Requirements: R1 (emits schema) — preserve CREO-S1..S5, add EPCA-S1..S3
+  - [x] MODIFIED Requirements: R4 (sequential accept-env-up) — preserve CREO-S14..S17 semantics, add EPCA-S4 covering pattern-form short-circuit
+  - [x] MODIFIED Requirements: R5 (endpoint values) — replace narrative; preserve CREO-S18..S20 byte-faithful; add EPCA-S5..S6
+  - [x] ADDED Requirements: R12 pre-resolve phase — scenarios EPCA-S7..S10
+- [ ] (skipped) author design.md — single-page trade-off doc covered inline in proposal.md "Why" / "Out-of-scope"; no separate file needed for an amendment of this size
+- [x] `openspec validate REQ-spec-pattern-contract-amendment-1777818469` green
+- [x] `check-scenario-refs.sh --specs-search-path /workspace/source .` green (no scenario refs in non-spec files for this REQ)
+
+## Stage: implementation
+- [x] no implementation in this REQ — pure spec amendment
+
+## Stage: PR (gates before push)
+- [x] `make ci-lint` — N/A for spec-only change; checker runs over no-op diff
+- [x] `make ci-unit-test` — N/A for spec-only change
+- [x] `make ci-integration-test` — N/A for spec-only change
+- [x] git push feat/REQ-spec-pattern-contract-amendment-1777818469
+- [x] gh pr create --label sisyphus, body uses `Refs #342 #359` (NOT `Closes` — impl REQs close)
+
+## Stage: handoff (after PR merge, separate REQs)
+- [ ] (followup REQ) sisyphus orch pattern resolver impl — see #359 Phase B
+- [ ] (followup REQ) ttpos-server-go `.sisyphus/env.yaml` pattern adoption — see #359 Phase C
+- [ ] (followup REQ) ttpos-flutter `.sisyphus/env.yaml` pattern adoption (supersedes flutter#167) — see #359 Phase C

--- a/orchestrator/tests/test_contract_endpoint_pattern_amendment_challenger.py
+++ b/orchestrator/tests/test_contract_endpoint_pattern_amendment_challenger.py
@@ -1,0 +1,499 @@
+"""Challenger contract tests for REQ-spec-pattern-contract-amendment-1777818469.
+
+Black-box contracts derived **exclusively** from:
+
+  openspec/changes/REQ-spec-pattern-contract-amendment-1777818469/specs/
+    feat-cross-repo-env-orchestration/spec.md
+
+Scenarios covered (all EPCA-* — the new amendment scenarios):
+
+  EPCA-S1   pattern-form emit with literal + ${SISYPHUS_*} parses cleanly
+  EPCA-S2   mixed bare-string + pattern emits in one list parses cleanly
+  EPCA-S3   pattern referencing a placeholder absent from `vars` is rejected
+  EPCA-S4   pattern-form value reaches consumers without parsing layer output
+  EPCA-S5   pattern resolves to a fully-substituted string value
+  EPCA-S6   resolved pattern value is byte-identical (opaque passthrough)
+  EPCA-S7   pre-resolve assembles bundle from (manifests, req_context) alone
+  EPCA-S8   unresolved ${SISYPHUS_*} reference fails loud with attribution
+  EPCA-S9   pre-resolved bundle is observable before any layer runtime data
+  EPCA-S10  manifest-fetch failure during pre-resolve is distinguishable
+
+The proposal is spec-only (no impl in this REQ); the downstream impl REQ MUST
+make these tests green.  Dev MUST NOT modify the tests to make them pass —
+fix the implementation instead.  If a test is genuinely wrong, escalate to
+spec_fixer; do not patch around it in code.
+"""
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable
+
+import pytest
+
+from orchestrator.cross_repo_env import (
+    Manifest,
+    ManifestError,
+    parse_manifest,
+)
+
+
+# ─── canonical entry points the spec mandates ────────────────────────────────
+
+def _pre_resolve():
+    """Return ``orchestrator.cross_repo_env.pre_resolve_endpoint_bundle`` or
+    fail loud.
+
+    R12 mandates a pre-resolve phase that, from manifests + REQ context alone,
+    produces ``stage_runs.context.endpoint_bundle_pre_resolved``.  The
+    canonical pure-logic seam for this is a function on
+    ``orchestrator.cross_repo_env``.  A missing symbol is itself a contract
+    violation so we surface it as a test failure — not a collection error.
+    """
+    from orchestrator import cross_repo_env
+
+    fn = getattr(cross_repo_env, "pre_resolve_endpoint_bundle", None)
+    assert callable(fn), (
+        "Spec R12 mandates "
+        "orchestrator.cross_repo_env.pre_resolve_endpoint_bundle to exist as "
+        "the canonical pre-resolve seam.  It MUST take only (topology, "
+        "manifest_loader, req_context) and return a partial bundle keyed by "
+        "OWNER/REPO with each pattern-form emit resolved to a string."
+    )
+    return fn
+
+
+def _pre_resolve_error():
+    """Return ``orchestrator.cross_repo_env.PreResolveError`` or fail loud."""
+    from orchestrator import cross_repo_env
+
+    cls = getattr(cross_repo_env, "PreResolveError", None)
+    assert isinstance(cls, type) and issubclass(cls, Exception), (
+        "Spec R12 mandates a dedicated PreResolveError exception so the "
+        "orchestrator can attribute pre-resolve failures distinctly from "
+        "R10's runtime layer-attribution.  Expected at "
+        "orchestrator.cross_repo_env.PreResolveError."
+    )
+    return cls
+
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+def _loader_from(graph: dict[str, str | None]) -> Callable[[str], Manifest | None]:
+    """Build a manifest_loader from a {repo: yaml_text_or_None} dict.
+
+    yaml_text == None means "no manifest present" (R8 allows this).  Use the
+    sentinel ``"__FETCH_FAIL__"`` to simulate an upstream fetch error (the
+    loader raises ``RuntimeError`` — the contract under test is that
+    pre-resolve translates this into ``PreResolveError`` with attribution).
+    """
+
+    def _load(repo: str) -> Manifest | None:
+        text = graph.get(repo, None)
+        if text is None:
+            return None
+        if text == "__FETCH_FAIL__":
+            raise RuntimeError(f"simulated manifest fetch HTTP 5xx for {repo}")
+        return parse_manifest(text)
+
+    return _load
+
+
+_REQ_CTX = {
+    "SISYPHUS_NAMESPACE": "req-7-foo",
+    "SISYPHUS_REQ_ID": "REQ-7-foo",
+    "SISYPHUS_REQ_BRANCH": "feat/REQ-7-foo",
+    "SISYPHUS_SOURCE_REPO_SHA": "deadbeef",
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# EPCA-S1 — pattern-form emit with literal + ${SISYPHUS_*} parses
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_epca_s1_pattern_emit_with_literal_and_sisyphus_var_parses() -> None:
+    """EPCA-S1: pattern-form emit with one literal + one ${SISYPHUS_*} placeholder
+    MUST validate cleanly.  The validator MUST record the entry as a
+    pattern-form emit with field name ``endpoint`` (observable downstream as a
+    pre-resolved value in the bundle).
+    """
+    text = """
+emits:
+  - endpoint:
+      pattern: "ttpos-server-go.{NAMESPACE}.svc.cluster.local:{PORT}"
+      vars:
+        NAMESPACE: "${SISYPHUS_NAMESPACE}"
+        PORT: "8080"
+"""
+    # Parsing alone MUST not raise.
+    m = parse_manifest(text)
+    assert isinstance(m, Manifest)
+
+    # The recorded distinction is observable through pre_resolve: the field
+    # ``endpoint`` MUST appear in the bundle for this repo with the resolved
+    # string value (proving it was treated as pattern-form, not bare-string).
+    pre_resolve = _pre_resolve()
+    bundle = pre_resolve(
+        ["ZonEaseTech/ttpos-server-go"],
+        _loader_from({"ZonEaseTech/ttpos-server-go": text}),
+        _REQ_CTX,
+    )
+    repo_bundle = bundle["ZonEaseTech/ttpos-server-go"]
+    assert (
+        repo_bundle.get("endpoint")
+        == "ttpos-server-go.req-7-foo.svc.cluster.local:8080"
+    ), (
+        "EPCA-S1: pattern-form emit MUST resolve via vars + ${SISYPHUS_*} "
+        "expansion to a fully-substituted string; the bundle MUST surface the "
+        "field under its declared name."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# EPCA-S2 — mixed bare-string + pattern emits in one list is valid
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_epca_s2_mixed_bare_and_pattern_emits_in_one_list() -> None:
+    """EPCA-S2: a single ``emits`` list MAY mix bare-string and pattern entries.
+    Validator records ``namespace`` as bare-string, ``endpoint`` as pattern.
+    """
+    text = """
+emits:
+  - namespace
+  - endpoint:
+      pattern: "svc.{NS}:8080"
+      vars:
+        NS: "${SISYPHUS_NAMESPACE}"
+"""
+    # Parsing succeeds.
+    m = parse_manifest(text)
+    assert isinstance(m, Manifest)
+
+    # Behavioural distinction: pre-resolve MUST surface ONLY the pattern-form
+    # entry (bare-string emits are filled in at layer runtime per R4).
+    pre_resolve = _pre_resolve()
+    bundle = pre_resolve(
+        ["org/x"],
+        _loader_from({"org/x": text}),
+        _REQ_CTX,
+    )
+    repo_bundle = bundle.get("org/x", {})
+    assert repo_bundle.get("endpoint") == "svc.req-7-foo:8080", (
+        "EPCA-S2: pattern-form `endpoint` MUST be pre-resolved into the bundle."
+    )
+    assert "namespace" not in repo_bundle, (
+        "EPCA-S2: bare-string emits MUST NOT appear in the pre-resolve bundle "
+        "(they are filled in at layer runtime by R4)."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# EPCA-S3 — pattern referencing undeclared placeholder is rejected
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_epca_s3_pattern_with_undeclared_placeholder_is_rejected() -> None:
+    """EPCA-S3: a pattern that references ``{PORT}`` while ``vars`` declares
+    only ``NS`` MUST be rejected at validation time, naming ``PORT``.
+    """
+    text = """
+emits:
+  - endpoint:
+      pattern: "svc.{NS}.local:{PORT}"
+      vars:
+        NS: "${SISYPHUS_NAMESPACE}"
+"""
+    with pytest.raises(ManifestError, match=r"\bPORT\b"):
+        parse_manifest(text)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# EPCA-S4 — pattern-form value injected without parsing layer output
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_epca_s4_pre_resolve_independent_of_layer_runtime_output() -> None:
+    """EPCA-S4 (+ structural facet of EPCA-S9): pre-resolve MUST be a function
+    of (topology, manifest_loader, req_context) **only**.  In particular it
+    MUST NOT take any layer-runtime input (e.g. ``accept-env-up`` JSON, layer
+    completion status, pod readiness).  This is what lets APK build receive
+    BACKEND_ENDPOINT in parallel with — not after — backend `accept-env-up`.
+    """
+    pre_resolve = _pre_resolve()
+    sig = inspect.signature(pre_resolve)
+    param_names = [p.name for p in sig.parameters.values()]
+
+    # Strict: only these three parameters (in any order) are allowed.
+    forbidden_substrings = (
+        "output",       # accept-env-up json output
+        "json",
+        "result",
+        "runtime",
+        "ready",
+        "endpoint_bundle",  # already-runtime bundle
+    )
+    for p in param_names:
+        for bad in forbidden_substrings:
+            assert bad not in p.lower(), (
+                f"EPCA-S4 / EPCA-S9: pre_resolve_endpoint_bundle MUST NOT "
+                f"depend on layer-runtime data; offending param: {p!r}.  "
+                f"Allowed inputs: topology, manifest_loader, req_context."
+            )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# EPCA-S5 — pattern resolves to a string value
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_epca_s5_pattern_resolves_to_string_value() -> None:
+    """EPCA-S5: pattern + literal + ${SISYPHUS_NAMESPACE} resolves to a JSON
+    string with placeholders fully substituted.
+    """
+    text = """
+emits:
+  - endpoint:
+      pattern: "ttpos-server-go.{NS}.svc.cluster.local:{PORT}"
+      vars:
+        NS: "${SISYPHUS_NAMESPACE}"
+        PORT: "8080"
+"""
+    pre_resolve = _pre_resolve()
+    bundle = pre_resolve(
+        ["ZonEaseTech/ttpos-server-go"],
+        _loader_from({"ZonEaseTech/ttpos-server-go": text}),
+        _REQ_CTX,  # SISYPHUS_NAMESPACE=req-7-foo
+    )
+    value = bundle["ZonEaseTech/ttpos-server-go"]["endpoint"]
+    assert value == "ttpos-server-go.req-7-foo.svc.cluster.local:8080"
+    # Spec mandates the resolved value is a (JSON) string.
+    assert isinstance(value, str)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# EPCA-S6 — resolved pattern value is opaque (no reformatting)
+# ═══════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.parametrize(
+    "pattern, vars_map, ctx, expected",
+    [
+        # ADB-style host:port (must NOT be URL-prefixed or stripped to host)
+        (
+            "redroid.{NS}.svc.cluster.local:5554",
+            {"NS": "${SISYPHUS_NAMESPACE}"},
+            {"SISYPHUS_NAMESPACE": "req-7-abc"},
+            "redroid.req-7-abc.svc.cluster.local:5554",
+        ),
+        # HTTP URL form (must pass through byte-identical)
+        (
+            "http://{HOST}:{PORT}/api",
+            {"HOST": "${SISYPHUS_NAMESPACE}.svc", "PORT": "8080"},
+            {"SISYPHUS_NAMESPACE": "ns-x"},
+            "http://ns-x.svc:8080/api",
+        ),
+        # Full literal — no placeholders
+        (
+            "literal-only-value",
+            {},
+            {"SISYPHUS_NAMESPACE": "ignored"},
+            "literal-only-value",
+        ),
+    ],
+)
+def test_epca_s6_resolved_value_passthrough_byte_identical(
+    pattern: str, vars_map: dict[str, str], ctx: dict[str, str], expected: str
+) -> None:
+    """EPCA-S6: post-resolution, the value MUST pass through byte-identical —
+    no URL prefixing, no port stripping, no host extraction.
+    """
+    vars_yaml = "\n".join(f'        {k}: "{v}"' for k, v in vars_map.items())
+    text = f"""
+emits:
+  - endpoint:
+      pattern: "{pattern}"
+      vars:
+{vars_yaml or "        DUMMY_KEY: \"_unused_\""}
+"""
+    # If pattern has no placeholders, vars may be empty.  Some YAML linters
+    # dislike an empty mapping, so synthesise a harmless key when needed.
+    if not vars_map:
+        text = f"""
+emits:
+  - endpoint:
+      pattern: "{pattern}"
+      vars: {{}}
+"""
+
+    full_ctx = dict(_REQ_CTX)
+    full_ctx.update(ctx)
+
+    pre_resolve = _pre_resolve()
+    bundle = pre_resolve(
+        ["org/x"],
+        _loader_from({"org/x": text}),
+        full_ctx,
+    )
+    assert bundle["org/x"]["endpoint"] == expected
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# EPCA-S7 — pre-resolve assembles bundle keyed by OWNER/REPO
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_epca_s7_pre_resolve_bundle_shape_keyed_by_owner_repo() -> None:
+    """EPCA-S7: pre-resolve produces ``dict[OWNER/REPO, dict[field, str]]`` —
+    the same shape persisted to ``stage_runs.context.endpoint_bundle_pre_resolved``.
+    """
+    text_be = """
+emits:
+  - endpoint:
+      pattern: "ttpos-server-go.{NS}.svc.cluster.local:{PORT}"
+      vars:
+        NS: "${SISYPHUS_NAMESPACE}"
+        PORT: "8080"
+"""
+    text_fe = """
+needs:
+  - ZonEaseTech/ttpos-server-go
+inputs:
+  BACKEND_ENDPOINT: "ZonEaseTech/ttpos-server-go.endpoint"
+"""
+    pre_resolve = _pre_resolve()
+    bundle = pre_resolve(
+        ["ZonEaseTech/ttpos-server-go", "ZonEaseTech/ttpos-flutter"],
+        _loader_from(
+            {
+                "ZonEaseTech/ttpos-server-go": text_be,
+                "ZonEaseTech/ttpos-flutter": text_fe,
+            }
+        ),
+        {"SISYPHUS_NAMESPACE": "req-7-foo"},
+    )
+    assert bundle == {
+        "ZonEaseTech/ttpos-server-go": {
+            "endpoint": "ttpos-server-go.req-7-foo.svc.cluster.local:8080",
+        },
+        # flutter has no pattern-form emits → no entry (or empty entry — both
+        # acceptable; the spec only requires the *server-go* shape).
+        **(
+            {"ZonEaseTech/ttpos-flutter": {}}
+            if "ZonEaseTech/ttpos-flutter" in bundle
+            else {}
+        ),
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# EPCA-S8 — unresolved ${SISYPHUS_*} reference fails loud with attribution
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_epca_s8_unresolved_sisyphus_var_raises_pre_resolve_error() -> None:
+    """EPCA-S8: a pattern referencing ``${SISYPHUS_NONEXISTENT_VAR}`` (not in
+    the REQ context allow-list) MUST cause pre-resolve to escalate **before**
+    the runner pod is created.  Concretely: the pure pre-resolve function
+    raises ``PreResolveError`` with attribution to:
+
+      - ``failed_phase == "pre_resolve"``
+      - ``failed_layer == "<offending OWNER/REPO>"``
+      - error message names the unresolved variable
+    """
+    text = """
+emits:
+  - endpoint:
+      pattern: "svc.{NS}:8080"
+      vars:
+        NS: "${SISYPHUS_NONEXISTENT_VAR}"
+"""
+    pre_resolve = _pre_resolve()
+    PreResolveError = _pre_resolve_error()
+
+    with pytest.raises(PreResolveError) as excinfo:
+        pre_resolve(
+            ["org/x"],
+            _loader_from({"org/x": text}),
+            {"SISYPHUS_NAMESPACE": "req-7-foo"},  # nonexistent var NOT here
+        )
+
+    err = excinfo.value
+    assert getattr(err, "failed_phase", None) == "pre_resolve", (
+        "EPCA-S8: PreResolveError MUST set failed_phase='pre_resolve'."
+    )
+    assert getattr(err, "failed_layer", None) == "org/x", (
+        "EPCA-S8: PreResolveError MUST identify the offending repo via "
+        "failed_layer='OWNER/REPO'."
+    )
+    assert "SISYPHUS_NONEXISTENT_VAR" in str(err), (
+        "EPCA-S8: error message MUST name the unresolved ${SISYPHUS_*} "
+        "reference so operators can fix the manifest or REQ-context allow-list."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# EPCA-S9 — bundle observable before any layer's accept-env-up runs
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_epca_s9_pre_resolve_observable_before_any_layer_runtime() -> None:
+    """EPCA-S9: pre-resolve MUST be callable using only manifests + req_context
+    (no layer started, no docker-compose up, no kubectl apply).  This is the
+    contract that lets APK-build dispatch run in parallel with the upstream
+    layer's `accept-env-up`.
+
+    Concretely: invoking pre-resolve in a hermetic test (no network, no DB,
+    no pod) MUST succeed and yield the bundle.  Combined with EPCA-S4's
+    structural assertion, this proves no runtime data is implicit.
+    """
+    text = """
+emits:
+  - endpoint:
+      pattern: "ttpos-server-go.{NS}.svc.cluster.local:{PORT}"
+      vars:
+        NS: "${SISYPHUS_NAMESPACE}"
+        PORT: "8080"
+"""
+    pre_resolve = _pre_resolve()
+    # We deliberately pass an in-memory loader; if pre-resolve secretly needs
+    # accept-env-up output, kubectl, asyncpg, or HTTP, this hermetic call
+    # would fail.  Success here is the contract.
+    bundle = pre_resolve(
+        ["ZonEaseTech/ttpos-server-go"],
+        _loader_from({"ZonEaseTech/ttpos-server-go": text}),
+        {"SISYPHUS_NAMESPACE": "req-7-foo"},
+    )
+    # Bundle shape: APK-build dispatch will read this exact key path.
+    assert (
+        bundle["ZonEaseTech/ttpos-server-go"]["endpoint"]
+        == "ttpos-server-go.req-7-foo.svc.cluster.local:8080"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# EPCA-S10 — manifest fetch failure during pre-resolve fails loud, distinct
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_epca_s10_manifest_fetch_failure_raises_distinguishable_error() -> None:
+    """EPCA-S10: a fetch failure (loader raises) MUST become a
+    ``PreResolveError`` whose attribution distinguishes it from a placeholder
+    failure:
+
+      - ``failed_phase == "pre_resolve"``
+      - ``failed_layer == "org/some-repo"``
+      - the error message MUST mention the manifest fetch (so it is not
+        confused with EPCA-S8's placeholder-resolution failure)
+    """
+    pre_resolve = _pre_resolve()
+    PreResolveError = _pre_resolve_error()
+
+    loader = _loader_from({"org/some-repo": "__FETCH_FAIL__"})
+
+    with pytest.raises(PreResolveError) as excinfo:
+        pre_resolve(["org/some-repo"], loader, _REQ_CTX)
+
+    err = excinfo.value
+    assert getattr(err, "failed_phase", None) == "pre_resolve", (
+        "EPCA-S10: failed_phase MUST be 'pre_resolve'."
+    )
+    assert getattr(err, "failed_layer", None) == "org/some-repo", (
+        "EPCA-S10: failed_layer MUST identify the repo whose manifest fetch "
+        "failed."
+    )
+    msg = str(err).lower()
+    assert any(token in msg for token in ("fetch", "manifest")), (
+        "EPCA-S10: error MUST distinguish manifest-fetch failure from "
+        "placeholder-resolution failure (mention 'fetch' or 'manifest')."
+    )


### PR DESCRIPTION
## Summary

Amend capability `feat-cross-repo-env-orchestration` (originally landed via spec #342, impl #354) with a **pre-resolved endpoint pattern contract**. Backend manifests declare endpoint *shape* (template `pattern` + `vars` map) statically; sisyphus pre-resolves the bundle **before** runner pod startup, so APK build / mobile-env-up / accept-agent can run in parallel with the upstream `accept-env-up` (no more 5–10 min serial floor). Bare-string emits remain a first-class legacy path so un-migrated business repos continue to validate and run untouched.

This is a **spec-only PR**. No code change. Implementation is tracked as a separate REQ per #359 Phase B; business-repo manifest adoption (`ttpos-server-go`, `ttpos-flutter`) is Phase C.

## What changed in the spec

- **MODIFIED R1** — `emits` entries now accept either a bare string (legacy) or a single-key object `{<field>: {pattern, vars}}` (new pattern form). Mixing both forms in one list is permitted. Pattern placeholders use `{VAR_NAME}`; vars values are literal strings or `${SISYPHUS_*}` REQ-context references.
- **MODIFIED R4** — pattern-form emit values come from the pre-resolved bundle (R12), **not** from parsing the layer's `accept-env-up` JSON output. Bare-string emits keep the runtime JSON-parse path.
- **MODIFIED R5** — renamed to "Endpoint value resolution and passthrough"; names two sources (pattern resolution / runtime JSON parse) and preserves the opaque passthrough rule for both.
- **ADDED R12** — pre-resolve phase between R2 topology and runner pod creation. Defines the `${SISYPHUS_*}` REQ-context variable namespace (NAMESPACE / REQ_ID / REQ_BRANCH / SOURCE_REPO_SHA), persists the partial bundle in `stage_runs.context.endpoint_bundle_pre_resolved`, and fails-loud (with `failed_phase: pre_resolve`) on unresolved placeholders or manifest fetch failure.

## Why

Implementation experiment (`ttpos-flutter#167`, `ttpos-arch-lab#16`) showed the runtime "层 emit 真值" model fails three load-bearing requirements: APK build can't wait for backend `accept-env-up` (latency); consumers end up encoding the backend's endpoint shape in 5+ call-sites (no single source of truth); runtime BASE_URL injection into a built APK is a security footgun. Pattern contract solves all three by moving shape declaration to the backend manifest and resolution to REQ-start.

## Test plan

This is a spec-only change; no executable tests. Sisyphus's machine checkers will verify:

- [x] `openspec validate REQ-spec-pattern-contract-amendment-1777818469` — green locally
- [x] `check-scenario-refs.sh` — green locally (no orphan refs)
- [ ] `dev_cross_check` (`make ci-lint` on changed files) — N/A for spec-only diff, will pass through
- [ ] `staging_test` (`make ci-unit-test && make ci-integration-test`) — N/A; baseline unchanged
- [ ] `pr_ci_watch` — GitHub Actions on this branch

After merge, the impl REQ (#359 Phase B) will land:
- `R1` unit tests for pattern-form schema acceptance / rejection
- `R12` unit tests for pre-resolve substitution and fail-loud paths
- An end-to-end smoke run with `ttpos-flutter` consuming a pattern-form `BACKEND_ENDPOINT`

## Out of scope

- Cross-repo PR merge ordering automation
- Pattern syntax beyond `{VAR_NAME}` (no defaults, expressions, conditionals)
- Variable namespaces other than `${SISYPHUS_*}`
- Pre-resolve for non-`emits` fields (e.g. `inputs` patterns)
- Migration tooling for legacy bare-string emits

## Roll-out

1. Merge this spec amendment.
2. Open impl REQ "sisyphus orch pattern resolver" (Phase B in #359).
3. Open per-repo manifest REQs for `ttpos-server-go` and `ttpos-flutter` (Phase C); the latter supersedes the closed-when-this-lands `flutter#167`.

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-spec-pattern-contract-amendment-1777818469`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/4vz7nmaj)