### PR TITLE
fix(orch): per-REQ source-repo tag override (closes #362)

### DIFF
--- a/openspec/changes/REQ-fix-orch-source-repo-tag-1777824479/proposal.md
+++ b/openspec/changes/REQ-fix-orch-source-repo-tag-1777824479/proposal.md
@@ -1,0 +1,88 @@
+# REQ-fix-orch-source-repo-tag-1777824479
+
+> closes phona/sisyphus#362
+
+## Why
+
+5/3 dogfood Phase D 派 REQ-chore-d-dogfood-marker-1777823112 立即 escalate：
+
+```
+clone.exec: default_base="feat/develop-hwt", base_overrides={}
+clone.failed: "validating base branch 'feat/develop-hwt' for phona/sisyphus"
+=== FAIL clone: base branch 'feat/develop-hwt' not found on origin for phona/sisyphus ===
+```
+
+REQ 是给 ttpos-flutter 的（base `feat/develop-hwt`，跟仓 default branch 一致），
+但 orchestrator 跑去 clone `phona/sisyphus@feat/develop-hwt` —— sisyphus 没这分支。
+
+根因：
+
+- 部署 helm `env.default_involved_repos: [phona/sisyphus]`（单仓自 dogfood 配的）。
+- 直接 analyze 入口 + ctx 没 involved_repos + tags 也没 `repo:<org>/<name>` →
+  multi-layer fallback 落到 L4 = `phona/sisyphus`。
+- 实际 REQ 应当 clone `ZonEaseTech/ttpos-flutter`，但 orch 缺一个**per-REQ
+  source repo override** 的概念。把 helm `default_involved_repos` 改成 ttpos
+  会破坏所有 sisyphus 自 dogfood REQ；只能临时绕开（`--no-intent` 直 BKD 模式
+  失去 orch pipeline dogfood 价值）。
+
+类似 case：跨 project / 跨 lab 派 REQ 都会撞，cross-repo env spec
+（#342 #359 Phase B）已实现 manifest reader，但**入口仍假设源仓 = helm 默认**。
+
+## What changes
+
+加一条 `source-repo:<org>/<name>` BKD intent issue tag，作为 multi-layer
+involved_repos fallback 的 **L0**（最高优先级），赢过 intake / ctx / `repo:` /
+settings.default：
+
+- ` _clone.py` 新增 `_extract_source_repo_tags()` + `_SOURCE_REPO_TAG_PREFIX`
+  常量，复用现有 `_REPO_SLUG_RE` 校验规则。`_extract_repo_tags` 重构为
+  `_extract_tags_with_prefix(tags, prefix, *, log_event)` 内部 helper，
+  避免两套 prefix 解析逻辑并行漂移。
+- `resolve_repos()` 在 layer table 顶部插入新行 `("tags.source-repo", ...)`，
+  其它层顺序不变。
+- 多个 `source-repo:` tag 合并成列表（跟 `repo:` 一致）。
+- 非法 slug 走 `clone.invalid_source_repo_tag` warning。
+
+### 为什么 L0 而不是 L3 同层？
+
+`source-repo:` 跟 `base:` tag 是同语义 —— 显式 per-REQ override，赢过其它
+一切。而现有 `repo:` tag 是「ctx 完全空时的 fallback」，加性、不抢 ctx。两个
+不同 use case：
+
+| tag | 优先级 | 典型用途 |
+|---|---|---|
+| `source-repo:` (L0) | 顶层 | helm 默认错了，本 REQ explicitly 换仓 |
+| `repo:` (L3) | ctx 空时 fallback | intake 没跑、helm 没配，BKD tag 手动声明 |
+
+用户在 BKD intent issue 上挂 `source-repo:ZonEaseTech/ttpos-flutter` 即可
+让 orch 把 clone 目标改到 ttpos-flutter，不必改 helm values，不必走 intake，
+也不影响其它 REQ。
+
+## Impact
+
+- 修：所有「helm default = repoA、本 REQ 给 repoB」场景（dogfood 期跨仓 REQ
+  全卡的根因）
+- 不破坏：现有 `repo:` tag / settings.default_involved_repos 行为完全不变
+  （仅在新 layer 没命中时按原顺序走）
+- 不动 contract：BKD `base:<branch>` / `base:<repo>:<branch>` tag 不变
+- 不动 sisyphus-clone-repos.sh：clone helper 只接收最终 repo list，不管是
+  哪一层算出来的
+
+## Affected specs
+
+- `multi-layer-involved-repos-fallback`：
+  - MODIFIED 一条 Requirement（4-layer → 5-layer，新 L0）+ 1 个 scenario
+    (S1 优先级)
+  - ADDED 一条 Requirement 约束 `source-repo:` tag 的 slug 校验 + extractor
+    行为 + 与 `repo:` tag 互不干扰
+  - ADDED 一个 scenario 复现 closes #362 的实证 case
+
+## Affected code
+
+- `orchestrator/src/orchestrator/actions/_clone.py` — 新增 prefix /
+  extractor / docstring；refactor `_extract_repo_tags` 走共享 helper；
+  `resolve_repos` 加 L0 layer
+- `orchestrator/tests/test_contract_clone_fallback_direct_analyze.py` —
+  扩 `test_resolve_repos_layer_priority` 覆盖 L0
+- `orchestrator/tests/test_contract_source_repo_tag_override.py` (新文件) —
+  per-REQ override + closes #362 实证 case + extractor 校验

--- a/openspec/changes/REQ-fix-orch-source-repo-tag-1777824479/specs/multi-layer-involved-repos-fallback/spec.md
+++ b/openspec/changes/REQ-fix-orch-source-repo-tag-1777824479/specs/multi-layer-involved-repos-fallback/spec.md
@@ -1,0 +1,115 @@
+# multi-layer-involved-repos-fallback delta
+
+## MODIFIED Requirements
+
+### Requirement: _clone.resolve_repos MUST resolve involved_repos through a 5-layer fallback in fixed priority order
+
+The orchestrator's server-side clone helper SHALL resolve the list of
+repos to clone into the runner pod via a 5-layer ordered fallback. The
+helper MUST consult the layers in this exact priority and return the
+first layer whose normalized list is non-empty. The function MUST also
+return a `source_label` string identifying which layer matched (for
+observability and structured logging via `clone.exec` / `clone.done`):
+
+| order | source_label                                  | input                                                              |
+|-------|-----------------------------------------------|--------------------------------------------------------------------|
+| 0     | `tags.source-repo`                            | BKD intent issue tags shaped `source-repo:<org>/<name>`            |
+| 1     | `ctx.intake_finalized_intent.involved_repos`  | intake-agent finalized intent JSON written by webhook              |
+| 2     | `ctx.involved_repos`                          | explicit ctx field set by upstream caller / fixture                |
+| 3     | `tags.repo`                                   | BKD intent issue tags shaped `repo:<org>/<name>`                   |
+| 4     | `settings.default_involved_repos`             | env `SISYPHUS_DEFAULT_INVOLVED_REPOS` (csv or JSON)                |
+
+L0 (`tags.source-repo`) is a per-REQ explicit override and MUST win
+over intake / ctx / `repo:` / settings. This is the same semantic as
+the `base:` BKD tag (explicit per-REQ override of `default_base_branch`).
+The existing L3 `tags.repo` layer is preserved as an additive fallback
+used only when ctx is empty (its position in the table MUST NOT change).
+
+When all five layers yield an empty (or non-list / all-non-string)
+result, the helper MUST return `([], "none")` and the caller MUST skip
+the server-side clone (let the analyze-agent run its prompt-driven
+fallback per `analyze.md.j2` Part A.3).
+
+The helper MUST normalize each layer's input by filtering out
+non-string and empty entries while preserving original order and
+deduplicating repeated slugs.
+
+#### Scenario: MLIRF-S1 tags.source-repo wins over every other layer
+
+- **GIVEN** `resolve_repos` is called with
+  `ctx={"intake_finalized_intent": {"involved_repos": ["L1/x"]}, "involved_repos": ["L2/x"]}`,
+  `tags=["source-repo:L0/x", "repo:L3/x"]`, `default_repos=["L4/x"]`
+- **WHEN** the function returns
+- **THEN** the result MUST be `(["L0/x"], "tags.source-repo")`
+
+## ADDED Requirements
+
+### Requirement: _clone helper MUST extract `source-repo:<org>/<name>` tags with strict slug validation and MUST NOT collide with the `repo:` extractor
+
+The helper SHALL extract the slug after the literal prefix
+`source-repo:` from each tag in the `tags` argument, MUST validate it
+against the same regex used for `repo:` tags
+(`^[A-Za-z0-9][A-Za-z0-9-]{0,38}/[A-Za-z0-9][A-Za-z0-9._-]*$`), MUST
+drop tags that do not start with `source-repo:` or whose slug fails
+validation, MUST log a `clone.invalid_source_repo_tag` warning when a
+`source-repo:` tag has an invalid slug (so operators can spot typos),
+MUST tolerate non-string entries in the `tags` iterable without raising,
+and MUST deduplicate repeated valid slugs while preserving
+first-occurrence order.
+
+The two extractors (`_extract_repo_tags` and `_extract_source_repo_tags`)
+MUST be independent: a `source-repo:foo/bar` tag MUST NOT also be
+counted by `_extract_repo_tags` (because `source-repo:` does not start
+with `repo:`), and a `repo:foo/bar` tag MUST NOT be counted by
+`_extract_source_repo_tags` (because `repo:` does not start with
+`source-repo:`). This isolation lets `resolve_repos` use both extractors
+in parallel layers without double-counting.
+
+#### Scenario: SRTO-S1 source-repo: tag override wins over helm default_involved_repos (closes #362)
+
+- **GIVEN** `settings.default_involved_repos = ["phona/sisyphus"]` (helm
+  configured for sisyphus self-dogfood) and a direct-analyze REQ
+  with `ctx = {"intent_title": "fix something in ttpos-flutter"}`
+  (no `involved_repos`) and
+  `tags = ["intent:analyze", "source-repo:ZonEaseTech/ttpos-flutter"]`
+- **WHEN** `resolve_repos(ctx, tags=tags, default_repos=settings.default_involved_repos)`
+  returns
+- **THEN** the result MUST be
+  `(["ZonEaseTech/ttpos-flutter"], "tags.source-repo")`
+- **AND** the L4 `phona/sisyphus` MUST NOT appear in the result
+- **AND** subsequent `clone_involved_repos_into_runner` invocations on
+  the same inputs MUST issue exactly one `--base ...` clone for
+  `ZonEaseTech/ttpos-flutter` (and zero clones of `phona/sisyphus`)
+
+#### Scenario: SRTO-S2 source-repo: tag wins even when intake_finalized_intent declares a different repo
+
+- **GIVEN** `resolve_repos` is called with
+  `ctx={"intake_finalized_intent": {"involved_repos": ["other/intake-pick"]}}`,
+  `tags=["source-repo:explicit/override"]`, `default_repos=[]`
+- **WHEN** the function returns
+- **THEN** the result MUST be
+  `(["explicit/override"], "tags.source-repo")`
+- **AND** the intake pick MUST NOT appear (the explicit per-REQ tag
+  overrides intake-agent's understanding by design)
+
+#### Scenario: SRTO-S3 multiple source-repo: tags merge to a deduped, ordered list
+
+- **GIVEN** `_extract_source_repo_tags` is called with
+  `tags = ["intent:analyze", "source-repo:phona/sisyphus", "source-repo:ZonEaseTech/ttpos-flutter", "source-repo:phona/sisyphus", "source-repo:invalid org/name", "source-repo:/missing-org", "source-repo:phona/repo-with.dots_and-dash"]`
+- **WHEN** the function returns
+- **THEN** the result MUST be exactly
+  `["phona/sisyphus", "ZonEaseTech/ttpos-flutter", "phona/repo-with.dots_and-dash"]`
+  (dedup by first occurrence; invalid slugs dropped)
+
+#### Scenario: SRTO-S4 source-repo: and repo: tag extractors are independent
+
+- **GIVEN** `tags = ["source-repo:A/x", "repo:B/y"]`
+- **WHEN** `_extract_source_repo_tags(tags)` and `_extract_repo_tags(tags)`
+  are both called
+- **THEN** `_extract_source_repo_tags(tags)` MUST return `["A/x"]`
+  (only the source-repo tag) and MUST NOT include `B/y`
+- **AND** `_extract_repo_tags(tags)` MUST return `["B/y"]` (only the
+  repo tag) and MUST NOT include `A/x`
+- **AND** when fed through `resolve_repos` with empty ctx and empty
+  default_repos, the result MUST be `(["A/x"], "tags.source-repo")`
+  (L0 hits before L3 falls through)

--- a/openspec/changes/REQ-fix-orch-source-repo-tag-1777824479/tasks.md
+++ b/openspec/changes/REQ-fix-orch-source-repo-tag-1777824479/tasks.md
@@ -1,0 +1,36 @@
+# tasks: REQ-fix-orch-source-repo-tag-1777824479
+
+## Stage: spec
+
+- [x] add `openspec/changes/REQ-fix-orch-source-repo-tag-1777824479/proposal.md`
+- [x] add MODIFIED Requirement to `specs/multi-layer-involved-repos-fallback/spec.md`
+  delta — 4-layer 升 5-layer、L0 = `tags.source-repo`
+- [x] add ADDED Requirement to same delta — `source-repo:<org>/<name>` slug 校验 +
+  与 `repo:` tag 隔离
+- [x] add scenarios SRTO-S1 ~ SRTO-S4
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/actions/_clone.py` —— 新增
+  `_SOURCE_REPO_TAG_PREFIX` 常量、`_extract_source_repo_tags` 函数；
+  `_extract_repo_tags` refactor 走共享 `_extract_tags_with_prefix` helper
+- [x] `orchestrator/src/orchestrator/actions/_clone.py` —— `resolve_repos`
+  在 layer table 顶部插入 L0 = `("tags.source-repo", ...)`
+- [x] `orchestrator/src/orchestrator/actions/_clone.py` —— docstring
+  更新（5-layer 表 + L0 vs L3 对比）
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_contract_clone_fallback_direct_analyze.py` ——
+  扩 `test_resolve_repos_layer_priority` 覆盖 5 层全 fall-through
+- [x] `orchestrator/tests/test_contract_source_repo_tag_override.py` ——
+  新文件覆盖 L0 winning scenario + 多 tag 合并 + 非法 slug 拒绝 +
+  closes #362 实证场景
+- [x] `make ci-lint` 全绿
+- [x] `make ci-unit-test` 全绿
+- [x] `make ci-integration-test` 全绿（无 PG → exit 5 视 pass）
+
+## Stage: PR
+
+- [x] git push origin feat/REQ-fix-orch-source-repo-tag-1777824479
+- [x] gh pr create --label sisyphus，PR body 末尾贴 sisyphus:cross-link footer

--- a/orchestrator/src/orchestrator/actions/_clone.py
+++ b/orchestrator/src/orchestrator/actions/_clone.py
@@ -13,15 +13,26 @@ REQ-clone-fallback-direct-analyze-1777119520：multi-layer fallback for direct
 analyze entry。原版只读 ctx，intake 跳过时 ctx 是空的，sisyphus 把 clone
 完全推给 agent prompt。新版按下列优先级解析：
 
+0. tags 里 `source-repo:<org>/<name>` 形式的 per-REQ 显式 source override
+   （REQ-fix-orch-source-repo-tag-1777824479 / closes #362）—— 跟 `base:` tag
+   同语义，赢过其它一切。给"helm 默认 = repoA、本 REQ 给 repoB"场景兜底，
+   不必为了一个 ad-hoc REQ 改 helm values 或走 intake。多个 `source-repo:` tag
+   会形成列表，跟 `repo:` 一致。
 1. ctx.intake_finalized_intent.involved_repos —— intake 路径产物
 2. ctx.involved_repos —— 直接被 caller 写到 ctx 的 involved
-3. tags 里 `repo:<org>/<name>` 形式的 explicit opt-in
+3. tags 里 `repo:<org>/<name>` 形式的 explicit opt-in（旧加性 fallback）
 4. settings.default_involved_repos —— 单仓部署的 last-resort
 
-L3/L4 都是显式信号：tag 是用户在 BKD intent issue 上挂的，env 是 operator
+L0 跟 L3/L4 都是显式信号：tag 是用户在 BKD intent issue 上挂的，env 是 operator
 在 sisyphus 部署时配的。**故意不**从 issue 标题 / prompt 自由文本解析
 slug —— 假阳性风险高（"src/orchestrator"、"M14b/M14c" 之类路径会误命中），
 不如等用户显式打 tag 或 ops 配 default。
+
+L0 vs L3 的区别：
+- `source-repo:` (L0) = 强 override，赢过 intake 的理解。用于"helm 默认错了，
+  这个 REQ 我 explicitly 要换仓"。
+- `repo:` (L3) = 加性 fallback，仅在 ctx 完全空时使用。用于"intake 没跑、
+  helm 没配，但 BKD tag 上声明一下"。
 """
 from __future__ import annotations
 
@@ -38,9 +49,10 @@ log = structlog.get_logger(__name__)
 _CLONE_HELPER = "/opt/sisyphus/scripts/sisyphus-clone-repos.sh"
 _CLONE_TIMEOUT_SEC = 600
 
-# `repo:<org>/<name>` BKD tag 形式。github org/repo slug 规则：
-# org 字母数字 + 连字符；repo 字母数字 + . _ -。
+# `repo:<org>/<name>` / `source-repo:<org>/<name>` BKD tag 形式。github
+# org/repo slug 规则：org 字母数字 + 连字符；repo 字母数字 + . _ -。
 _REPO_TAG_PREFIX = "repo:"
+_SOURCE_REPO_TAG_PREFIX = "source-repo:"
 _REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,38}/[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
@@ -61,22 +73,46 @@ def _normalize_repos(raw: object) -> list[str]:
     return out
 
 
-def _extract_repo_tags(tags: Iterable[str] | None) -> list[str]:
-    """从 BKD issue tags 抽 `repo:<org>/<name>` 并校验 slug 合法。"""
+def _extract_tags_with_prefix(
+    tags: Iterable[str] | None, prefix: str, *, log_event: str,
+) -> list[str]:
+    """从 BKD issue tags 抽 `<prefix><org>/<name>` 并校验 slug 合法。
+
+    `repo:` 跟 `source-repo:` 走同一套 slug 规则，只是 prefix + warning
+    event 名不同；用 prefix 参数化避免两份相同逻辑的并行漂移。
+    """
     if not tags:
         return []
     out: list[str] = []
     for t in tags:
-        if not isinstance(t, str) or not t.startswith(_REPO_TAG_PREFIX):
+        if not isinstance(t, str) or not t.startswith(prefix):
             continue
-        slug = t[len(_REPO_TAG_PREFIX):].strip()
+        slug = t[len(prefix):].strip()
         if _REPO_SLUG_RE.match(slug):
             out.append(slug)
         else:
-            log.warning("clone.invalid_repo_tag", tag=t)
+            log.warning(log_event, tag=t)
     # 去重保留顺序
     seen: set[str] = set()
     return [r for r in out if not (r in seen or seen.add(r))]
+
+
+def _extract_repo_tags(tags: Iterable[str] | None) -> list[str]:
+    """从 BKD issue tags 抽 `repo:<org>/<name>` 并校验 slug 合法。"""
+    return _extract_tags_with_prefix(
+        tags, _REPO_TAG_PREFIX, log_event="clone.invalid_repo_tag",
+    )
+
+
+def _extract_source_repo_tags(tags: Iterable[str] | None) -> list[str]:
+    """从 BKD issue tags 抽 `source-repo:<org>/<name>` 并校验 slug 合法。
+
+    REQ-fix-orch-source-repo-tag-1777824479 (closes #362)：per-REQ source
+    repo override。多个 `source-repo:` tag 形成列表，跟 `repo:` 一致。
+    """
+    return _extract_tags_with_prefix(
+        tags, _SOURCE_REPO_TAG_PREFIX, log_event="clone.invalid_source_repo_tag",
+    )
 
 
 def resolve_repos(
@@ -91,6 +127,9 @@ def resolve_repos(
     """
     finalized = (ctx or {}).get("intake_finalized_intent") or {}
     layers: list[tuple[str, object]] = [
+        # REQ-fix-orch-source-repo-tag-1777824479 (closes #362): `source-repo:`
+        # tag 是 per-REQ 显式 override，赢过 intake / ctx / `repo:` / settings。
+        ("tags.source-repo", _extract_source_repo_tags(tags)),
         ("ctx.intake_finalized_intent.involved_repos", finalized.get("involved_repos")),
         ("ctx.involved_repos", (ctx or {}).get("involved_repos")),
         ("tags.repo", _extract_repo_tags(tags)),

--- a/orchestrator/tests/test_contract_clone_fallback_direct_analyze.py
+++ b/orchestrator/tests/test_contract_clone_fallback_direct_analyze.py
@@ -1,8 +1,9 @@
 """contract regression for REQ-clone-fallback-direct-analyze-1777119520:
 
 multi-layer involved_repos fallback for direct analyze entry。
-- _resolve_repos / resolve_repos 必须按 4-layer 顺序：ctx.intake → ctx.involved
-  → tags.repo → settings.default
+- _resolve_repos / resolve_repos 必须按 5-layer 顺序：tags.source-repo →
+  ctx.intake → ctx.involved → tags.repo → settings.default
+  （L0 = source-repo 由 REQ-fix-orch-source-repo-tag-1777824479 加入）
 - _clone helper 不能从自由文本（intent_title / prompt body）反向推断 repos
   （假阳性风险高，规则强制改用显式 tag 或 settings env）
 - start_analyze + start_analyze_with_finalized_intent 必须把 tags +
@@ -20,7 +21,18 @@ _PRODUCTION_SOURCE = Path(__file__).resolve().parent.parent / "src" / "orchestra
 
 
 def test_resolve_repos_layer_priority():
-    """priority: L1 > L2 > L3 > L4。"""
+    """priority: L0 > L1 > L2 > L3 > L4。
+
+    L0 = `tags.source-repo`（REQ-fix-orch-source-repo-tag-1777824479 引入）。
+    """
+    # L0 winning over L1/L2/L3/L4
+    repos, src = _clone.resolve_repos(
+        {"intake_finalized_intent": {"involved_repos": ["L1/x"]},
+         "involved_repos": ["L2/x"]},
+        tags=["source-repo:L0/x", "repo:L3/x"], default_repos=["L4/x"],
+    )
+    assert (repos, src) == (["L0/x"], "tags.source-repo")
+
     repos, src = _clone.resolve_repos(
         {"intake_finalized_intent": {"involved_repos": ["L1/x"]},
          "involved_repos": ["L2/x"]},

--- a/orchestrator/tests/test_contract_source_repo_tag_override.py
+++ b/orchestrator/tests/test_contract_source_repo_tag_override.py
@@ -1,0 +1,107 @@
+"""contract regression for REQ-fix-orch-source-repo-tag-1777824479 (closes #362):
+
+per-REQ source-repo tag override. The `source-repo:<org>/<name>` BKD tag
+is L0 (top priority) of the multi-layer involved_repos fallback — it
+wins over intake / ctx / `repo:` / settings.default_involved_repos.
+
+Use case: helm `default_involved_repos = [phona/sisyphus]` (single-repo
+self-dogfood deployment) but a one-off REQ targets a different repo
+(e.g., `ZonEaseTech/ttpos-flutter`). Without this override the orch
+clones the helm-default and validates the REQ's `base:` against the
+wrong repo — observed 5/3 Phase D dogfood as repeated escalate of every
+cross-repo REQ until operator gave up and used `--no-intent` direct
+BKD mode (losing orch pipeline dogfood value).
+"""
+from __future__ import annotations
+
+from orchestrator.actions import _clone
+
+
+def test_source_repo_tag_overrides_helm_default_repro_362():
+    """实证 case from phona/sisyphus#362: helm default = phona/sisyphus,
+    REQ uses `source-repo:ZonEaseTech/ttpos-flutter`, expect ttpos-flutter
+    cloned (not phona/sisyphus).
+    """
+    repos, src = _clone.resolve_repos(
+        {"intent_title": "fix something in ttpos-flutter"},
+        tags=["intent:analyze", "source-repo:ZonEaseTech/ttpos-flutter"],
+        default_repos=["phona/sisyphus"],
+    )
+    assert repos == ["ZonEaseTech/ttpos-flutter"]
+    assert src == "tags.source-repo"
+    assert "phona/sisyphus" not in repos
+
+
+def test_source_repo_tag_overrides_intake_finalized_intent():
+    """L0 must win over L1 (intake finalized intent) — explicit per-REQ
+    tag should override even what intake-agent figured out, because the
+    user manually pinned a different source repo at REQ creation time.
+    """
+    repos, src = _clone.resolve_repos(
+        {"intake_finalized_intent": {"involved_repos": ["other/intake-pick"]}},
+        tags=["source-repo:explicit/override"],
+        default_repos=[],
+    )
+    assert repos == ["explicit/override"]
+    assert src == "tags.source-repo"
+
+
+def test_multiple_source_repo_tags_merge_dedup_preserve_order():
+    """Multiple `source-repo:` tags merge to a list, dedup by first
+    occurrence, preserve order, drop invalid slugs.
+    """
+    out = _clone._extract_source_repo_tags([
+        "intent:analyze",
+        "source-repo:phona/sisyphus",
+        "source-repo:ZonEaseTech/ttpos-flutter",
+        "source-repo:phona/sisyphus",            # dup -> drop
+        "source-repo:invalid org/name",          # space in slug -> drop
+        "source-repo:/missing-org",              # empty org -> drop
+        "source-repo:no-slash-here",             # no slash -> drop
+        "source-repo:phona/repo-with.dots_and-dash",
+    ])
+    assert out == [
+        "phona/sisyphus",
+        "ZonEaseTech/ttpos-flutter",
+        "phona/repo-with.dots_and-dash",
+    ]
+
+
+def test_source_repo_extractor_isolated_from_repo_extractor():
+    """`source-repo:foo/bar` MUST NOT also be picked up by
+    `_extract_repo_tags`, and vice versa. Otherwise L0 + L3 would
+    double-count and `resolve_repos` priority semantics would break.
+    """
+    tags = ["source-repo:A/x", "repo:B/y"]
+    assert _clone._extract_source_repo_tags(tags) == ["A/x"]
+    assert _clone._extract_repo_tags(tags) == ["B/y"]
+
+    # End-to-end via resolve_repos: L0 hits, L3 is shadowed.
+    repos, src = _clone.resolve_repos({}, tags=tags, default_repos=[])
+    assert repos == ["A/x"]
+    assert src == "tags.source-repo"
+
+
+def test_source_repo_extractor_tolerates_non_string_tags():
+    """非字符串 tag 必须不报错 —— 跟 `_extract_repo_tags` 同等鲁棒。"""
+    out = _clone._extract_source_repo_tags(
+        ["source-repo:phona/x", 42, None, "source-repo:phona/y"]
+    )
+    assert out == ["phona/x", "phona/y"]
+
+
+def test_source_repo_no_tag_falls_through_to_lower_layers():
+    """No `source-repo:` tag → resolve_repos must fall through to
+    L1/L2/L3/L4 unchanged (the new layer is purely additive on top).
+    """
+    # Falls through to L4 (settings default) when nothing else set
+    repos, src = _clone.resolve_repos(
+        {}, tags=["intent:analyze"], default_repos=["phona/sisyphus"],
+    )
+    assert (repos, src) == (["phona/sisyphus"], "settings.default_involved_repos")
+
+    # Falls through to L3 (`repo:` tag) when ctx empty and source-repo absent
+    repos, src = _clone.resolve_repos(
+        {}, tags=["repo:phona/sisyphus"], default_repos=["unused/x"],
+    )
+    assert (repos, src) == (["phona/sisyphus"], "tags.repo")

--- a/orchestrator/tests/test_contract_source_repo_tag_override_challenger.py
+++ b/orchestrator/tests/test_contract_source_repo_tag_override_challenger.py
@@ -1,0 +1,316 @@
+"""Challenger contract tests for REQ-fix-orch-source-repo-tag-1777824479.
+
+Black-box contracts derived **exclusively** from:
+
+  openspec/changes/REQ-fix-orch-source-repo-tag-1777824479/specs/
+    multi-layer-involved-repos-fallback/spec.md
+
+Scenarios covered:
+
+  MLIRF-S1  tags.source-repo wins over every other layer (L0 priority)
+  SRTO-S1   source-repo: overrides helm default (closes #362) — and
+            clone_involved_repos_into_runner clones the override slug only
+  SRTO-S2   source-repo: wins even when intake_finalized_intent declares
+            a different repo
+  SRTO-S3   multiple source-repo: tags merge to a deduped, ordered list
+            (invalid slugs dropped silently — but emit a warning event)
+  SRTO-S4   source-repo and repo extractors are independent (no
+            double-counting; resolve_repos picks L0 before L3 falls through)
+
+Plus a few derived properties spelled out as MUSTs in the new ADDED
+Requirement that ride along the same scenarios:
+
+  * `_extract_source_repo_tags` MUST tolerate non-string entries
+    without raising
+  * `_extract_source_repo_tags` MUST log a warning event named
+    `clone.invalid_source_repo_tag` when a `source-repo:` tag has an
+    invalid slug
+
+Dev MUST NOT modify these tests to make them pass — fix the
+implementation instead.  If a test is genuinely wrong, escalate to
+spec_fixer; do not patch around it in code.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from orchestrator.actions import _clone
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+
+class _FakeExecResult:
+    def __init__(
+        self,
+        exit_code: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+        duration_sec: float = 0.0,
+    ) -> None:
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+        self.duration_sec = duration_sec
+
+
+class _CapturingRC:
+    """Records every exec_in_runner invocation for clone-command assertions."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def exec_in_runner(self, req_id: str, cmd: str, timeout_sec: int = 600):
+        self.calls.append({"req_id": req_id, "cmd": cmd, "timeout": timeout_sec})
+        return _FakeExecResult(exit_code=0, stdout="ok")
+
+
+def _resolve(ctx, tags, default_repos):
+    return _clone.resolve_repos(ctx, tags=tags, default_repos=default_repos)
+
+
+# ─── canonical seam: extractor MUST exist ────────────────────────────────────
+
+
+def test_extract_source_repo_tags_symbol_exists():
+    """The new ADDED Requirement mandates `_extract_source_repo_tags` as the
+    canonical extractor for `source-repo:` tags. Missing the symbol is itself
+    a contract violation — surface it as a test failure rather than a
+    collection error so the agent gets a readable signal."""
+    fn = getattr(_clone, "_extract_source_repo_tags", None)
+    assert callable(fn), (
+        "Spec mandates orchestrator.actions._clone._extract_source_repo_tags "
+        "as the canonical extractor for `source-repo:<org>/<name>` BKD intent "
+        "issue tags. Function MUST be importable from the _clone module."
+    )
+
+
+# ─── MLIRF-S1: L0 priority over every other layer ───────────────────────────
+
+
+def test_mlirf_s1_source_repo_tag_wins_over_every_other_layer():
+    """MLIRF-S1: GIVEN intake_finalized_intent=['L1/x'], involved=['L2/x'],
+    tags=['source-repo:L0/x','repo:L3/x'], default=['L4/x']; THEN result is
+    (['L0/x'], 'tags.source-repo')."""
+    repos, src = _resolve(
+        ctx={
+            "intake_finalized_intent": {"involved_repos": ["L1/x"]},
+            "involved_repos": ["L2/x"],
+        },
+        tags=["source-repo:L0/x", "repo:L3/x"],
+        default_repos=["L4/x"],
+    )
+    assert (repos, src) == (["L0/x"], "tags.source-repo"), (
+        "L0 (tags.source-repo) MUST win over L1/L2/L3/L4 (MLIRF-S1)."
+    )
+
+
+# ─── SRTO-S1: closes #362 — override beats helm default; clone uses override ─
+
+
+def test_srto_s1_source_repo_overrides_helm_default_resolve():
+    """SRTO-S1 (resolve part): the helm-default sisyphus self-dogfood case
+    where direct-analyze REQ carries `source-repo:ZonEaseTech/ttpos-flutter`
+    MUST resolve to the ttpos slug and never fall through to L4."""
+    repos, src = _resolve(
+        ctx={"intent_title": "fix something in ttpos-flutter"},
+        tags=["intent:analyze", "source-repo:ZonEaseTech/ttpos-flutter"],
+        default_repos=["phona/sisyphus"],
+    )
+    assert repos == ["ZonEaseTech/ttpos-flutter"], (
+        "SRTO-S1: source-repo override MUST resolve to the per-REQ slug, "
+        "not the helm default."
+    )
+    assert src == "tags.source-repo", (
+        "SRTO-S1: source_label MUST identify the L0 layer for observability."
+    )
+    assert "phona/sisyphus" not in repos, (
+        "SRTO-S1: the L4 helm default MUST NOT appear once L0 hits."
+    )
+
+
+@pytest.mark.asyncio
+async def test_srto_s1_clone_helper_clones_override_only_not_helm_default():
+    """SRTO-S1 (clone-helper part): subsequent
+    `clone_involved_repos_into_runner` invocations on the same inputs MUST
+    issue exactly one clone for the override repo and zero clones of the
+    helm default. The black-box assertion is on the shell command shipped
+    to the runner pod."""
+    captured = _CapturingRC()
+    with patch(
+        "orchestrator.actions._clone.k8s_runner.get_controller",
+        return_value=captured,
+    ):
+        repos, exit_code = await _clone.clone_involved_repos_into_runner(
+            "REQ-fix-orch-source-repo-tag-1777824479",
+            {"involved_repos": ["ZonEaseTech/ttpos-flutter"]},
+        )
+
+    assert repos == ["ZonEaseTech/ttpos-flutter"]
+    assert exit_code is None
+    assert len(captured.calls) == 1, (
+        "SRTO-S1: clone helper MUST issue exactly one runner-side clone "
+        "command for the resolved repo list."
+    )
+    cmd = captured.calls[0]["cmd"]
+    assert "ZonEaseTech/ttpos-flutter" in cmd, (
+        "SRTO-S1: the runner-side clone command MUST mention the override "
+        "slug ZonEaseTech/ttpos-flutter."
+    )
+    assert "phona/sisyphus" not in cmd, (
+        "SRTO-S1: the runner-side clone command MUST NOT mention the helm "
+        "default phona/sisyphus once the override is in effect."
+    )
+
+
+# ─── SRTO-S2: source-repo wins even over intake_finalized_intent ─────────────
+
+
+def test_srto_s2_source_repo_wins_over_intake_finalized_intent():
+    """SRTO-S2: explicit per-REQ tag overrides intake-agent's pick."""
+    repos, src = _resolve(
+        ctx={"intake_finalized_intent": {"involved_repos": ["other/intake-pick"]}},
+        tags=["source-repo:explicit/override"],
+        default_repos=[],
+    )
+    assert (repos, src) == (["explicit/override"], "tags.source-repo"), (
+        "SRTO-S2: source-repo: tag MUST override intake_finalized_intent."
+    )
+    assert "other/intake-pick" not in repos, (
+        "SRTO-S2: intake's pick MUST NOT appear once explicit override exists."
+    )
+
+
+# ─── SRTO-S3: dedup, order, invalid drop ─────────────────────────────────────
+
+
+def test_srto_s3_multiple_source_repo_tags_dedup_and_drop_invalid():
+    """SRTO-S3: extractor MUST return deduped, first-occurrence-ordered
+    list with invalid slugs dropped. Exact spec input/output."""
+    out = _clone._extract_source_repo_tags(
+        [
+            "intent:analyze",
+            "source-repo:phona/sisyphus",
+            "source-repo:ZonEaseTech/ttpos-flutter",
+            "source-repo:phona/sisyphus",  # duplicate
+            "source-repo:invalid org/name",  # space → invalid slug
+            "source-repo:/missing-org",  # empty org
+            "source-repo:phona/repo-with.dots_and-dash",
+        ]
+    )
+    assert out == [
+        "phona/sisyphus",
+        "ZonEaseTech/ttpos-flutter",
+        "phona/repo-with.dots_and-dash",
+    ], (
+        "SRTO-S3: extractor MUST preserve first occurrence, drop "
+        "duplicates and invalid slugs, and yield exactly the three "
+        "valid slugs in the order they first appear."
+    )
+
+
+def test_srto_s3_extractor_tolerates_non_string_entries():
+    """ADDED Requirement: extractor MUST tolerate non-string entries in
+    the iterable without raising. This guards against accidental shape
+    drift in BKD tag payloads (e.g. None / int slipping through)."""
+    out = _clone._extract_source_repo_tags(
+        [None, 42, {"k": "v"}, "source-repo:phona/sisyphus", b"source-repo:bytes/x"]
+    )
+    assert out == ["phona/sisyphus"], (
+        "Extractor MUST silently ignore non-string entries and only emit "
+        "valid slugs from str-typed `source-repo:` tags."
+    )
+
+
+def test_srto_s3_extractor_emits_warning_for_invalid_slug(capsys):
+    """ADDED Requirement: extractor MUST log a `clone.invalid_source_repo_tag`
+    warning when a `source-repo:` tag has an invalid slug, so operators
+    can spot typos. The exact event name is part of the contract.
+
+    structlog writes to stdout (caplog does not capture it), so we read
+    the captured stdout/stderr via capsys.
+    """
+    out = _clone._extract_source_repo_tags(
+        [
+            "source-repo:phona/sisyphus",  # valid → no warning
+            "source-repo:invalid org/name",  # invalid → warning
+            "source-repo:/missing-org",  # invalid → warning
+        ]
+    )
+    assert out == ["phona/sisyphus"]
+    captured = capsys.readouterr()
+    output = captured.out + captured.err
+    assert "clone.invalid_source_repo_tag" in output, (
+        "Extractor MUST emit a warning event named "
+        "`clone.invalid_source_repo_tag` for each invalid slug "
+        "(operators rely on this event name for typo alerts).\n"
+        f"Captured log output was:\n{output}"
+    )
+
+
+# ─── SRTO-S4: source-repo / repo extractors are independent ─────────────────
+
+
+def test_srto_s4_extractors_are_independent_no_double_counting():
+    """SRTO-S4: source-repo: and repo: extractors MUST NOT cross-pollute.
+    A `source-repo:A/x` tag MUST NOT count as a `repo:` slug, and a
+    `repo:B/y` tag MUST NOT count as a `source-repo:` slug."""
+    tags = ["source-repo:A/x", "repo:B/y"]
+
+    src_only = _clone._extract_source_repo_tags(tags)
+    repo_only = _clone._extract_repo_tags(tags)
+
+    assert src_only == ["A/x"], (
+        "SRTO-S4: _extract_source_repo_tags MUST extract only A/x."
+    )
+    assert "B/y" not in src_only, (
+        "SRTO-S4: _extract_source_repo_tags MUST NOT include the repo: tag."
+    )
+    assert repo_only == ["B/y"], (
+        "SRTO-S4: _extract_repo_tags MUST extract only B/y."
+    )
+    assert "A/x" not in repo_only, (
+        "SRTO-S4: _extract_repo_tags MUST NOT include the source-repo: tag "
+        "(prefix `repo:` does not match `source-repo:`)."
+    )
+
+
+def test_srto_s4_resolve_repos_l0_hits_before_l3_falls_through():
+    """SRTO-S4 (resolve part): with both layers populated and ctx empty,
+    L0 (tags.source-repo) MUST be the layer that matches. The repo: L3
+    tag MUST NOT contribute because the resolver picks the first non-empty
+    layer in priority order — it does not concatenate."""
+    repos, src = _resolve(
+        ctx={},
+        tags=["source-repo:A/x", "repo:B/y"],
+        default_repos=[],
+    )
+    assert (repos, src) == (["A/x"], "tags.source-repo"), (
+        "SRTO-S4: resolve_repos MUST stop at L0 once it has a non-empty "
+        "extracted list — the L3 repo: tag MUST NOT appear in the result."
+    )
+    assert "B/y" not in repos, (
+        "SRTO-S4: layers do NOT concatenate; only the first non-empty wins."
+    )
+
+
+# ─── Empty-everything safety net (cross-check the new layer doesn't break it) ─
+
+
+def test_all_layers_empty_with_only_invalid_source_repo_tags_returns_none():
+    """Defensive corollary of SRTO-S3 + the L0 layer addition: if the only
+    `source-repo:` tags present are invalid, L0 MUST be considered empty
+    and the resolver MUST fall through to subsequent layers. With every
+    layer empty the result MUST be `([], 'none')` per the existing
+    Requirement (last paragraph of the MODIFIED block)."""
+    repos, src = _resolve(
+        ctx={},
+        tags=["source-repo:invalid org/name", "source-repo:/missing-org"],
+        default_repos=[],
+    )
+    assert (repos, src) == ([], "none"), (
+        "Invalid-only source-repo: tags MUST NOT count as L0 hits, and with "
+        "every layer empty the result MUST be ([], 'none')."
+    )


### PR DESCRIPTION
## Summary

- Add `source-repo:<org>/<name>` BKD intent issue tag as L0 (top
  priority) of the multi-layer involved_repos fallback in
  `_clone.resolve_repos`. Wins over intake / ctx / `repo:` /
  `settings.default_involved_repos`.
- Use case from phona/sisyphus#362 / 5/3 dogfood Phase D failure: helm
  `default_involved_repos = [phona/sisyphus]` (single-repo dogfood
  deployment) but a one-off REQ targets `ZonEaseTech/ttpos-flutter`.
  Without this override the orch falls through to L4 helm default,
  clones `phona/sisyphus`, validates the REQ's `base:feat/develop-hwt`
  against sisyphus where that branch doesn't exist, and escalates
  every cross-repo REQ.
- `source-repo:` tag is a strong override (matches `base:` tag
  semantics). Existing `repo:` tag remains as additive L3 fallback
  (used only when ctx is empty) — both extractors are independent
  so there is no double-counting.

## Why L0 vs L3?

| tag | priority | use case |
|---|---|---|
| `source-repo:` (L0) | top | helm default is wrong, this REQ explicitly switches repo |
| `repo:` (L3) | ctx-empty fallback | intake didn't run, helm not configured, BKD tag declares manually |

User attaches `source-repo:ZonEaseTech/ttpos-flutter` on the BKD intent
issue and orch routes the clone there — no helm value change required,
no intake required, no impact on other REQs.

## Changes

- `orchestrator/src/orchestrator/actions/_clone.py` — new
  `_SOURCE_REPO_TAG_PREFIX`, `_extract_source_repo_tags`; refactored
  `_extract_repo_tags` to share `_extract_tags_with_prefix` helper;
  `resolve_repos` layer table prepends L0; docstring updated
  (5-layer table + L0 vs L3 comparison)
- `openspec/changes/REQ-fix-orch-source-repo-tag-1777824479/` —
  proposal + tasks + delta to `multi-layer-involved-repos-fallback`
  spec (MODIFIED 4-layer -> 5-layer Requirement; ADDED Requirement
  for `source-repo:` extractor + isolation from `repo:`; 4 scenarios
  including the closes #362 reproduction)
- `orchestrator/tests/test_contract_clone_fallback_direct_analyze.py` —
  extended `test_resolve_repos_layer_priority` to cover L0
- `orchestrator/tests/test_contract_source_repo_tag_override.py` (new)
  — 6 tests covering L0 priority, intake override, dedup, extractor
  isolation, non-string tolerance, fall-through, and the closes #362
  reproduction scenario

## Test plan

- [x] `make ci-lint` — green (full scan)
- [x] `make ci-unit-test` — focused tests 11/11 pass; full-suite shows
  31 pre-existing failures in `test_runner_gc.py` /
  `test_engine.py` / `test_intent_status_sync.py` that are present
  on base 8448dec without these changes (test pollution, unrelated
  to this REQ — passes in isolation)
- [x] `make ci-integration-test` — no PG → exit 5 → pass
- [x] `openspec validate REQ-fix-orch-source-repo-tag-1777824479` — green
- [x] `bash scripts/check-scenario-refs.sh --specs-search-path .` — 823
  scenarios resolved
- [ ] After merge: redispatch a cross-repo REQ with
  `--tag source-repo:ZonEaseTech/ttpos-flutter` and confirm orch
  clones ttpos-flutter (not phona/sisyphus)

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-fix-orch-source-repo-tag-1777824479\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/a4dfmx3u)