### PR TITLE
feat(stage): stage precheck phase (closes #373)

### DIFF
--- a/docs/integration-contracts.md
+++ b/docs/integration-contracts.md
@@ -118,6 +118,39 @@ unset TOKEN
 
 ## 2. Makefile target 契约（硬约束）
 
+### 2.0 ci-precheck（可选，推荐实现）
+
+sisyphus 在每个 stage agent 起来的**第 0 步**会对每个 source repo 尝试运行 `make ci-precheck`。
+
+**语义**：
+
+| 情况 | sisyphus 行为 |
+|---|---|
+| target **不存在**（`make: No rule to make target 'ci-precheck'`） | **skip**，不 fail，继续推进 |
+| target **存在且退码 0** | pass，继续推进 |
+| target **存在且退码非 0** | **emit `result:fail` + `fail-reason:precheck:ci_precheck`**，agent 立即停止 |
+
+这样老业务仓无需修改即可接入；新仓可以按需实现，让环境问题在 7 min watchdog 之前暴露。
+
+**推荐实现内容**（轻量，整体 <10 s）：
+
+```makefile
+.PHONY: ci-precheck
+
+ci-precheck:
+	@echo "=== ci-precheck: tool versions ==="
+	@go version
+	@docker version --format 'docker {{.Server.Version}}' 2>/dev/null || echo "docker unavailable"
+	@echo "=== ci-precheck: required env vars ==="
+	@[ -n "$(GH_TOKEN)" ]       || { echo "GH_TOKEN missing"; exit 1; }
+	@[ -n "$(SISYPHUS_REQ_ID)" ] || { echo "SISYPHUS_REQ_ID missing"; exit 1; }
+	@echo "=== ci-precheck: external dependencies ==="
+	@# 可选：探活数据库 / 外部 API，视业务而定
+	@echo "ci-precheck OK"
+```
+
+> **注意**：`ci-precheck` 不应启动 docker compose 或跑编译——那是 `ci-unit-test` / `ci-integration-test` 的活。只做「能拿到工具、env 变量存在、外部依赖可到达」的快速自检。
+
 ### 2.1 source repo 必须有
 
 > 这套契约对齐 **`ttpos-ci`** 标准（`ci-env` / `ci-setup` / `ci-lint` / `ci-unit-test` / `ci-integration-test` / `ci-build`），

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -1,6 +1,6 @@
 # Task Index
 
-Last updated: 2026-04-27
+Last updated: 2026-05-04
 
 ## Active
 
@@ -11,5 +11,9 @@ Last updated: 2026-04-27
 | [-] | [TASK-router-session-completed-audit](TASK-router-session-completed-audit.md) | in_progress | claude | REQ-router-session-completed-audit |
 
 ## Completed
+
+| ID | Title | Status | Owner | REQ |
+|---|---|---|---|---|
+| [-] | stage precheck phase | completed | claude | REQ-feat-precheck-373 |
 
 ## Closed

--- a/orchestrator/src/orchestrator/prompts/_shared/precheck.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/precheck.md.j2
@@ -1,0 +1,92 @@
+## Precheck Phase（第 0 步，必须先跑）
+
+在做任何正式工作之前，验证运行环境是否就绪。任一项失败立即 emit `result:fail` 并停止，不继续后续步骤。
+
+```bash
+POD=runner-{{ req_id | lower }}
+NS=sisyphus-runners
+PROJECT={{ project_alias }}
+MY={{ issue_id or '$(basename $PWD)' }}
+```
+
+### Precheck 1: GH_TOKEN 有效
+
+在 runner pod 内验证 `$GH_TOKEN` 能通过 GitHub API 认证：
+
+```bash
+mcp__{{ mcp_capability_providers['ssh_exec'] }}__exec_run(
+  server_id="{{ aissh_server_id or '5b25f0cd-4fef-4a1f-a4c0-14ecf1395d84' }}",
+  command="kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c \
+    'curl -fsS -o /dev/null -H \"Authorization: token $GH_TOKEN\" \
+     https://api.github.com/user && echo GH_TOKEN_OK || echo GH_TOKEN_FAIL'"
+)
+```
+
+输出 `GH_TOKEN_FAIL` 或命令非 0 退码 → 立即执行：
+
+```bash
+curl -sS -X PATCH http://localhost:3000/api/projects/$PROJECT/issues/$MY \
+  -H 'content-type: application/json' \
+  -d '{"tags":["{{ stage }}","{{ req_id }}","result:fail","fail-reason:precheck:gh_token"],"statusId":"review"}'
+```
+
+然后**停止，不继续**。
+
+### Precheck 2: KUBECONFIG 可用
+
+```bash
+mcp__{{ mcp_capability_providers['ssh_exec'] }}__exec_run(
+  server_id="{{ aissh_server_id or '5b25f0cd-4fef-4a1f-a4c0-14ecf1395d84' }}",
+  command="kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c \
+    'kubectl cluster-info --request-timeout=5s >/dev/null 2>&1 && echo KUBECONFIG_OK || echo KUBECONFIG_FAIL'"
+)
+```
+
+输出 `KUBECONFIG_FAIL` → 立即执行：
+
+```bash
+curl -sS -X PATCH http://localhost:3000/api/projects/$PROJECT/issues/$MY \
+  -H 'content-type: application/json' \
+  -d '{"tags":["{{ stage }}","{{ req_id }}","result:fail","fail-reason:precheck:kubeconfig"],"statusId":"review"}'
+```
+
+然后**停止，不继续**。
+
+### Precheck 3: ci-precheck target（可选，target 缺失 = skip）
+
+对 `/workspace/source/` 下每个 source repo 运行 `make ci-precheck`。
+**target 不存在（"No rule to make target"）= skip**，不 fail。
+target 存在但退码非 0 才视为 fail。
+
+```bash
+mcp__{{ mcp_capability_providers['ssh_exec'] }}__exec_run(
+  server_id="{{ aissh_server_id or '5b25f0cd-4fef-4a1f-a4c0-14ecf1395d84' }}",
+  command="kubectl -n sisyphus-runners exec runner-{{ req_id | lower }} -- bash -c '
+    FAIL=0
+    for repo_dir in /workspace/source/*/; do
+      [ -d \"$repo_dir\" ] || continue
+      cd \"$repo_dir\"
+      if make -n ci-precheck >/dev/null 2>&1; then
+        make ci-precheck || { echo \"CI_PRECHECK_FAIL: $repo_dir\"; FAIL=1; }
+      else
+        echo \"CI_PRECHECK_SKIP: $repo_dir (no target)\"
+      fi
+    done
+    [ \"$FAIL\" -eq 0 ] && echo CI_PRECHECK_OK || echo CI_PRECHECK_FAIL
+  '"
+)
+```
+
+输出含 `CI_PRECHECK_FAIL` → 立即执行：
+
+```bash
+curl -sS -X PATCH http://localhost:3000/api/projects/$PROJECT/issues/$MY \
+  -H 'content-type: application/json' \
+  -d '{"tags":["{{ stage }}","{{ req_id }}","result:fail","fail-reason:precheck:ci_precheck"],"statusId":"review"}'
+```
+
+然后**停止，不继续**。
+
+---
+
+Precheck 全部通过（或 skip）后继续下面的正式步骤。

--- a/orchestrator/src/orchestrator/prompts/accept.md.j2
+++ b/orchestrator/src/orchestrator/prompts/accept.md.j2
@@ -13,6 +13,10 @@
 
 ─────────
 
+{% include "_shared/precheck.md.j2" %}
+
+─────────
+
 ## 验收 (ACCEPT / AI-QA) — thanatos M1
 AGENT_ROLE=accept-agent
 REQ={{ req_id }}

--- a/orchestrator/src/orchestrator/prompts/analyze.md.j2
+++ b/orchestrator/src/orchestrator/prompts/analyze.md.j2
@@ -19,6 +19,10 @@
 
 ─────────
 
+{% include "_shared/precheck.md.j2" %}
+
+─────────
+
 ## RESUME GUARD（防重复执行）
 
 你被 wake 后，**第一件事**是先通过客观事实自检 analyze 阶段是否已经完成。在 runner pod 或本地 workspace 执行：

--- a/orchestrator/src/orchestrator/prompts/bugfix.md.j2
+++ b/orchestrator/src/orchestrator/prompts/bugfix.md.j2
@@ -12,6 +12,10 @@
 
 ─────────
 
+{% include "_shared/precheck.md.j2" %}
+
+─────────
+
 ## BUG FIX (DEV-FIX)
 AGENT_ROLE=dev-fix-agent
 REQ={{ req_id }}

--- a/orchestrator/src/orchestrator/prompts/challenger.md.j2
+++ b/orchestrator/src/orchestrator/prompts/challenger.md.j2
@@ -13,6 +13,10 @@
 
 ─────────
 
+{% include "_shared/precheck.md.j2" %}
+
+─────────
+
 ## 挑战者 (CHALLENGER, M18)
 AGENT_ROLE=challenger-agent
 REQ={{ req_id }}

--- a/orchestrator/src/orchestrator/prompts/staging_test.md.j2
+++ b/orchestrator/src/orchestrator/prompts/staging_test.md.j2
@@ -12,6 +12,10 @@
 
 ─────────
 
+{% include "_shared/precheck.md.j2" %}
+
+─────────
+
 ## 调试环境测试 (STAGING TEST)  M15 / 多仓 / [LEGACY BKD-agent path]
 AGENT_ROLE=staging-test-agent
 REQ={{ req_id }}

--- a/orchestrator/tests/test_contract_stage_precheck.py
+++ b/orchestrator/tests/test_contract_stage_precheck.py
@@ -1,0 +1,249 @@
+"""Contract tests for REQ-feat-precheck-373.
+
+Scenarios covered:
+  SPC-S1   _shared/precheck.md.j2 exists in the prompts package directory
+  SPC-S2   precheck partial contains GH_TOKEN validity check
+  SPC-S3   precheck partial contains KUBECONFIG check
+  SPC-S4   precheck partial contains ci-precheck make target invocation
+  SPC-S5   precheck partial contains result:fail tag instruction
+  SPC-S6   precheck partial contains fail-reason:precheck: tag pattern
+  SPC-S7   precheck partial documents skip semantics for missing target
+  SPC-S8   analyze.md.j2 includes precheck partial
+  SPC-S9   challenger.md.j2 includes precheck partial
+  SPC-S10  accept.md.j2 includes precheck partial
+  SPC-S11  staging_test.md.j2 includes precheck partial
+  SPC-S12  bugfix.md.j2 includes precheck partial
+  SPC-S13  pr_ci_watch.md.j2 does NOT include precheck partial (no make invocation)
+  SPC-S14  intake.md.j2 does NOT include precheck partial (pure chat stage)
+  SPC-S15  docs/integration-contracts.md contains ci-precheck section
+  SPC-S16  integration-contracts ci-precheck section documents skip-if-missing semantics
+  SPC-S17  precheck partial includes runner pod exec pattern (mcp ssh_exec)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_PROMPTS_DIR = (
+    Path(__file__).resolve().parent.parent / "src" / "orchestrator" / "prompts"
+)
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_DOCS_DIR = _REPO_ROOT / "docs"
+
+
+def _read_prompt(rel: str) -> str:
+    return (_PROMPTS_DIR / rel).read_text(encoding="utf-8")
+
+
+def _read_doc(rel: str) -> str:
+    return (_DOCS_DIR / rel).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# SPC-S1  precheck partial exists
+# ---------------------------------------------------------------------------
+
+
+def test_spc_s1_precheck_partial_exists() -> None:
+    """SPC-S1: _shared/precheck.md.j2 must exist in the prompts package directory."""
+    path = _PROMPTS_DIR / "_shared" / "precheck.md.j2"
+    assert path.exists(), (
+        "SPC-S1 FAILED: _shared/precheck.md.j2 not found.\n"
+        f"Expected path: {path}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# SPC-S2  GH_TOKEN check present
+# ---------------------------------------------------------------------------
+
+
+def test_spc_s2_precheck_contains_gh_token_check() -> None:
+    """SPC-S2: precheck partial must instruct the agent to verify GH_TOKEN validity."""
+    text = _read_prompt("_shared/precheck.md.j2")
+    assert "GH_TOKEN" in text, (
+        "SPC-S2 FAILED: _shared/precheck.md.j2 does not reference GH_TOKEN. "
+        "The precheck must verify that GH_TOKEN is active before proceeding."
+    )
+    assert "api.github.com" in text, (
+        "SPC-S2 FAILED: _shared/precheck.md.j2 does not contain a GitHub API probe. "
+        "Expected a curl to api.github.com/user to validate GH_TOKEN."
+    )
+
+
+# ---------------------------------------------------------------------------
+# SPC-S3  KUBECONFIG check present
+# ---------------------------------------------------------------------------
+
+
+def test_spc_s3_precheck_contains_kubeconfig_check() -> None:
+    """SPC-S3: precheck partial must verify KUBECONFIG / kubectl cluster access."""
+    text = _read_prompt("_shared/precheck.md.j2")
+    assert "KUBECONFIG" in text or "kubectl cluster-info" in text, (
+        "SPC-S3 FAILED: _shared/precheck.md.j2 does not contain a KUBECONFIG check. "
+        "Expected `kubectl cluster-info` or a KUBECONFIG reference."
+    )
+
+
+# ---------------------------------------------------------------------------
+# SPC-S4  ci-precheck make target invocation present
+# ---------------------------------------------------------------------------
+
+
+def test_spc_s4_precheck_invokes_ci_precheck_target() -> None:
+    """SPC-S4: precheck partial must instruct the agent to run `make ci-precheck`."""
+    text = _read_prompt("_shared/precheck.md.j2")
+    assert "make ci-precheck" in text or "ci-precheck" in text, (
+        "SPC-S4 FAILED: _shared/precheck.md.j2 does not mention `ci-precheck` make target. "
+        "The precheck must attempt `make ci-precheck` on each source repo."
+    )
+
+
+# ---------------------------------------------------------------------------
+# SPC-S5  result:fail tag instruction present
+# ---------------------------------------------------------------------------
+
+
+def test_spc_s5_precheck_emits_result_fail_tag() -> None:
+    """SPC-S5: precheck partial must instruct the agent to tag the issue with result:fail on failure."""
+    text = _read_prompt("_shared/precheck.md.j2")
+    assert "result:fail" in text, (
+        "SPC-S5 FAILED: _shared/precheck.md.j2 does not contain `result:fail` tag instruction. "
+        "On any precheck failure the agent must PATCH the BKD issue with result:fail."
+    )
+
+
+# ---------------------------------------------------------------------------
+# SPC-S6  fail-reason:precheck: tag pattern present
+# ---------------------------------------------------------------------------
+
+
+def test_spc_s6_precheck_emits_fail_reason_tag() -> None:
+    """SPC-S6: precheck partial must include fail-reason:precheck: tag pattern."""
+    text = _read_prompt("_shared/precheck.md.j2")
+    assert "fail-reason:precheck:" in text, (
+        "SPC-S6 FAILED: _shared/precheck.md.j2 does not include `fail-reason:precheck:` "
+        "tag pattern. Each failure item must produce a distinct fail-reason tag "
+        "(e.g. fail-reason:precheck:gh_token)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# SPC-S7  skip semantics documented for missing target
+# ---------------------------------------------------------------------------
+
+
+def test_spc_s7_precheck_documents_skip_when_target_missing() -> None:
+    """SPC-S7: precheck partial must document that missing ci-precheck target means skip (not fail)."""
+    text = _read_prompt("_shared/precheck.md.j2")
+    has_skip_doc = "skip" in text.lower() or "不存在" in text or "No rule" in text
+    assert has_skip_doc, (
+        "SPC-S7 FAILED: _shared/precheck.md.j2 does not document skip semantics for "
+        "a missing ci-precheck target. Old repos without the target must not be failed."
+    )
+
+
+# ---------------------------------------------------------------------------
+# SPC-S8 – SPC-S12  stage prompts include precheck partial
+# ---------------------------------------------------------------------------
+
+
+_STAGES_WITH_PRECHECK = [
+    "analyze.md.j2",
+    "challenger.md.j2",
+    "accept.md.j2",
+    "staging_test.md.j2",
+    "bugfix.md.j2",
+]
+
+
+@pytest.mark.parametrize("rel_path", _STAGES_WITH_PRECHECK)
+def test_spc_s8_to_s12_stage_includes_precheck(rel_path: str) -> None:
+    """SPC-S8 to SPC-S12: each runner-pod stage must include the precheck partial."""
+    text = _read_prompt(rel_path)
+    assert '_shared/precheck.md.j2' in text or "precheck.md.j2" in text, (
+        f"SPC FAILED: {rel_path} does not include _shared/precheck.md.j2. "
+        "All runner-pod stage agents must run the precheck phase as their first step."
+    )
+
+
+# ---------------------------------------------------------------------------
+# SPC-S13  pr_ci_watch does NOT include precheck
+# ---------------------------------------------------------------------------
+
+
+def test_spc_s13_pr_ci_watch_excludes_precheck() -> None:
+    """SPC-S13: pr_ci_watch.md.j2 must NOT include precheck (it only calls GitHub REST, no make)."""
+    text = _read_prompt("pr_ci_watch.md.j2")
+    assert "precheck.md.j2" not in text, (
+        "SPC-S13 FAILED: pr_ci_watch.md.j2 includes precheck partial. "
+        "pr-ci-watch only calls GitHub REST API and does not invoke make targets in "
+        "source repos, so precheck is not applicable."
+    )
+
+
+# ---------------------------------------------------------------------------
+# SPC-S14  intake does NOT include precheck
+# ---------------------------------------------------------------------------
+
+
+def test_spc_s14_intake_excludes_precheck() -> None:
+    """SPC-S14: intake.md.j2 must NOT include precheck (pure chat stage, no runner work)."""
+    text = _read_prompt("intake.md.j2")
+    assert "precheck.md.j2" not in text, (
+        "SPC-S14 FAILED: intake.md.j2 includes precheck partial. "
+        "Intake is a pure chat stage with no runner pod invocations; precheck is not applicable."
+    )
+
+
+# ---------------------------------------------------------------------------
+# SPC-S15  integration-contracts.md contains ci-precheck section
+# ---------------------------------------------------------------------------
+
+
+def test_spc_s15_integration_contracts_contains_ci_precheck_section() -> None:
+    """SPC-S15: docs/integration-contracts.md must document the ci-precheck target contract."""
+    text = _read_doc("integration-contracts.md")
+    assert "ci-precheck" in text, (
+        "SPC-S15 FAILED: docs/integration-contracts.md does not mention ci-precheck. "
+        "The target contract must be documented so business repo owners know what to implement."
+    )
+
+
+# ---------------------------------------------------------------------------
+# SPC-S16  integration-contracts ci-precheck section documents skip semantics
+# ---------------------------------------------------------------------------
+
+
+def test_spc_s16_integration_contracts_ci_precheck_documents_skip() -> None:
+    """SPC-S16: the ci-precheck section in integration-contracts.md must document
+    that a missing target means skip (backward-compatible with old repos)."""
+    text = _read_doc("integration-contracts.md")
+    # Find the relevant section around ci-precheck
+    idx = text.find("ci-precheck")
+    assert idx != -1, "ci-precheck not found in integration-contracts.md"
+    # Check the surrounding ~2000 chars for skip semantics
+    section = text[idx : idx + 2000]
+    has_skip = "skip" in section.lower() or "不存在" in section or "No rule" in section
+    assert has_skip, (
+        "SPC-S16 FAILED: the ci-precheck section in integration-contracts.md does not "
+        "document skip semantics when the target is missing. Old repos without the target "
+        "must be silently skipped (not failed)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# SPC-S17  precheck partial uses mcp ssh_exec exec_run pattern
+# ---------------------------------------------------------------------------
+
+
+def test_spc_s17_precheck_uses_ssh_exec_pattern() -> None:
+    """SPC-S17: precheck partial must use the mcp__ssh_exec__exec_run pattern
+    to run commands on the runner pod (same pattern as runner_container.md.j2)."""
+    text = _read_prompt("_shared/precheck.md.j2")
+    assert "mcp__" in text and "exec_run" in text, (
+        "SPC-S17 FAILED: _shared/precheck.md.j2 does not use the mcp__*__exec_run pattern. "
+        "Commands must go through the ssh_exec MCP provider — BKD agents cannot run "
+        "kubectl directly (no local kubectl / KUBECONFIG)."
+    )


### PR DESCRIPTION
## Summary

- Add `_shared/precheck.md.j2` partial: three env checks (GH_TOKEN, KUBECONFIG, `make ci-precheck`) run as the first step of every runner-pod stage agent
- Any check failure immediately PATCHes the BKD issue with `result:fail` + `fail-reason:precheck:<item>` and stops — no more 7-min watchdog waste
- `make ci-precheck` is opt-in: target missing = **skip** (backward-compatible with all existing business repos)
- Inject precheck into `analyze`, `challenger`, `accept`, `staging_test`, `bugfix`; exclude `pr_ci_watch` (REST-only) and `intake` (pure chat)
- Add §2.0 `ci-precheck` contract in `docs/integration-contracts.md` with recommended template

## Test plan

- [x] 17 new contract tests (`SPC-S1` – `SPC-S17`) all green
- [x] Full unit suite: 2251 passed, no new failures introduced
- [x] `make ci-lint` green

<!-- sisyphus:cross-link -->
**sisyphus REQ**: `REQ-feat-precheck-373`