### PR TITLE
test(router): pin verifier decision parsing contract (closes #371)

### DIFF
--- a/openspec/changes/REQ-test-router-decision-contract-1777860546/proposal.md
+++ b/openspec/changes/REQ-test-router-decision-contract-1777860546/proposal.md
@@ -1,0 +1,73 @@
+# REQ-test-router-decision-contract-1777860546 — router verifier decision parsing contract test
+
+Refs phona/sisyphus#371. Complementary to phona/sisyphus#763
+(verifier prompt mandates `decision:<action>` tag) and
+phona/sisyphus#372 (decode-fail telemetry).
+
+## 现状
+
+`router.derive_verifier_event(description, tags)` is the single funnel where
+`session.completed` from a verifier sub-issue gets translated into a state
+machine `Event`. The 5/4 v5 dogfood incident (logged on phona/sisyphus#371)
+showed the operational cost when this funnel silently picks `VERIFY_ESCALATE`:
+the REQ stalls in `ESCALATED`, no error appears in router logs, a human
+spends ~30 minutes diagnosing what should have been "verifier said pass".
+
+REQ-fix-verifier-decision-tag-1777812498 (closes phona/sisyphus#356) added
+the plain `decision:<action>[-<fixer>]` tag fallback in `verifier_parser`
+specifically to handle that incident's input shape. Today the contract is:
+
+| Input shape                                                                | Routing                                              |
+|----------------------------------------------------------------------------|------------------------------------------------------|
+| tag `decision:<base64-json>` + `verify:<known-stage>` (full schema)        | per-stage pass / `VERIFY_FIX_NEEDED` / `VERIFY_INFRA_RETRY` |
+| tag `decision:pass` / `decision:fix-dev` / `decision:fix-spec` / `decision:escalate` / `decision:retry` (plain string) | synthesized low-confidence decision → same routes |
+| tag `decision:fail` / any other plain string                               | `VERIFY_ESCALATE` (no synthesis — pinned)            |
+| description ` ```json ``` ` block (no tag)                                 | per-stage pass / `VERIFY_FIX_NEEDED`                 |
+| valid decision but `verify:<unknown_stage>`                                | `VERIFY_ESCALATE` reason="unknown verifier stage"    |
+| valid decision but no `verify:<stage>` tag                                 | `VERIFY_ESCALATE` reason="unknown verifier stage"    |
+| base64 that decodes but isn't valid JSON                                   | `VERIFY_ESCALATE` reason="no decision JSON"          |
+| valid JSON that fails schema (e.g. missing `confidence`)                   | `VERIFY_ESCALATE` reason="invalid decision: …"       |
+| nothing parseable anywhere                                                 | `VERIFY_ESCALATE` reason="no decision JSON"          |
+
+This contract is currently tested only end-to-end (engine + webhook tests) and
+inside the parser's own unit tests. Drift in any of the cells above is
+discoverable only when a live REQ silently sticks.
+
+## 提议
+
+Add a single contract test file —
+`orchestrator/tests/router/test_verifier_decision_parsing.py` — that:
+
+1. Parametrises the table above against `router.derive_verifier_event`.
+2. Asserts both the returned `Event` and a substring of the diagnostic
+   `reason` (so the routing decision and the reason it was made are both
+   pinned).
+3. Adds a small number of focused single-purpose tests for invariants that
+   don't fit a parametrised case cleanly (precedence of base64 tag over
+   plain tag, defensive None/empty inputs).
+
+Scope is intentionally narrow: only `orchestrator/tests/router/` is added.
+`router.py`, `verifier_parser.py`, prompts and `state.py` are not modified.
+If running the contract test reveals a divergence from the expected routes,
+that is the signal phona/sisyphus#371 was after — the failure tells us
+exactly which row of the table changed, and the fix lands in a follow-up
+issue, not in this REQ.
+
+## Why a new spec capability
+
+The closest existing capability is `verifier-decision-tag-fallback`
+(REQ-fix-verifier-decision-tag-1777812498), which specifies the parser-layer
+synthesis. The router-layer contract (decision dict → state machine event,
+including unknown-stage escalate, schema-invalid escalate, no-JSON escalate)
+is currently un-spec'd. Introducing `router-decision-contract-tests` keeps
+the parser contract and the router contract independently archivable; future
+parser additions (new aliases) and router changes (new `verify:<stage>`
+routes) won't have to share a single growing spec file.
+
+## 关联
+
+- closes phona/sisyphus#371
+- 互补 phona/sisyphus#763 (verifier prompt mandates `decision:<action>` tag)
+- 互补 phona/sisyphus#372 (decode-fail telemetry)
+- builds on REQ-fix-verifier-decision-tag-1777812498
+  (capability `verifier-decision-tag-fallback`, parser synthesis layer)

--- a/openspec/changes/REQ-test-router-decision-contract-1777860546/specs/router-decision-contract-tests/spec.md
+++ b/openspec/changes/REQ-test-router-decision-contract-1777860546/specs/router-decision-contract-tests/spec.md
@@ -1,0 +1,77 @@
+# Spec delta — router-decision-contract-tests
+
+## ADDED Requirements
+
+### Requirement: router SHALL pin the verifier decision → state-machine Event contract via a parametrised contract test
+
+The orchestrator MUST ship a parametrised contract test (located at
+`orchestrator/tests/router/test_verifier_decision_parsing.py`) that exercises
+`orchestrator.router.derive_verifier_event(description, tags)` against every
+input shape currently produced by verifier-agents in production, and SHALL
+assert both the returned `Event` and a stable substring of the diagnostic
+`reason`. The test SHALL cover, at minimum: a tag-base64 happy path that
+routes to a stage-specific pass event, a tag-base64 fix decision that routes
+to `VERIFY_FIX_NEEDED`, a plain `decision:<action>` tag fallback path, a
+description-only ` ```json ``` ` path, every silent-escalate case (unknown
+verifier stage, schema-invalid JSON, base64 that decodes to invalid JSON,
+plain `decision:fail` tag, empty inputs), and a precedence test asserting
+that a base64 decision tag wins over a plain `decision:<action>` tag. The
+test MUST NOT modify `router.py`, `verifier_parser.py`, prompts, or
+`state.py`; if executing the test reveals a routing divergence, that is the
+intended regression signal — the fix lands in a follow-up issue, not in this
+test file.
+
+#### Scenario: RDCT-S1 contract test runs in isolation under pytest
+- **GIVEN** the orchestrator package is installed and pytest is available
+- **WHEN** an operator runs
+  `pytest orchestrator/tests/router/test_verifier_decision_parsing.py -v`
+- **THEN** every parametrised case and every focused invariant test passes
+- **AND** the run does not depend on a database, network, BKD, or Kubernetes
+
+#### Scenario: RDCT-S2 happy path tag-base64 routes to per-stage pass event
+- **GIVEN** `tags = ["decision:<base64-of-valid-pass>", "verify:dev_cross_check"]`
+  where the JSON decodes to a schema-valid pass decision
+- **WHEN** `derive_verifier_event(None, tags)` is called
+- **THEN** the returned `Event` is `Event.DEV_CROSS_CHECK_PASS`
+- **AND** the returned reason is the empty string
+
+#### Scenario: RDCT-S3 plain `decision:pass` tag routes via parser fallback
+- **GIVEN** `tags = ["decision:pass", "verify:dev_cross_check"]` (the exact
+  shape that triggered the 5/4 v5 dogfood incident; phona/sisyphus#371)
+- **WHEN** `derive_verifier_event(None, tags)` is called
+- **THEN** the returned `Event` is `Event.DEV_CROSS_CHECK_PASS`
+- **AND** the contract test pins that this is now a happy path post
+  REQ-fix-verifier-decision-tag-1777812498 (closes phona/sisyphus#356),
+  not `VERIFY_ESCALATE`
+
+#### Scenario: RDCT-S4 plain `decision:fail` tag still escalates (no synthesis)
+- **GIVEN** `tags = ["decision:fail", "verify:dev_cross_check"]`
+- **WHEN** `derive_verifier_event(None, tags)` is called
+- **THEN** the returned `Event` is `Event.VERIFY_ESCALATE`
+- **AND** the returned `reason` contains the substring `no decision JSON`,
+  since `decision:fail` is intentionally absent from the parser's plain-tag
+  alias table
+
+#### Scenario: RDCT-S5 schema-invalid base64 tag escalates with `invalid decision` reason
+- **GIVEN** `tags = ["decision:eyJhY3Rpb24iOiJwYXNzIn0=", "verify:dev_cross_check"]`
+  (base64 of `{"action":"pass"}`, which is missing the required `confidence` field)
+- **WHEN** `derive_verifier_event(None, tags)` is called
+- **THEN** the returned `Event` is `Event.VERIFY_ESCALATE`
+- **AND** the returned `reason` contains the substring `invalid decision`
+
+#### Scenario: RDCT-S6 unknown verifier stage with valid pass decision escalates
+- **GIVEN** a schema-valid pass decision in a base64 tag, but the only
+  `verify:<stage>` tag is `verify:unknown_stage` (a stage not in the
+  router's `_VERIFY_PASS_ROUTING` table)
+- **WHEN** `derive_verifier_event(None, tags)` is called
+- **THEN** the returned `Event` is `Event.VERIFY_ESCALATE`
+- **AND** the returned `reason` contains the substring `unknown verifier stage`
+
+#### Scenario: RDCT-S7 base64 tag wins over plain tag at the same precedence boundary
+- **GIVEN** `tags` contains both a base64 tag carrying a `fix` decision and
+  a plain `decision:pass` tag, plus `verify:dev_cross_check`
+- **WHEN** `derive_verifier_event(None, tags)` is called
+- **THEN** the returned `Event` is `Event.VERIFY_FIX_NEEDED` (the base64
+  decision wins)
+- **AND** the returned decision dict carries the base64 payload's `fixer`
+  value, not the plain tag's synthesized `null`

--- a/openspec/changes/REQ-test-router-decision-contract-1777860546/tasks.md
+++ b/openspec/changes/REQ-test-router-decision-contract-1777860546/tasks.md
@@ -1,0 +1,22 @@
+# Tasks — REQ-test-router-decision-contract-1777860546
+
+## Stage: contract / spec
+- [x] author `openspec/changes/.../specs/router-decision-contract-tests/spec.md`
+- [x] verify `openspec validate REQ-test-router-decision-contract-1777860546`
+- [x] verify `check-scenario-refs.sh` clean
+
+## Stage: implementation
+- [x] add `orchestrator/tests/router/test_verifier_decision_parsing.py`
+- [x] cover parametrised table (12 rows: 4 happy, 5 escalate, 1 description-only, 2 unknown-stage)
+- [x] cover 3 focused invariants (no-stage escalate, None/None defensive, base64 precedence)
+- [x] no production code change (`router.py`, `verifier_parser.py`, `state.py` untouched)
+
+## Stage: PR
+- [x] `make ci-lint` green
+- [x] new tests pass standalone (`pytest tests/router/test_verifier_decision_parsing.py -v`)
+- [x] tests near the change (`tests/router/`, `test_router.py`, `test_verifier.py`,
+      `test_router_validate_audit_schema.py`, `test_webhook_verifier_retry.py`) all green
+- [x] orchestrator-wide unit-test failures are pre-existing (tracked in phona/sisyphus#364
+      — test isolation pollution, unrelated to this REQ's diff)
+- [x] push `feat/REQ-test-router-decision-contract-1777860546`
+- [x] open PR with `sisyphus` label and cross-link footer

--- a/orchestrator/tests/router/test_verifier_decision_parsing.py
+++ b/orchestrator/tests/router/test_verifier_decision_parsing.py
@@ -1,0 +1,205 @@
+"""Contract test for `derive_verifier_event` decision parsing (closes phona/sisyphus#371).
+
+Pin the verifier session.completed → Event mapping so future drift in the
+verifier output format / parser fallback layers fails at unit-test time, not
+only when a live REQ silently sticks at ESCALATED.
+
+Origin incident: 5/4 v5 dogfood — verifier-agent emitted a plain
+`decision:pass` tag (no base64 JSON), router's old parser found nothing
+parseable and routed VERIFY_ESCALATE without surfacing the failure.
+REQ-fix-verifier-decision-tag-1777812498 (closes #356) added the plain
+`decision:<action>[-<fixer>]` tag fallback in `verifier_parser`; this test
+locks both the happy paths AND the silent-escalate paths so neither side
+of the contract regresses.
+
+Note: the cases below pin **current** post-#356 behavior. Issue #371 listed
+expectations from before the fallback landed (e.g. plain `decision:pass`
+escalating); those have been updated in place to the now-correct routes,
+with comments where the case differs from the original sketch.
+"""
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from orchestrator.router import derive_verifier_event
+from orchestrator.state import Event
+
+
+def _b64(d: dict) -> str:
+    """Standard base64, no padding — same shape verifier-agent emits."""
+    return base64.b64encode(json.dumps(d).encode()).decode().rstrip("=")
+
+
+_VALID_PASS = {"action": "pass", "fixer": None, "reason": "ok", "confidence": "high"}
+_VALID_FIX_DEV = {"action": "fix", "fixer": "dev", "reason": "bug", "confidence": "high"}
+
+
+CASES: list[tuple[str, str | None, list[str], Event, str]] = [
+    # (label, description, tags, expected_event, expected_reason_substring)
+    #
+    # ─── 1) tag base64 happy paths ────────────────────────────────────────
+    (
+        "tag-base64 valid pass + dev_cross_check stage → DEV_CROSS_CHECK_PASS",
+        None,
+        [f"decision:{_b64(_VALID_PASS)}", "verify:dev_cross_check"],
+        Event.DEV_CROSS_CHECK_PASS,
+        "",
+    ),
+    (
+        "tag-base64 valid fix-dev → VERIFY_FIX_NEEDED",
+        None,
+        [f"decision:{_b64(_VALID_FIX_DEV)}", "verify:dev_cross_check"],
+        Event.VERIFY_FIX_NEEDED,
+        "",
+    ),
+    # ─── 2) plain decision:<action> tag fallback (post-#356) ──────────────
+    # Was VERIFY_ESCALATE pre-#356 (the v5 incident); now routes via parser
+    # synthesis to the matching pass/fix/escalate/retry event.
+    (
+        "plain decision:pass tag → DEV_CROSS_CHECK_PASS (orch-fallback synth)",
+        None,
+        ["decision:pass", "verify:dev_cross_check"],
+        Event.DEV_CROSS_CHECK_PASS,
+        "",
+    ),
+    (
+        "plain decision:fix-dev tag → VERIFY_FIX_NEEDED (orch-fallback synth)",
+        None,
+        ["decision:fix-dev", "verify:dev_cross_check"],
+        Event.VERIFY_FIX_NEEDED,
+        "",
+    ),
+    (
+        "plain decision:escalate tag → VERIFY_ESCALATE (intentional)",
+        None,
+        ["decision:escalate", "verify:dev_cross_check"],
+        Event.VERIFY_ESCALATE,
+        "",
+    ),
+    (
+        "plain decision:retry tag → VERIFY_INFRA_RETRY",
+        None,
+        ["decision:retry", "verify:dev_cross_check"],
+        Event.VERIFY_INFRA_RETRY,
+        "",
+    ),
+    # ─── 3) silent-escalate paths (the regressions we're guarding) ────────
+    # `decision:fail` is NOT in `_PLAIN_TAG_TO_DECISION`; no decision can be
+    # synthesized → router escalates with explicit reason. This pins that
+    # adding `decision:fail` to the alias table later would be a contract
+    # change, not a bugfix.
+    (
+        "plain decision:fail tag → VERIFY_ESCALATE (no synth, pinned)",
+        None,
+        ["decision:fail", "verify:dev_cross_check"],
+        Event.VERIFY_ESCALATE,
+        "no decision JSON",
+    ),
+    # base64 of `{"action":"pass"}` — parses as JSON but fails schema
+    # (missing required `confidence`). The test in #371 used this exact
+    # payload; the reason wording is "invalid decision: <why>".
+    (
+        "tag-base64 partial schema (missing confidence) → VERIFY_ESCALATE invalid decision",
+        None,
+        ["decision:eyJhY3Rpb24iOiJwYXNzIn0=", "verify:dev_cross_check"],
+        Event.VERIFY_ESCALATE,
+        "invalid decision",
+    ),
+    # base64 of `{"x":1~}` — base64 decodes but the result is not valid JSON.
+    # Parser's `_extract_from_tags` records a failed attempt; nothing else
+    # provides a decision; raw doesn't contain "action" → not retry-worthy.
+    (
+        "tag-base64 garbled JSON → VERIFY_ESCALATE no decision JSON",
+        None,
+        ["decision:eyJ4Ijoxfn0=", "verify:dev_cross_check"],
+        Event.VERIFY_ESCALATE,
+        "no decision JSON",
+    ),
+    # ─── 4) description-only path (agent forgot the tag) ──────────────────
+    (
+        "description ```json``` block with no tag → DEV_CROSS_CHECK_PASS",
+        '```json\n{"action":"pass","fixer":null,"reason":"x","confidence":"high"}\n```',
+        ["verify:dev_cross_check"],
+        Event.DEV_CROSS_CHECK_PASS,
+        "",
+    ),
+    # ─── 5) unknown verifier stage → escalate with named reason ───────────
+    (
+        "valid decision but unknown verify:<stage> → VERIFY_ESCALATE unknown stage",
+        None,
+        [f"decision:{_b64(_VALID_PASS)}", "verify:unknown_stage"],
+        Event.VERIFY_ESCALATE,
+        "unknown verifier stage",
+    ),
+    # ─── 6) nothing at all → escalate, no decision ────────────────────────
+    (
+        "no tag and no description JSON → VERIFY_ESCALATE no decision JSON",
+        "boring agent message with zero JSON",
+        ["verify:dev_cross_check"],
+        Event.VERIFY_ESCALATE,
+        "no decision JSON",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "description", "tags", "expected_event", "expected_reason_kw"),
+    CASES,
+    ids=[c[0] for c in CASES],
+)
+def test_derive_verifier_event_contract(
+    label: str,
+    description: str | None,
+    tags: list[str],
+    expected_event: Event,
+    expected_reason_kw: str,
+) -> None:
+    event, _decision, reason = derive_verifier_event(description, tags)
+    assert event == expected_event, f"{label}: event {event} != {expected_event} (reason={reason!r})"
+    if expected_reason_kw:
+        assert expected_reason_kw in reason, (
+            f"{label}: expected reason to contain {expected_reason_kw!r}, got {reason!r}"
+        )
+    else:
+        assert reason == "", f"{label}: expected empty reason on happy path, got {reason!r}"
+
+
+def test_pass_decision_without_stage_tag_escalates() -> None:
+    """A valid pass decision but no `verify:<stage>` tag → unknown stage escalate.
+
+    Defends against the case where a verifier issue PATCHes its decision tag
+    correctly but never carried a `verify:<stage>` tag at all (router can't
+    pick a pass route, must escalate rather than guess).
+    """
+    event, decision, reason = derive_verifier_event(None, [f"decision:{_b64(_VALID_PASS)}"])
+    assert event == Event.VERIFY_ESCALATE
+    assert decision is not None
+    assert decision["action"] == "pass"
+    assert "unknown verifier stage" in reason
+
+
+def test_empty_inputs_give_no_decision_escalate() -> None:
+    """Defensive: None / empty inputs land in VERIFY_ESCALATE, not a crash."""
+    event, decision, reason = derive_verifier_event(None, None)
+    assert event == Event.VERIFY_ESCALATE
+    assert decision is None
+    assert "no decision JSON" in reason
+
+
+def test_base64_tag_wins_over_plain_tag() -> None:
+    """Both `decision:<base64>` and plain `decision:<action>` present → base64 wins.
+
+    Pinned because adding aliases shouldn't change precedence: the tag-base64
+    happy path is the authoritative format that all other layers fall back from.
+    """
+    valid_fix = {"action": "fix", "fixer": "spec", "reason": "spec drift", "confidence": "high"}
+    event, decision, _reason = derive_verifier_event(
+        None,
+        [f"decision:{_b64(valid_fix)}", "decision:pass", "verify:dev_cross_check"],
+    )
+    assert event == Event.VERIFY_FIX_NEEDED
+    assert decision is not None
+    assert decision["fixer"] == "spec"

--- a/orchestrator/tests/router/test_verifier_decision_parsing_challenger.py
+++ b/orchestrator/tests/router/test_verifier_decision_parsing_challenger.py
@@ -1,0 +1,253 @@
+"""Challenger contract test for `derive_verifier_event` (REQ-test-router-decision-contract-1777860546).
+
+Independent black-box pin of the spec capability `router-decision-contract-tests`
+(see `openspec/changes/REQ-test-router-decision-contract-1777860546/specs/...`).
+
+Authored by the challenger stage from the spec only — no peeking at the dev's
+parametrised test file in this same directory. One test function per spec
+scenario (RDCT-S1 .. RDCT-S7) plus a few additional silent-escalate rows
+called out in the proposal.md routing table that the spec text calls "every
+silent-escalate case" without naming them individually.
+
+Runs as a pure unit test: no DB, no network, no BKD client, no K8s.
+"""
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import pytest
+
+from orchestrator.router import derive_verifier_event
+from orchestrator.state import Event
+
+# ─── helpers ─────────────────────────────────────────────────────────────
+
+
+def _b64_tag(decision: dict[str, Any]) -> str:
+    """Build a `decision:<base64-json>` tag exactly the way verifier-agent does.
+
+    URL-safe base64, padding stripped — matches the shape the parser layer
+    accepts (see verifier-decision-tag-fallback capability).
+    """
+    raw = json.dumps(decision, separators=(",", ":")).encode("utf-8")
+    return "decision:" + base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _valid_pass() -> dict[str, Any]:
+    return {
+        "action": "pass",
+        "fixer": None,
+        "scope": None,
+        "reason": "spec-conformant",
+        "confidence": "high",
+    }
+
+
+def _valid_fix(fixer: str = "spec") -> dict[str, Any]:
+    return {
+        "action": "fix",
+        "fixer": fixer,
+        "scope": "openspec/",
+        "reason": "drift",
+        "confidence": "high",
+    }
+
+
+# ─── RDCT-S1 — runs as a unit test, no external deps ─────────────────────
+
+
+def test_rdct_s1_no_external_dependencies():
+    """The whole test module must be importable + invokable without any
+    network / DB / BKD / K8s side effects. If this test runs at all under
+    `pytest -m "not integration"`, S1 is satisfied — but pin it explicitly
+    so future drift (e.g. someone adds an `async` PG fixture into the
+    router import path) trips this case first.
+    """
+    event, decision, reason = derive_verifier_event(None, None)
+    # Defensive shape — values asserted in S-defensive case below.
+    assert isinstance(event, Event)
+    assert decision is None or isinstance(decision, dict)
+    assert isinstance(reason, str)
+
+
+# ─── RDCT-S2 — happy path tag-base64 → per-stage pass ────────────────────
+
+
+def test_rdct_s2_base64_pass_routes_to_stage_pass():
+    tags = [_b64_tag(_valid_pass()), "verify:dev_cross_check"]
+    event, decision, reason = derive_verifier_event(None, tags)
+    assert event == Event.DEV_CROSS_CHECK_PASS, f"reason={reason!r}"
+    assert decision is not None and decision["action"] == "pass"
+    assert reason == ""
+
+
+# ─── RDCT-S3 — plain `decision:pass` parser fallback (closes phona/sisyphus#371) ─
+
+
+def test_rdct_s3_plain_decision_pass_tag_falls_back_to_stage_pass():
+    """The exact shape that triggered the 5/4 v5 dogfood incident: a plain
+    `decision:pass` tag without the base64 JSON. Post REQ-fix-verifier-
+    decision-tag-1777812498 (closes phona/sisyphus#356) the parser layer
+    synthesises a low-confidence decision so this is now a happy path.
+    """
+    tags = ["decision:pass", "verify:dev_cross_check"]
+    event, decision, _reason = derive_verifier_event(None, tags)
+    assert event == Event.DEV_CROSS_CHECK_PASS
+    assert decision is not None
+    assert decision["action"] == "pass"
+
+
+# ─── RDCT-S4 — plain `decision:fail` is intentionally NOT in the alias table ─
+
+
+def test_rdct_s4_plain_decision_fail_tag_escalates_with_no_json_reason():
+    """`decision:fail` is not a synthesised happy path. The parser table only
+    aliases pass / fix-dev / fix-spec / escalate / retry — `fail` falls
+    through and surfaces as an escalate with `no decision JSON`.
+    """
+    tags = ["decision:fail", "verify:dev_cross_check"]
+    event, _decision, reason = derive_verifier_event(None, tags)
+    assert event == Event.VERIFY_ESCALATE
+    assert "no decision JSON" in reason, f"got reason={reason!r}"
+
+
+# ─── RDCT-S5 — schema-invalid base64 → escalate with `invalid decision` ──
+
+
+def test_rdct_s5_schema_invalid_base64_escalates_with_invalid_decision_reason():
+    """`{"action":"pass"}` is well-formed JSON but missing the required
+    `confidence` field. The router must escalate with a reason naming the
+    schema violation (so `verifier_parse_retry` can decide retry-worthiness
+    from the reason text — see #372 telemetry).
+    """
+    bad_payload = base64.urlsafe_b64encode(b'{"action":"pass"}').decode("ascii").rstrip("=")
+    tags = [f"decision:{bad_payload}", "verify:dev_cross_check"]
+    event, _decision, reason = derive_verifier_event(None, tags)
+    assert event == Event.VERIFY_ESCALATE
+    assert "invalid decision" in reason, f"got reason={reason!r}"
+
+
+# ─── RDCT-S6 — schema-valid base64 but verify:<unknown_stage> escalates ──
+
+
+def test_rdct_s6_unknown_verifier_stage_escalates_even_with_valid_decision():
+    """The decision JSON itself is fine; the `verify:<stage>` tag points at
+    a stage that has no entry in the router's pass-routing table. Escalate
+    rather than silently routing to an arbitrary default.
+    """
+    tags = [_b64_tag(_valid_pass()), "verify:unknown_stage"]
+    event, decision, reason = derive_verifier_event(None, tags)
+    assert event == Event.VERIFY_ESCALATE
+    assert decision is not None and decision["action"] == "pass"
+    assert "unknown verifier stage" in reason, f"got reason={reason!r}"
+
+
+# ─── RDCT-S7 — base64 tag wins precedence over plain decision:* tag ──────
+
+
+def test_rdct_s7_base64_decision_wins_over_plain_decision_tag():
+    """When BOTH a base64 and a plain decision tag are present, the base64
+    one (full schema, includes `fixer`) must win. Otherwise an agent that
+    appends `decision:pass` for legibility on top of a base64 fix decision
+    would cause the router to silently flip the action.
+    """
+    fix_payload = _valid_fix(fixer="spec")
+    tags = [_b64_tag(fix_payload), "decision:pass", "verify:dev_cross_check"]
+    event, decision, _reason = derive_verifier_event(None, tags)
+    assert event == Event.VERIFY_FIX_NEEDED
+    assert decision is not None
+    # The base64 payload's `fixer` survived — not the synthesised null from
+    # the plain `decision:pass` alias.
+    assert decision.get("fixer") == "spec"
+    assert decision["action"] == "fix"
+
+
+# ─── Additional silent-escalate rows from proposal.md routing table ──────
+#
+# The spec prose calls these out as "every silent-escalate case". They aren't
+# numbered scenarios but the proposal table pins them, and the whole point
+# of phona/sisyphus#371 is that any of them silently flipping to
+# VERIFY_ESCALATE is the failure mode we're guarding against.
+
+
+def test_defensive_none_inputs_escalate_without_crash():
+    """Spec proposal table row: `nothing parseable anywhere` → VERIFY_ESCALATE
+    reason=`no decision JSON`. Defensive — must not raise on None / None.
+    """
+    event, decision, reason = derive_verifier_event(None, None)
+    assert event == Event.VERIFY_ESCALATE
+    assert decision is None
+    assert "no decision JSON" in reason
+
+
+def test_empty_tag_list_escalates_without_crash():
+    """Same row as above but with `tags=[]` rather than `tags=None`."""
+    event, decision, reason = derive_verifier_event(None, [])
+    assert event == Event.VERIFY_ESCALATE
+    assert decision is None
+    assert "no decision JSON" in reason
+
+
+def test_valid_decision_without_any_verify_stage_tag_escalates():
+    """Spec proposal table row: `valid decision but no verify:<stage> tag`
+    → VERIFY_ESCALATE reason=`unknown verifier stage`.
+    """
+    tags = [_b64_tag(_valid_pass())]
+    event, _decision, reason = derive_verifier_event(None, tags)
+    assert event == Event.VERIFY_ESCALATE
+    assert "unknown verifier stage" in reason, f"got reason={reason!r}"
+
+
+def test_base64_that_decodes_but_is_not_json_escalates():
+    """Spec proposal table row: `base64 that decodes but isn't valid JSON`
+    → VERIFY_ESCALATE reason=`no decision JSON`.
+    """
+    not_json = base64.urlsafe_b64encode(b"this is not json").decode("ascii").rstrip("=")
+    tags = [f"decision:{not_json}", "verify:dev_cross_check"]
+    event, _decision, reason = derive_verifier_event(None, tags)
+    assert event == Event.VERIFY_ESCALATE
+    assert "no decision JSON" in reason, f"got reason={reason!r}"
+
+
+def test_base64_fix_routes_to_verify_fix_needed_regardless_of_stage():
+    """Cross-stage smoke for the fix path: a base64 fix decision should
+    still surface as VERIFY_FIX_NEEDED on a different known stage, since
+    the per-stage routing table only governs the pass branch.
+    """
+    fix_payload = _valid_fix(fixer="dev")
+    for stage in ("verify:staging_test", "verify:pr_ci", "verify:spec_lint"):
+        tags = [_b64_tag(fix_payload), stage]
+        event, decision, _reason = derive_verifier_event(None, tags)
+        assert event == Event.VERIFY_FIX_NEEDED, f"stage={stage}"
+        assert decision is not None and decision["action"] == "fix"
+        assert decision.get("fixer") == "dev"
+
+
+# ─── Sanity: contract test imports succeed without any orch boot side-effects ─
+
+
+def test_module_imports_are_pure():
+    """Reading `from orchestrator.router import derive_verifier_event` must
+    not require Settings / DB / BKD secrets — `conftest.py` only sets a
+    handful of dummy env vars, so anything heavier breaks here first.
+    """
+    # If the import at module top failed, pytest would never have collected
+    # this test. The fact that we get here is the assertion.
+    assert callable(derive_verifier_event)
+    assert hasattr(Event, "VERIFY_ESCALATE")
+    assert hasattr(Event, "VERIFY_FIX_NEEDED")
+    assert hasattr(Event, "DEV_CROSS_CHECK_PASS")
+
+
+# ─── Deliberately not pulled in: ─────────────────────────────────────────
+# - decision_to_event / validate_decision / extract_decision_from_issue are
+#   internal-by-convention helpers — black-box contract is `derive_verifier_event`.
+# - derive_verifier_event_with_retry_info is a wrapper that adds a retry-worthiness
+#   bool; that's #372 territory, not this REQ.
+# - description ` ```json``` ` block parsing is exercised by test_verifier.py
+#   already; we don't duplicate it here so the contract surface stays minimal.
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Add `orchestrator/tests/router/test_verifier_decision_parsing.py` — a parametrised contract test for `router.derive_verifier_event` covering every verifier-agent output shape in production: tag-base64 happy paths, plain `decision:<action>` tag fallback (post-#356), description-only ` ```json ``` ` blocks, and every silent-escalate path (unknown stage, schema-invalid, garbled base64, plain `decision:fail`, empty inputs).
- Three focused invariants pin no-stage escalate, defensive `None`/empty inputs, and base64-over-plain-tag precedence.
- No production code change — `router.py`, `verifier_parser.py`, prompts, `state.py` untouched.

## Why

5/4 v5 dogfood — verifier-agent emitted plain `decision:pass` (string, no base64 JSON), the router silently picked `VERIFY_ESCALATE`, the REQ stuck in `ESCALATED` for 30+ minutes with no error log. REQ-fix-verifier-decision-tag-1777812498 (closes phona/sisyphus#356) added the parser fallback; this test pins both halves so a regression in either side fails at unit-test time, not when a live REQ silently sticks.

## Test plan

- [x] `pytest orchestrator/tests/router/test_verifier_decision_parsing.py -v` → 15 passed (12 parametrised + 3 invariants)
- [x] `make ci-lint` clean (full scan)
- [x] `openspec validate REQ-test-router-decision-contract-1777860546` clean
- [x] `scripts/check-scenario-refs.sh` clean
- [x] near-by tests still green: `tests/router/`, `test_router.py`, `test_verifier.py`, `test_router_validate_audit_schema.py`, `test_webhook_verifier_retry.py` (153 passed)
- [ ] CI green

> Pre-existing orchestrator-wide unit-test failures (~31, test isolation pollution) tracked separately in phona/sisyphus#364 and are unrelated to this diff.

Refs: phona/sisyphus#371 (closes), phona/sisyphus#763 (prompt mandate, complementary), phona/sisyphus#372 (decode-fail telemetry, complementary).

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-test-router-decision-contract-1777860546\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/qhcv5k72)