### PR TITLE
feat(state): silent-drop lint v2 (closes #376)

### DIFF
--- a/.github/workflows/orchestrator-ci.yml
+++ b/.github/workflows/orchestrator-ci.yml
@@ -41,6 +41,13 @@ jobs:
       - name: ruff
         run: uv run ruff check src/ tests/
 
+      - name: state-machine transition lint (REQ #376)
+        # Detects silently-dropped (state, event) → no-progress transitions
+        # by requiring explicit progress="no" or "explicit-noop" annotation
+        # on every self-loop in TRANSITIONS. See scripts/lint-state-transitions.py.
+        working-directory: ${{ github.workspace }}
+        run: python3 scripts/lint-state-transitions.py
+
       - name: pytest
         run: uv run pytest -v --tb=short -m "not integration"
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ help: ## 显示帮助信息
 
 # ========== ttpos-ci 标准 target（self-dogfood） ==========
 
-ci-lint: ## ruff lint；BASE_REV 非空 → 仅 lint 变更 *.py
+ci-lint: ## ruff lint + state-machine transition lint；BASE_REV 非空 → 仅 lint 变更 *.py
+	@echo "ci-lint: state-machine transition lint (REQ #376)"
+	@python3 scripts/lint-state-transitions.py
 	@if [ -z "$$BASE_REV" ]; then \
 		echo "ci-lint: full scan (BASE_REV empty)"; \
 		cd orchestrator && uv run ruff check src/ tests/; \

--- a/openspec/changes/REQ-feat-silent-lint-376-v2-1777866643/proposal.md
+++ b/openspec/changes/REQ-feat-silent-lint-376-v2-1777866643/proposal.md
@@ -1,0 +1,70 @@
+# Proposal: state-machine silent-drop lint v2 (closes #376)
+
+## Problem
+
+5/4 v5 卡死链路（issue #376 实证）：
+
+1. verifier #802 emit `decision:pass` 字符串 tag
+2. router `derive_verifier_event` 解析失败 → 返 `Event.VERIFY_ESCALATE`
+3. webhook 派 VERIFY_ESCALATE 给 ESCALATED state
+4. `TRANSITIONS[(ESCALATED, VERIFY_ESCALATE)]` 是 `Transition(ESCALATED, None, ...)` —— self-loop, 不动
+5. **零日志、零反馈、REQ 永久卡 ESCALATED**
+
+事故根因：state 表里"合法 transition"和"语义上让 REQ 推不动的 transition"在静态层面
+没区分。router 派事件成功 + state.decide() 返合法 transition，所有信号都"对" ——
+但语义是死循环。需要把这种"显式 no-progress"transition 在静态层面挑出来供 review。
+
+## Solution
+
+`Transition` dataclass 加 `progress` 字段（`"yes"` / `"no"` / `"explicit-noop"` /
+`None` 自动推导），新增 `scripts/lint-state-transitions.py` 在 dev / CI 期遍历
+`TRANSITIONS` 表：
+
+1. **自动分类**：
+   - `next_state != src_state` → 派生 progress = `"yes"`（推进）
+   - `next_state == src_state` → "raw no-progress"，要求显式 `progress` 字段
+2. **强制显式**：raw no-progress transition 若没声明 `progress`，lint fail。
+   声明值必须是 `"no"`（候选死锁，需 telemetry）或 `"explicit-noop"`（acknowledged
+   intentional self-loop）。
+3. **一致性校验**：
+   - `progress="yes"` 但 `next_state == src_state` → 矛盾，fail
+   - `progress="no"` / `"explicit-noop"` 但 `next_state != src_state` → 矛盾，fail
+4. **报告**：人类可读输出，按 progress 分桶列举所有 transition，便于 code review。
+5. **CI gate**：`make ci-lint` 包含本 lint，`.github/workflows/orchestrator-ci.yml`
+   上一步执行；新加 transition 必须显式标注 progress 才能合 PR。
+
+第一次跑就把今晚 `(ESCALATED, VERIFY_ESCALATE) → ESCALATED` 标 `explicit-noop`
+（语义：用户 follow-up 后 verifier 仍判 escalate，留原地等下一次，是 intentional），
+跟 #372 decode-fail telemetry 配合，未来 `progress="no"` 桶非空时 emit 警告。
+
+## Why not 方案 B（运行期 metric）
+
+只跑运行期 metric（"卡 ESCALATED 超 N 分钟告警"）也能发现死循环，但晚了一拍 ——
+新加 transition 时就该在 PR review 阶段被人类看见 "这条是 no-progress, 真的对吗？"。
+静态 lint 让 transition 表本身成为"已审"的 source-of-truth，运行期 metric 是兜底。
+两者互补，本 REQ 先做前者（成本低，价值高）。
+
+## Why not 方案 C（运行时 trace）
+
+orch 已经有 stage_runs / verifier_decisions 两表收集运行轨迹（observability/）。
+但表里"REQ 卡 ESCALATED"和"REQ 在 ESCALATED 反激活后正常推进"长得一样 —— 缺少
+"transition 应当推进却原地踏步"这一**意图**信号。本 REQ 把意图编码进 transition 表
+本身（progress 字段），让任何看 state.py 的人秒懂"这条故意 no-progress"vs"这条本该推进"。
+
+## Scope
+
+- `orchestrator/src/orchestrator/state.py` — `Transition` 加 `progress` 字段；
+  所有 self-loop transition 标 `explicit-noop`（含 SESSION_FAILED dict comp、
+  `(ESCALATED, VERIFY_ESCALATE)`、`(REVIEW_RUNNING, VERIFY_INFRA_RETRY)`）
+- `scripts/lint-state-transitions.py`（新）—— 遍历 TRANSITIONS 校验 + 报告
+- `Makefile` — `ci-lint` target 调本 lint
+- `.github/workflows/orchestrator-ci.yml` — 加 lint step
+- `orchestrator/tests/test_lint_state_transitions.py`（新）—— 单测覆盖：
+  推进 transition / 显式 no-progress / 矛盾 / 缺失 annotation 四类 case
+
+## Out of scope
+
+- 运行期"卡 ESCALATED 超 N 分钟"告警（#372 telemetry 范围）
+- 新加 transition 类型（如 progress="warn"）—— 本 REQ 只引入 yes/no/explicit-noop 三值
+- TRANSITIONS 之外的 state 反激活字典（`_ESCALATED_RESUME_EVENT_SOURCES`）—— 那些 entry
+  通过 `TRANSITIONS.update` 复用源 transition object，progress 字段自动继承

--- a/openspec/changes/REQ-feat-silent-lint-376-v2-1777866643/specs/state-transition-progress-lint/spec.md
+++ b/openspec/changes/REQ-feat-silent-lint-376-v2-1777866643/specs/state-transition-progress-lint/spec.md
@@ -1,0 +1,127 @@
+# state-transition-progress-lint
+
+## ADDED Requirements
+
+### Requirement: Transition dataclass exposes a progress field for static no-progress detection
+
+The `Transition` dataclass in `orchestrator/src/orchestrator/state.py` SHALL
+expose a `progress` attribute typed `str | None` that defaults to `None`. The
+allowed non-None values MUST be exactly the string literals `"yes"`, `"no"`,
+and `"explicit-noop"`. The dataclass MUST remain frozen, and the field MUST be
+settable as a keyword-only constructor argument.
+
+`progress="yes"` MUST mean "this transition advances the state machine to a
+different ReqState". `progress="no"` MUST mean "this transition does not
+advance state and is flagged as a deadlock candidate that needs telemetry or
+escalation". `progress="explicit-noop"` MUST mean "this is an intentional
+self-loop, acknowledged by the author (e.g. SESSION_FAILED action-decides
+self-loop)". `progress=None` SHALL be reserved for transitions whose semantic
+is auto-derivable from `(src_state, next_state)` —— specifically only allowed
+when `next_state != src_state` (lint will derive `"yes"`).
+
+#### Scenario: STPL-S1 Transition accepts progress kwarg with allowed values
+
+- **GIVEN** the `Transition` dataclass imported from `orchestrator.state`
+- **WHEN** constructing `Transition(next_state=ReqState.DONE, progress="yes")`
+- **THEN** the resulting instance MUST expose `.progress == "yes"`
+- **AND** the same MUST hold for `progress="no"` and `progress="explicit-noop"`
+- **AND** omitting `progress` MUST set `.progress` to `None`
+
+#### Scenario: STPL-S2 every existing self-loop transition has explicit progress annotation
+
+- **GIVEN** the current `TRANSITIONS` dict in `orchestrator.state`
+- **WHEN** iterating each `(src_state, event) → transition` entry
+- **THEN** every entry where `transition.next_state == src_state` MUST have
+  `transition.progress` set to one of `"no"` or `"explicit-noop"`
+- **AND** in particular `TRANSITIONS[(ReqState.ESCALATED, Event.VERIFY_ESCALATE)].progress`
+  MUST equal `"explicit-noop"`
+- **AND** `TRANSITIONS[(ReqState.REVIEW_RUNNING, Event.VERIFY_INFRA_RETRY)].progress`
+  MUST equal `"explicit-noop"`
+- **AND** every `(state, Event.SESSION_FAILED)` entry MUST have
+  `progress == "explicit-noop"`
+
+### Requirement: scripts/lint-state-transitions.py validates the TRANSITIONS table
+
+The repository SHALL provide an executable script at
+`scripts/lint-state-transitions.py` that, when invoked from the repo root with
+no arguments, MUST import `TRANSITIONS` from `orchestrator.state`, iterate every
+entry, and apply the following validation rules:
+
+1. **Self-loop annotation rule**: when `transition.next_state == src_state`,
+   `transition.progress` MUST be `"no"` or `"explicit-noop"`. If `progress`
+   is `None` or `"yes"`, the script MUST exit non-zero and print a line
+   identifying the offending `(state, event)` pair.
+2. **Advancing-transition consistency rule**: when
+   `transition.next_state != src_state`, `transition.progress` MUST NOT be
+   `"no"` or `"explicit-noop"`. If it is, the script MUST exit non-zero and
+   print the offending `(state, event)` pair.
+3. **Allowed value rule**: any non-None `progress` value other than
+   `"yes"` / `"no"` / `"explicit-noop"` MUST cause the script to exit non-zero.
+
+When all entries pass validation, the script MUST exit zero and MUST print a
+human-readable report containing per-bucket counts (yes / no / explicit-noop)
+and a list of every `(state, event) → next_state` pair that has
+`progress="no"` or `progress="explicit-noop"` so a human reviewer can audit
+intentional vs unacknowledged no-progress transitions in one glance.
+
+#### Scenario: STPL-S3 lint script exits zero on current TRANSITIONS table
+
+- **GIVEN** the `scripts/lint-state-transitions.py` script and the current
+  `orchestrator/src/orchestrator/state.py`
+- **WHEN** running `python3 scripts/lint-state-transitions.py` from repo root
+- **THEN** the process exit code MUST be 0
+- **AND** stdout MUST contain a line matching the substring `progress=yes`
+- **AND** stdout MUST contain a line matching the substring `progress=explicit-noop`
+- **AND** stdout MUST contain a line listing
+  `(escalated, verify.escalate) → escalated` under `explicit-noop`
+
+#### Scenario: STPL-S4 lint script flags an unannotated self-loop
+
+- **GIVEN** a synthetic `TRANSITIONS` dict that contains
+  `(ReqState.DONE, Event.PR_MERGED) → Transition(ReqState.DONE)` with no
+  `progress` field set
+- **WHEN** the lint module's validation function is called against that dict
+- **THEN** the function MUST return a non-empty list of violations
+- **AND** the violation MUST identify the `(done, pr.merged)` pair
+- **AND** the violation message MUST mention "self-loop requires progress
+  annotation"
+
+#### Scenario: STPL-S5 lint script flags a contradictory progress=yes self-loop
+
+- **GIVEN** a synthetic transition entry
+  `(ReqState.INIT, Event.INTENT_ANALYZE) → Transition(ReqState.INIT, progress="yes")`
+- **WHEN** the lint validation function is called against the dict
+- **THEN** the function MUST return a violation referencing
+  "progress=yes contradicts self-loop"
+
+#### Scenario: STPL-S6 lint script flags an unknown progress value
+
+- **GIVEN** a synthetic transition with `progress="maybe"`
+- **WHEN** the lint validation function is called
+- **THEN** the function MUST return a violation referencing the invalid value
+
+### Requirement: Makefile ci-lint and orchestrator-ci.yml invoke the lint
+
+`Makefile`'s `ci-lint` target SHALL invoke the lint script as part of its
+sequence so that `make ci-lint` (the contract used by sisyphus
+`dev_cross_check` checker per `docs/integration-contracts.md`) returns
+non-zero whenever a TRANSITIONS violation is introduced.
+
+`.github/workflows/orchestrator-ci.yml` SHALL include a step that runs
+`python3 scripts/lint-state-transitions.py` after the existing ruff step in
+the `lint-test` job, so PR CI catches violations independently of the
+sisyphus checker.
+
+#### Scenario: STPL-S7 ci-lint target invokes lint-state-transitions.py
+
+- **GIVEN** the repo root
+- **WHEN** running `make -n ci-lint` (dry-run print)
+- **THEN** the printed recipe MUST contain the literal substring
+  `lint-state-transitions.py`
+
+#### Scenario: STPL-S8 orchestrator-ci.yml runs the lint script
+
+- **GIVEN** the file `.github/workflows/orchestrator-ci.yml`
+- **WHEN** parsing it as YAML
+- **THEN** the `jobs.lint-test.steps` array MUST contain at least one step
+  whose `run` field references `scripts/lint-state-transitions.py`

--- a/openspec/changes/REQ-feat-silent-lint-376-v2-1777866643/tasks.md
+++ b/openspec/changes/REQ-feat-silent-lint-376-v2-1777866643/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+## Stage: spec
+- [x] author specs/state-transition-progress-lint/spec.md scenarios
+
+## Stage: implementation
+- [x] orchestrator/src/orchestrator/state.py: `Transition` dataclass 加 `progress: str | None = None` 字段
+- [x] orchestrator/src/orchestrator/state.py: 标注所有 self-loop transition 的 progress
+  - `(ESCALATED, VERIFY_ESCALATE)` → `explicit-noop`
+  - `(REVIEW_RUNNING, VERIFY_INFRA_RETRY)` → `explicit-noop`
+  - SESSION_FAILED dict comp 每条 → `explicit-noop`
+- [x] scripts/lint-state-transitions.py: 新建 lint 脚本
+- [x] Makefile: `ci-lint` target 加调用 `python3 scripts/lint-state-transitions.py`
+- [x] .github/workflows/orchestrator-ci.yml: lint-test job 加 lint step
+- [x] orchestrator/tests/test_lint_state_transitions.py: 单测覆盖（STPL-S1..S6 + bonus）
+
+## Stage: PR
+- [ ] make ci-lint 全绿（含新 lint script）
+- [ ] make ci-unit-test 全绿
+- [ ] make ci-integration-test 全绿（无 PG → exit 5 → pass）
+- [ ] git push origin feat/REQ-feat-silent-lint-376-v2-1777866643
+- [ ] gh pr create --label sisyphus 含 sisyphus footer

--- a/orchestrator/src/orchestrator/state.py
+++ b/orchestrator/src/orchestrator/state.py
@@ -84,10 +84,20 @@ class Event(StrEnum):
 
 @dataclass(frozen=True)
 class Transition:
-    """从 cur_state 收到 event 后的下一步。"""
+    """从 cur_state 收到 event 后的下一步。
+
+    progress 字段（REQ-feat-silent-lint-376-v2-1777866643 / closes #376）：
+      "yes"           推进 state（next_state != src_state；可省，lint 自动派生）
+      "no"            不推进，候选死锁，需 telemetry / 升级（lint 出报告供 review）
+      "explicit-noop" 不推进但 intentional（如 SESSION_FAILED action 自决，或
+                      ESCALATED 收 VERIFY_ESCALATE 留原地等下一次 follow-up）
+      None            自动派生：仅当 next_state != src_state 时合法
+    详见 scripts/lint-state-transitions.py。
+    """
     next_state: ReqState
     action: str | None = None
     reason: str | None = None
+    progress: str | None = None
 
 
 # (cur_state, event) → Transition
@@ -269,7 +279,8 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
                    "verifier decision=escalate 或 schema invalid"),
     (ReqState.REVIEW_RUNNING, Event.VERIFY_INFRA_RETRY):
         Transition(ReqState.REVIEW_RUNNING, "apply_verify_infra_retry",
-                   "decision=retry → 有界重跑 stage checker（infra flake；超 cap → escalate）"),
+                   "decision=retry → 有界重跑 stage checker（infra flake；超 cap → escalate）",
+                   progress="explicit-noop"),
 
     (ReqState.FIXER_RUNNING, Event.FIXER_DONE):
         Transition(ReqState.REVIEW_RUNNING, "invoke_verifier_after_fix",
@@ -293,7 +304,8 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
                    "用户续 escalate 的 verifier issue → 新 decision=fix → 起 fixer"),
     (ReqState.ESCALATED, Event.VERIFY_ESCALATE):
         Transition(ReqState.ESCALATED, None,
-                   "用户续了但 verifier 还是判 escalate → 留原地等下一次 follow-up"),
+                   "用户续了但 verifier 还是判 escalate → 留原地等下一次 follow-up",
+                   progress="explicit-noop"),
 
     # ─── 通用错误 ───────────────────────────────────────────────────────
     # session crash 在任何 running state 走 escalate action（self-loop, action 内部决定是否真 escalate）
