### PR TITLE
feat(orch): pattern resolver + pre-resolve bundle (#359 Phase B)

### DIFF
--- a/openspec/changes/REQ-feat-orch-pattern-resolver-1777819864/design.md
+++ b/openspec/changes/REQ-feat-orch-pattern-resolver-1777819864/design.md
@@ -1,0 +1,163 @@
+# Design notes
+
+## 数据模型
+
+```python
+@dataclass(frozen=True)
+class EmitPattern:
+    field: str               # e.g. "endpoint"
+    pattern: str             # e.g. "svc.{NS}:{PORT}"
+    vars: dict[str, str]     # {"NS": "${SISYPHUS_NAMESPACE}", "PORT": "8080"}
+```
+
+`Manifest.emits` 保持 `tuple[str, ...]`，列**全部** emit field name（pattern 与
+bare-string 共存）—— 这样 `inputs[X] = repo.field` 校验跟 R4 bundle 派发的 surface 都
+不变。新增 `Manifest.emit_patterns: dict[str, EmitPattern]` 只记录 pattern-form 条目。
+
+判别公式：`field in manifest.emit_patterns` ⇒ pattern-form；否则 bare-string。
+
+## YAML schema 决策
+
+YAML：
+
+```yaml
+emits:
+  - namespace                              # bare-string，老路
+  - endpoint:                              # pattern-form，新路（单键 dict）
+      pattern: "svc.{NS}:{PORT}"
+      vars:
+        NS: "${SISYPHUS_NAMESPACE}"
+        PORT: "8080"
+```
+
+接受规则：
+
+- entry 是 `str` ⇒ bare-string
+- entry 是 `dict` 且只有 1 key ⇒ pattern-form；该 key 是 field 名，value 是 `{pattern, vars}` map
+- 任何其他形态（多 key dict / null / list / 缺 pattern / 缺 vars）⇒ `ManifestError`
+
+placeholder 规则：
+
+- `re.findall(r"\{([A-Z_][A-Z0-9_]*)\}", pattern)` 收齐 placeholder
+- 每一个必须在 `vars` 出现，缺的全部一起报（错误信息含 first 缺项 ⇒ 满足
+  `match=r"\bPORT\b"` 类断言）
+- `vars` value：字面量（任意 string）或 `^\$\{SISYPHUS_[A-Z0-9_]+\}$`。其他 `${...}` 引用
+  在 R12 spec out-of-scope，本 REQ 也拒掉以防滥用 namespace。
+
+## pre_resolve_endpoint_bundle 实现
+
+```python
+def pre_resolve_endpoint_bundle(
+    topology: list[str],
+    manifest_loader: Callable[[str], Manifest | None],
+    req_context: dict[str, str],
+) -> dict[str, dict[str, str]]:
+    bundle: dict[str, dict[str, str]] = {}
+    for repo in topology:
+        try:
+            manifest = manifest_loader(repo)
+        except Exception as exc:
+            raise PreResolveError(
+                f"manifest fetch failed for {repo}: {exc}",
+                failed_phase="pre_resolve", failed_layer=repo,
+            ) from exc
+        if manifest is None or not manifest.emit_patterns:
+            continue
+        repo_bundle: dict[str, str] = {}
+        for field, ep in manifest.emit_patterns.items():
+            try:
+                repo_bundle[field] = _substitute(ep, req_context)
+            except _UnresolvedSisyphusVar as exc:
+                raise PreResolveError(
+                    f"unresolved {exc.var} in {repo}.{field}",
+                    failed_phase="pre_resolve", failed_layer=repo,
+                ) from exc
+        if repo_bundle:
+            bundle[repo] = repo_bundle
+    return bundle
+```
+
+- hermetic：参数只 `(topology, manifest_loader, req_context)`，无全局 / no I/O（loader 自己负责拉
+  manifest）—— EPCA-S4 inspect.signature 强制
+- `${SISYPHUS_*}` 展开点：`vars` value 命中 `${SISYPHUS_X}` ⇒ 必须 `req_context["SISYPHUS_X"]` 存在；
+  否则 raise（不回 fallback、不空字符串）
+- bare-string emits 完全跳过（不写 `repo_bundle`，bundle 里 repo entry 缺省即可）
+- 失败立刻 raise（不收集多 layer 错误一起报）—— spec 说 fail-loud，简单清晰
+
+## fail 分类
+
+`PreResolveError` 三种触发：
+
+| 触发 | failed_phase | failed_layer | 错误文本含 |
+|---|---|---|---|
+| manifest_loader 抛 | `pre_resolve` | offending OWNER/REPO | `fetch` 或 `manifest` |
+| `${SISYPHUS_X}` 不在 ctx | `pre_resolve` | offending OWNER/REPO | `SISYPHUS_X` |
+| pattern 引用 `{Y}` 但 vars 没 Y | （已被 parse 阶段拦） | n/a | ManifestError 路径 |
+
+EPCA-S10 测试 `assert any(token in msg for token in ("fetch", "manifest"))`，所以
+manifest fetch fail 文本必须含 `fetch` 或 `manifest`。EPCA-S8 测试要求 `SISYPHUS_NONEXISTENT_VAR` in
+str(err) —— 错误文本带变量名。
+
+## REQ context 装配（accept stage）
+
+`_run_multi_layer_with_cache` 拓扑结束后：
+
+```python
+req_context = {
+    "SISYPHUS_NAMESPACE": namespace,                           # accept-<reqid>
+    "SISYPHUS_REQ_ID": req_id,
+    "SISYPHUS_REQ_BRANCH": (ctx or {}).get("branch") or f"feat/{req_id}",
+    "SISYPHUS_SOURCE_REPO_SHA": (ctx or {}).get("source_sha") or "",
+}
+try:
+    pre_resolved = cross_repo_env.pre_resolve_endpoint_bundle(
+        topo, lambda r: manifests.get(r), req_context,
+    )
+except cross_repo_env.PreResolveError as e:
+    layers = _build_layers_skeleton(topo, source_repo, fail_index=topo.index(e.failed_layer))
+    await _record_accept_attribution(
+        req_id, failed_layer=e.failed_layer, failed_field=None, layers=layers,
+    )
+    pool = db.get_pool()
+    await stage_runs.update_latest_stage_run_context(
+        pool, req_id, "accept",
+        {"failed_phase": "pre_resolve"},
+    )
+    return {
+        "emit": Event.ACCEPT_ENV_UP_FAIL.value,
+        "reason": str(e),
+        "failed_phase": "pre_resolve",
+        "failed_layer": e.failed_layer,
+    }
+
+await stage_runs.update_latest_stage_run_context(
+    pool, req_id, "accept",
+    {"endpoint_bundle_pre_resolved": pre_resolved},
+)
+bundle: dict[str, dict] = {repo: dict(fields) for repo, fields in pre_resolved.items()}
+```
+
+后面 layer 循环：
+
+```python
+manifest = manifests.get(repo) or Manifest()
+bare_string_emits = [f for f in manifest.emits if f not in manifest.emit_patterns]
+for fld in bare_string_emits:
+    if fld not in parsed: ... fail
+    emits_extracted[fld] = parsed[fld]
+bundle.setdefault(repo, {}).update(emits_extracted)
+```
+
+—— 不动 pattern-form 路径，bare-string 走 R4 现路径，merge 而非 overwrite。
+
+## known scope gap
+
+R12 spec 说 pre-resolve 在 “before runner pod creation”。当前 impl 在 accept stage（pod
+已起）调用，因为 manifest 当下从 runner pod 内文件读。完全契约对齐需要 GitHub REST 拉
+manifest（绕开 pod），那是 follow-up REQ。EPCA-S1..S10 contract test 不依赖 pod 创建顺序，
+本 REQ 不阻塞。
+
+## migration
+
+无新 migration —— `stage_runs.context` JSONB 列已存在（0016 加上的），新增 key
+`endpoint_bundle_pre_resolved` / `failed_phase` 直接写。

--- a/openspec/changes/REQ-feat-orch-pattern-resolver-1777819864/proposal.md
+++ b/openspec/changes/REQ-feat-orch-pattern-resolver-1777819864/proposal.md
@@ -1,0 +1,81 @@
+# Proposal: orchestrator pattern resolver + pre-resolve bundle
+
+Refs #359 (Phase B driver), #342 (origin spec), #354 (impl-1 baseline),
+#360 (Phase A spec amendment).
+
+## 背景
+
+Phase A（spec amendment, PR #360 / commit `ab6177d`）已落 `feat-cross-repo-env-orchestration`
+增量：
+
+- R1 manifest schema 加了 pattern-form `emits` 子字段（`pattern` + `vars`）
+- R4 修订：pattern-form emit 值来自 R12 pre-resolve bundle，不再走 layer accept-env-up JSON
+- R5 改名 “endpoint value resolution and passthrough”，明确 2 路 source（pattern resolver / runtime JSON）
+- R12 新增 pre-resolve phase + `${SISYPHUS_*}` REQ-context 变量空间 + fail-loud
+
+Phase A 是 spec-only PR，配套 challenger contract test（`orchestrator/tests/test_contract_endpoint_pattern_amendment_challenger.py`）
+当前 RED：测试 import `orchestrator.cross_repo_env.pre_resolve_endpoint_bundle` /
+`PreResolveError`，两个符号都尚未实现。
+
+本 REQ 是 Phase B：在 orchestrator 落地 pattern resolver + pre-resolve bundle，
+让 EPCA-S1..S10 全绿。
+
+## 范围
+
+只动 `phona/sisyphus`：
+
+1. **`orchestrator/src/orchestrator/cross_repo_env.py`**：
+   - `parse_manifest` 接收 pattern-form `emits` entry：单键 dict，value 是 `{pattern, vars}` map。
+     placeholder `[A-Z_][A-Z0-9_]*` 必须在 `vars` 声明，未声明立 fail（R1 EPCA-S3）。
+     `vars` value 允许字面量或 `${SISYPHUS_*}` 引用。bare-string 与 pattern-form 同列共存
+     合法（EPCA-S2）。
+   - 新增 `EmitPattern` dataclass + `Manifest.emit_patterns: dict[str, EmitPattern]`。
+     `Manifest.emits` 仍列全部 emit field name（含 pattern 形 + bare-string），
+     `inputs` 引用校验复用现路径不动。
+   - 新增 `pre_resolve_endpoint_bundle(topology, manifest_loader, req_context) -> dict[str, dict[str, str]]`：
+     纯函数，hermetic（无 I/O）。逐 layer 拿 manifest，对每个 pattern-form emit 做 `{VAR}` 替换 +
+     `${SISYPHUS_*}` 展开，把结果写进 bundle。bare-string emit 不出现在 pre-resolve bundle（留给 R4）。
+   - 新增 `PreResolveError(failed_phase: str, failed_layer: str)`：覆盖 fetch fail / 未声明
+     placeholder / 未注册 `${SISYPHUS_*}` 三类失败，attribute 信息写在 exception 上。
+
+2. **`orchestrator/src/orchestrator/actions/create_accept.py`**：
+   - 拓扑解析后、per-layer `make accept-env-up` 之前调用 `pre_resolve_endpoint_bundle`，
+     bundle 用 `{SISYPHUS_NAMESPACE / SISYPHUS_REQ_ID / SISYPHUS_REQ_BRANCH /
+     SISYPHUS_SOURCE_REPO_SHA}` REQ context 解析。
+   - bundle 持久化到 `stage_runs.context.endpoint_bundle_pre_resolved`（observability）。
+   - 把 pre-resolved bundle 当作 in-memory `bundle` 起点 —— 后面层 inputs 注入直接读它。
+   - per-layer JSON parse 跳过 pattern-form emits（它们已在 bundle，再去 JSON 找会误报 missing）。
+   - `PreResolveError` 直接 `ACCEPT_ENV_UP_FAIL`，attribution 写 `failed_phase=pre_resolve`
+     + `failed_layer=<offending repo>`，跟 R10 runtime 失败区分开。
+
+3. **测试**：
+   - 让 challenger `test_contract_endpoint_pattern_amendment_challenger.py` 全绿（RED → GREEN）
+   - `orchestrator/tests/test_cross_repo_env.py` 加 `pre_resolve_*` 单测覆盖
+     EPCA-S2 跳 bare、EPCA-S5 字面量替换、EPCA-S6 byte-identical、EPCA-S8/S10 fail 路径
+   - 不写 integration test —— 全部用纯函数 + 内存 manifest_loader 即可
+
+## 不在范围内
+
+- runner pod 创建顺序重构（R12 spec 说 “before runner pod creation”，当前 impl 是 “before
+  per-layer accept-env-up”）。manifest 当下从 runner pod 读，pod 已起；要前移得加
+  GitHub REST manifest fetch path —— 留给后续 REQ。**不影响 EPCA-S1..S10 contract**（test 不
+  assert pod 创建顺序），写在 design.md 的 “known scope gap”。
+- APK build dispatch / mobile-env-up 并行触发：消费方还没落，`endpoint_bundle_pre_resolved`
+  现在只有 accept-stage 自己消费 + 落 stage_runs（observability + parity 用）。Phase C
+  业务仓改造里再接消费方。
+- 模式语法扩展（默认值、表达式、条件等）—— 已被 Phase A spec 显式 out-of-scope。
+
+## Roll-out
+
+1. 合本 PR（impl-only，无 spec 改动）
+2. challenger contract test EPCA-S1..S10 转绿，pr_ci_watch 通过
+3. Phase C 业务仓改造（ttpos-server-go / ttpos-flutter manifest 加 pattern form）独立 REQ 派发
+
+## 影响
+
+| 依赖 | 验证方式 |
+|---|---|
+| 现有单层路径 | R8 backward-compat，无 manifest / 无 needs 仍走 `_run_legacy_single_layer`，未触及 |
+| 现有多层 bare-string emits | R4 bare-string 路径不动，pattern fields 加在前面 seed bundle |
+| stage_runs schema | 复用现有 `context JSONB` 列（migration `0016_stage_runs_context`），加 key 不改 schema |
+| `_walk_and_load_manifests` | parse_manifest 扩展兼容旧 manifest（pattern-form 是新增 admissible form），不 break 旧 manifest |

--- a/openspec/changes/REQ-feat-orch-pattern-resolver-1777819864/specs/cross-repo-env-pattern-resolver/spec.md
+++ b/openspec/changes/REQ-feat-orch-pattern-resolver-1777819864/specs/cross-repo-env-pattern-resolver/spec.md
@@ -1,0 +1,129 @@
+## ADDED Requirements
+
+### Requirement: cross_repo_env exposes pure pattern resolver + PreResolveError
+
+The orchestrator MUST extend `orchestrator.cross_repo_env` with a hermetic pure-logic pattern
+resolver implementing R12 of `feat-cross-repo-env-orchestration`. Concretely the module SHALL
+expose:
+
+- `EmitPattern` — frozen dataclass holding `field`, `pattern`, `vars` (a mapping
+  string→string, where a value is either a literal or a reference of the form
+  `${SISYPHUS_*}`).
+- `Manifest.emit_patterns: dict[str, EmitPattern]` — a parallel record of pattern-form
+  entries keyed by field name. The pre-existing `Manifest.emits` tuple MUST continue to list
+  every emit field (bare-string + pattern-form) so `inputs` reference validation and the R4
+  bundle surface remain unchanged.
+- `PreResolveError(message, *, failed_phase, failed_layer)` — `Exception` subclass carrying
+  the offending repo (`failed_layer`) and the constant phase sentinel
+  `failed_phase == "pre_resolve"` (distinct from R10's runtime layer-attribution).
+- `pre_resolve_endpoint_bundle(topology, manifest_loader, req_context)` — a pure function
+  taking exactly those three positional/keyword parameters and no others. It MUST iterate
+  `topology` in order, call `manifest_loader(repo)` for each, substitute every pattern-form
+  emit's placeholders using the entry's `vars` map plus `${SISYPHUS_*}` references resolved
+  against `req_context`, and return a partial bundle of the shape
+  `dict[str, dict[str, str]]` keyed by `OWNER/REPO`. Bare-string emits MUST NOT appear in
+  the returned bundle (they are filled in by R4 at layer runtime).
+
+The function MUST raise `PreResolveError` and abort the iteration on first failure, attributing
+to `failed_layer` the offending repo. Failure modes covered:
+
+1. `manifest_loader(repo)` raises any exception — wrapped as `PreResolveError` whose message
+   contains the literal substring `manifest fetch` (so EPCA-S10's distinguishability
+   assertion holds).
+2. A pattern's `vars` value references `${SISYPHUS_X}` and `req_context["SISYPHUS_X"]` is
+   missing — `PreResolveError` whose message names `SISYPHUS_X`.
+3. A pattern declares a `{VAR}` placeholder absent from `vars` — already rejected at parse
+   time by R1, but the resolver re-checks for defence in depth and raises
+   `PreResolveError` if it slips through.
+
+#### Scenario: IMPL-S1 pre_resolve_endpoint_bundle is hermetic and three-arg only
+- **GIVEN** the implementation of `pre_resolve_endpoint_bundle`
+- **WHEN** `inspect.signature(pre_resolve_endpoint_bundle)` is examined
+- **THEN** the parameter names MUST NOT contain any of `output`, `json`, `result`, `runtime`,
+  `ready`, or `endpoint_bundle` — proving the function does not depend on layer-runtime data
+  (consistent with EPCA-S4/S9 in `feat-cross-repo-env-orchestration`)
+
+#### Scenario: IMPL-S2 mixed bare-string and pattern entries in one emits list
+- **GIVEN** a manifest text containing
+  ```yaml
+  emits:
+    - namespace
+    - endpoint:
+        pattern: "svc.{NS}:8080"
+        vars:
+          NS: "${SISYPHUS_NAMESPACE}"
+  ```
+- **WHEN** `parse_manifest` runs on the text
+- **THEN** the returned `Manifest.emits` MUST equal `("namespace", "endpoint")` and
+  `Manifest.emit_patterns` MUST contain only key `"endpoint"` (`"namespace"` MUST NOT
+  appear in `emit_patterns`)
+
+#### Scenario: IMPL-S3 pre-resolve substitutes literal vars verbatim
+- **GIVEN** a pattern-form emit `pattern: "svc.{NS}:{PORT}"` with
+  `vars: {NS: "${SISYPHUS_NAMESPACE}", PORT: "8080"}` and `req_context = {SISYPHUS_NAMESPACE: "ns-x"}`
+- **WHEN** `pre_resolve_endpoint_bundle(["org/x"], loader, req_context)` runs
+- **THEN** `bundle["org/x"]["endpoint"] == "svc.ns-x:8080"`, with the literal `8080`
+  substituted byte-identical (no expansion attempt on non-`${SISYPHUS_*}` values)
+
+#### Scenario: IMPL-S4 manifest_loader exception → PreResolveError(manifest fetch)
+- **GIVEN** a manifest_loader that raises `RuntimeError("simulated 5xx")` when asked for
+  `org/some-repo`
+- **WHEN** `pre_resolve_endpoint_bundle(["org/some-repo"], loader, req_ctx)` runs
+- **THEN** it MUST raise `PreResolveError` whose `failed_phase == "pre_resolve"` and
+  `failed_layer == "org/some-repo"` and whose message contains the substring
+  `"manifest fetch"` so EPCA-S10's distinguishability assertion holds
+
+#### Scenario: IMPL-S5 unresolved ${SISYPHUS_*} → PreResolveError naming the variable
+- **GIVEN** a manifest with `vars: {NS: "${SISYPHUS_GHOST}"}` and `req_context` lacking
+  `SISYPHUS_GHOST`
+- **WHEN** `pre_resolve_endpoint_bundle(["org/x"], loader, req_ctx)` runs
+- **THEN** it MUST raise `PreResolveError` whose message contains `SISYPHUS_GHOST`,
+  `failed_phase == "pre_resolve"`, `failed_layer == "org/x"`
+
+#### Scenario: IMPL-S6 bundle shape excludes repos without pattern-form emits
+- **GIVEN** topology `[org/be, org/fe]` where `org/be` has one pattern-form emit and
+  `org/fe` has only `needs` + `inputs` (no pattern emits)
+- **WHEN** pre-resolve runs
+- **THEN** the returned bundle MUST contain key `"org/be"` with the resolved field, and
+  MUST either omit `"org/fe"` entirely or map it to an empty dict — no other shapes are
+  acceptable
+
+---
+
+### Requirement: accept stage wires pre-resolve before per-layer accept-env-up
+
+In `orchestrator.actions.create_accept`, the multi-layer entry point MUST call
+`pre_resolve_endpoint_bundle` immediately after topology resolution and **before** any
+per-layer `make accept-env-up` invocation. The orchestrator MUST:
+
+1. Build a `req_context` map containing at minimum `SISYPHUS_NAMESPACE`,
+   `SISYPHUS_REQ_ID`, `SISYPHUS_REQ_BRANCH`, `SISYPHUS_SOURCE_REPO_SHA`. Missing context
+   keys (e.g. when source SHA is not yet recorded) MUST default to the empty string —
+   manifests that reference them WILL fail explicitly via R12 fail-loud, which is the
+   desired behaviour.
+2. Persist the returned bundle under `stage_runs.context.endpoint_bundle_pre_resolved` for
+   the open accept stage_run, so observability (Metabase Q-series queries, admin readouts)
+   sees pre-resolved values without joining elsewhere.
+3. Seed the in-memory `bundle` (which drives R4 `inputs` injection) with the pre-resolved
+   values. Subsequent per-layer JSON parse MUST iterate only **bare-string** emits — fields
+   already in the pre-resolved bundle MUST NOT be re-extracted from the layer's
+   accept-env-up output (R4 EPCA-S4 invariant).
+4. On `PreResolveError` the stage MUST emit `ACCEPT_ENV_UP_FAIL` with attribution
+   `failed_layer = e.failed_layer`, `failed_phase = "pre_resolve"`, and the error message
+   surfaced as `reason` in the action result.
+
+#### Scenario: IMPL-S7 pre-resolve fail aborts before any layer accept-env-up runs
+- **GIVEN** a multi-layer topology where `pre_resolve_endpoint_bundle` raises
+  `PreResolveError(failed_layer="org/x")`
+- **WHEN** `create_accept` enters its multi-layer path
+- **THEN** the action MUST return an `ACCEPT_ENV_UP_FAIL` event with
+  `failed_phase == "pre_resolve"` and `failed_layer == "org/x"`; no `make accept-env-up`
+  invocation MUST be attempted; `stage_runs.context.failed_phase` MUST equal `"pre_resolve"`
+
+#### Scenario: IMPL-S8 pre-resolved values seed bundle and skip JSON re-extraction
+- **GIVEN** a pattern-form emit `org/be.endpoint = "svc.ns-x:8080"` resolved by pre-resolve;
+  `org/be`'s `make accept-env-up` outputs JSON without an `endpoint` key (because the
+  pattern-form path does not require it)
+- **WHEN** `create_accept` processes the layer's stdout
+- **THEN** the layer MUST NOT fail with `missing emit field 'endpoint'`; the bundle MUST
+  retain the pre-resolved value `"svc.ns-x:8080"` for `org/be.endpoint`

--- a/openspec/changes/REQ-feat-orch-pattern-resolver-1777819864/tasks.md
+++ b/openspec/changes/REQ-feat-orch-pattern-resolver-1777819864/tasks.md
@@ -1,0 +1,29 @@
+# Tasks
+
+## Stage: contract / spec
+- [x] author `openspec/changes/REQ-feat-orch-pattern-resolver-1777819864/proposal.md`
+- [x] author `openspec/changes/REQ-feat-orch-pattern-resolver-1777819864/design.md` 含数据模型 + REQ ctx 装配代码段 + known scope gap
+- [x] author spec delta `specs/feat-cross-repo-env-orchestration/spec.md` —— ADDED 实现 R12 impl 注释 + scenarios IMPL-S1..S6（impl-side 自检 scenario，区别于 EPCA spec 检查）
+
+## Stage: implementation
+- [x] `cross_repo_env.py`：加 `EmitPattern` dataclass + `Manifest.emit_patterns` 字段
+- [x] `cross_repo_env.py`：`parse_manifest` 接 pattern-form `emits` entry + 单键 dict 校验
+- [x] `cross_repo_env.py`：placeholder discovery + vars/sisyphus-ref 校验（EPCA-S3 拒未声明）
+- [x] `cross_repo_env.py`：`PreResolveError(failed_phase, failed_layer)` exception
+- [x] `cross_repo_env.py`：`pre_resolve_endpoint_bundle(topology, manifest_loader, req_context)` 纯函数
+- [x] `actions/create_accept.py`：拓扑结束后调用 pre-resolve；persist 到 `stage_runs.context.endpoint_bundle_pre_resolved`
+- [x] `actions/create_accept.py`：`PreResolveError` ⇒ `ACCEPT_ENV_UP_FAIL` + `failed_phase=pre_resolve` 记入 attribution
+- [x] `actions/create_accept.py`：bundle 用 pre-resolved 起点；per-layer JSON parse 跳过 pattern-form emits
+
+## Stage: tests
+- [x] challenger `test_contract_endpoint_pattern_amendment_challenger.py` 全绿（EPCA-S1..S10）
+- [x] `test_cross_repo_env.py`：加 `parse_manifest` pattern-form 单测（EPCA-S1 / S2 / S3）
+- [x] `test_cross_repo_env.py`：加 `pre_resolve_endpoint_bundle` 边界单测（fetch fail / unresolved sisyphus var / mixed bare+pattern）
+- [x] `test_create_accept_*.py` 不需要新 mock（pure-logic tests 已覆盖；create_accept wiring 走 spec_lint + pr_ci_watch）
+
+## Stage: PR（推之前必须全绿）
+- [x] git push feat/REQ-feat-orch-pattern-resolver-1777819864
+- [x] `make ci-lint` → 全绿
+- [x] `make ci-unit-test` → 全绿
+- [x] `make ci-integration-test` → 全绿（无 PG 视为 pass）
+- [x] gh pr create --label sisyphus + sisyphus cross-link footer

--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -36,6 +36,7 @@ from ..config import settings
 from ..cross_repo_env import (
     Manifest,
     ManifestError,
+    PreResolveError,
     TopologyError,
 )
 from ..prompts import render
@@ -827,6 +828,61 @@ async def _run_multi_layer_with_cache(
     source_branch = (ctx or {}).get("branch") or f"feat/{req_id}"
     dir_map = cross_repo_env.workspace_dir_map(topo)
 
+    # ── R12 pre-resolve ──────────────────────────────────────────────────
+    # before any per-layer accept-env-up runs, resolve every pattern-form emit
+    # against (manifests, REQ context). this seeds the bundle so consumers see
+    # pattern-form values without parsing layer accept-env-up JSON output, and
+    # makes the bundle observable at stage_runs.context.endpoint_bundle_pre_resolved
+    # before any layer side-effect.
+    req_context = {
+        "SISYPHUS_NAMESPACE": namespace,
+        "SISYPHUS_REQ_ID": req_id,
+        "SISYPHUS_REQ_BRANCH": source_branch,
+        "SISYPHUS_SOURCE_REPO_SHA": (ctx or {}).get("source_sha") or "",
+    }
+    pool = db.get_pool()
+    try:
+        pre_resolved = cross_repo_env.pre_resolve_endpoint_bundle(
+            topo, lambda r: manifests.get(r), req_context,
+        )
+    except PreResolveError as e:
+        log.warning(
+            "create_accept.pre_resolve_failed",
+            req_id=req_id, failed_layer=e.failed_layer, error=str(e),
+        )
+        layers_record = _build_layers_skeleton(
+            topo, source_repo, fail_index=topo.index(e.failed_layer),
+        )
+        await _record_accept_attribution(
+            req_id, failed_layer=e.failed_layer, failed_field=None, layers=layers_record,
+        )
+        try:
+            await stage_runs.update_latest_stage_run_context(
+                pool, req_id, "accept", {"failed_phase": e.failed_phase},
+            )
+        except Exception as ctx_exc:
+            log.warning(
+                "create_accept.pre_resolve_attribution_write_failed",
+                req_id=req_id, error=str(ctx_exc),
+            )
+        return {
+            "emit": Event.ACCEPT_ENV_UP_FAIL.value,
+            "reason": str(e),
+            "failed_phase": e.failed_phase,
+            "failed_layer": e.failed_layer,
+        }
+    if pre_resolved:
+        try:
+            await stage_runs.update_latest_stage_run_context(
+                pool, req_id, "accept",
+                {"endpoint_bundle_pre_resolved": pre_resolved},
+            )
+        except Exception as ctx_exc:
+            log.warning(
+                "create_accept.pre_resolve_persist_failed",
+                req_id=req_id, error=str(ctx_exc),
+            )
+
     # ── Branch resolution + idempotent re-clone on resolved branch ────────
     for repo in topo:
         if repo == source_repo:
@@ -872,7 +928,9 @@ async def _run_multi_layer_with_cache(
             }
 
     # ── Sequential per-layer env-up ──────────────────────────────────────
-    bundle: dict[str, dict] = {}
+    # bundle starts seeded with pattern-form emits (R12); bare-string emits get merged
+    # in by the per-layer JSON parse below (R4).
+    bundle: dict[str, dict] = {repo: dict(fields) for repo, fields in pre_resolved.items()}
     layers_record: list[dict] = [
         {"repo": r, "status": "skipped", "duration_ms": 0} for r in topo
     ]
@@ -952,8 +1010,14 @@ async def _run_multi_layer_with_cache(
                 "failed_layer": repo,
             }
 
+        # R4 amendment: pattern-form emits are pre-resolved (already in bundle from R12).
+        # the JSON parse only extracts bare-string emits — pattern-form fields MUST NOT
+        # be re-extracted from the layer's accept-env-up output.
+        bare_string_emits = [
+            fld for fld in manifest.emits if fld not in manifest.emit_patterns
+        ]
         emits_extracted: dict = {}
-        for fld in manifest.emits:
+        for fld in bare_string_emits:
             if fld not in parsed:
                 layers_record[idx]["status"] = "failed"
                 log.warning("create_accept.layer_emit_missing",
@@ -968,7 +1032,8 @@ async def _run_multi_layer_with_cache(
                     "failed_field": fld,
                 }
             emits_extracted[fld] = parsed[fld]
-        bundle[repo] = emits_extracted
+        # merge bare-string emits onto whatever R12 pre-resolve already seeded for this repo
+        bundle.setdefault(repo, {}).update(emits_extracted)
         layers_record[idx]["status"] = "success"
         if repo == source_repo:
             final_endpoint_json = parsed

--- a/orchestrator/src/orchestrator/cross_repo_env.py
+++ b/orchestrator/src/orchestrator/cross_repo_env.py
@@ -33,6 +33,15 @@ _INPUT_REF_RE = re.compile(r"^([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)\.([A-Za-z0-9_]+)
 _DEFAULT_BRANCHES: dict[str, str] = {"develop": "develop", "release": "release"}
 _ALLOWED_TOP_KEYS: frozenset[str] = frozenset({"emits", "needs", "inputs", "branches"})
 
+# pattern-form emit (R12): {VAR_NAME} placeholders in emits[].pattern, vars values that are
+# either literal strings or ${SISYPHUS_*} REQ-context references.
+_PLACEHOLDER_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+_PLACEHOLDER_USE_RE = re.compile(r"\{([A-Z_][A-Z0-9_]*)\}")
+# any ${...} sigil in a vars value — used to spot disallowed namespaces at parse time.
+_DOLLAR_REF_RE = re.compile(r"\$\{([^}]*)\}")
+# the sole admissible interpolation target inside vars values.
+_SISYPHUS_REF_RE = re.compile(r"\$\{(SISYPHUS_[A-Z0-9_]+)\}")
+
 
 class ManifestError(ValueError):
     """raised by parse_manifest when schema validation fails."""
@@ -42,10 +51,40 @@ class TopologyError(ValueError):
     """raised by resolve_topology when the dependency graph contains a cycle."""
 
 
+class PreResolveError(Exception):
+    """R12 pre-resolve failure with layer attribution.
+
+    `failed_phase` is the constant sentinel `"pre_resolve"` so the orchestrator can
+    distinguish this from R10's runtime layer-attribution. `failed_layer` is the
+    OWNER/REPO of the manifest whose pattern / fetch failed first (resolution aborts on
+    first failure — fail-loud, no aggregation).
+    """
+
+    def __init__(
+        self, message: str, *, failed_phase: str = "pre_resolve", failed_layer: str,
+    ) -> None:
+        super().__init__(message)
+        self.failed_phase = failed_phase
+        self.failed_layer = failed_layer
+
+
+@dataclass(frozen=True)
+class EmitPattern:
+    """parsed pattern-form `emits` entry (R1 amendment)."""
+
+    field: str
+    pattern: str
+    vars: dict[str, str]
+
+
 @dataclass(frozen=True)
 class Manifest:
     """parsed `.sisyphus/env.yaml` contents.
 
+    `emits` lists every emit field name (bare-string + pattern-form combined) so
+    `inputs` reference validation and the R4 bundle surface stay uniform.
+    `emit_patterns` carries pattern-form entries keyed by field name; `field in
+    emit_patterns` discriminates pattern-form from bare-string.
     `inputs` maps env var name → (upstream repo full name, field name on that repo's emits).
     `branches` is always populated with develop/release defaults merged in.
     """
@@ -54,6 +93,7 @@ class Manifest:
     needs: tuple[str, ...] = ()
     inputs: dict[str, tuple[str, str]] = field(default_factory=dict)
     branches: dict[str, str] = field(default_factory=lambda: dict(_DEFAULT_BRANCHES))
+    emit_patterns: dict[str, EmitPattern] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -86,7 +126,7 @@ def parse_manifest(text: str) -> Manifest:
     if extras:
         raise ManifestError(f"manifest has unknown top-level keys: {sorted(extras)}")
 
-    emits = _coerce_string_list(raw.get("emits"), field_name="emits")
+    emits, emit_patterns = _parse_emits(raw.get("emits"))
     needs_list = _coerce_string_list(raw.get("needs"), field_name="needs")
     for n in needs_list:
         if not _REPO_NAME_RE.match(n):
@@ -136,7 +176,106 @@ def parse_manifest(text: str) -> Manifest:
         needs=tuple(needs_list),
         inputs=inputs,
         branches=branches,
+        emit_patterns=emit_patterns,
     )
+
+
+def _parse_emits(raw: Any) -> tuple[list[str], dict[str, EmitPattern]]:
+    """Accept the dual emits schema (R1 amendment).
+
+    Returns (ordered field-name list, pattern-form record). Field names from both forms
+    appear in the list in declaration order so `inputs` reference validation continues to
+    treat the two forms uniformly.
+    """
+    if raw is None:
+        return [], {}
+    if not isinstance(raw, list):
+        raise ManifestError(f"emits must be a list, got {type(raw).__name__}")
+
+    field_names: list[str] = []
+    seen: set[str] = set()
+    patterns: dict[str, EmitPattern] = {}
+
+    for entry in raw:
+        if isinstance(entry, str):
+            name = entry.strip()
+            if not name:
+                raise ManifestError(f"emits entry {entry!r} must be a non-empty string")
+            if name in seen:
+                raise ManifestError(f"emits entry {name!r} appears more than once")
+            seen.add(name)
+            field_names.append(name)
+            continue
+        if isinstance(entry, dict):
+            if len(entry) != 1:
+                raise ManifestError(
+                    f"pattern-form emits entry must be a single-key mapping, got {sorted(entry.keys())}"
+                )
+            (name, body), = entry.items()
+            if not isinstance(name, str) or not name.strip():
+                raise ManifestError(f"pattern-form emits key {name!r} must be a non-empty string")
+            name = name.strip()
+            if name in seen:
+                raise ManifestError(f"emits entry {name!r} appears more than once")
+            ep = _parse_emit_pattern(name, body)
+            seen.add(name)
+            field_names.append(name)
+            patterns[name] = ep
+            continue
+        raise ManifestError(
+            f"emits entry must be a string or single-key mapping, got {type(entry).__name__}"
+        )
+
+    return field_names, patterns
+
+
+def _parse_emit_pattern(field_name: str, body: Any) -> EmitPattern:
+    if not isinstance(body, dict):
+        raise ManifestError(
+            f"emits[{field_name!r}] body must be a mapping with `pattern` and `vars`"
+        )
+    extras = set(body.keys()) - {"pattern", "vars"}
+    if extras:
+        raise ManifestError(
+            f"emits[{field_name!r}] has unknown sub-keys: {sorted(extras)}"
+        )
+    pattern = body.get("pattern")
+    if not isinstance(pattern, str) or not pattern:
+        raise ManifestError(f"emits[{field_name!r}].pattern must be a non-empty string")
+    vars_raw = body.get("vars")
+    if not isinstance(vars_raw, dict):
+        raise ManifestError(
+            f"emits[{field_name!r}].vars must be a mapping (use `vars: {{}}` for none)"
+        )
+    declared_vars: dict[str, str] = {}
+    for k, v in vars_raw.items():
+        if not isinstance(k, str) or not _PLACEHOLDER_NAME_RE.match(k):
+            raise ManifestError(
+                f"emits[{field_name!r}].vars key {k!r} must match [A-Z_][A-Z0-9_]*"
+            )
+        if not isinstance(v, str):
+            raise ManifestError(
+                f"emits[{field_name!r}].vars[{k!r}] must be a string (literal or ${{SISYPHUS_*}})"
+            )
+        # only the ${SISYPHUS_*} namespace is admissible inside vars values; any other
+        # ${...} sigil (${ENV_X}, ${SECRET_X}, …) is rejected per R12 out-of-scope guard.
+        for ref in _DOLLAR_REF_RE.findall(v):
+            if not ref.startswith("SISYPHUS_") or not _PLACEHOLDER_NAME_RE.match(ref):
+                raise ManifestError(
+                    f"emits[{field_name!r}].vars[{k!r}]={v!r}: only ${{SISYPHUS_*}} "
+                    "references are supported (other ${{...}} namespaces are out-of-scope per R12)"
+                )
+        declared_vars[k] = v
+    used = set(_PLACEHOLDER_USE_RE.findall(pattern))
+    missing = sorted(used - declared_vars.keys())
+    if missing:
+        raise ManifestError(
+            f"emits[{field_name!r}].pattern references undeclared placeholder "
+            f"{missing[0]!r}; declare it under vars (all missing: {missing})"
+        )
+    # Note: declared but unused vars are tolerated — they are harmless and easier to
+    # iterate on than reject.
+    return EmitPattern(field=field_name, pattern=pattern, vars=declared_vars)
 
 
 def _coerce_string_list(raw: Any, *, field_name: str) -> list[str]:
@@ -275,3 +414,96 @@ def resolve_branch(
         reason="branch_resolution_failed",
         failed_class=cls,
     )
+
+
+def pre_resolve_endpoint_bundle(
+    topology: list[str],
+    manifest_loader: Callable[[str], Manifest | None],
+    req_context: dict[str, str],
+) -> dict[str, dict[str, str]]:
+    """Pure R12 pre-resolve: assemble the partial endpoint bundle from manifests + REQ ctx.
+
+    For each repo in `topology` (caller usually passes the topo-sorted leaves-first list),
+    look up its manifest, substitute every pattern-form emit's `{VAR}` placeholders using
+    the entry's `vars` map, expanding `${SISYPHUS_*}` references against `req_context`.
+
+    Bare-string emits are intentionally absent from the returned bundle — they are filled
+    in at layer runtime by R4. Repos without pattern-form emits are omitted (or, if a
+    repo's manifest is `None`, simply skipped).
+
+    Hermetic by construction: no I/O, no asyncio. The caller injects `manifest_loader`
+    (e.g. a runner-pod read shim or a GitHub REST fetch) so unit tests stay infrastructure-free
+    and APK-build dispatch can call this with cached manifests in parallel with
+    `accept-env-up`.
+    """
+    bundle: dict[str, dict[str, str]] = {}
+    for repo in topology:
+        try:
+            manifest = manifest_loader(repo)
+        except Exception as exc:
+            raise PreResolveError(
+                f"manifest fetch failed for {repo}: {exc}",
+                failed_layer=repo,
+            ) from exc
+        if manifest is None or not manifest.emit_patterns:
+            continue
+        repo_bundle: dict[str, str] = {}
+        for fname, ep in manifest.emit_patterns.items():
+            try:
+                repo_bundle[fname] = _substitute_pattern(ep, req_context)
+            except _UnresolvedSisyphusVar as exc:
+                raise PreResolveError(
+                    f"unresolved {exc.var} reference in {repo}.{fname}: not in REQ context",
+                    failed_layer=repo,
+                ) from exc
+            except KeyError as exc:
+                # defence-in-depth: parse_manifest already rejects undeclared placeholders
+                raise PreResolveError(
+                    f"pattern in {repo}.{fname} references undeclared placeholder {exc.args[0]!r}",
+                    failed_layer=repo,
+                ) from exc
+        if repo_bundle:
+            bundle[repo] = repo_bundle
+    return bundle
+
+
+class _UnresolvedSisyphusVar(Exception):
+    def __init__(self, var: str) -> None:
+        super().__init__(var)
+        self.var = var
+
+
+def _substitute_pattern(ep: EmitPattern, req_context: dict[str, str]) -> str:
+    """Resolve EmitPattern.vars then substitute placeholders into the pattern.
+
+    Each `vars` value may interleave literals and ${SISYPHUS_*} references in any order
+    (e.g. `${SISYPHUS_NAMESPACE}.svc`). All such references are expanded against
+    `req_context`; a reference whose name is missing from `req_context` aborts with
+    `_UnresolvedSisyphusVar` so the caller can attribute the failure to the offending repo.
+    """
+    resolved_vars: dict[str, str] = {}
+    for k, v in ep.vars.items():
+        resolved_vars[k] = _expand_sisyphus_refs(v, req_context)
+
+    def _replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name not in resolved_vars:
+            raise KeyError(name)
+        return resolved_vars[name]
+
+    return _PLACEHOLDER_USE_RE.sub(_replace, ep.pattern)
+
+
+def _expand_sisyphus_refs(value: str, req_context: dict[str, str]) -> str:
+    """Expand every ${SISYPHUS_X} occurrence in `value` using `req_context`.
+
+    Raises `_UnresolvedSisyphusVar` on the first reference whose name is not registered.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name not in req_context:
+            raise _UnresolvedSisyphusVar(name)
+        return req_context[name]
+
+    return _SISYPHUS_REF_RE.sub(_replace, value)

--- a/orchestrator/tests/test_actions_create_accept_multi_layer.py
+++ b/orchestrator/tests/test_actions_create_accept_multi_layer.py
@@ -567,3 +567,152 @@ async def test_teardown_single_layer_falls_back_to_resolver(monkeypatch):
     assert result["env_down_ok"] is True
     cmds = [c for (c, _e) in rc.calls]
     assert any("ttpos-flutter" not in c and "make accept-env-down" in c for c in cmds)
+
+
+# ─── R12: pattern-form emit + pre-resolve wiring (IMPL-S7 / IMPL-S8) ─────
+
+@pytest.mark.asyncio
+async def test_multi_layer_pattern_form_emit_pre_resolved_seeds_bundle(monkeypatch):
+    """IMPL-S8: pattern-form `endpoint` is pre-resolved (R12); flutter's accept-env-up
+    JSON only needs to emit `device` (the bare-string emit). pre-resolved value reaches
+    flutter's BACKEND_ENDPOINT input without touching server-go's accept-env-up output.
+    """
+    rc = FakeRunnerController()
+    # 1. read source (flutter) manifest
+    rc.script(
+        "/workspace/source/ttpos-flutter/.sisyphus/env.yaml",
+        FakeExec(stdout=(
+            "__MANIFEST_FOUND__\n"
+            "emits:\n  - device\n"
+            "needs:\n  - ZonEaseTech/ttpos-server-go\n"
+            "inputs:\n  BACKEND_ENDPOINT: ZonEaseTech/ttpos-server-go.endpoint\n"
+        )),
+    )
+    # 2. branch_exists check for ttpos-server-go same-name
+    rc.script("git ls-remote --heads", FakeExec(stdout="", exit_code=0))
+    # 3. clone server-go on develop bootstrap branch
+    rc.script("sisyphus-clone-repos.sh", FakeExec(stdout="cloned", exit_code=0))
+    # 4. read server-go manifest with pattern-form endpoint
+    rc.script(
+        "/workspace/source/ttpos-server-go/.sisyphus/env.yaml",
+        FakeExec(stdout=(
+            "emits:\n"
+            "  - endpoint:\n"
+            '      pattern: "ttpos-server-go.{NS}.svc.cluster.local:{PORT}"\n'
+            "      vars:\n"
+            '        NS: "${SISYPHUS_NAMESPACE}"\n'
+            '        PORT: "8080"\n'
+        )),
+    )
+    # 5. branch resolution: same-name check (False)
+    rc.script("git ls-remote --heads", FakeExec(stdout="", exit_code=0))
+    # 6. branch resolution: candidate develop check (True)
+    rc.script(
+        "git ls-remote --heads",
+        FakeExec(stdout="abc123\trefs/heads/develop\n", exit_code=0),
+    )
+    # 7. final clone on develop
+    rc.script("sisyphus-clone-repos.sh", FakeExec(stdout="cloned", exit_code=0))
+    # 8. server-go layer-up: stdout JSON intentionally omits the pattern-form `endpoint`
+    #    field — pre-resolved value MUST take precedence (R12).
+    rc.script(
+        "make accept-env-up",
+        FakeExec(stdout='log\n{"unrelated":"x"}', exit_code=0),
+    )
+    # 9. flutter layer-up: emits device + thanatos block
+    rc.script(
+        "make accept-env-up",
+        FakeExec(
+            stdout=(
+                'log\n{"device":"redroid:5554","thanatos":'
+                '{"pod":"th","namespace":"ns","skill_repo":"phona/skill"}}'
+            ),
+            exit_code=0,
+        ),
+    )
+    _patch_runner(monkeypatch, rc)
+    _patch_skip(monkeypatch)
+    _patch_ensure_runner_with_clone(monkeypatch)
+    _patch_db(monkeypatch)
+    bkd = _patch_bkd(monkeypatch)
+    _patch_pr_links(monkeypatch)
+
+    from orchestrator.actions import create_accept as mod
+
+    result = await mod.create_accept(
+        body=FakeBody(),
+        req_id="REQ-test-pattern-1",
+        tags=[],
+        ctx={
+            "cloned_repos": ["ZonEaseTech/ttpos-flutter"],
+            "branch": "feat/REQ-test-pattern-1",
+        },
+    )
+
+    # accept dispatched (no missing emit field for pattern-form endpoint)
+    assert bkd.create_issue.await_count == 1
+    expected_pre = "ttpos-server-go.accept-req-test-pattern-1.svc.cluster.local:8080"
+    # primary endpoint comes from pre-resolved bundle (server-go.endpoint)
+    assert result["endpoint"] == expected_pre
+    # flutter received BACKEND_ENDPOINT from pre-resolved bundle
+    layer_up_calls = [(c, e) for (c, e) in rc.calls if "make accept-env-up" in c]
+    assert len(layer_up_calls) == 2
+    assert layer_up_calls[1][1].get("BACKEND_ENDPOINT") == expected_pre
+
+
+@pytest.mark.asyncio
+async def test_multi_layer_pre_resolve_unresolved_var_aborts_before_layer_up(monkeypatch):
+    """IMPL-S7: PreResolveError before any `make accept-env-up` call."""
+    rc = FakeRunnerController()
+    # source flutter manifest
+    rc.script(
+        "/workspace/source/ttpos-flutter/.sisyphus/env.yaml",
+        FakeExec(stdout=(
+            "__MANIFEST_FOUND__\n"
+            "needs:\n  - ZonEaseTech/ttpos-server-go\n"
+            "inputs:\n  BACKEND_ENDPOINT: ZonEaseTech/ttpos-server-go.endpoint\n"
+        )),
+    )
+    rc.script("git ls-remote --heads", FakeExec(stdout="", exit_code=0))
+    rc.script("sisyphus-clone-repos.sh", FakeExec(stdout="cloned", exit_code=0))
+    # server-go manifest references a SISYPHUS var that won't be in REQ context
+    rc.script(
+        "/workspace/source/ttpos-server-go/.sisyphus/env.yaml",
+        FakeExec(stdout=(
+            "emits:\n"
+            "  - endpoint:\n"
+            '      pattern: "svc.{NS}"\n'
+            "      vars:\n"
+            '        NS: "${SISYPHUS_DOES_NOT_EXIST}"\n'
+        )),
+    )
+    rc.script("git ls-remote --heads", FakeExec(stdout="", exit_code=0))
+    rc.script(
+        "git ls-remote --heads",
+        FakeExec(stdout="abc\trefs/heads/develop\n", exit_code=0),
+    )
+    rc.script("sisyphus-clone-repos.sh", FakeExec(stdout="cloned", exit_code=0))
+    _patch_runner(monkeypatch, rc)
+    _patch_skip(monkeypatch)
+    _patch_ensure_runner_with_clone(monkeypatch)
+    _patch_db(monkeypatch)
+    _patch_bkd(monkeypatch)
+    _patch_pr_links(monkeypatch)
+
+    from orchestrator.actions import create_accept as mod
+
+    result = await mod.create_accept(
+        body=FakeBody(),
+        req_id="REQ-test-pattern-fail",
+        tags=[],
+        ctx={
+            "cloned_repos": ["ZonEaseTech/ttpos-flutter"],
+            "branch": "feat/REQ-test-pattern-fail",
+        },
+    )
+
+    assert result["emit"].endswith("env-up.fail") or "fail" in result["emit"]
+    assert result["failed_phase"] == "pre_resolve"
+    assert result["failed_layer"] == "ZonEaseTech/ttpos-server-go"
+    # critical: NO `make accept-env-up` invocation should have occurred
+    assert not any("make accept-env-up" in c for (c, _e) in rc.calls)

--- a/orchestrator/tests/test_contract_endpoint_pattern_amendment_challenger.py
+++ b/orchestrator/tests/test_contract_endpoint_pattern_amendment_challenger.py
@@ -26,7 +26,7 @@ spec_fixer; do not patch around it in code.
 from __future__ import annotations
 
 import inspect
-from typing import Any, Callable
+from collections.abc import Callable
 
 import pytest
 
@@ -35,7 +35,6 @@ from orchestrator.cross_repo_env import (
     ManifestError,
     parse_manifest,
 )
-
 
 # ─── canonical entry points the spec mandates ────────────────────────────────
 

--- a/orchestrator/tests/test_cross_repo_env.py
+++ b/orchestrator/tests/test_cross_repo_env.py
@@ -318,3 +318,170 @@ def test_resolve_topology_self_cycle():
     graph = {"A": ["A"]}
     with pytest.raises(TopologyError, match=r"A -> A"):
         resolve_topology("A", _loader(graph))
+
+
+# ─── R12: pattern-form parse + pre_resolve_endpoint_bundle ─────────────────
+
+def test_parse_emits_records_pattern_alongside_bare_string():
+    """IMPL-S2: mixed bare-string + pattern-form emits in one list parse cleanly."""
+    from orchestrator.cross_repo_env import EmitPattern
+    text = """
+emits:
+  - namespace
+  - endpoint:
+      pattern: "svc.{NS}:8080"
+      vars:
+        NS: "${SISYPHUS_NAMESPACE}"
+"""
+    m = parse_manifest(text)
+    assert m.emits == ("namespace", "endpoint")
+    assert "namespace" not in m.emit_patterns
+    assert m.emit_patterns["endpoint"] == EmitPattern(
+        field="endpoint",
+        pattern="svc.{NS}:8080",
+        vars={"NS": "${SISYPHUS_NAMESPACE}"},
+    )
+
+
+def test_parse_emits_rejects_pattern_with_undeclared_placeholder():
+    """EPCA-S3: pattern referencing a placeholder absent from `vars` is rejected."""
+    text = """
+emits:
+  - endpoint:
+      pattern: "svc.{NS}.local:{PORT}"
+      vars:
+        NS: "${SISYPHUS_NAMESPACE}"
+"""
+    with pytest.raises(ManifestError, match=r"\bPORT\b"):
+        parse_manifest(text)
+
+
+def test_parse_emits_rejects_non_sisyphus_dollar_ref():
+    """vars values may only reference ${SISYPHUS_*}; ${ENV_X} is rejected (R12 out-of-scope)."""
+    text = """
+emits:
+  - endpoint:
+      pattern: "svc.{X}"
+      vars:
+        X: "${ENV_FOO}"
+"""
+    with pytest.raises(ManifestError, match=r"SISYPHUS"):
+        parse_manifest(text)
+
+
+def test_parse_emits_rejects_multi_key_dict_form():
+    """A pattern-form entry must be a single-key mapping."""
+    text = """
+emits:
+  - {endpoint: {pattern: "x", vars: {}}, extra: 1}
+"""
+    with pytest.raises(ManifestError, match="single-key"):
+        parse_manifest(text)
+
+
+def test_parse_emits_rejects_duplicate_field_names():
+    """Bare-string and pattern-form emits cannot redeclare the same field."""
+    text = """
+emits:
+  - endpoint
+  - endpoint:
+      pattern: "x"
+      vars: {}
+"""
+    with pytest.raises(ManifestError, match="more than once"):
+        parse_manifest(text)
+
+
+def test_pre_resolve_skips_bare_string_emits():
+    """IMPL-S6: bare-string emits don't appear in pre-resolve bundle."""
+    from orchestrator.cross_repo_env import pre_resolve_endpoint_bundle
+    manifests: dict[str, Manifest] = {
+        "org/be": parse_manifest(
+            """
+emits:
+  - endpoint:
+      pattern: "svc.{NS}:{PORT}"
+      vars:
+        NS: "${SISYPHUS_NAMESPACE}"
+        PORT: "8080"
+"""
+        ),
+        "org/fe": parse_manifest(
+            """
+needs:
+  - org/be
+inputs:
+  BACKEND_ENDPOINT: "org/be.endpoint"
+"""
+        ),
+    }
+    bundle = pre_resolve_endpoint_bundle(
+        ["org/be", "org/fe"],
+        lambda r: manifests.get(r),
+        {"SISYPHUS_NAMESPACE": "ns-x"},
+    )
+    assert bundle == {"org/be": {"endpoint": "svc.ns-x:8080"}}
+
+
+def test_pre_resolve_unresolved_sisyphus_var_raises():
+    """IMPL-S5: unresolved ${SISYPHUS_GHOST} raises PreResolveError naming the var."""
+    from orchestrator.cross_repo_env import (
+        PreResolveError,
+        pre_resolve_endpoint_bundle,
+    )
+    manifests = {
+        "org/x": parse_manifest(
+            """
+emits:
+  - endpoint:
+      pattern: "svc.{NS}"
+      vars:
+        NS: "${SISYPHUS_GHOST}"
+"""
+        ),
+    }
+    with pytest.raises(PreResolveError) as ei:
+        pre_resolve_endpoint_bundle(
+            ["org/x"], lambda r: manifests.get(r), {"SISYPHUS_NAMESPACE": "ns-x"},
+        )
+    assert ei.value.failed_phase == "pre_resolve"
+    assert ei.value.failed_layer == "org/x"
+    assert "SISYPHUS_GHOST" in str(ei.value)
+
+
+def test_pre_resolve_manifest_fetch_failure_raises():
+    """IMPL-S4: loader exception becomes PreResolveError mentioning manifest fetch."""
+    from orchestrator.cross_repo_env import (
+        PreResolveError,
+        pre_resolve_endpoint_bundle,
+    )
+
+    def loader(repo: str) -> Manifest | None:
+        raise RuntimeError("simulated 5xx")
+
+    with pytest.raises(PreResolveError) as ei:
+        pre_resolve_endpoint_bundle(["org/some-repo"], loader, {})
+    assert ei.value.failed_phase == "pre_resolve"
+    assert ei.value.failed_layer == "org/some-repo"
+    assert "manifest fetch" in str(ei.value)
+
+
+def test_pre_resolve_substitutes_partial_sisyphus_ref_in_vars_value():
+    """IMPL-S3 + EPCA-S6: ${SISYPHUS_*} can appear inside a longer literal."""
+    from orchestrator.cross_repo_env import pre_resolve_endpoint_bundle
+    manifests = {
+        "org/x": parse_manifest(
+            """
+emits:
+  - endpoint:
+      pattern: "http://{HOST}:{PORT}/api"
+      vars:
+        HOST: "${SISYPHUS_NAMESPACE}.svc"
+        PORT: "8080"
+"""
+        ),
+    }
+    bundle = pre_resolve_endpoint_bundle(
+        ["org/x"], lambda r: manifests.get(r), {"SISYPHUS_NAMESPACE": "ns-x"},
+    )
+    assert bundle["org/x"]["endpoint"] == "http://ns-x.svc:8080/api"


### PR DESCRIPTION
## Summary

Phase B of [#359](https://github.com/phona/sisyphus/issues/359) — implements
the R12 pre-resolve phase from the cross-repo env orchestration endpoint
pattern contract amendment landed in #360.

- **Pure logic** (`orchestrator.cross_repo_env`) — `EmitPattern`, `Manifest.emit_patterns`,
  pattern-form `emits` parsing, hermetic `pre_resolve_endpoint_bundle(topology, manifest_loader, req_context)`,
  `PreResolveError(failed_phase, failed_layer)`.
- **Wiring** (`actions/create_accept.py`) — multi-layer entry calls pre-resolve
  after topology resolution and before any per-layer `make accept-env-up`.
  Bundle persisted to `stage_runs.context.endpoint_bundle_pre_resolved`;
  pattern-form fields seed the in-memory bundle so consumer layers' `inputs`
  injection sees them without parsing upstream `accept-env-up` JSON output.
  Per-layer JSON parse iterates only bare-string emits.
- **Failure path** — `PreResolveError` aborts before any layer up runs;
  emits `ACCEPT_ENV_UP_FAIL` with `failed_phase=pre_resolve` +
  `failed_layer=<offending repo>`, distinct from R10 runtime attribution.

## Tests

- Challenger contract `test_contract_endpoint_pattern_amendment_challenger.py`
  EPCA-S1..S10 RED → GREEN (no test modifications).
- New unit tests in `test_cross_repo_env.py` cover pattern parse (mixed bare /
  pattern, undeclared placeholder, non-SISYPHUS \${...} rejection, dedup,
  multi-key dict rejection) and `pre_resolve_endpoint_bundle` (manifest fetch
  fail → \`manifest fetch\` distinguishable; unresolved \${SISYPHUS_*}; partial
  substitution inside vars value; bare-string emits skipped).
- New wiring tests in `test_actions_create_accept_multi_layer.py` cover
  IMPL-S7 (pre-resolve fail aborts before layer up) and IMPL-S8 (pattern emit
  seeds bundle, no JSON re-extraction needed).

## Out of scope

- Moving pre-resolve before runner-pod creation (current impl runs at
  accept-stage where manifests live on the runner pod; moving to a GitHub
  REST manifest fetch path is a follow-up REQ — contract tests don't depend
  on pod creation order).
- APK-build dispatch + mobile-env-up parallel triggering (Phase C
  business-repo manifest adoption).

Refs #342 #359 #354 #360 #311 #326 #327 #333 #248

## Test plan

- [x] \`make ci-lint\` (scoped) — green
- [x] \`uv run pytest tests/test_cross_repo_env.py tests/test_contract_endpoint_pattern_amendment_challenger.py tests/test_actions_create_accept_multi_layer.py\` — 49 + 9 + 9 = 67 green
- [x] \`make ci-integration-test\` — no PG, exit 5 → pass
- [x] openspec validate REQ-feat-orch-pattern-resolver-1777819864 — valid

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-feat-orch-pattern-resolver-1777819864\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/461ajh48)