### PR TITLE
feat(prompts): stage agent step-0 unified precheck phase (closes #373)

### DIFF
--- a/docs/integration-contracts.md
+++ b/docs/integration-contracts.md
@@ -200,6 +200,36 @@ make ci-integration-test
 staging-test checker 只跑 `make ci-unit-test && make ci-integration-test`，
 **不跑 contract tag**。contract test 的 RED 阶段由 challenger 自行验证。
 
+### 2.6 `make ci-precheck`（业务仓**可选**契约 target，REQ-feat-precheck-373）
+
+stage agent 第 0.5 步会跑统一 precheck phase（`_shared/hooks/precheck.md.j2`），
+对每个 `/workspace/source/<repo>/` 调一次 `make ci-precheck`。**业务仓侧可选实现**。
+
+| 行为 | sisyphus 解释 |
+|---|---|
+| 缺 target（`make -n ci-precheck` 输出 `No rule to make target`） | **soft pass** —— 仓还没 opt-in，不阻塞 stage |
+| target 存在，退码 0 | pass |
+| target 存在，退非 0 | **hard fail** → agent emit `result:fail` + `fail-reason:precheck:ci-precheck:<repo>`，结束 session（verifier 直接 escalate，不重试） |
+
+设计意图：把「跑到 dev_cross_check 才发现 fvm symlink / token / KUBECONFIG 缺，
+watchdog 7 min kill」的等待浪费截断在 stage 第 0.5 步。`ci-precheck` 替业务仓做
+环境自检 —— 检什么仓自己拍：
+
+```makefile
+.PHONY: ci-precheck
+ci-precheck: ## stage agent 0.5 步：环境/工具/lock 自检；缺则非 0 退出
+	@command -v fvm >/dev/null || { echo "fvm 缺"; exit 1; }
+	@[ -L .fvm/flutter_sdk ] || { echo ".fvm/flutter_sdk symlink 缺"; exit 1; }
+	@flutter doctor --machine >/dev/null || { echo "flutter doctor 红"; exit 1; }
+	@echo "ci-precheck OK"
+```
+
+最简实现 `@echo OK`（仓承认自己 opt-in 但暂无想检的项），方便逐步加项。
+
+> **operator 侧关掉**：helm values `SISYPHUS_STAGE_PRECHECK_ENABLED='{"analyze":false,...}'`
+> 把对应 stage 设 False，hook 不渲段；或 `SISYPHUS_ENABLED_PROMPT_HOOKS='["mcp_preflight",
+> "self_issue_constraint"]'` 全 stage 关掉 precheck 段（pluggable invariant）。
+
 > **历史命名**：早期契约依次叫过 `accept-up` / `accept-down`（M14 之前）和
 > `ci-accept-env-up` / `ci-accept-env-down`（REQ-accept-contract-docs-1777121224）。
 > 当前唯一支持名为 `accept-env-up` / `accept-env-down`（REQ-rename-accept-targets-1777124774，

--- a/openspec/changes/REQ-feat-precheck-373-1777864856/proposal.md
+++ b/openspec/changes/REQ-feat-precheck-373-1777864856/proposal.md
@@ -1,0 +1,77 @@
+# Proposal: stage-agent step-0 unified precheck phase
+
+Closes #373.
+
+## 背景
+
+`联调加速 #4` (#373) 复盘了 5/4 dogfood 现场：v3/v4/v5 REQ 派出去后，runner pod 一路跑到
+`dev_cross_check` 才发现 `fvm/flutter_sdk` symlink 缺，watchdog 7 min kill，整 stage 重派 —
+ANALYZE + CHALLENGER 几千 token 全白烧。同 pattern 之前出过：MCP 缺 (#270)、
+runner GH_TOKEN 缺 (#365)、KUBECONFIG 错 (#292)。
+
+每次都是「跑到深处才 fail」的等待浪费。MCP 缺已经被 #270 的 `mcp_preflight` hook 封死
+(`enabled_prompt_hooks` pluggable hook 框架)，但其它 env / 工具 / 业务仓自检还没统一入口。
+
+## 范围
+
+只动 `phona/sisyphus`：
+
+1. **新增 hook `_shared/hooks/precheck.md.j2`** —— stage agent 第 0 步统一 precheck phase。
+   按 #270 同款 pluggable hook 模式（`enabled_prompt_hooks` filename + config-list，
+   见 memory `feedback_prompt_pluggable_via_filename_convention`）。
+   当 `stage_precheck_enabled[stage]` 为 True 时渲染下列 fail-fast 段落：
+   - **Pod env 必填**：`SISYPHUS_REQ_ID` / `GH_TOKEN` / `KUBECONFIG`
+   - **工具必装**：`gh auth status` / `kubectl version --client` / `make --version`
+   - **业务仓自报**：`/workspace/source/<repo>/` 跑 `make ci-precheck`（业务仓**可选**契约
+     target，echo OK 即可；缺 target = soft pass，不阻塞）
+   任一硬性 check fail → update-issue tags 加 `result:fail` + `fail-reason:precheck:<item>`，
+   立即结束 session（verifier 直接 escalate，**不重试**——precheck 失败基本是
+   ops/部署 bug，重跑无意义）。
+
+2. **config 加 `stage_precheck_enabled: dict[str, bool]`**（pydantic-settings）：
+   默认 `{intake: False, analyze: True, challenger: True, accept: True, staging_test: True,
+   pr_ci_watch: True, done_archive: False, bugfix: True}`。
+   与 `stage_mcp_requirements` 平行，operator 可 helm values 覆盖。
+
+3. **enabled_prompt_hooks 默认值改为 `["mcp_preflight", "precheck", "self_issue_constraint"]`**：
+   precheck 排在 mcp_preflight 之后（precheck 需要 MCP exec_run 可用），
+   排在 self_issue_constraint 之前（fail-fast 段必须先于业务约束段）。
+
+4. **docs/integration-contracts.md 加 §2.6 ci-precheck 契约**：
+   ttpos-ci 标准外加一条**可选** target `make ci-precheck`：
+   - 业务仓可选实现，缺 target = `precheck` hook 跳过该仓
+   - 实现示例：`echo OK` / `flutter doctor --machine` / `which fvm` 等
+   - 退码 0 = pass，非 0 = fail（被 hook 转成 `fail-reason:precheck:ci-precheck:<repo>`）
+
+5. **测试**：`tests/test_prompts_precheck.py` 覆盖：
+   - hook 启用时 stage prompt 渲出 precheck 段（含三类 check）
+   - hook 关闭时段落消失（pluggable invariant）
+   - intake 默认 False → 渲不出（避开 chat brainstorm 误打）
+   - 默认 hook 顺序 mcp_preflight → precheck → self_issue_constraint
+   - precheck 段引用 `mcp__{{ provider }}__exec_run`，不硬编 `aissh-tao` 字面量
+
+## 不在范围内
+
+- 业务仓侧 `ci-precheck` 实现（fixture repo / ttpos-flutter / ttpos-server-go） —— 各仓
+  独立 PR 跟进，本 REQ 只立契约 + sisyphus 侧执行框架
+- runner pod entrypoint 内置 precheck —— 走 prompt hook 而非 entrypoint，能 helm 覆盖
+  + 跟既有 mcp_preflight 同模式，单一来源，避免 entrypoint / prompt 双 fail-fast 路径
+- pre-stage independent precheck stage —— 沿用 hook 模式（agent 第 0 步），不引入
+  状态机新 state；新 stage 状态机 coverage / verifier 路径成本远高于一段 prompt
+
+## Roll-out
+
+1. 合本 PR
+2. 默认 hook 列表升级，所有现存 REQ 下个 stage dispatch 自动带新 precheck 段
+3. 各业务仓 (#373 关联 follow-up) 按 docs §2.6 加 `ci-precheck` target，echo OK 起步
+4. 收集 30 天 `result:fail` + `fail-reason:precheck:*` 命中数据，验证 7 min watchdog 等待
+   是否被 precheck 截断（Metabase Q-precheck-fail-rate 后续 REQ）
+
+## 影响
+
+| 依赖 | 验证方式 |
+|---|---|
+| 既有 mcp_preflight hook | 顺序锁在第一位，precheck 在第二位（fail-fast 链） |
+| `stage_mcp_requirements` | 不动，precheck 用独立 `stage_precheck_enabled`（关注点分离） |
+| 现有业务仓无 `ci-precheck` target | hook 内 `make -n ci-precheck` 探测，缺则 soft pass |
+| operator helm 覆盖 | `SISYPHUS_ENABLED_PROMPT_HOOKS` / `SISYPHUS_STAGE_PRECHECK_ENABLED` 走原通道 |

--- a/openspec/changes/REQ-feat-precheck-373-1777864856/specs/feat-stage-precheck/spec.md
+++ b/openspec/changes/REQ-feat-precheck-373-1777864856/specs/feat-stage-precheck/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: shared `precheck` hook renders step-0 fail-fast section in stage agent prompts
+
+The orchestrator MUST ship a Jinja2 partial at
+`orchestrator/src/orchestrator/prompts/_shared/hooks/precheck.md.j2`
+that — when included via the `enabled_prompt_hooks` filename loop — renders a step-0
+fail-fast precheck section into stage-agent prompts. The hook MUST gate rendering on
+`stage_precheck_enabled.get(stage, False)`, so the section is emitted only for stages whose
+agents work inside the runner pod (analyze / challenger / accept / staging_test /
+pr_ci_watch / bugfix). When the section IS rendered, it SHALL instruct the agent to:
+
+1. Verify pod env vars `SISYPHUS_REQ_ID`, `GH_TOKEN`, `KUBECONFIG` are non-empty inside the
+   runner pod.
+2. Verify the runner pod has a working `gh auth status`, `kubectl version --client`, and
+   `make --version` (tool-presence smoke).
+3. For each `/workspace/source/<repo>/`, run `make ci-precheck` (exit 0 = pass).
+   The `ci-precheck` target is OPTIONAL on the business repo side; a `make -n ci-precheck`
+   probe MUST treat the literal substring `No rule to make target` as a soft-skip (repo
+   has not opted in yet) — only a non-zero exit AFTER the target was found counts as fail.
+4. On any HARD precheck failure: PATCH the agent's own BKD issue with tags appended
+   `result:fail` + `fail-reason:precheck:<item>` (item ∈ `env:SISYPHUS_REQ_ID`,
+   `env:GH_TOKEN`, `env:KUBECONFIG`, `tool:gh`, `tool:kubectl`, `tool:make`,
+   `ci-precheck:<repo>`), set `statusId='review'`, and END the session immediately
+   (no follow-up, verifier escalates without retry).
+
+The hook MUST NOT hard-code the literal `aissh-tao` provider name; all SSH-exec invocations
+SHALL use `mcp__{{ mcp_capability_providers['ssh_exec'] }}__exec_run` so helm-values overrides
+of the provider propagate to rendered prompts.
+
+#### Scenario: PRECHECK-S1 hook renders section for ssh-pod-bound stages
+- **GIVEN** the default `stage_precheck_enabled` configuration
+- **WHEN** `analyze.md.j2`, `challenger.md.j2`, `accept.md.j2`, `staging_test.md.j2`,
+  `pr_ci_watch.md.j2`, and `bugfix.md.j2` are rendered with the minimum required context
+- **THEN** every rendered output MUST contain the precheck section title
+  `## Stage Precheck` and reference the three precheck classes
+  (env / tool / `make ci-precheck`)
+
+#### Scenario: PRECHECK-S2 hook stays silent for chat-only stages
+- **GIVEN** the default `stage_precheck_enabled` configuration where `intake` resolves to False
+- **WHEN** `intake.md.j2` is rendered
+- **THEN** the rendered output MUST NOT contain the substring `Stage Precheck`,
+  preserving the chat-brainstorm flavour of the intake prompt
+
+#### Scenario: PRECHECK-S3 hook stays silent when disabled via enabled_prompt_hooks
+- **GIVEN** an operator override that sets `enabled_prompt_hooks = ["mcp_preflight",
+  "self_issue_constraint"]` (precheck removed)
+- **WHEN** `analyze.md.j2` is rendered
+- **THEN** the rendered output MUST NOT contain the substring `Stage Precheck`,
+  while the other hook sections (`MCP 依赖预检`, `只改本 issue`) MUST still be present —
+  proving the for-loop honours `enabled_prompt_hooks` (pluggable invariant)
+
+#### Scenario: PRECHECK-S4 hook documents fail tag scheme
+- **GIVEN** an `analyze.md.j2` render where the precheck section is emitted
+- **WHEN** the rendered text is searched
+- **THEN** it MUST contain the literals `result:fail` and `fail-reason:precheck:`
+  so the agent emits the canonical tag scheme on hard fail
+
+#### Scenario: PRECHECK-S5 hook respects mcp_capability_providers indirection
+- **GIVEN** an operator override that swaps `mcp_capability_providers['ssh_exec']` from
+  `aissh-tao` to a different provider name
+- **WHEN** `analyze.md.j2` is rendered
+- **THEN** the precheck section MUST reference `mcp__<new-provider>__exec_run` and MUST
+  NOT contain the substring `mcp__aissh-tao__exec_run`
+
+#### Scenario: PRECHECK-S6 default hook ordering is preflight → precheck → self-issue
+- **GIVEN** the default `enabled_prompt_hooks` configuration shipped by the orchestrator
+- **WHEN** the list is inspected
+- **THEN** it MUST equal `["mcp_preflight", "precheck", "self_issue_constraint"]` exactly
+  (order matters: MCP must work before precheck can shell into the pod, and both fail-fast
+  segments must precede the self-issue policy hook)

--- a/openspec/changes/REQ-feat-precheck-373-1777864856/tasks.md
+++ b/openspec/changes/REQ-feat-precheck-373-1777864856/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## Stage: contract / spec
+- [x] author `openspec/changes/REQ-feat-precheck-373-1777864856/proposal.md`
+- [x] author spec delta `specs/feat-stage-precheck/spec.md` —— ADDED requirements + scenarios PRECHECK-S1..S6
+
+## Stage: implementation
+- [x] `orchestrator/src/orchestrator/prompts/_shared/hooks/precheck.md.j2`：新建 hook 模板
+- [x] `orchestrator/src/orchestrator/config.py`：加 `stage_precheck_enabled: dict[str, bool]` 字段（pydantic-settings）
+- [x] `orchestrator/src/orchestrator/config.py`：默认 `enabled_prompt_hooks = ["mcp_preflight", "precheck", "self_issue_constraint"]`
+- [x] `orchestrator/src/orchestrator/prompts/__init__.py`：注入 `stage_precheck_enabled` 为 jinja2 global
+- [x] `docs/integration-contracts.md` §2.6：加 `ci-precheck` 业务仓可选契约 target
+
+## Stage: tests
+- [x] `orchestrator/tests/test_prompts_precheck.py`：单测覆盖 PRECHECK-S1..S6
+- [x] `tests/test_prompts_mcp_preflight.py`：同步 enabled_prompt_hooks 默认值 assertion (含 precheck)
+
+## Stage: PR（推之前必须全绿）
+- [x] git push feat/REQ-feat-precheck-373-1777864856
+- [x] `make ci-lint` → 全绿
+- [x] `make ci-unit-test` → 全绿
+- [x] `make ci-integration-test` → 全绿（无 PG 视为 pass）
+- [x] gh pr create --label sisyphus + sisyphus cross-link footer

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -227,12 +227,37 @@ class Settings(BaseSettings):
     # 跟具体 stage 业务无关、跨 stage 复用、operator 想改要做到不动模板源码。每个
     # stage prompt 在 hook slot 处 for-loop 渲所有 enabled 的 hook 文件；hook body
     # 自行靠 `stage` 变量决定要不要落地。
-    # 默认两条：mcp-preflight（issue #270 的 fail-fast）+ self-issue-constraint
-    # （只 PATCH 自己 issue 的硬规矩）。operator 通过 SISYPHUS_ENABLED_PROMPT_HOOKS
-    # 全量覆盖（JSON 数组），增删改某个 hook 一行 helm values 搞定，不用 fork prompt。
+    # 默认三条：mcp_preflight（issue #270 的 fail-fast）+ precheck（issue #373
+    # 的 env / 工具 / ci-precheck fail-fast）+ self_issue_constraint（只 PATCH
+    # 自己 issue 的硬规矩）。顺序锁死：MCP 必须先就位，precheck 才能 exec_run 进 pod；
+    # 两段 fail-fast 必须排在 self_issue_constraint 之前。operator 通过
+    # SISYPHUS_ENABLED_PROMPT_HOOKS 全量覆盖（JSON 数组），不用 fork prompt。
     enabled_prompt_hooks: list[str] = Field(
-        default_factory=lambda: ["mcp_preflight", "self_issue_constraint"],
+        default_factory=lambda: ["mcp_preflight", "precheck", "self_issue_constraint"],
         description="按文件名约定加载的 prompt hook 列表（_shared/hooks/<name>.md.j2）",
+    )
+
+    # ─── REQ-feat-precheck-373-1777864856：stage agent step-0 precheck（#373）
+    # 跟 stage_mcp_requirements 平行，决定 precheck hook 在哪些 stage 渲染段落。
+    # 默认在所有「跑 runner pod」的 stage 都开（analyze / challenger / accept /
+    # staging_test / pr_ci_watch / bugfix），intake / done_archive 关掉
+    # （intake 是 chat brainstorm；done_archive 是 orchestrator 后台动作，不派 agent）。
+    # 关注点分离 = 不复用 stage_mcp_requirements：
+    #   - mcp_requirements 控「需要哪些 MCP capability」
+    #   - precheck_enabled 控「是否做 env/tool/ci-precheck fail-fast」
+    # operator 走 helm values（SISYPHUS_STAGE_PRECHECK_ENABLED=JSON dict）覆盖。
+    stage_precheck_enabled: dict[str, bool] = Field(
+        default_factory=lambda: {
+            "intake": False,
+            "analyze": True,
+            "challenger": True,
+            "accept": True,
+            "staging_test": True,
+            "pr_ci_watch": True,
+            "bugfix": True,
+            "done_archive": False,
+        },
+        description="每个 stage 是否在 prompt 头部渲 precheck fail-fast 段",
     )
 
     # ─── REQ-clone-fallback-direct-analyze-1777119520：multi-layer involved_repos

--- a/orchestrator/src/orchestrator/prompts/__init__.py
+++ b/orchestrator/src/orchestrator/prompts/__init__.py
@@ -46,6 +46,8 @@ _env.globals["mcp_capability_providers"] = settings.mcp_capability_providers
 _env.globals["mcp_capability_probe_tools"] = settings.mcp_capability_probe_tools
 _env.globals["stage_mcp_requirements"] = settings.stage_mcp_requirements
 _env.globals["enabled_prompt_hooks"] = settings.enabled_prompt_hooks
+# REQ-feat-precheck-373-1777864856：precheck hook 读 stage_precheck_enabled 决定渲不渲段。
+_env.globals["stage_precheck_enabled"] = settings.stage_precheck_enabled
 
 
 def render(template_name: str, **context) -> str:

--- a/orchestrator/src/orchestrator/prompts/_shared/hooks/precheck.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/hooks/precheck.md.j2
@@ -1,0 +1,104 @@
+{# REQ-feat-precheck-373-1777864856 — Stage agent step-0 unified precheck (closes #373).
+
+   解决「跑到 dev_cross_check 才发现 fvm symlink / GH_TOKEN / KUBECONFIG 缺，
+   watchdog 7 min kill 整 stage 重派」的等待浪费。env / 工具 / 业务仓 ci-precheck
+   缺时立即 emit result:fail，verifier 直接 escalate（不重试）。
+
+   render 期望：
+   - `stage` — 字符串，本 prompt 对应的 stage 名（'analyze' / 'accept' …）。
+              include 方触发前 `{% set stage = "analyze" %}`。
+   - `stage_precheck_enabled` / `mcp_capability_providers` — 由 prompts/__init__.py
+     注入为 jinja2 globals，不用每个 render() 显式传。
+   - `req_id` / `aissh_server_id` — 由 stage prompt render 时透传。
+
+   pluggable invariant：本 hook 的渲染由 `enabled_prompt_hooks` 列表决定。
+   helm operator 把它从 list 拿掉（如临时 debug）整段就消失，
+   `stage_precheck_enabled` 决定每个 stage 渲不渲染（intake/done_archive 默认 False）。
+#}
+{%- set _enabled = stage_precheck_enabled.get(stage, False) if stage is defined else False -%}
+{%- if _enabled -%}
+## Stage Precheck (HARD CONSTRAINT — 第 0.5 步必做，紧跟 MCP 预检)
+
+本 stage (`{{ stage }}`) 在干任何业务（clone / push / 写代码 / 起 lab）之前
+**必须先跑下面的 precheck**。任一项 hard fail 都立即 emit `result:fail` +
+`fail-reason:precheck:<item>` 然后**结束 session**，verifier 会直接 escalate
+（precheck 失败基本是 ops/部署 bug，重跑无意义）。
+
+### Step 0.5：env / 工具 / 业务仓自报三类 check
+
+**全部命令通过 `mcp__{{ mcp_capability_providers['ssh_exec'] }}__exec_run` 进 runner pod 跑**
+（你 BKD agent 在 Coder workspace，没装 kubectl，详见 runner_container.md.j2）。
+
+```bash
+POD=runner-{{ req_id | lower }}
+NS=sisyphus-runners
+
+# ── A. Pod env 必填（缺任意一个 = hard fail） ──────────────────────────
+mcp__{{ mcp_capability_providers['ssh_exec'] }}__exec_run(
+  server_id="{{ aissh_server_id or '5b25f0cd-4fef-4a1f-a4c0-14ecf1395d84' }}",
+  command="kubectl -n $NS exec $POD -- bash -c '
+    set -e
+    [ -n \"$SISYPHUS_REQ_ID\" ] || { echo PRECHECK_FAIL:env:SISYPHUS_REQ_ID; exit 11; }
+    [ -n \"$GH_TOKEN\" ]        || { echo PRECHECK_FAIL:env:GH_TOKEN;        exit 12; }
+    [ -n \"$KUBECONFIG\" ]      || { echo PRECHECK_FAIL:env:KUBECONFIG;      exit 13; }
+    echo PRECHECK_OK:env
+  '"
+)
+
+# ── B. 工具必装（缺任意一个 = hard fail） ──────────────────────────────
+mcp__{{ mcp_capability_providers['ssh_exec'] }}__exec_run(
+  server_id="{{ aissh_server_id or '5b25f0cd-4fef-4a1f-a4c0-14ecf1395d84' }}",
+  command="kubectl -n $NS exec $POD -- bash -c '
+    set -e
+    gh auth status >/dev/null 2>&1   || { echo PRECHECK_FAIL:tool:gh;       exit 21; }
+    kubectl version --client >/dev/null 2>&1 || { echo PRECHECK_FAIL:tool:kubectl; exit 22; }
+    make --version >/dev/null 2>&1   || { echo PRECHECK_FAIL:tool:make;     exit 23; }
+    echo PRECHECK_OK:tool
+  '"
+)
+
+# ── C. 业务仓自报（每个 /workspace/source/<repo>/ 跑一遍 make ci-precheck） ──
+# `ci-precheck` 是业务仓**可选**契约 target（详见 docs/integration-contracts.md §2.6）。
+# 缺 target = soft pass（仓还没 opt-in）；target 存在但退非 0 = hard fail。
+mcp__{{ mcp_capability_providers['ssh_exec'] }}__exec_run(
+  server_id="{{ aissh_server_id or '5b25f0cd-4fef-4a1f-a4c0-14ecf1395d84' }}",
+  command="kubectl -n $NS exec $POD -- bash -c '
+    set -u
+    fail=0
+    for d in /workspace/source/*/ ; do
+      [ -d \"$d\" ] || continue
+      repo=$(basename \"$d\")
+      probe=$(cd \"$d\" && make -n ci-precheck 2>&1 || true)
+      if echo \"$probe\" | grep -q \"No rule to make target\"; then
+        echo PRECHECK_SKIP:ci-precheck:$repo  # repo 还没 opt-in，soft pass
+        continue
+      fi
+      if (cd \"$d\" && make ci-precheck); then
+        echo PRECHECK_OK:ci-precheck:$repo
+      else
+        echo PRECHECK_FAIL:ci-precheck:$repo
+        fail=1
+      fi
+    done
+    exit $fail
+  '"
+)
+```
+
+### 失败处理（HARD CONSTRAINT）
+
+任意上面命令打印 `PRECHECK_FAIL:<item>`（或 exec 退非 0）：
+
+1. **不要**继续业务动作（不要 clone、不要写代码、不要等回信）
+2. update-issue tags 追加 `result:fail` + `fail-reason:precheck:<item>`，statusId='review'
+   - tags 必须 merge（先 GET，保留 `sisyphus`/`{{ req_id }}`/`{{ stage }}`，再 PATCH）
+3. 在 BKD chat 发一条诊断 message：复述 fail item + 命中的命令输出
+4. **结束 session**（不 follow-up，verifier 直接 escalate）
+
+> 这条规则覆盖在所有其它指令之上。在缺 GH_TOKEN / KUBECONFIG / fvm 的环境里硬撞业务命令
+> 只会让你跑到 dev_cross_check 才发现，watchdog 7 min kill 后整 stage 重派，
+> 上游 ANALYZE / CHALLENGER 几千 token 全白烧。早 fail 早 escalate，让 ops 修部署。
+
+─────────
+
+{%- endif -%}

--- a/orchestrator/src/orchestrator/prompts/bugfix.md.j2
+++ b/orchestrator/src/orchestrator/prompts/bugfix.md.j2
@@ -1,3 +1,4 @@
+{% set stage = "bugfix" %}
 {% include "_shared/tools_whitelist.md.j2" %}
 
 ─────────

--- a/orchestrator/src/orchestrator/prompts/pr_ci_watch.md.j2
+++ b/orchestrator/src/orchestrator/prompts/pr_ci_watch.md.j2
@@ -1,3 +1,4 @@
+{% set stage = "pr_ci_watch" %}
 {% include "_shared/tools_whitelist.md.j2" %}
 
 ─────────

--- a/orchestrator/src/orchestrator/prompts/staging_test.md.j2
+++ b/orchestrator/src/orchestrator/prompts/staging_test.md.j2
@@ -1,3 +1,4 @@
+{% set stage = "staging_test" %}
 {% include "_shared/tools_whitelist.md.j2" %}
 
 ─────────

--- a/orchestrator/tests/test_contract_pr_issue_traceability_challenger.py
+++ b/orchestrator/tests/test_contract_pr_issue_traceability_challenger.py
@@ -96,6 +96,9 @@ def _render_jinja2(template_name: str, **kwargs: Any) -> str:
     env.globals["mcp_capability_probe_tools"] = _runtime_settings.mcp_capability_probe_tools
     env.globals["stage_mcp_requirements"] = _runtime_settings.stage_mcp_requirements
     env.globals["enabled_prompt_hooks"] = _runtime_settings.enabled_prompt_hooks
+    # REQ-feat-precheck-373-1777864856：precheck hook 也是 globals-driven，否则
+    # `_shared/hooks/precheck.md.j2` 渲到 `stage_precheck_enabled.get(...)` UndefinedError。
+    env.globals["stage_precheck_enabled"] = _runtime_settings.stage_precheck_enabled
     return env.get_template(template_name).render(**kwargs)
 
 

--- a/orchestrator/tests/test_contract_prompts_precheck_challenger.py
+++ b/orchestrator/tests/test_contract_prompts_precheck_challenger.py
@@ -1,0 +1,362 @@
+"""Challenger contract tests for REQ-feat-precheck-373-1777864856.
+
+Black-box contracts derived exclusively from:
+  openspec/changes/REQ-feat-precheck-373-1777864856/specs/feat-stage-precheck/spec.md
+  openspec/changes/REQ-feat-precheck-373-1777864856/proposal.md
+
+Scenarios covered:
+  PRECHECK-S1  hook renders ## Stage Precheck section + 3 check classes for the
+               6 ssh-pod-bound stages (analyze / challenger / accept /
+               staging_test / pr_ci_watch / bugfix)
+  PRECHECK-S2  hook stays silent for chat-only stages (intake)
+  PRECHECK-S3  hook stays silent when removed from enabled_prompt_hooks; sibling
+               hook sections (mcp_preflight, self_issue_constraint) remain
+  PRECHECK-S4  hook documents canonical fail tag scheme
+               (`result:fail` + `fail-reason:precheck:`)
+  PRECHECK-S5  hook references mcp__<provider>__exec_run via
+               mcp_capability_providers indirection (no hard-coded `aissh-tao`)
+  PRECHECK-S6  default enabled_prompt_hooks order is exactly
+               ["mcp_preflight", "precheck", "self_issue_constraint"]
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation
+instead. If a test is wrong, escalate to spec_fixer to correct the spec, not the
+test.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import jinja2
+import pytest
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+# 6 stage prompts whose agents work inside the runner pod (per spec Requirement
+# body: "analyze / challenger / accept / staging_test / pr_ci_watch / bugfix").
+_SSH_POD_STAGES: list[tuple[str, str]] = [
+    ("analyze", "analyze.md.j2"),
+    ("challenger", "challenger.md.j2"),
+    ("accept", "accept.md.j2"),
+    ("staging_test", "staging_test.md.j2"),
+    ("pr_ci_watch", "pr_ci_watch.md.j2"),
+    ("bugfix", "bugfix.md.j2"),
+]
+
+# Generous superset context — individual prompts only consume the subset they
+# care about; surplus keys are ignored. We deliberately do NOT introspect each
+# template's required keys (would couple the contract to dev's internal var
+# naming). Default jinja `Undefined` makes `{{ missing }}` render as empty
+# string, which is enough to assert section-level presence/absence.
+_KITCHEN_SINK_CTX: dict[str, Any] = {
+    "req_id": "REQ-feat-precheck-373-1777864856",
+    "stage": "analyze",
+    "trigger": "success",
+    "aissh_server_id": "test-server-id",
+    "project_id": "nnvxh8wj",
+    "project_alias": "nnvxh8wj",
+    "issue_id": "iss-self",
+    "intent_issue_id": "iss-intent",
+    "parent_issue_id": "iss-parent",
+    "src_issue_id": "iss-src",
+    "accept_issue_id": "iss-acc",
+    "cloned_repos": ["phona/sisyphus"],
+    "bkd_intent_issue_url": "http://example.test/projects/nnvxh8wj/issues/intent",
+    "status_block": {"stage": "analyze", "req_id": "REQ-X"},
+    "branch": "feat/REQ-feat-precheck-373-1777864856",
+    "pr_url": "http://example.test/pr/1",
+    "pr_number": 1,
+    "repo_full_name": "phona/sisyphus",
+    "spec_home_repo": "phona/sisyphus",
+    "spec_home_repo_basename": "sisyphus",
+    "history": [],
+    "stderr_tail": "",
+    "artifact_paths": [],
+    "checker_stdout": "",
+    "checker_stderr": "",
+    "checker_exit_code": 0,
+    "intake_summary": None,
+}
+
+
+def _prod_render(template_name: str, **extra_ctx: Any) -> str:
+    """Render via the production renderer (uses real settings + globals)."""
+    from orchestrator.prompts import render
+
+    ctx = dict(_KITCHEN_SINK_CTX)
+    ctx.update(extra_ctx)
+    return render(template_name, **ctx)
+
+
+def _isolated_env_render(
+    template_name: str,
+    *,
+    enabled_prompt_hooks: list[str],
+    mcp_capability_providers: dict[str, str] | None = None,
+    stage_precheck_enabled: dict[str, bool] | None = None,
+    extra_ctx: dict[str, Any] | None = None,
+) -> str:
+    """Render with a fresh jinja Environment whose globals we fully control.
+
+    Used by override scenarios (S3, S5) so tests are not coupled to test order
+    or to a monkey-patch on the production `_env` global.
+    """
+    from orchestrator.config import settings
+
+    prompts_dir = (
+        Path(__file__).resolve().parent.parent
+        / "src"
+        / "orchestrator"
+        / "prompts"
+    )
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(prompts_dir)),
+        autoescape=jinja2.select_autoescape(
+            disabled_extensions=("md", "j2", "txt"), default=False,
+        ),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    env.globals["enabled_prompt_hooks"] = enabled_prompt_hooks
+    env.globals["mcp_capability_providers"] = (
+        mcp_capability_providers
+        if mcp_capability_providers is not None
+        else dict(settings.mcp_capability_providers)
+    )
+    env.globals["mcp_capability_probe_tools"] = dict(
+        settings.mcp_capability_probe_tools,
+    )
+    env.globals["stage_mcp_requirements"] = dict(
+        settings.stage_mcp_requirements,
+    )
+    env.globals["stage_precheck_enabled"] = (
+        stage_precheck_enabled
+        if stage_precheck_enabled is not None
+        else dict(settings.stage_precheck_enabled)
+    )
+
+    ctx = dict(_KITCHEN_SINK_CTX)
+    if extra_ctx:
+        ctx.update(extra_ctx)
+    return env.get_template(template_name).render(**ctx)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PRECHECK-S1  hook renders the section for every ssh-pod-bound stage
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(("stage_name", "template"), _SSH_POD_STAGES)
+def test_precheck_s1_section_emitted_for_ssh_pod_stages(
+    stage_name: str, template: str,
+) -> None:
+    """PRECHECK-S1: with default config, every ssh-pod-bound stage prompt MUST
+    contain the `## Stage Precheck` heading and reference all three precheck
+    classes (env / tool / `make ci-precheck`)."""
+    out = _prod_render(template, stage=stage_name)
+
+    assert "## Stage Precheck" in out, (
+        f"PRECHECK-S1 FAILED: {template} does not render the `## Stage Precheck`"
+        f" heading under default config. The precheck hook must be included for"
+        f" stage {stage_name!r} (one of analyze / challenger / accept /"
+        f" staging_test / pr_ci_watch / bugfix)."
+    )
+
+    # Reference the three precheck classes per spec Requirement body.
+    assert "SISYPHUS_REQ_ID" in out, (
+        f"PRECHECK-S1 FAILED: {template} precheck section omits the env-var"
+        f" check for SISYPHUS_REQ_ID (spec class 1: pod env)."
+    )
+    assert "GH_TOKEN" in out, (
+        f"PRECHECK-S1 FAILED: {template} precheck section omits the env-var"
+        f" check for GH_TOKEN (spec class 1: pod env)."
+    )
+    assert "KUBECONFIG" in out, (
+        f"PRECHECK-S1 FAILED: {template} precheck section omits the env-var"
+        f" check for KUBECONFIG (spec class 1: pod env)."
+    )
+    assert "gh auth status" in out, (
+        f"PRECHECK-S1 FAILED: {template} precheck section omits the"
+        f" `gh auth status` tool-presence smoke (spec class 2: tools)."
+    )
+    assert "kubectl" in out, (
+        f"PRECHECK-S1 FAILED: {template} precheck section omits the kubectl"
+        f" tool-presence smoke (spec class 2: tools)."
+    )
+    assert "make --version" in out or "make -n" in out or "make " in out, (
+        f"PRECHECK-S1 FAILED: {template} precheck section omits any reference"
+        f" to a `make` tool-presence / probe (spec class 2: tools)."
+    )
+    assert "ci-precheck" in out, (
+        f"PRECHECK-S1 FAILED: {template} precheck section omits the per-repo"
+        f" `make ci-precheck` invocation (spec class 3: business-repo opt-in)."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PRECHECK-S2  hook stays silent for chat-only stages (intake)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_precheck_s2_intake_does_not_render_section() -> None:
+    """PRECHECK-S2: under the default `stage_precheck_enabled` configuration,
+    the intake.md.j2 prompt MUST NOT contain the substring `Stage Precheck`,
+    so the chat-brainstorm flavour of intake is preserved."""
+    out = _prod_render("intake.md.j2", stage="intake")
+
+    assert "Stage Precheck" not in out, (
+        "PRECHECK-S2 FAILED: intake.md.j2 rendered the precheck section.\n"
+        "intake is a chat-only brainstorm stage; the default value of\n"
+        "stage_precheck_enabled['intake'] MUST be False so the precheck hook\n"
+        "stays silent (rendering nothing) for this template.\n"
+        "If the section is appearing, either the default config flipped or\n"
+        "the hook body is rendering unconditionally."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PRECHECK-S3  hook stays silent when removed from enabled_prompt_hooks
+#              while sibling hook sections remain (pluggable invariant)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_precheck_s3_disabled_via_enabled_prompt_hooks() -> None:
+    """PRECHECK-S3: if an operator removes `precheck` from
+    `enabled_prompt_hooks`, the analyze.md.j2 prompt MUST NOT contain the
+    `Stage Precheck` substring; the other two sibling hook sections
+    (`MCP 依赖预检` from mcp_preflight, `只改本 issue` from
+    self_issue_constraint) MUST still be present — proving the for-loop honours
+    `enabled_prompt_hooks` (pluggable hook invariant from REQ #270)."""
+    out = _isolated_env_render(
+        "analyze.md.j2",
+        enabled_prompt_hooks=["mcp_preflight", "self_issue_constraint"],
+    )
+
+    assert "Stage Precheck" not in out, (
+        "PRECHECK-S3 FAILED: analyze.md.j2 rendered the precheck section even\n"
+        "though `precheck` was removed from `enabled_prompt_hooks`. The hook\n"
+        "loop must gate inclusion strictly on the configured list — no\n"
+        "unconditional `{% include %}` of the precheck partial may exist."
+    )
+
+    assert "MCP 依赖预检" in out, (
+        "PRECHECK-S3 FAILED: analyze.md.j2 stopped rendering the `MCP 依赖预检`\n"
+        "section when only precheck was removed. The mcp_preflight hook must\n"
+        "still render — confirming the for-loop is selective per hook name,\n"
+        "not all-or-nothing."
+    )
+
+    assert "只改本 issue" in out, (
+        "PRECHECK-S3 FAILED: analyze.md.j2 stopped rendering the\n"
+        "`只改本 issue` section when only precheck was removed. The\n"
+        "self_issue_constraint hook must still render — confirming the\n"
+        "for-loop is selective per hook name, not all-or-nothing."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PRECHECK-S4  hook documents the canonical fail tag scheme
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_precheck_s4_documents_fail_tag_scheme() -> None:
+    """PRECHECK-S4: when the precheck section is emitted (default config), the
+    rendered analyze.md.j2 text MUST contain the canonical fail-tag literals
+    `result:fail` and `fail-reason:precheck:` so the agent emits the correct
+    tags on hard fail (verifier escalates without retry)."""
+    out = _prod_render("analyze.md.j2", stage="analyze")
+
+    assert "result:fail" in out, (
+        "PRECHECK-S4 FAILED: analyze.md.j2 precheck section does not document\n"
+        "the literal tag `result:fail`. Agents need to see this exact tag\n"
+        "string to write the canonical fail tag on hard precheck failure."
+    )
+
+    assert "fail-reason:precheck:" in out, (
+        "PRECHECK-S4 FAILED: analyze.md.j2 precheck section does not document\n"
+        "the literal tag prefix `fail-reason:precheck:`. Agents need this\n"
+        "exact prefix to encode the failing item (e.g.\n"
+        "`fail-reason:precheck:env:GH_TOKEN`,\n"
+        "`fail-reason:precheck:tool:kubectl`,\n"
+        "`fail-reason:precheck:ci-precheck:<repo>`)."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PRECHECK-S5  hook honours mcp_capability_providers['ssh_exec'] indirection
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_precheck_s5_uses_provider_indirection_not_hardcoded_aissh_tao() -> None:
+    """PRECHECK-S5: when an operator overrides
+    `mcp_capability_providers['ssh_exec']` to a different provider name, the
+    precheck section in the rendered prompt MUST reference
+    `mcp__<new-provider>__exec_run` and MUST NOT contain
+    `mcp__aissh-tao__exec_run` — proving the hook does not hard-code the
+    aissh-tao literal."""
+    out = _isolated_env_render(
+        "analyze.md.j2",
+        enabled_prompt_hooks=["mcp_preflight", "precheck", "self_issue_constraint"],
+        mcp_capability_providers={"ssh_exec": "fake-ssh-provider"},
+    )
+
+    # Sanity: the precheck section MUST be present in this render path.
+    assert "## Stage Precheck" in out, (
+        "PRECHECK-S5 SETUP FAILED: precheck section was not rendered at all,\n"
+        "so the provider-indirection assertion below is vacuous. Check that\n"
+        "the test's enabled_prompt_hooks + stage_precheck_enabled defaults\n"
+        "actually emit the section."
+    )
+
+    # Slice the precheck section so we don't catch unrelated mentions of
+    # `mcp__aissh-tao__exec_run` in other hook sections (mcp_preflight, etc.).
+    # The section starts at `## Stage Precheck` and ends at the next H2.
+    start = out.index("## Stage Precheck")
+    rest = out[start + len("## Stage Precheck"):]
+    next_h2 = rest.find("\n## ")
+    section = (
+        rest[: next_h2]
+        if next_h2 != -1
+        else rest
+    )
+
+    assert "mcp__fake-ssh-provider__exec_run" in section, (
+        "PRECHECK-S5 FAILED: precheck section does not reference\n"
+        "`mcp__fake-ssh-provider__exec_run` after overriding\n"
+        "mcp_capability_providers['ssh_exec'] = 'fake-ssh-provider'. The\n"
+        "hook must compose the SSH-exec tool name from\n"
+        "`mcp__{{ mcp_capability_providers['ssh_exec'] }}__exec_run`, not a\n"
+        "hard-coded `aissh-tao` literal."
+    )
+
+    assert "mcp__aissh-tao__exec_run" not in section, (
+        "PRECHECK-S5 FAILED: precheck section still contains the literal\n"
+        "`mcp__aissh-tao__exec_run` after overriding the ssh_exec provider.\n"
+        "The hook is hard-coding the default provider name; replace with\n"
+        "`mcp__{{ mcp_capability_providers['ssh_exec'] }}__exec_run` so helm\n"
+        "values overrides propagate."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PRECHECK-S6  default enabled_prompt_hooks ordering
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_precheck_s6_default_enabled_prompt_hooks_ordering() -> None:
+    """PRECHECK-S6: the default `enabled_prompt_hooks` shipped by the
+    orchestrator MUST equal exactly
+    `["mcp_preflight", "precheck", "self_issue_constraint"]` (order matters:
+    MCP must work before precheck can shell into the pod, and both fail-fast
+    segments must precede the self-issue policy hook)."""
+    from orchestrator.config import settings
+
+    assert list(settings.enabled_prompt_hooks) == [
+        "mcp_preflight",
+        "precheck",
+        "self_issue_constraint",
+    ], (
+        "PRECHECK-S6 FAILED: settings.enabled_prompt_hooks default is\n"
+        f"  {list(settings.enabled_prompt_hooks)!r}\n"
+        "but the spec requires exactly\n"
+        "  ['mcp_preflight', 'precheck', 'self_issue_constraint']\n"
+        "Order matters — mcp_preflight first (MCP must be up before\n"
+        "precheck can shell), precheck second (fail-fast before policy),\n"
+        "self_issue_constraint last (policy hook)."
+    )

--- a/orchestrator/tests/test_prompts_mcp_preflight.py
+++ b/orchestrator/tests/test_prompts_mcp_preflight.py
@@ -65,11 +65,12 @@ def test_mcp_capability_probe_tools_default_routes_ssh_exec_to_servers_list() ->
 
 
 def test_enabled_prompt_hooks_default_includes_mcp_preflight_and_self_issue_constraint() -> None:
-    """v1 默认开两条 hook：mcp_preflight + self_issue_constraint。
-    顺序也锁住：preflight 先于 self_issue_constraint，因为 fail-fast 段必须先于
-    业务约束段。新加默认 hook 时务必同步本断言（让 operator 升级时看得到 diff）。"""
+    """v2（REQ-feat-precheck-373）默认开三条 hook：mcp_preflight + precheck +
+    self_issue_constraint。顺序锁死：preflight 必须先就位才能让 precheck exec_run
+    进 pod；两段 fail-fast 都必须先于业务约束段。新加默认 hook 时务必同步本断言
+    （让 operator 升级时看得到 diff）。"""
     hooks = settings.enabled_prompt_hooks
-    assert hooks == ["mcp_preflight", "self_issue_constraint"], hooks
+    assert hooks == ["mcp_preflight", "precheck", "self_issue_constraint"], hooks
 
 
 # ── Step 2: prompts source 不再硬编码 ─────────────────────────────────────

--- a/orchestrator/tests/test_prompts_precheck.py
+++ b/orchestrator/tests/test_prompts_precheck.py
@@ -1,0 +1,208 @@
+"""REQ-feat-precheck-373-1777864856：stage-agent step-0 unified precheck hook 回归测试。
+
+GitHub issue #373 起源：5/4 dogfood v3/v4/v5 REQ 派出去后跑到 dev_cross_check 才
+发现 fvm/flutter_sdk symlink 缺，watchdog 7min kill 整 stage 重派，前面 ANALYZE +
+CHALLENGER 几千 token 全白烧。同 pattern 之前出过 token 缺 (#365) / KUBECONFIG 错
+(#292)。
+
+方案：复用 #270 的 pluggable hook 框架（`enabled_prompt_hooks` filename + config-list），
+新增 `_shared/hooks/precheck.md.j2`，stage agent 第 0.5 步统一跑：
+- pod env 必填 (SISYPHUS_REQ_ID / GH_TOKEN / KUBECONFIG)
+- 工具必装 (gh / kubectl / make)
+- 业务仓自报 (`make ci-precheck`，仓侧**可选**契约 target)
+任一硬失败 → result:fail + fail-reason:precheck:<item>，verifier 直接 escalate（不重试）。
+
+本文件覆盖 PRECHECK-S1..S6（spec/feat-stage-precheck/spec.md）。
+"""
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.config import settings
+from orchestrator.prompts import _env, render
+
+# ── PRECHECK-S6 / config schema ────────────────────────────────────────────
+
+
+def test_enabled_prompt_hooks_default_includes_precheck_in_canonical_order() -> None:
+    """PRECHECK-S6: 默认顺序锁死：mcp_preflight → precheck → self_issue_constraint。
+
+    顺序不是装饰：
+    - mcp_preflight 必须先就位 —— precheck 要 `mcp__<provider>__exec_run` 进 pod
+    - 两段 fail-fast 必须排在 self_issue_constraint 之前（业务约束段）
+    新加 hook 务必同步本断言（让 operator 升级时看得到 diff）。
+    """
+    assert settings.enabled_prompt_hooks == [
+        "mcp_preflight",
+        "precheck",
+        "self_issue_constraint",
+    ], settings.enabled_prompt_hooks
+
+
+def test_stage_precheck_enabled_default_covers_runner_pod_stages() -> None:
+    """precheck 默认在所有「跑 runner pod」的 stage 都开；intake / done_archive 关掉。
+
+    intake 是 chat brainstorm，done_archive 是 orchestrator 后台动作（不派 agent），
+    都不该被 precheck 框约束。
+    """
+    enabled = settings.stage_precheck_enabled
+    for stage in ("analyze", "challenger", "accept", "staging_test", "pr_ci_watch", "bugfix"):
+        assert enabled[stage] is True, (stage, enabled)
+    for stage in ("intake", "done_archive"):
+        assert enabled[stage] is False, (stage, enabled)
+
+
+# ── PRECHECK-S1 / hook 渲段 ────────────────────────────────────────────────
+
+
+def _render_kwargs(stage: str) -> dict:
+    common = {
+        "req_id": "REQ-precheck-test",
+        "aissh_server_id": "abc-123",
+        "project_id": "p1",
+        "project_alias": "p1",
+        "issue_id": "i1",
+    }
+    if stage == "accept":
+        return {
+            **common,
+            "endpoint": "http://lab.test",
+            "namespace": "ns",
+            "source_issue_id": "src",
+        }
+    if stage in ("staging_test", "pr_ci_watch", "bugfix"):
+        return {**common, "source_issue_id": "src"}
+    return common
+
+
+@pytest.mark.parametrize(
+    "template,stage",
+    [
+        ("analyze.md.j2", "analyze"),
+        ("challenger.md.j2", "challenger"),
+        ("accept.md.j2", "accept"),
+        ("staging_test.md.j2", "staging_test"),
+        ("pr_ci_watch.md.j2", "pr_ci_watch"),
+        ("bugfix.md.j2", "bugfix"),
+    ],
+)
+def test_precheck_section_renders_for_runner_pod_bound_stages(
+    template: str, stage: str,
+) -> None:
+    """PRECHECK-S1: 所有跑 runner pod 的 stage prompt 必须渲出 precheck 段，
+    含三类 check（env / tool / ci-precheck）+ stage 名 + fail tag scheme。
+
+    任一缺失说明 hook 没接好 / `stage` 变量没 set / for-loop 没读
+    `enabled_prompt_hooks` → agent 跳过 precheck，回到 7 min 卡死老路。
+    """
+    out = render(template, **_render_kwargs(stage))
+    assert "Stage Precheck" in out, f"{template} 缺 Stage Precheck 段标题"
+    assert f"`{stage}`" in out, f"{template} precheck 段没渲染本 stage 名"
+    # 三类 check 都得在
+    assert "SISYPHUS_REQ_ID" in out, f"{template} precheck 段缺 env 检查"
+    assert "gh auth status" in out, f"{template} precheck 段缺 gh 工具检查"
+    assert "kubectl version --client" in out, f"{template} precheck 段缺 kubectl 工具检查"
+    assert "make ci-precheck" in out, f"{template} precheck 段缺业务仓 ci-precheck 调用"
+    # PRECHECK-S4: fail tag scheme
+    assert "result:fail" in out and "fail-reason:precheck:" in out, (
+        f"{template} 缺 fail tag scheme（agent 不会按规约 emit fail）"
+    )
+
+
+# ── PRECHECK-S2 / 静默条件 ────────────────────────────────────────────────
+
+
+def test_intake_does_not_render_precheck_section() -> None:
+    """PRECHECK-S2: intake 是 chat brainstorm，stage_precheck_enabled[intake] = False。
+
+    hook 必须在 stage 没 set 或 stage_precheck_enabled[stage] 为 False 时静默 ——
+    否则 brainstorm 也被迫做 pod-level precheck，没装 aissh-tao 的 workspace 上
+    intake 也直接红，测试场景里 chat 通道完全没法跑。
+    """
+    out = render(
+        "intake.md.j2",
+        req_id="REQ-x",
+        aissh_server_id="a",
+        project_id="p",
+        project_alias="p",
+        issue_id="i",
+    )
+    assert "Stage Precheck" not in out, (
+        "intake 渲出了 precheck 段。如果你刚把 intake 加到 stage_precheck_enabled=True，"
+        "请同步更新本 assertion 的 rationale。"
+    )
+
+
+# ── PRECHECK-S3 / pluggable invariant ─────────────────────────────────────
+
+
+def test_disabling_precheck_via_enabled_prompt_hooks_drops_section(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PRECHECK-S3: pluggable invariant —— operator 把 precheck 从
+    enabled_prompt_hooks 拿掉（如临时调试 / 不走 runner pod 的部署），
+    分支 stage 渲出来不能再有 precheck 段；其它 hook 必须照旧。
+    用 monkeypatch 直接覆盖 jinja global 模拟运行时切换 —— 比改 settings 更直接，
+    避开 pydantic-settings 实例缓存 / 单例延迟。
+    """
+    monkeypatch.setitem(
+        _env.globals,
+        "enabled_prompt_hooks",
+        ["mcp_preflight", "self_issue_constraint"],
+    )
+    out = render("analyze.md.j2", **_render_kwargs("analyze"))
+    assert "Stage Precheck" not in out, (
+        "关掉 precheck 后段还在 → for-loop 没读 enabled_prompt_hooks，pluggable invariant 破了"
+    )
+    # 其它 hook 不能连坐被砍
+    assert "MCP 依赖预检" in out, "mcp_preflight 被误连坐"
+    assert "只改本 issue" in out, "self_issue_constraint 被误连坐"
+
+
+def test_disabling_stage_precheck_enabled_drops_section_for_that_stage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """补充 invariant：operator 关掉单 stage 的 precheck（如分阶段灰度），
+    其它 stage 不受影响 —— stage_precheck_enabled 是 dict 级开关。
+    """
+    monkeypatch.setitem(
+        _env.globals,
+        "stage_precheck_enabled",
+        {**settings.stage_precheck_enabled, "analyze": False},
+    )
+    out_off = render("analyze.md.j2", **_render_kwargs("analyze"))
+    out_on = render("challenger.md.j2", **_render_kwargs("challenger"))
+    assert "Stage Precheck" not in out_off, "analyze 关掉了 precheck，但段还在"
+    assert "Stage Precheck" in out_on, "关 analyze 误连坐 challenger"
+
+
+# ── PRECHECK-S5 / provider 不硬编 ─────────────────────────────────────────
+
+
+def test_precheck_hook_does_not_hardcode_aissh_tao_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PRECHECK-S5: 换 MCP provider 时 precheck 段必须跟着变 —— 不能硬编 aissh-tao。
+
+    本 invariant 跟 mcp_preflight 测试里的 `test_no_hardcoded_aissh_tao_literal`
+    类似但更针对运行时：覆盖 mcp_capability_providers['ssh_exec']，渲出来必须
+    含新 provider，绝不出现 aissh-tao。
+    """
+    monkeypatch.setitem(
+        _env.globals,
+        "mcp_capability_providers",
+        {**settings.mcp_capability_providers, "ssh_exec": "test-provider"},
+    )
+    out = render("analyze.md.j2", **_render_kwargs("analyze"))
+    # 段头到 step 内的命令都得切到新 provider
+    assert "mcp__test-provider__exec_run" in out, (
+        "precheck 段没用 mcp_capability_providers['ssh_exec'] 渲 exec_run 调用"
+    )
+    # 找 precheck 段 slice，避免 mcp_preflight 段内合规出现 aissh-tao 干扰
+    start = out.index("Stage Precheck")
+    # precheck 段以分隔线 `─────────` 结束（hook 末尾）
+    end = out.index("─────────", start)
+    precheck_block = out[start:end]
+    assert "aissh-tao" not in precheck_block, (
+        "precheck 段硬编了 aissh-tao 字面量，operator 换 provider 时跟不上"
+    )


### PR DESCRIPTION
## Summary

- Adds `_shared/hooks/precheck.md.j2` to the pluggable hook framework so every runner-pod-bound stage agent (analyze / challenger / accept / staging_test / pr_ci_watch / bugfix) does an env / tool / `make ci-precheck` fail-fast at step 0.5, before any business work.
- Hard fail tags `result:fail` + `fail-reason:precheck:<item>` and ends the session — verifier escalates without retry, instead of letting the agent burn ANALYZE/CHALLENGER tokens then get watchdog-killed at `dev_cross_check` 7 min later (the dogfood incident in #373).
- New config knobs:
  - `enabled_prompt_hooks` default = `["mcp_preflight", "precheck", "self_issue_constraint"]` (order locked: MCP must work before precheck shells into the pod; both fail-fast hooks before self-issue policy).
  - `stage_precheck_enabled: dict[str, bool]` controls per-stage participation (intake / done_archive default off).
- `make ci-precheck` documented in `docs/integration-contracts.md` §2.6 as an **optional** business-repo contract target. Missing target = soft pass (repo not opted in yet); present + non-zero exit = hard fail.

## Test plan

- [x] `tests/test_prompts_precheck.py` covers PRECHECK-S1..S6 (12 tests, all green)
  - hook renders for the six runner-pod stages with all three check classes + fail-tag scheme
  - silent for intake (default off)
  - silent when removed from `enabled_prompt_hooks` (pluggable invariant)
  - silent when `stage_precheck_enabled[stage]` is False (per-stage gate)
  - precheck block uses `mcp_capability_providers['ssh_exec']` indirection (no `aissh-tao` hardcoding)
  - default hook list ordered preflight → precheck → self-issue
- [x] Updated `tests/test_prompts_mcp_preflight.py` default-list assertion
- [x] `make ci-lint` green
- [x] `make ci-unit-test` — 31 pre-existing failures (test isolation pollution tracked in #364), all my new tests pass; rendering helper in `test_contract_pr_issue_traceability_challenger.py` updated to inject the new global so xlink tests stay green
- [x] `make ci-integration-test` — exit 5 → pass (no PG)
- [x] `openspec validate REQ-feat-precheck-373-1777864856` valid
- [x] `scripts/check-scenario-refs.sh` OK

## Roll-out

1. Merge this PR
2. Default hook list ships in next orch image / hot-reload — every stage dispatch will start emitting the precheck section automatically
3. Follow-up per-repo PRs to add `make ci-precheck` (echo OK at minimum) on ttpos-flutter / ttpos-server-go / fixture repo (handled outside this REQ)
4. Watch Metabase for `fail-reason:precheck:*` tag distribution to validate that the 7 min watchdog waste from #373 is being intercepted

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-feat-precheck-373-1777864856\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/qvotzvcm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)