### PR TITLE
fix(admission): exclude pending-user-review from inflight cap (closes #384)

### DIFF
--- a/openspec/changes/REQ-fix-admission-pur-cap-1777866614/proposal.md
+++ b/openspec/changes/REQ-fix-admission-pur-cap-1777866614/proposal.md
@@ -1,0 +1,68 @@
+# REQ-fix-admission-pur-cap-1777866614: fix(admission): inflight cap 排除 pending-user-review
+
+## 问题
+
+`admission.py:42` `_INFLIGHT_EXCLUDE_STATES`：
+
+```python
+_INFLIGHT_EXCLUDE_STATES = ("init", "done", "escalated", "gh-incident-open")
+```
+
+排除了 `escalated`（注释说"消耗 0 runner pod"），但**没排除
+`pending-user-review`** —— PUR 跟 escalated 一样**也不消耗 runner pod**：进 PUR
+之前 verifier escalate 路径已经把 runner Pod 拆掉了，REQ 只是在等用户在 BKD
+issue 里 follow-up 续推。
+
+## 实证（5/4 凌晨，issue #384）
+
+orch state distribution：8 PUR + 2 challenger-running = 10/10，
+新 REQ 被 admission 全部 reject `inflight-cap-exceeded:10/10`。
+
+8 个 PUR 都是 4/29-5/3 的老 REQ，没人理就堆着。verifier escalate→人 resume
+路径 by design 把 REQ 推 PUR 等再次确认，但用户没 UX 提醒，每次 resume 都加一个
+PUR，永久积累堵 cap。
+
+## 方案
+
+### 把 `pending-user-review` 加进 `_INFLIGHT_EXCLUDE_STATES`
+
+`orchestrator/src/orchestrator/admission.py`:
+
+```python
+_INFLIGHT_EXCLUDE_STATES = (
+    "init", "done", "escalated", "gh-incident-open", "pending-user-review",
+)
+```
+
+加一段注释解释 PUR 跟 escalated 同档（runner pod 已拆，等人续推），并指 issue
+#384 作为 incident reference。
+
+### 不动 PUR 的 UX 提醒（拆单独 issue）
+
+issue #384 还提到 watchdog 周期 emit "REQ X 已 PUR Y 小时" 的 UX 改进。本 REQ
+只做 admission cap fix，UX 改进单立项，不在本 PR 范围。
+
+### 同步更新 spec 和测试
+
+- `openspec/specs/orch-rate-limit` 把 requirement 里的 exclude state 列表加上
+  `pending-user-review`，并新增 scenario `ORCH-RATE-S7` 显式覆盖"8 PUR + 2
+  running 时新 REQ 仍能通过"。
+- `orchestrator/tests/test_admission.py`：
+  - 在已有 `test_inflight_count_under_cap_admits` 的 SQL state-list 断言里
+    追加 `assert "pending-user-review" in state_list`。
+  - 新增 `test_inflight_excludes_pending_user_review`（ORCH-RATE-S7）：
+    `_FakePool(count=2)` 模拟 SQL 已排除 8 PUR 后只看到 2 个真 inflight，
+    断言 admit=True。
+
+## 影响
+
+- runtime：admission cap 算法只多排除一个状态，cap=0 短路逻辑不变；其他 stage
+  的状态机 transition 完全不受影响。
+- 操作：堵 cap 的 PUR 老 REQ 立刻不再卡新 REQ；老 PUR 本身仍照常等用户续推。
+- 观测：`admission.cap_rejected` warning 频率应明显下降。
+
+## 验证
+
+- `pytest orchestrator/tests/test_admission.py` 全过（含新 ORCH-RATE-S7）。
+- `openspec validate openspec/changes/REQ-fix-admission-pur-cap-1777866614` 通过。
+- `check-scenario-refs.sh` 通过（ORCH-RATE-S7 引用与定义匹配）。

--- a/openspec/changes/REQ-fix-admission-pur-cap-1777866614/specs/orch-rate-limit/spec.md
+++ b/openspec/changes/REQ-fix-admission-pur-cap-1777866614/specs/orch-rate-limit/spec.md
@@ -1,0 +1,96 @@
+## MODIFIED Requirements
+
+### Requirement: orchestrator gates fresh REQ entry on in-flight count and node disk pressure
+
+The sisyphus orchestrator SHALL run an admission check at the start of the
+two fresh-entry actions — `start_intake` and `start_analyze` — and MUST
+reject the REQ before any runner Pod / PVC creation when either
+condition holds:
+
+1. The number of REQs whose state is not in
+   `{init, done, escalated, gh-incident-open, pending-user-review}`
+   (excluding the calling REQ itself) is greater than or equal to
+   `settings.inflight_req_cap`. A cap value of `0` SHALL disable this
+   check unconditionally. The `pending-user-review` exclusion is
+   required because PUR REQs have already had their runner Pod torn
+   down and are parked waiting for a human follow-up — counting them
+   against the cap caused incident #384, where 8 long-parked PUR rows
+   starved every fresh REQ.
+2. The K8s node's disk usage ratio reported by
+   `RunnerController.node_disk_usage_ratio()` is greater than or equal
+   to `settings.admission_disk_pressure_threshold`.
+
+Rejection MUST be expressed by returning
+`{"emit": "verify.escalate", "reason": <human-readable string>}` from
+the action handler, after writing
+`ctx.escalated_reason = "rate-limit:inflight-cap-exceeded"` or
+`"rate-limit:disk-pressure"` so the existing escalate pathway tags the
+REQ with the correct reason. The continuation action
+`start_analyze_with_finalized_intent` MUST NOT run the gate — that REQ
+already passed admission at intake time.
+
+The disk-pressure check SHALL fail open (admit + log warning) when:
+- the runner controller is not initialised (development without K8s),
+- the existing `runner_gc._DISK_CHECK_DISABLED` short-circuit flag is
+  set (cluster-scoped `nodes:list` denied by RBAC), or
+- the underlying `node_disk_usage_ratio()` raises any exception other
+  than what the GC loop already handles.
+
+#### Scenario: ORCH-RATE-S1 cap=0 disables the in-flight gate
+
+- **GIVEN** `settings.inflight_req_cap = 0` and 50 active REQs in
+  `req_state`
+- **WHEN** `check_admission(pool, req_id="REQ-new")` runs
+- **THEN** the result's `admit` is `True` regardless of the count
+
+#### Scenario: ORCH-RATE-S2 in-flight count under cap admits
+
+- **GIVEN** `settings.inflight_req_cap = 10` and the SQL count of
+  non-terminal REQs other than `REQ-new` is `9`
+- **WHEN** `check_admission(pool, req_id="REQ-new")` runs
+- **THEN** the result's `admit` is `True` and `reason` is `None`
+
+#### Scenario: ORCH-RATE-S3 in-flight count at cap rejects
+
+- **GIVEN** `settings.inflight_req_cap = 10` and the SQL count of
+  non-terminal REQs other than `REQ-new` is `10`
+- **WHEN** `check_admission(pool, req_id="REQ-new")` runs
+- **THEN** the result's `admit` is `False` and `reason` MUST contain
+  the substring `inflight-cap-exceeded`
+
+#### Scenario: ORCH-RATE-S4 disk usage under threshold admits
+
+- **GIVEN** `settings.admission_disk_pressure_threshold = 0.75` and
+  `node_disk_usage_ratio()` returns `0.50`
+- **WHEN** `check_admission(pool, req_id="REQ-new")` runs with the
+  in-flight count well below the cap
+- **THEN** the result's `admit` is `True`
+
+#### Scenario: ORCH-RATE-S5 disk usage above threshold rejects
+
+- **GIVEN** `settings.admission_disk_pressure_threshold = 0.75` and
+  `node_disk_usage_ratio()` returns `0.80`
+- **WHEN** `check_admission(pool, req_id="REQ-new")` runs with the
+  in-flight count well below the cap
+- **THEN** the result's `admit` is `False` and `reason` MUST contain
+  the substring `disk-pressure`
+
+#### Scenario: ORCH-RATE-S6 missing runner controller fails open
+
+- **GIVEN** `k8s_runner.get_controller()` raises `RuntimeError`
+  (development environment without K8s)
+- **WHEN** `check_admission(pool, req_id="REQ-new")` runs
+- **THEN** the result's `admit` is `True` (fail open) and disk check
+  is skipped without raising
+
+#### Scenario: ORCH-RATE-S7 pending-user-review excluded from in-flight cap
+
+- **GIVEN** `settings.inflight_req_cap = 10`
+- **AND** `req_state` holds 8 REQs in `pending-user-review` (PUR) plus
+  2 REQs in `challenger-running`
+- **WHEN** `check_admission(pool, req_id="REQ-new")` runs
+- **THEN** the SQL passed to `pool.fetchrow` MUST include
+  `pending-user-review` in the excluded-states array
+- **AND** the count returned by the SQL is `2` (only the two
+  `challenger-running` REQs), not `10`
+- **AND** the result's `admit` is `True` (2 < 10)

--- a/openspec/changes/REQ-fix-admission-pur-cap-1777866614/tasks.md
+++ b/openspec/changes/REQ-fix-admission-pur-cap-1777866614/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: REQ-fix-admission-pur-cap-1777866614
+
+## Stage: contract / spec
+
+- [x] author `specs/orch-rate-limit/spec.md` MODIFIED Requirements 把
+      `pending-user-review` 加进排除状态列表
+- [x] add scenario `ORCH-RATE-S7 pending-user-review excluded from in-flight cap`
+
+## Stage: implementation
+
+- [x] `orchestrator/src/orchestrator/admission.py`:
+      `_INFLIGHT_EXCLUDE_STATES` 末尾加 `"pending-user-review"`，更新注释
+      解释 PUR 跟 escalated 同档（runner pod 已拆）
+
+## Stage: tests
+
+- [x] `orchestrator/tests/test_admission.py::test_inflight_count_under_cap_admits`
+      —— SQL state-list 断言追加 `pending-user-review`
+- [x] `orchestrator/tests/test_admission.py::test_inflight_excludes_pending_user_review`
+      —— 新 case ORCH-RATE-S7：`_FakePool(count=2)` 模拟 8 PUR 已排除，admit=True
+
+## Stage: PR
+
+- [x] `git push origin feat/REQ-fix-admission-pur-cap-1777866614`
+- [x] `gh pr create` with proposal summary + verification plan

--- a/orchestrator/src/orchestrator/admission.py
+++ b/orchestrator/src/orchestrator/admission.py
@@ -39,8 +39,12 @@ log = structlog.get_logger(__name__)
 # rows that haven't dispatched yet from being counted as work-in-progress;
 # excluding `gh-incident-open` keeps escalated-but-waiting-for-human REQs out
 # of the cap (they consume no runner Pod). Done / escalated are terminal.
+# `pending-user-review` is in the same bucket as `escalated`/`gh-incident-open`:
+# the runner Pod is already torn down and the REQ is parked waiting for a
+# human follow-up. Counting PUR REQs against the cap caused a stuck-cap
+# incident (#384) where 8 long-parked PUR rows starved fresh REQs.
 _INFLIGHT_EXCLUDE_STATES: tuple[str, ...] = (
-    "init", "done", "escalated", "gh-incident-open",
+    "init", "done", "escalated", "gh-incident-open", "pending-user-review",
 )
 
 

--- a/orchestrator/tests/test_admission.py
+++ b/orchestrator/tests/test_admission.py
@@ -80,6 +80,7 @@ async def test_inflight_count_under_cap_admits(monkeypatch):
     assert "done" in state_list
     assert "escalated" in state_list
     assert "gh-incident-open" in state_list
+    assert "pending-user-review" in state_list
 
 
 # ─── Scenario S3: count at cap rejects ────────────────────────────────────
@@ -108,6 +109,34 @@ async def test_inflight_count_above_cap_rejects(monkeypatch):
     assert decision.admit is False
     assert "inflight-cap-exceeded" in decision.reason
     assert "15/10" in decision.reason
+
+
+# ─── Scenario S7: pending-user-review excluded from in-flight cap ─────────
+
+
+@pytest.mark.asyncio
+async def test_inflight_excludes_pending_user_review(monkeypatch):
+    """ORCH-RATE-S7 — 8 PUR + 2 running with cap=10 admits a fresh REQ.
+
+    The bug (#384) was that PUR REQs (runner Pod already torn down, parked
+    waiting for human follow-up) were counted against `inflight_req_cap`.
+    `_INFLIGHT_EXCLUDE_STATES` now contains `pending-user-review`, so the
+    SQL count returned to admission only reflects REQs that actually hold
+    runner resources.
+    """
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    monkeypatch.setattr(admission.settings, "admission_disk_pressure_threshold", 0.75)
+    _install_controller(ratio=0.10)
+    # Pool returns 2 — the SQL excluded the 8 PUR rows because PUR is in the
+    # state list. With cap=10 and inflight=2 the fresh REQ admits.
+    pool = _FakePool(count=2)
+
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+
+    assert decision.admit is True
+    assert decision.reason is None
+    state_list, _ = pool.last_args
+    assert "pending-user-review" in state_list
 
 
 # ─── Scenario S4: disk under threshold admits ─────────────────────────────

--- a/orchestrator/tests/test_contract_admission_pur_cap_challenger.py
+++ b/orchestrator/tests/test_contract_admission_pur_cap_challenger.py
@@ -1,0 +1,191 @@
+"""Challenger contract tests for REQ-fix-admission-pur-cap-1777866614.
+
+Black-box contracts derived exclusively from
+  openspec/changes/REQ-fix-admission-pur-cap-1777866614/specs/orch-rate-limit/spec.md
+
+Scenario covered:
+  ORCH-RATE-S7  pending-user-review excluded from in-flight cap
+
+Dev MUST NOT modify these tests to make them pass — fix the implementation
+instead. If a test is truly wrong, escalate to spec_fixer to correct the spec.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class _CapturePool:
+    """Minimal pool stub: capture fetchrow args, return a fixed count.
+
+    Black-box: the spec says the SQL passed to ``pool.fetchrow`` MUST include
+    ``pending-user-review`` in the excluded-states array. We do not assert on
+    the SQL string itself (implementation detail) — only on the parameters.
+    """
+
+    def __init__(self, count: int) -> None:
+        self._count = count
+        self.last_args: tuple = ()
+        self.fetchrow_calls: int = 0
+
+    async def fetchrow(self, sql, *args):
+        self.fetchrow_calls += 1
+        self.last_args = args
+        return {"n": self._count}
+
+
+def _install_disk_ok_controller() -> None:
+    """Install a controller whose disk usage is well below any threshold,
+    so the disk-pressure gate is a no-op for these tests.
+    """
+    from orchestrator import k8s_runner
+
+    fake = MagicMock()
+    fake.node_disk_usage_ratio = AsyncMock(return_value=0.0)
+    k8s_runner.set_controller(fake)
+
+
+@pytest.fixture(autouse=True)
+def _reset_controller():
+    from orchestrator import k8s_runner, runner_gc
+
+    runner_gc._DISK_CHECK_DISABLED = False
+    k8s_runner.set_controller(None)
+    yield
+    runner_gc._DISK_CHECK_DISABLED = False
+    k8s_runner.set_controller(None)
+
+
+# ─── ORCH-RATE-S7 ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_orch_rate_s7_pending_user_review_excluded_from_inflight_cap(
+    monkeypatch,
+) -> None:
+    """ORCH-RATE-S7: PUR REQs MUST NOT count toward the in-flight cap.
+
+    Spec scenario:
+      GIVEN settings.inflight_req_cap = 10
+      AND   req_state holds 8 REQs in pending-user-review (PUR) plus
+            2 REQs in challenger-running
+      WHEN  check_admission(pool, req_id="REQ-new") runs
+      THEN  the SQL passed to pool.fetchrow MUST include
+            'pending-user-review' in the excluded-states array
+      AND   the count returned by the SQL is 2 (only the two
+            challenger-running REQs), not 10
+      AND   the result's admit is True (2 < 10)
+
+    Why this matters: PUR REQs have already had their runner Pod torn down
+    and are parked waiting for human follow-up — counting them against the
+    cap caused incident #384, where 8 long-parked PUR rows starved every
+    fresh REQ.
+    """
+    from orchestrator import admission
+
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    monkeypatch.setattr(
+        admission.settings, "admission_disk_pressure_threshold", 0.95
+    )
+    _install_disk_ok_controller()
+
+    # The contract: by the time fetchrow is invoked, the SQL has already
+    # filtered out the 8 PUR rows, so the row count seen by the caller is 2.
+    pool = _CapturePool(count=2)
+
+    decision = await admission.check_admission(pool, req_id="REQ-new")
+
+    # 1. fetchrow was invoked exactly once (admission must consult the pool).
+    assert pool.fetchrow_calls == 1, (
+        "ORCH-RATE-S7: check_admission MUST call pool.fetchrow exactly once "
+        f"to count in-flight REQs (got {pool.fetchrow_calls} calls)"
+    )
+
+    # 2. The excluded-states array passed to the SQL MUST contain
+    #    'pending-user-review'. We accept any positional arg that is a
+    #    list/tuple of strings so we don't lock down the parameter order.
+    state_list = _find_state_list(pool.last_args)
+    assert state_list is not None, (
+        "ORCH-RATE-S7: check_admission MUST pass an excluded-states list to "
+        f"pool.fetchrow; saw args={pool.last_args!r}"
+    )
+    assert "pending-user-review" in state_list, (
+        "ORCH-RATE-S7: the excluded-states array passed to pool.fetchrow MUST "
+        "include 'pending-user-review' so PUR REQs do not count against the "
+        f"in-flight cap. Saw excluded states: {state_list!r}"
+    )
+
+    # 3. Admission MUST succeed: count=2 < cap=10.
+    assert decision.admit is True, (
+        "ORCH-RATE-S7: with 2 challenger-running REQs and cap=10, admission "
+        f"MUST admit a fresh REQ. Got admit={decision.admit!r} "
+        f"reason={getattr(decision, 'reason', None)!r}"
+    )
+    assert getattr(decision, "reason", None) is None, (
+        "ORCH-RATE-S7: a successful admission MUST report reason=None. "
+        f"Got reason={decision.reason!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_orch_rate_s7_excluded_states_also_contain_legacy_terminals(
+    monkeypatch,
+) -> None:
+    """Companion guard: the existing terminal/parked exclusions MUST stay.
+
+    The MODIFIED requirement explicitly enumerates the excluded-states set as
+    ``{init, done, escalated, gh-incident-open, pending-user-review}``. Adding
+    PUR MUST NOT silently drop any of the prior four states — otherwise the
+    fix would regress the cap behaviour for terminal/incident REQs.
+    """
+    from orchestrator import admission
+
+    monkeypatch.setattr(admission.settings, "inflight_req_cap", 10)
+    monkeypatch.setattr(
+        admission.settings, "admission_disk_pressure_threshold", 0.95
+    )
+    _install_disk_ok_controller()
+
+    pool = _CapturePool(count=0)
+
+    await admission.check_admission(pool, req_id="REQ-new")
+
+    state_list = _find_state_list(pool.last_args)
+    assert state_list is not None, (
+        "check_admission MUST pass an excluded-states list to pool.fetchrow; "
+        f"saw args={pool.last_args!r}"
+    )
+
+    required = {
+        "init",
+        "done",
+        "escalated",
+        "gh-incident-open",
+        "pending-user-review",
+    }
+    missing = required - set(state_list)
+    assert not missing, (
+        "Per the MODIFIED requirement the excluded-states set MUST be the "
+        f"superset of {sorted(required)!r}. Missing: {sorted(missing)!r}. "
+        f"Saw: {sorted(set(state_list))!r}"
+    )
+
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _find_state_list(args: tuple):
+    """Locate the excluded-states sequence among ``pool.fetchrow`` positional
+    args without assuming a specific parameter order.
+
+    The spec only constrains *what* MUST be in the state list, not where it
+    sits in the argument tuple — so we accept the first positional arg that
+    looks like a sequence of state-name strings.
+    """
+    for arg in args:
+        if isinstance(arg, (list, tuple)) and arg and all(
+            isinstance(x, str) for x in arg
+        ):
+            return list(arg)
+    return None


### PR DESCRIPTION
## Summary

Add `pending-user-review` to `_INFLIGHT_EXCLUDE_STATES` so PUR REQs no longer
count against `inflight_req_cap`.

PUR sits in the same bucket as `escalated` / `gh-incident-open`: the runner
Pod was already torn down by the verifier→escalate path, and the REQ is just
parked waiting for a human follow-up. Counting these against the cap caused
incident #384 — 8 long-parked PUR rows + 2 challenger-running = 10/10, every
fresh REQ rejected with `inflight-cap-exceeded:10/10`.

The PUR UX side of #384 (watchdog reminders for long-parked PUR) is **out of
scope** here and will be a separate follow-up issue.

## Changes

- `orchestrator/src/orchestrator/admission.py`: append `"pending-user-review"`
  to `_INFLIGHT_EXCLUDE_STATES`, expand the comment to explain the bucket and
  point at #384.
- `orchestrator/tests/test_admission.py`:
  - existing `test_inflight_count_under_cap_admits` — assert PUR is in the
    SQL state-list parameter.
  - new `test_inflight_excludes_pending_user_review` (ORCH-RATE-S7) — fakes
    the SQL "8 PUR + 2 running" scenario by returning `count=2` and asserting
    admit=True.
- `openspec/changes/REQ-fix-admission-pur-cap-1777866614/`: proposal, tasks,
  `MODIFIED Requirements` for `orch-rate-limit` (exclude-list updated, new
  scenario ORCH-RATE-S7).

## Test plan

- [x] `BASE_REV=$(git merge-base HEAD origin/main) make ci-lint` — green
- [x] `pytest orchestrator/tests/test_admission.py` — 15 passed (was 14)
- [x] `openspec validate --changes REQ-fix-admission-pur-cap-1777866614 --strict` — ✓
- [x] `scripts/check-scenario-refs.sh --specs-search-path . .` — OK (824 defs)
- [ ] sisyphus pipeline (`spec_lint` / `dev_cross_check` / `staging_test` /
      `pr_ci_watch`) — verified on PR after push

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-fix-admission-pur-cap-1777866614\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/sle3yp9z)