@@ -302,7 +314,9 @@ TRANSITIONS: dict[tuple[ReqState, Event], Transition] = {
     #   retry 用完 / non-transient → action 内部手 CAS 推到 ESCALATED
     # next_state 写当前 state 是因为"action 自己决定是否真 escalate"，跟 apply_verify_pass 同模式
     **{
-        (st, Event.SESSION_FAILED): Transition(st, "escalate", "session crash → auto-resume or escalate")
+        (st, Event.SESSION_FAILED): Transition(st, "escalate",
+                                               "session crash → auto-resume or escalate",
+                                               progress="explicit-noop")
         for st in [
             ReqState.INTAKING, ReqState.ANALYZING,
             ReqState.ANALYZE_ARTIFACT_CHECKING,

--- a/orchestrator/tests/test_contract_state_transition_progress_lint_challenger.py
+++ b/orchestrator/tests/test_contract_state_transition_progress_lint_challenger.py
@@ -1,0 +1,289 @@
+"""Contract tests for state-transition-progress-lint (REQ-feat-silent-lint-376-v2-1777866643).
+
+Black-box behavioral contracts derived from:
+  openspec/changes/REQ-feat-silent-lint-376-v2-1777866643/specs/state-transition-progress-lint/spec.md
+
+Scenarios covered:
+  STPL-S1  Transition accepts progress kwarg with allowed values + frozen dataclass
+  STPL-S2  every existing self-loop transition has explicit progress annotation
+  STPL-S3  lint script exits zero on current TRANSITIONS table + report substrings
+  STPL-S4  lint flags an unannotated self-loop
+  STPL-S5  lint flags a contradictory progress=yes self-loop
+  STPL-S6  lint flags an unknown progress value
+  STPL-S7  ci-lint target invokes lint-state-transitions.py
+  STPL-S8  orchestrator-ci.yml runs the lint script in lint-test job
+"""
+from __future__ import annotations
+
+import dataclasses
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from orchestrator.state import TRANSITIONS, Event, ReqState, Transition
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LINT_SCRIPT = REPO_ROOT / "scripts" / "lint-state-transitions.py"
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _load_lint_module():
+    """Load scripts/lint-state-transitions.py as an importable module for introspection."""
+    assert LINT_SCRIPT.exists(), f"missing lint script at {LINT_SCRIPT}"
+    spec = importlib.util.spec_from_file_location(
+        "_lint_state_transitions_under_test", LINT_SCRIPT
+    )
+    assert spec is not None and spec.loader is not None, f"could not load {LINT_SCRIPT}"
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except SystemExit:
+        # tolerate scripts that auto-run + sys.exit on import; we only want the namespace
+        pass
+    return module
+
+
+_VALIDATE_NAME_CANDIDATES = (
+    "validate",
+    "validate_transitions",
+    "lint",
+    "lint_transitions",
+    "check",
+    "check_transitions",
+    "find_violations",
+    "collect_violations",
+)
+
+
+def _get_validate_fn(module):
+    """Resolve the spec's 'validation function' on the lint module.
+
+    The spec mandates a callable that takes a TRANSITIONS-shaped dict and returns
+    a list of violations, but does not pin a name. Try common names first; fall
+    back to scanning public callables that accept one positional arg and return
+    a list when given an empty dict.
+    """
+    for name in _VALIDATE_NAME_CANDIDATES:
+        fn = getattr(module, name, None)
+        if callable(fn):
+            return fn
+    for name in dir(module):
+        if name.startswith("_"):
+            continue
+        fn = getattr(module, name)
+        if not callable(fn):
+            continue
+        try:
+            result = fn({})
+        except Exception:
+            continue
+        if isinstance(result, list):
+            return fn
+    pytest.fail(
+        f"could not locate validation function on {LINT_SCRIPT.name}; "
+        f"tried names {_VALIDATE_NAME_CANDIDATES} and a public-callable scan"
+    )
+
+
+def _violations_blob(violations) -> str:
+    """Coerce a list of violations (str / tuple / dict / dataclass / ...) into a single
+    searchable string so we can match spec-mandated wording without locking in a shape."""
+    return " | ".join(str(v) for v in violations)
+
+
+# ─── STPL-S1 ──────────────────────────────────────────────────────────────────
+
+
+def test_stpl_s1_transition_accepts_progress_kwarg_with_allowed_values():
+    t_default = Transition(next_state=ReqState.DONE)
+    assert t_default.progress is None, "omitting progress must default to None"
+
+    for value in ("yes", "no", "explicit-noop"):
+        t = Transition(next_state=ReqState.DONE, progress=value)
+        assert t.progress == value, f"progress={value!r} not preserved"
+
+
+def test_stpl_s1_transition_dataclass_is_frozen():
+    assert dataclasses.is_dataclass(Transition), "Transition must be a dataclass"
+    params = getattr(Transition, "__dataclass_params__", None)
+    assert params is not None and params.frozen, "Transition must remain a frozen dataclass"
+
+
+# ─── STPL-S2 ──────────────────────────────────────────────────────────────────
+
+
+def test_stpl_s2_every_self_loop_has_explicit_progress_annotation():
+    offenders = []
+    for (src_state, event), transition in TRANSITIONS.items():
+        if transition.next_state != src_state:
+            continue
+        if transition.progress not in ("no", "explicit-noop"):
+            offenders.append(((src_state, event), transition.progress))
+    assert not offenders, (
+        "every self-loop transition must have progress in {'no','explicit-noop'}; "
+        f"offenders: {offenders}"
+    )
+
+
+def test_stpl_s2_escalated_verify_escalate_is_explicit_noop():
+    t = TRANSITIONS[(ReqState.ESCALATED, Event.VERIFY_ESCALATE)]
+    assert t.progress == "explicit-noop"
+
+
+def test_stpl_s2_review_running_verify_infra_retry_is_explicit_noop():
+    t = TRANSITIONS[(ReqState.REVIEW_RUNNING, Event.VERIFY_INFRA_RETRY)]
+    assert t.progress == "explicit-noop"
+
+
+def test_stpl_s2_all_session_failed_entries_are_explicit_noop():
+    offenders = []
+    for (src_state, event), transition in TRANSITIONS.items():
+        if event != Event.SESSION_FAILED:
+            continue
+        if transition.progress != "explicit-noop":
+            offenders.append((src_state, transition.progress))
+    assert not offenders, (
+        "every (state, SESSION_FAILED) entry must have progress=='explicit-noop'; "
+        f"offenders: {offenders}"
+    )
+
+
+# ─── STPL-S3 ──────────────────────────────────────────────────────────────────
+
+
+def test_stpl_s3_lint_script_exits_zero_on_current_transitions_table():
+    assert LINT_SCRIPT.exists(), f"missing lint script at {LINT_SCRIPT}"
+    proc = subprocess.run(
+        [sys.executable, str(LINT_SCRIPT)],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        f"lint must exit 0 on current TRANSITIONS, got {proc.returncode}\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    out = proc.stdout
+    assert "progress=yes" in out, f"stdout missing 'progress=yes' bucket header: {out!r}"
+    assert "progress=explicit-noop" in out, (
+        f"stdout missing 'progress=explicit-noop' bucket header: {out!r}"
+    )
+    assert "(escalated, verify.escalate) → escalated" in out, (
+        "stdout must list '(escalated, verify.escalate) → escalated' under explicit-noop "
+        f"bucket; got:\n{out}"
+    )
+
+
+# ─── STPL-S4 ──────────────────────────────────────────────────────────────────
+
+
+def test_stpl_s4_lint_flags_unannotated_self_loop():
+    module = _load_lint_module()
+    validate = _get_validate_fn(module)
+    fake = {
+        (ReqState.DONE, Event.PR_MERGED): Transition(next_state=ReqState.DONE),
+    }
+    violations = validate(fake)
+    assert isinstance(violations, list) and violations, (
+        f"validate() must return non-empty list for unannotated self-loop; got {violations!r}"
+    )
+    blob = _violations_blob(violations).lower()
+    assert "done" in blob and "pr.merged" in blob, (
+        f"violation must identify (done, pr.merged) pair; got {violations!r}"
+    )
+    assert "self-loop requires progress annotation" in blob, (
+        "violation message must mention 'self-loop requires progress annotation'; "
+        f"got {violations!r}"
+    )
+
+
+# ─── STPL-S5 ──────────────────────────────────────────────────────────────────
+
+
+def test_stpl_s5_lint_flags_contradictory_progress_yes_self_loop():
+    module = _load_lint_module()
+    validate = _get_validate_fn(module)
+    fake = {
+        (ReqState.INIT, Event.INTENT_ANALYZE): Transition(
+            next_state=ReqState.INIT, progress="yes"
+        ),
+    }
+    violations = validate(fake)
+    assert isinstance(violations, list) and violations, (
+        f"validate() must return non-empty list for progress=yes self-loop; got {violations!r}"
+    )
+    blob = _violations_blob(violations).lower()
+    assert "progress=yes contradicts self-loop" in blob, (
+        "violation must reference 'progress=yes contradicts self-loop'; "
+        f"got {violations!r}"
+    )
+
+
+# ─── STPL-S6 ──────────────────────────────────────────────────────────────────
+
+
+def test_stpl_s6_lint_flags_unknown_progress_value():
+    module = _load_lint_module()
+    validate = _get_validate_fn(module)
+    # Use an advancing pair (INIT → ANALYZING) so we isolate the "unknown progress
+    # value" rule from the self-loop rules.
+    fake = {
+        (ReqState.INIT, Event.INTENT_ANALYZE): Transition(
+            next_state=ReqState.ANALYZING, progress="maybe"
+        ),
+    }
+    violations = validate(fake)
+    assert isinstance(violations, list) and violations, (
+        f"validate() must return non-empty list for unknown progress value; got {violations!r}"
+    )
+    blob = _violations_blob(violations)
+    assert "maybe" in blob, (
+        f"violation must reference the invalid value 'maybe'; got {violations!r}"
+    )
+
+
+# ─── STPL-S7 ──────────────────────────────────────────────────────────────────
+
+
+def test_stpl_s7_ci_lint_target_invokes_lint_state_transitions_py():
+    if shutil.which("make") is None:
+        pytest.skip("make not on PATH; STPL-S7 verifies the Makefile contract")
+    proc = subprocess.run(
+        ["make", "-n", "ci-lint"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"`make -n ci-lint` failed: stderr={proc.stderr!r}"
+    assert "lint-state-transitions.py" in proc.stdout, (
+        "`make -n ci-lint` recipe must reference scripts/lint-state-transitions.py; "
+        f"got:\n{proc.stdout}"
+    )
+
+
+# ─── STPL-S8 ──────────────────────────────────────────────────────────────────
+
+
+def test_stpl_s8_orchestrator_ci_yml_runs_lint_script():
+    workflow = REPO_ROOT / ".github" / "workflows" / "orchestrator-ci.yml"
+    assert workflow.exists(), f"missing workflow at {workflow}"
+    data = yaml.safe_load(workflow.read_text())
+    jobs = (data or {}).get("jobs") or {}
+    lint_test = jobs.get("lint-test") or {}
+    steps = lint_test.get("steps") or []
+    matched = [
+        step
+        for step in steps
+        if isinstance(step, dict) and "scripts/lint-state-transitions.py" in (step.get("run") or "")
+    ]
+    assert matched, (
+        "jobs.lint-test.steps must include at least one step whose `run` references "
+        f"scripts/lint-state-transitions.py; got steps: {steps!r}"
+    )

--- a/orchestrator/tests/test_lint_state_transitions.py
+++ b/orchestrator/tests/test_lint_state_transitions.py
@@ -1,0 +1,172 @@
+"""Unit tests for scripts/lint-state-transitions.py (REQ-feat-silent-lint-376-v2).
+
+Covers spec scenarios STPL-S1..S6:
+  S1  Transition accepts progress kwarg with allowed values
+  S2  Every existing self-loop transition has explicit progress annotation
+  S3  Lint script exits zero on current TRANSITIONS table (snapshot)
+  S4  Synthetic unannotated self-loop fails validation
+  S5  Synthetic progress=yes self-loop fails validation
+  S6  Unknown progress value fails validation
+
+S7/S8 (Makefile + workflow YAML) live in test_contract_lint_state_transitions_ci.py
+since they live outside the orchestrator package and would couple this module
+to repo layout. Keep this file focused on the lint logic itself.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from orchestrator.state import TRANSITIONS, Event, ReqState, Transition
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+LINT_SCRIPT = REPO_ROOT / "scripts" / "lint-state-transitions.py"
+
+
+def _load_lint_module():
+    """Import the lint script as a module without running its main()."""
+    spec = importlib.util.spec_from_file_location("_lint_state_transitions", LINT_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ─── STPL-S1: Transition accepts progress kwarg with allowed values ───────────
+@pytest.mark.parametrize("value", ["yes", "no", "explicit-noop"])
+def test_stpl_s1_transition_accepts_progress_values(value: str) -> None:
+    t = Transition(next_state=ReqState.DONE, progress=value)
+    assert t.progress == value
+
+
+def test_stpl_s1_transition_default_progress_is_none() -> None:
+    t = Transition(next_state=ReqState.DONE)
+    assert t.progress is None
+
+
+# ─── STPL-S2: every existing self-loop transition has explicit progress ────────
+def test_stpl_s2_all_existing_self_loops_annotated() -> None:
+    """Snapshot test: every (state, event) where next_state == src_state MUST
+    have progress in {"no", "explicit-noop"}. New self-loops added without
+    annotation will fail this test."""
+    unannotated: list[str] = []
+    for (src_state, event), trans in TRANSITIONS.items():
+        if trans.next_state == src_state:
+            if trans.progress not in ("no", "explicit-noop"):
+                unannotated.append(
+                    f"({src_state.value}, {event.value}) → {trans.next_state.value} "
+                    f"progress={trans.progress!r}"
+                )
+    assert not unannotated, (
+        "self-loop transitions without explicit progress annotation:\n  "
+        + "\n  ".join(unannotated)
+    )
+
+
+def test_stpl_s2_known_self_loops_have_expected_annotation() -> None:
+    """Specific snapshot for the two named transitions in the proposal."""
+    assert TRANSITIONS[
+        (ReqState.ESCALATED, Event.VERIFY_ESCALATE)
+    ].progress == "explicit-noop"
+    assert TRANSITIONS[
+        (ReqState.REVIEW_RUNNING, Event.VERIFY_INFRA_RETRY)
+    ].progress == "explicit-noop"
+    # SESSION_FAILED dict comprehension entries
+    for st in (
+        ReqState.INTAKING, ReqState.ANALYZING, ReqState.SPEC_LINT_RUNNING,
+        ReqState.STAGING_TEST_RUNNING, ReqState.PR_CI_RUNNING,
+        ReqState.REVIEW_RUNNING, ReqState.FIXER_RUNNING,
+    ):
+        assert TRANSITIONS[(st, Event.SESSION_FAILED)].progress == "explicit-noop", (
+            f"({st.value}, session.failed) missing explicit-noop annotation"
+        )
+
+
+# ─── STPL-S3: lint script exits zero on current TRANSITIONS table ─────────────
+def test_stpl_s3_lint_script_exits_zero_on_real_transitions() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(LINT_SCRIPT)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, (
+        f"lint exited {proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    # Report content sanity
+    assert "progress=yes" in proc.stdout
+    assert "progress=explicit-noop" in proc.stdout
+    assert "(escalated, verify.escalate)" in proc.stdout
+
+
+# ─── STPL-S4: unannotated self-loop fails validation ──────────────────────────
+def test_stpl_s4_unannotated_self_loop_violates() -> None:
+    mod = _load_lint_module()
+    fake = {
+        (ReqState.DONE, Event.PR_MERGED): Transition(next_state=ReqState.DONE),
+    }
+    violations = mod.validate(fake)
+    assert len(violations) == 1
+    assert "(done, pr.merged)" in violations[0]
+    assert "self-loop requires progress annotation" in violations[0]
+
+
+# ─── STPL-S5: progress=yes self-loop fails validation ─────────────────────────
+def test_stpl_s5_progress_yes_self_loop_violates() -> None:
+    mod = _load_lint_module()
+    fake = {
+        (ReqState.INIT, Event.INTENT_ANALYZE): Transition(
+            next_state=ReqState.INIT, progress="yes"
+        ),
+    }
+    violations = mod.validate(fake)
+    assert len(violations) == 1
+    assert "progress=yes contradicts self-loop" in violations[0]
+
+
+# ─── STPL-S6: unknown progress value fails validation ─────────────────────────
+def test_stpl_s6_unknown_progress_value_violates() -> None:
+    mod = _load_lint_module()
+    fake = {
+        (ReqState.INIT, Event.INTENT_ANALYZE): Transition(
+            next_state=ReqState.ANALYZING, progress="maybe"
+        ),
+    }
+    violations = mod.validate(fake)
+    assert len(violations) == 1
+    assert "unknown progress value" in violations[0]
+    assert "'maybe'" in violations[0]
+
+
+# ─── Bonus: progress=no/explicit-noop on advancing transition is contradiction ─
+@pytest.mark.parametrize("value", ["no", "explicit-noop"])
+def test_progress_no_on_advancing_transition_violates(value: str) -> None:
+    mod = _load_lint_module()
+    fake = {
+        (ReqState.INIT, Event.INTENT_ANALYZE): Transition(
+            next_state=ReqState.ANALYZING, progress=value
+        ),
+    }
+    violations = mod.validate(fake)
+    assert len(violations) == 1
+    assert "contradicts advancing transition" in violations[0]
+
+
+# ─── Bonus: empty / advancing-only dict yields no violations ──────────────────
+def test_validate_returns_empty_for_clean_advancing_transitions() -> None:
+    mod = _load_lint_module()
+    fake = {
+        (ReqState.INIT, Event.INTENT_ANALYZE): Transition(next_state=ReqState.ANALYZING),
+        (ReqState.ANALYZING, Event.ANALYZE_DONE): Transition(
+            next_state=ReqState.SPEC_LINT_RUNNING, progress="yes"
+        ),
+        (ReqState.ESCALATED, Event.VERIFY_ESCALATE): Transition(
+            next_state=ReqState.ESCALATED, progress="explicit-noop"
+        ),
+    }
+    assert mod.validate(fake) == []

--- a/scripts/lint-state-transitions.py
+++ b/scripts/lint-state-transitions.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""state-machine silent-drop lint (REQ-feat-silent-lint-376-v2 / closes #376).
+
+遍历 orchestrator.state.TRANSITIONS，把 (state, event) → no-progress transition
+（next_state == src_state）静态挑出来，强制作者用 `progress` 字段显式标注 ——
+"no"（候选死锁，需 telemetry）或 "explicit-noop"（intentional self-loop，acked）。
+
+事故背景：5/4 v5 verifier emit `decision:pass` 字符串 tag → router 解析失败回
+fallback `Event.VERIFY_ESCALATE` → ESCALATED state 收到走 self-loop（next=ESCALATED,
+action=None）→ REQ 永久卡 ESCALATED 零反馈。所有"信号"都对，但语义死循环。
+
+本 lint 让"显式 no-progress"在静态层面被人类 review 时一眼可见，禁止悄悄合入。
+
+退码：
+  0  全绿
+  1  违反任意规则（详见 stderr 列表）
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# 让脚本可从 repo root 直接 `python3 scripts/lint-state-transitions.py` 跑
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_ORCH_SRC = _REPO_ROOT / "orchestrator" / "src"
+if str(_ORCH_SRC) not in sys.path:
+    sys.path.insert(0, str(_ORCH_SRC))
+
+
+ALLOWED_PROGRESS = ("yes", "no", "explicit-noop")
+
+
+def validate(transitions: dict) -> list[str]:
+    """返 violation 字符串列表。空 list 即全绿。"""
+    violations: list[str] = []
+    for (src_state, event), trans in transitions.items():
+        progress = getattr(trans, "progress", None)
+        is_self_loop = trans.next_state == src_state
+
+        if progress is not None and progress not in ALLOWED_PROGRESS:
+            violations.append(
+                f"({src_state.value}, {event.value}): "
+                f"unknown progress value {progress!r}; "
+                f"allowed = {ALLOWED_PROGRESS}"
+            )
+            continue
+
+        if is_self_loop:
+            if progress is None:
+                violations.append(
+                    f"({src_state.value}, {event.value}): "
+                    f"self-loop requires progress annotation "
+                    f"(set progress='no' for deadlock candidate or "
+                    f"progress='explicit-noop' for intentional self-loop)"
+                )
+            elif progress == "yes":
+                violations.append(
+                    f"({src_state.value}, {event.value}): "
+                    f"progress=yes contradicts self-loop "
+                    f"(next_state={trans.next_state.value} == src_state)"
+                )
+        else:
+            if progress in ("no", "explicit-noop"):
+                violations.append(
+                    f"({src_state.value}, {event.value}): "
+                    f"progress={progress!r} contradicts advancing transition "
+                    f"(next_state={trans.next_state.value} != src_state)"
+                )
+    return violations
+
+
+def render_report(transitions: dict) -> str:
+    """人类可读报告：按 progress 桶分组列举所有 transition。"""
+    buckets: dict[str, list[str]] = {"yes": [], "no": [], "explicit-noop": []}
+    for (src_state, event), trans in sorted(
+        transitions.items(), key=lambda kv: (kv[0][0].value, kv[0][1].value)
+    ):
+        progress = getattr(trans, "progress", None)
+        is_self_loop = trans.next_state == src_state
+        # 派生 yes：non-self-loop 且 progress 未声明
+        effective = progress or ("yes" if not is_self_loop else "?")
+        if effective in buckets:
+            buckets[effective].append(
+                f"  ({src_state.value}, {event.value}) → {trans.next_state.value}"
+                + (f"  [action={trans.action}]" if trans.action else "")
+            )
+
+    lines = ["=== State machine transition lint ==="]
+    lines.append(f"Total transitions: {len(transitions)}")
+    lines.append(f"  progress=yes (advances)             : {len(buckets['yes'])}")
+    lines.append(f"  progress=explicit-noop (intentional): {len(buckets['explicit-noop'])}")
+    lines.append(f"  progress=no (deadlock candidate)    : {len(buckets['no'])}")
+    lines.append("")
+    lines.append("--- explicit-noop (acknowledged self-loops) ---")
+    lines.extend(buckets["explicit-noop"] or ["  (none)"])
+    lines.append("")
+    lines.append("--- no (deadlock candidates, may need telemetry) ---")
+    lines.extend(buckets["no"] or ["  (none)"])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    from orchestrator.state import TRANSITIONS  # imported lazily so import errors stay scoped
+
+    violations = validate(TRANSITIONS)
+    print(render_report(TRANSITIONS))
+    print("")
+    if violations:
+        print("=== VIOLATIONS ===", file=sys.stderr)
+        for v in violations:
+            print(v, file=sys.stderr)
+        print(f"\n{len(violations)} violation(s); fix state.py and re-run.",
+              file=sys.stderr)
+        return 1
+    print("ALL OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add a `progress` field to the `Transition` dataclass and a new
`scripts/lint-state-transitions.py` that statically catches
`(state, event)` self-loop transitions where the state machine cannot
make forward progress, by forcing every such entry to be annotated as
`progress="no"` (deadlock candidate) or `progress="explicit-noop"`
(intentional acknowledged self-loop).

Closes #376.

## Why

5/4 verifier emitted a `decision:pass` string tag → router fell back to
`Event.VERIFY_ESCALATE` → `(ESCALATED, VERIFY_ESCALATE)` self-loop fired
→ REQ silently stuck in `ESCALATED` with zero feedback. The transition
was technically "legal", but semantically a deadlock. Static lint
surfaces such transitions at PR-review time so a human sees them,
complementing the runtime telemetry in #372.

## What

- `Transition` gains `progress: str | None` accepting `"yes"`, `"no"`,
  `"explicit-noop"`, or `None` (auto-derived as `"yes"` for advancing
  transitions only).
- All current self-loops annotated `explicit-noop`:
  - `(ESCALATED, VERIFY_ESCALATE)` — user follow-up still escalating
  - `(REVIEW_RUNNING, VERIFY_INFRA_RETRY)` — bounded infra retry
  - 12 \`(*_RUNNING, SESSION_FAILED)\` action-decides entries
- `scripts/lint-state-transitions.py` validates the table and emits a
  per-bucket report (yes/no/explicit-noop) for human review.
- \`make ci-lint\` invokes the lint first (sisyphus dev_cross_check
  contract).
- \`.github/workflows/orchestrator-ci.yml\` adds a dedicated step that
  runs the lint independent of the sisyphus checker.
- \`orchestrator/tests/test_lint_state_transitions.py\` covers spec
  scenarios STPL-S1..S6 plus edge cases (13 tests, all green).

## Test plan

- [x] \`python3 scripts/lint-state-transitions.py\` exits 0 against current state.py
- [x] \`make ci-lint\` green (state-machine lint + ruff orch + ruff thanatos)
- [x] \`make ci-integration-test\` green (no PG → exit 5 → pass)
- [x] \`uv run pytest tests/test_lint_state_transitions.py\` 13/13 passed
- [x] Negative test: stripping the annotation from \`(ESCALATED, VERIFY_ESCALATE)\` correctly fails the lint
- [x] \`openspec validate REQ-feat-silent-lint-376-v2-1777866643\` is valid
- Note: the broader unit-test suite shows 31 pre-existing failures from test
  isolation pollution (issue #364, "PR CI 不可信"). Failing tests pass when
  run individually; none touch state.py or the new lint module.

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-feat-silent-lint-376-v2-1777866643\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/9x5frqwh)