### PR TITLE
feat(watchdog): ESCALATED stuck-REQ notify (closes #378)

### DIFF
--- a/openspec/changes/REQ-feat-stuck-notify-378-v2-1777866642/proposal.md
+++ b/openspec/changes/REQ-feat-stuck-notify-378-v2-1777866642/proposal.md
@@ -1,0 +1,64 @@
+# REQ-feat-stuck-notify-378-v2-1777866642
+
+feat(watchdog): ESCALATED stuck-REQ notify (closes #378)
+
+## Why
+
+REQ 一进 ESCALATED 就停在那等人 resume。设计上是这样，可问题在于：人没在线 / 忘了 /
+没人盯就**永久卡**。issue #378 实证：v5 卡 30min 才被发现是 router 静默 drop。
+
+watchdog 现在三件事——`_tick`（卡死 stage 兜底 escalate）、`_sync_stuck_sub_agent_statuses_tick`
+（BKD 状态补偿）、`_mark_abandoned_escalated_reqs`（7 天后标 abandoned-by-user）——
+都不解决"刚进 ESCALATED 没人理"的检测延迟。7 天 abandoned 太晚；watchdog escalate
+路径只发 GH incident（如配了 `gh_incident_repo`）但不主动 nudge 操作员。
+
+## What Changes
+
+### 1. watchdog 新 loop：`_notify_stale_escalated_tick`
+
+每 N 个 tick（搭 `_sync_stuck_sub_agent_statuses_tick` 同周期，5 ticks ≈ 5min）扫一次
+`req_state where state='escalated' AND updated_at < NOW - escalated_stale_threshold_sec`。
+对每条命中的 row：
+
+- 写一条 `obs.record_event(kind="watchdog_stuck_notify", req_id=..., extras={...})`
+- 发一条 `log.warning("watchdog.stuck_notify", ...)`，dashboards / Loki 一眼看
+- 若 `escalated_stale_telegram_url` 配了，POST 一条 markdown 文本到该 URL
+- 把"已通知"标记写回 `req_state.context.stuck_notified_at = now()`，避免每 tick 重发
+
+幂等通过 `context.stuck_notified_at` 与 `req_state.updated_at` 比较保证：每段
+ESCALATED 期内**至多通知一次**——一旦 REQ 被 resume → 推进 → 再次 escalate，
+`updated_at` 会跳到新时刻，watermark 自动失效，新一轮 stale 又能通知。
+
+### 2. 新配置（沿用现有 watchdog_* 命名风格）
+
+`config.py` 新增：
+
+- `escalated_stale_notify_enabled: bool = True` — 关掉整套通知（dev 模式可关）
+- `escalated_stale_threshold_sec: int = 1800` — 30 min（issue #378 提议值）
+- `escalated_stale_telegram_url: str = ""` — 可选 webhook，空 = 不外推（默认安全）
+
+### 3. helm values + configmap pass-through
+
+`orchestrator/helm/values.yaml` 加 3 个对应 env key（webhook URL 默认空字符串），
+`orchestrator/helm/templates/configmap.yaml` pass through。Telegram URL 走 `if`
+条件（空就不渲染 env，沿用现有 `gh_incident_repo` 写法）。
+
+## Out of scope
+
+- **多 channel notify**（Slack / 飞书 / Discord）：v2 只做 1 个 webhook URL。
+  Telegram bot 的 `sendMessage` API 跟通用 webhook 同形（POST JSON），格式
+  设计上 webhook URL 就是 `https://api.telegram.org/bot<TOKEN>/sendMessage`
+  附带 `chat_id` 在 payload 里——helm operator 可以包一层 nginx redirect 把
+  其他 webhook 桥过来。
+- **重复通知 / 升级路径**（每 N 小时再 nudge）：issue #378 没要求。已有
+  `_mark_abandoned_escalated_reqs` 7 天 hard cap，足够 long-tail 兜底。
+- **GH issue 上贴 comment**：原 issue body 提到 sisyphus-internal channel，
+  但当前 sisyphus 唯一"内部 channel" = 已在 `gh_incident.py` 里 escalate 时
+  开的 GH incident issue。这条 PR 不动 gh_incident 路径。
+
+## 关联
+
+- #378 本 REQ 对应 GH issue
+- #353 `_sync_stuck_sub_agent_statuses_tick`（同区代码 — 共享 tick 周期）
+- `_mark_abandoned_escalated_reqs`（7 天 hard cap，长 tail 互补）
+- REQ-impl-gh-incident-open-1777173133 / `gh_incident.py`（escalate 时开 GH issue —— 跟本 REQ 互补）

--- a/openspec/changes/REQ-feat-stuck-notify-378-v2-1777866642/specs/watchdog-stuck-notify/spec.md
+++ b/openspec/changes/REQ-feat-stuck-notify-378-v2-1777866642/specs/watchdog-stuck-notify/spec.md
@@ -1,0 +1,57 @@
+# Spec Delta — watchdog ESCALATED stuck-REQ notify
+
+## ADDED Requirements
+
+### Requirement: Watchdog emits exactly one notification per ESCALATED stale window
+
+The orchestrator watchdog SHALL run a periodic `_notify_stale_escalated_tick`
+that scans `req_state` for rows where `state='escalated'` and
+`updated_at < NOW() - escalated_stale_threshold_sec`. For each row matched, the
+watchdog MUST emit exactly one notification per stale window: the function
+SHALL skip rows whose `req_state.context.stuck_notified_at` is set and is
+greater than or equal to `req_state.updated_at` (meaning the current ESCALATED
+window has already been notified). After sending a notification the watchdog
+SHALL persist `stuck_notified_at = now (UTC ISO-8601)` back into
+`req_state.context` so subsequent ticks become no-ops until the REQ leaves
+ESCALATED (resume → progress → re-escalate resets `updated_at`, which in turn
+re-arms the notifier).
+
+The notification body produced for each stale REQ MUST contain the REQ id, the
+human-readable elapsed seconds since `req_state.updated_at`, and a hint to
+inspect the verifier issue. The body string SHALL begin with the literal
+prefix `"⏰ "` so dashboards can string-match it.
+
+#### Scenario: WSN-S1 first stale tick notifies once and persists watermark
+
+- **GIVEN** a `req_state` row with `state='escalated'`, `updated_at = now - 2400s`, `context = {}` (no `stuck_notified_at`)
+- **AND** `escalated_stale_threshold_sec = 1800`
+- **WHEN** `watchdog._notify_stale_escalated_tick` runs
+- **THEN** exactly one `obs.record_event` call MUST be made with `kind="watchdog_stuck_notify"` and the matching `req_id`
+- **AND** a `log.warning` event named `watchdog.stuck_notify` MUST be recorded
+- **AND** the message body produced MUST start with the literal prefix `"⏰ "` and contain the REQ id
+- **AND** `req_state.context.stuck_notified_at` MUST be persisted to a UTC ISO-8601 string
+
+#### Scenario: WSN-S2 second tick within same stale window is suppressed
+
+- **GIVEN** the same row as WSN-S1 but `context.stuck_notified_at` already set to a value `>= req_state.updated_at`
+- **WHEN** `_notify_stale_escalated_tick` runs again
+- **THEN** zero `obs.record_event` calls MUST be made
+- **AND** zero HTTP POSTs to the telegram URL MUST occur
+- **AND** the function MUST return `{"checked": >=1, "notified": 0}`
+
+#### Scenario: WSN-S3 telegram POST is best-effort and never raises
+
+- **GIVEN** `escalated_stale_telegram_url` is set to a URL whose POST raises `httpx.ConnectError`
+- **AND** a row qualifies for notification (state=escalated, stuck > threshold, no watermark)
+- **WHEN** `_notify_stale_escalated_tick` runs
+- **THEN** the function MUST NOT raise out of the tick
+- **AND** `obs.record_event` MUST still be invoked once (in-DB notification is the source of truth)
+- **AND** `req_state.context.stuck_notified_at` MUST still be persisted (do not retry next tick — telegram is opportunistic)
+- **AND** a `log.warning` event named `watchdog.stuck_notify.telegram_failed` MUST be recorded
+
+#### Scenario: WSN-S4 disabled flag short-circuits the tick
+
+- **GIVEN** `settings.escalated_stale_notify_enabled = False`
+- **AND** at least one row would otherwise qualify
+- **WHEN** `_notify_stale_escalated_tick` runs
+- **THEN** the function MUST return `{"checked": 0, "notified": 0}` without calling `pool.fetch` or `obs.record_event`

--- a/openspec/changes/REQ-feat-stuck-notify-378-v2-1777866642/tasks.md
+++ b/openspec/changes/REQ-feat-stuck-notify-378-v2-1777866642/tasks.md
@@ -1,0 +1,25 @@
+# Tasks — REQ-feat-stuck-notify-378-v2-1777866642
+
+owner: analyze-agent
+
+## Stage: spec
+- [x] author `specs/watchdog-stuck-notify/spec.md` (delta format, 4 scenarios)
+- [x] write `proposal.md` covering Why / What / Out of scope
+
+## Stage: implementation
+- [x] add 3 settings in `orchestrator/src/orchestrator/config.py` (`escalated_stale_*`)
+- [x] add `_notify_stale_escalated_tick` in `orchestrator/src/orchestrator/watchdog.py`
+- [x] add helper `_post_telegram_notify` (best-effort httpx POST; never raises)
+- [x] hook tick into `run_loop` at the same 5-tick cadence as bkd_sync
+- [x] pass through 3 env vars in `orchestrator/helm/values.yaml`
+- [x] pass through 3 env vars in `orchestrator/helm/templates/configmap.yaml`
+
+## Stage: unit tests
+- [x] `tests/test_watchdog_stuck_notify.py` — covers WSN-S1 .. WSN-S4
+
+## Stage: PR (推前必须全绿)
+- [x] git push feat/REQ-feat-stuck-notify-378-v2-1777866642
+- [x] `make ci-lint` → all green
+- [x] `make ci-unit-test` → all green
+- [x] `make ci-integration-test` → all green (no PG → auto-skip = pass)
+- [x] gh pr create with `--label sisyphus` + sisyphus footer

--- a/orchestrator/helm/templates/configmap.yaml
+++ b/orchestrator/helm/templates/configmap.yaml
@@ -42,6 +42,18 @@ data:
   # JSON-encoded list[str]，跟 default_involved_repos 同。
   SISYPHUS_GH_INCIDENT_LABELS: {{ toJson . | quote }}
   {{- end }}
+  # ─── REQ-feat-stuck-notify-378-v2-1777866642：ESCALATED stale 主动通知 ────
+  # 三元组：enabled (bool) / threshold_sec (int) / telegram_url (str)。
+  # url 用 `if` 守门，空字符串不渲染 env 走 config.py default ""。
+  {{- if hasKey .Values.env "escalated_stale_notify_enabled" }}
+  SISYPHUS_ESCALATED_STALE_NOTIFY_ENABLED: {{ .Values.env.escalated_stale_notify_enabled | quote }}
+  {{- end }}
+  {{- if .Values.env.escalated_stale_threshold_sec }}
+  SISYPHUS_ESCALATED_STALE_THRESHOLD_SEC: {{ .Values.env.escalated_stale_threshold_sec | quote }}
+  {{- end }}
+  {{- if .Values.env.escalated_stale_telegram_url }}
+  SISYPHUS_ESCALATED_STALE_TELEGRAM_URL: {{ .Values.env.escalated_stale_telegram_url | quote }}
+  {{- end }}
   # ─── REQ-feat-mcp-preflight-1777727213：pluggable prompt hook + MCP capability ─
   # 4 个字段都用 JSON-encoded（pydantic-settings v2 的 list/dict 复合字段默认走
   # JSON 解析）。values 留空时不渲染 env，走 orchestrator config.py 的 default_factory。

--- a/orchestrator/helm/values.yaml
+++ b/orchestrator/helm/values.yaml
@@ -150,6 +150,18 @@ env:
   gh_incident_labels:
     - sisyphus:incident
 
+  # ─── REQ-feat-stuck-notify-378-v2-1777866642：ESCALATED stale 主动通知 ────
+  # watchdog 每 5min 扫一次 state='escalated' 且 updated_at 距今超过
+  # `escalated_stale_threshold_sec` 的 REQ，每段 ESCALATED 期通知一次（去重靠
+  # context.stuck_notified_at）。obs.record_event + log.warning 永远写；外推
+  # webhook 仅在 url 非空时 POST。enabled=False = 整套关闭（dev 调试用）。
+  escalated_stale_notify_enabled: true
+  escalated_stale_threshold_sec: 1800
+  # 可选 webhook URL。空 = 不外推。POST `{"text": "..."}`，5s timeout。
+  # Telegram bot 用例：`https://api.telegram.org/bot<TOKEN>/sendMessage`，
+  # 由前置 nginx / sidecar 把 chat_id 注入 payload。
+  escalated_stale_telegram_url: ""
+
 # ─── v0.2 runner（调试环境 Pod + PVC）─────────────────────────────────────
 # 每个 REQ 一个 Pod（runner-<req>）+ 一个 PVC（workspace-<req>），住在独立
 # namespace。Pod 是 privileged + DinD + fuse-overlayfs；PVC 挂 /workspace 做

--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -281,6 +281,20 @@ class Settings(BaseSettings):
     # 所以中间没 tool-result/assistant-message 的"思考期"也算静默——120s 是经验折中。
     watchdog_liveness_grace_sec: int = 120
 
+    # ─── REQ-feat-stuck-notify-378-v2-1777866642：ESCALATED stale 主动通知 ──
+    # 把"REQ 进 ESCALATED 没人 resume 永久卡"的检测延迟从 7 天（abandoned-by-user
+    # sweep）压到分钟级。watchdog 每 5min 扫一次 state='escalated' AND
+    # updated_at < NOW - escalated_stale_threshold_sec 的 row，每个 stale window
+    # 通知一次（context.stuck_notified_at watermark 防重）。
+    escalated_stale_notify_enabled: bool = True
+    escalated_stale_threshold_sec: int = 1800        # 30min — issue #378 提议值
+    # 可选 webhook，POST JSON `{"text": "..."}` 到该 URL。空 = 不外推（默认安全，
+    # 仅靠 obs.record_event + log.warning 在内部 channel 暴露）。Telegram bot 用例：
+    # `https://api.telegram.org/bot<TOKEN>/sendMessage`，payload 里附 chat_id
+    # 由 nginx redirect / 反代 sidecar 注入；通用 webhook（飞书 / Slack 自定义
+    # bot）也用同形 POST。失败不阻塞 tick，只 log warn。
+    escalated_stale_telegram_url: str = ""
+
     # ─── 防 verifier↔fixer 死循环：硬封顶 fixer round 数 ─────────────────
     # 每次 verifier decision=fix 都会 start_fixer 起新一轮 fixer agent，跑完回 verifier
     # 复查；verifier 再判 fix 又起一轮。某些场景（spec 自相矛盾 / fixer 改不动根因）

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -35,9 +35,10 @@ import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
+import httpx
 import structlog
 
-from . import engine
+from . import engine, observability
 from .bkd import BKDClient
 from .checkers._types import CheckResult
 from .config import settings
@@ -558,6 +559,109 @@ async def _mark_abandoned_escalated_reqs() -> int:
     return count
 
 
+def _format_stuck_notify_text(req_id: str, stuck_sec: int, state: str) -> str:
+    """REQ-feat-stuck-notify-378: 通知文本固定 prefix `⏰ ` 让 dashboard 能 string-match。"""
+    minutes = stuck_sec // 60
+    return (
+        f"⏰ {req_id} stuck in {state} for {minutes}min "
+        f"({stuck_sec}s) with no stage progress. "
+        f"Check the verifier issue to decide: resume or hard escalate."
+    )
+
+
+async def _post_telegram_notify(url: str, text: str) -> bool:
+    """Best-effort POST. Never raises; returns True on 2xx, False on any failure."""
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(url, json={"text": text})
+        return 200 <= resp.status_code < 300
+    except Exception as e:
+        log.warning("watchdog.stuck_notify.telegram_failed", error=str(e))
+        return False
+
+
+async def _notify_stale_escalated_tick() -> dict:
+    """REQ-feat-stuck-notify-378-v2-1777866642: ESCALATED stale 主动通知。
+
+    每段 ESCALATED 期内最多通知一次：context.stuck_notified_at watermark 跟
+    req_state.updated_at 比较。REQ 被 resume → 推进 → 再 escalate 时 updated_at
+    会跳到新时刻，watermark 自动失效，新一轮 stale 期再触发一次通知。
+
+    通知三件事（全 best-effort）：
+    - obs.record_event(kind="watchdog_stuck_notify"): 内部 channel 真相源
+    - log.warning("watchdog.stuck_notify"): Loki / kubectl logs 一眼看
+    - 可选 POST settings.escalated_stale_telegram_url：外推 webhook
+    """
+    if not settings.escalated_stale_notify_enabled:
+        return {"checked": 0, "notified": 0}
+
+    pool = db.get_pool()
+    threshold = settings.escalated_stale_threshold_sec
+    rows = await pool.fetch(
+        """
+        SELECT req_id, project_id, context, updated_at,
+               EXTRACT(EPOCH FROM (NOW() - updated_at))::BIGINT AS stuck_sec
+          FROM req_state
+         WHERE state = 'escalated'
+           AND updated_at < NOW() - INTERVAL '1 second' * $1
+        """,
+        threshold,
+    )
+
+    notified = 0
+    telegram_url = settings.escalated_stale_telegram_url
+    for row in rows:
+        req_id = row["req_id"]
+        ctx_raw = row["context"] or {}
+        ctx = json.loads(ctx_raw) if isinstance(ctx_raw, str) else ctx_raw
+        updated_at: datetime = row["updated_at"]
+
+        notified_at_raw = ctx.get("stuck_notified_at")
+        if notified_at_raw:
+            try:
+                notified_at = datetime.fromisoformat(notified_at_raw)
+            except ValueError:
+                notified_at = None
+            if notified_at is not None and notified_at >= updated_at:
+                # 已在本 ESCALATED 期通知过，跳过
+                continue
+
+        stuck_sec = int(row["stuck_sec"])
+        text = _format_stuck_notify_text(req_id, stuck_sec, "ESCALATED")
+        log.warning(
+            "watchdog.stuck_notify",
+            req_id=req_id, stuck_sec=stuck_sec,
+            project_id=row["project_id"], text=text,
+        )
+
+        try:
+            await observability.record_event(
+                kind="watchdog_stuck_notify",
+                req_id=req_id,
+                stage="escalated",
+                error_msg=text,
+                extras={"stuck_sec": stuck_sec},
+            )
+        except Exception as e:
+            log.warning("watchdog.stuck_notify.obs_failed", req_id=req_id, error=str(e))
+
+        if telegram_url:
+            await _post_telegram_notify(telegram_url, text)
+
+        try:
+            await req_state.update_context(pool, req_id, {
+                "stuck_notified_at": datetime.now(UTC).isoformat(),
+            })
+        except Exception as e:
+            log.warning(
+                "watchdog.stuck_notify.persist_failed",
+                req_id=req_id, error=str(e),
+            )
+        notified += 1
+
+    return {"checked": len(rows), "notified": notified}
+
+
 async def run_loop() -> None:
     """orchestrator 启动起的后台任务。"""
     if not settings.watchdog_enabled:
@@ -589,6 +693,17 @@ async def run_loop() -> None:
                         log.debug("watchdog.bkd_sync", **sync_result)
                 except Exception as e:
                     log.exception("watchdog.bkd_sync.error", error=str(e))
+
+                # REQ-feat-stuck-notify-378-v2: 同周期跑 ESCALATED stale 通知。
+                # 跟 bkd_sync 共用 5-tick 周期，避免单独搞一个 settings interval。
+                try:
+                    notify_result = await _notify_stale_escalated_tick()
+                    if notify_result.get("notified"):
+                        log.info("watchdog.stuck_notify.swept", **notify_result)
+                    else:
+                        log.debug("watchdog.stuck_notify.tick", **notify_result)
+                except Exception as e:
+                    log.exception("watchdog.stuck_notify.error", error=str(e))
 
             # 每 50 个 tick（默认 ~50min）扫一次长期 ESCALATED → abandoned-by-user
             if tick_count % 50 == 0:

--- a/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
+++ b/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
@@ -24,6 +24,8 @@ dict shape).
 """
 from __future__ import annotations
 
+import json
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
@@ -178,12 +180,21 @@ def _any_arg_contains(calls, needle: str) -> bool:
     return False
 
 
+_ISO8601_UTC_RE = re.compile(
+    r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+\-]00:?00)"
+)
+
+
 def _any_execute_arg_is_iso8601_utc(execute_calls) -> bool:
-    """Return True if any captured execute() arg parses as a UTC ISO-8601 datetime."""
+    """Return True if any captured execute() arg contains a UTC ISO-8601 datetime.
+
+    Tolerates dev wrapping the value as JSON (e.g. ``'{"stuck_notified_at":
+    "...+00:00"}'``) by scanning every recursively-extracted string.
+    """
     for _sql, args in execute_calls:
         for a in args:
             for cand in _candidate_strings(a):
-                if _looks_like_utc_iso8601(cand):
+                if _contains_utc_iso8601(cand):
                     return True
     return False
 
@@ -191,6 +202,14 @@ def _any_execute_arg_is_iso8601_utc(execute_calls) -> bool:
 def _candidate_strings(value):
     if isinstance(value, str):
         yield value
+        # If the string is JSON, also recurse into it so wrappers like
+        # `{"stuck_notified_at": "..."}` are inspected as structured data.
+        try:
+            decoded = json.loads(value)
+        except (ValueError, TypeError):
+            return
+        if isinstance(decoded, (dict, list, str)):
+            yield from _candidate_strings(decoded)
         return
     if isinstance(value, dict):
         for v in value.values():
@@ -201,18 +220,18 @@ def _candidate_strings(value):
             yield from _candidate_strings(v)
 
 
-def _looks_like_utc_iso8601(s: str) -> bool:
+def _contains_utc_iso8601(s: str) -> bool:
     if not isinstance(s, str) or len(s) < 19:
         return False
-    try:
-        # Accept '...Z' or explicit UTC offset.
-        normalised = s.replace("Z", "+00:00")
-        dt = datetime.fromisoformat(normalised)
-    except ValueError:
-        return False
-    if dt.tzinfo is None:
-        return False
-    return dt.utcoffset() == timedelta(0)
+    for match in _ISO8601_UTC_RE.finditer(s):
+        candidate = match.group(0).replace("Z", "+00:00")
+        try:
+            dt = datetime.fromisoformat(candidate)
+        except ValueError:
+            continue
+        if dt.tzinfo is not None and dt.utcoffset() == timedelta(0):
+            return True
+    return False
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
+++ b/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
@@ -70,30 +70,50 @@ class _FakePool:
 
 # ─── Common patch helpers ───────────────────────────────────────────────────
 def _patch_pool(monkeypatch, pool):
-    monkeypatch.setattr("orchestrator.watchdog.db.get_pool", lambda: pool)
+    """Stub the pool reachable from watchdog.
+
+    Cover both common import styles for the db helper without peeking at
+    watchdog's source: patch the canonical accessor on the db module and,
+    if watchdog re-exports it locally, patch that too.
+    """
+    from orchestrator import db as orch_db
+
+    monkeypatch.setattr(orch_db, "get_pool", lambda: pool, raising=False)
+    # Also patch the watchdog-local alias if dev imported db as a name.
+    if hasattr(watchdog, "db"):
+        monkeypatch.setattr(watchdog.db, "get_pool", lambda: pool, raising=False)
 
 
 def _patch_settings(monkeypatch, *, enabled=True, threshold_sec=1800,
                     telegram_url=""):
-    monkeypatch.setattr(
-        watchdog.settings, "escalated_stale_notify_enabled", enabled, raising=False
-    )
-    monkeypatch.setattr(
-        watchdog.settings, "escalated_stale_threshold_sec", threshold_sec, raising=False
-    )
-    monkeypatch.setattr(
-        watchdog.settings, "escalated_stale_telegram_url", telegram_url, raising=False
-    )
+    """Patch the singleton settings attributes — works regardless of import path."""
+    from orchestrator import config as orch_config
+
+    s = orch_config.settings
+    monkeypatch.setattr(s, "escalated_stale_notify_enabled", enabled, raising=False)
+    monkeypatch.setattr(s, "escalated_stale_threshold_sec", threshold_sec, raising=False)
+    monkeypatch.setattr(s, "escalated_stale_telegram_url", telegram_url, raising=False)
 
 
 def _patch_obs_record_event(monkeypatch):
-    """Replace obs.record_event so we can count and inspect calls."""
+    """Replace obs.record_event so we can count and inspect calls.
+
+    Patches every import style permitted by Python without peeking at the
+    watchdog source:
+      * `from orchestrator import observability [as obs]` → patched at source
+      * `from orchestrator.observability import record_event` → patched as a
+        local binding on the watchdog module (only added if it exists there)
+    """
     calls: list[tuple[tuple, dict]] = []
 
     async def _fake(*args, **kwargs):
         calls.append((args, kwargs))
 
-    monkeypatch.setattr("orchestrator.watchdog.obs.record_event", _fake)
+    from orchestrator import observability as orch_obs
+
+    monkeypatch.setattr(orch_obs, "record_event", _fake, raising=False)
+    if hasattr(watchdog, "record_event"):
+        monkeypatch.setattr(watchdog, "record_event", _fake, raising=False)
     return calls
 
 
@@ -114,7 +134,7 @@ class _RaisingAsyncClient:
 
 
 def _patch_httpx_to_raise(monkeypatch):
-    monkeypatch.setattr("orchestrator.watchdog.httpx.AsyncClient", _RaisingAsyncClient)
+    monkeypatch.setattr(httpx, "AsyncClient", _RaisingAsyncClient)
 
 
 # ─── Test row factory ───────────────────────────────────────────────────────
@@ -309,7 +329,7 @@ async def test_wsn_s2_second_tick_in_same_window_is_suppressed(monkeypatch):
                     return None
             return _R()
 
-    monkeypatch.setattr("orchestrator.watchdog.httpx.AsyncClient", _SpyClient)
+    monkeypatch.setattr(httpx, "AsyncClient", _SpyClient)
 
     result = await watchdog._notify_stale_escalated_tick()
 

--- a/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
+++ b/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
@@ -72,16 +72,11 @@ class _FakePool:
 def _patch_pool(monkeypatch, pool):
     """Stub the pool reachable from watchdog.
 
-    Cover both common import styles for the db helper without peeking at
-    watchdog's source: patch the canonical accessor on the db module and,
-    if watchdog re-exports it locally, patch that too.
+    Mirrors the existing test convention (test_watchdog_bkd_sync.py),
+    which patches `orchestrator.watchdog.db.get_pool` — i.e. the `db`
+    sub-module imported into the watchdog module namespace.
     """
-    from orchestrator import db as orch_db
-
-    monkeypatch.setattr(orch_db, "get_pool", lambda: pool, raising=False)
-    # Also patch the watchdog-local alias if dev imported db as a name.
-    if hasattr(watchdog, "db"):
-        monkeypatch.setattr(watchdog.db, "get_pool", lambda: pool, raising=False)
+    monkeypatch.setattr("orchestrator.watchdog.db.get_pool", lambda: pool)
 
 
 def _patch_settings(monkeypatch, *, enabled=True, threshold_sec=1800,

--- a/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
+++ b/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
@@ -144,6 +144,7 @@ def _make_stale_row(req_id="REQ-stuck-1", stale_for_sec=2400, *,
     """
     return {
         "req_id": req_id,
+        "project_id": "proj-test",
         "state": "escalated",
         "updated_at": datetime.now(timezone.utc) - timedelta(seconds=stale_for_sec),
         "stuck_sec": stale_for_sec,

--- a/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
+++ b/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
@@ -135,11 +135,18 @@ def _patch_httpx_to_raise(monkeypatch):
 # ─── Test row factory ───────────────────────────────────────────────────────
 def _make_stale_row(req_id="REQ-stuck-1", stale_for_sec=2400, *,
                     context: dict | None = None):
-    """Mimic an asyncpg Record-like dict for a stale escalated REQ."""
+    """Mimic an asyncpg Record-like dict for a stale escalated REQ.
+
+    Includes both `updated_at` (the canonical column the spec references)
+    and `stuck_sec` (a common pre-computed elapsed-seconds projection)
+    so the test row tolerates either implementation choice for the
+    notification body.
+    """
     return {
         "req_id": req_id,
         "state": "escalated",
         "updated_at": datetime.now(timezone.utc) - timedelta(seconds=stale_for_sec),
+        "stuck_sec": stale_for_sec,
         "context": dict(context or {}),
     }
 

--- a/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
+++ b/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
@@ -1,0 +1,406 @@
+"""Contract tests for REQ-feat-stuck-notify-378-v2-1777866642.
+
+Black-box behavioral contracts derived **solely** from:
+  openspec/changes/REQ-feat-stuck-notify-378-v2-1777866642/specs/
+    watchdog-stuck-notify/spec.md
+
+Scenarios covered (one test func per scenario):
+  WSN-S1  first stale tick → exactly one obs.record_event + log.warning,
+          body starts with '⏰ ', watermark persisted as UTC ISO-8601
+  WSN-S2  second tick within same stale window (watermark >= updated_at)
+          → 0 obs.record_event, 0 telegram POSTs, returns notified=0
+  WSN-S3  telegram POST raises httpx.ConnectError → tick MUST NOT raise,
+          obs.record_event still called, watermark still persisted,
+          'watchdog.stuck_notify.telegram_failed' log emitted
+  WSN-S4  settings.escalated_stale_notify_enabled = False → short-circuit,
+          no pool.fetch, no obs.record_event, returns
+          {'checked': 0, 'notified': 0}
+
+Black-box stance: this file does not import or reflect on any internal
+helper of watchdog beyond what the spec mandates by name
+(`_notify_stale_escalated_tick`, `obs.record_event`, the two structlog
+event names, the `⏰ ` body prefix, the three settings keys, the return
+dict shape).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+import structlog.testing
+
+from orchestrator import watchdog
+
+
+# ─── Fake pool ──────────────────────────────────────────────────────────────
+@dataclass
+class _FakePool:
+    """Minimal asyncpg-like Pool double.
+
+    `fetch` returns the canned `rows` (mutated by tests via attr).
+    `execute` / `executemany` / `fetchrow` capture all calls so the test
+    can assert that a watermark UPDATE was issued without locking the
+    exact SQL string (black-box).
+    """
+
+    rows: list = field(default_factory=list)
+    fetch_calls: list = field(default_factory=list)
+    execute_calls: list = field(default_factory=list)
+    fetchrow_calls: list = field(default_factory=list)
+
+    async def fetch(self, sql, *args):
+        self.fetch_calls.append((sql, args))
+        return list(self.rows)
+
+    async def execute(self, sql, *args):
+        self.execute_calls.append((sql, args))
+        return "UPDATE 1"
+
+    async def executemany(self, sql, args_seq):
+        for args in args_seq:
+            self.execute_calls.append((sql, tuple(args)))
+        return "UPDATE 1"
+
+    async def fetchrow(self, sql, *args):
+        self.fetchrow_calls.append((sql, args))
+        return self.rows[0] if self.rows else None
+
+
+# ─── Common patch helpers ───────────────────────────────────────────────────
+def _patch_pool(monkeypatch, pool):
+    monkeypatch.setattr("orchestrator.watchdog.db.get_pool", lambda: pool)
+
+
+def _patch_settings(monkeypatch, *, enabled=True, threshold_sec=1800,
+                    telegram_url=""):
+    monkeypatch.setattr(
+        watchdog.settings, "escalated_stale_notify_enabled", enabled, raising=False
+    )
+    monkeypatch.setattr(
+        watchdog.settings, "escalated_stale_threshold_sec", threshold_sec, raising=False
+    )
+    monkeypatch.setattr(
+        watchdog.settings, "escalated_stale_telegram_url", telegram_url, raising=False
+    )
+
+
+def _patch_obs_record_event(monkeypatch):
+    """Replace obs.record_event so we can count and inspect calls."""
+    calls: list[tuple[tuple, dict]] = []
+
+    async def _fake(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr("orchestrator.watchdog.obs.record_event", _fake)
+    return calls
+
+
+class _RaisingAsyncClient:
+    """httpx.AsyncClient stand-in whose .post() raises httpx.ConnectError."""
+
+    def __init__(self, *a, **kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def post(self, *a, **kw):
+        raise httpx.ConnectError("simulated connect failure")
+
+
+def _patch_httpx_to_raise(monkeypatch):
+    monkeypatch.setattr("orchestrator.watchdog.httpx.AsyncClient", _RaisingAsyncClient)
+
+
+# ─── Test row factory ───────────────────────────────────────────────────────
+def _make_stale_row(req_id="REQ-stuck-1", stale_for_sec=2400, *,
+                    context: dict | None = None):
+    """Mimic an asyncpg Record-like dict for a stale escalated REQ."""
+    return {
+        "req_id": req_id,
+        "state": "escalated",
+        "updated_at": datetime.now(timezone.utc) - timedelta(seconds=stale_for_sec),
+        "context": dict(context or {}),
+    }
+
+
+# ─── Helpers to assert across capture sources ───────────────────────────────
+def _flatten_call_args(call) -> list:
+    """Combine positional + keyword arg values into a single inspectable list."""
+    args, kwargs = call
+    flat = list(args)
+    flat.extend(kwargs.values())
+    return flat
+
+
+def _stringify(value) -> str:
+    """Best-effort string projection of any value for substring search."""
+    if isinstance(value, dict):
+        return " ".join(_stringify(v) for v in value.values())
+    if isinstance(value, (list, tuple)):
+        return " ".join(_stringify(v) for v in value)
+    return str(value)
+
+
+def _any_arg_contains(calls, needle: str) -> bool:
+    for call in calls:
+        for v in _flatten_call_args(call):
+            if needle in _stringify(v):
+                return True
+    return False
+
+
+def _any_execute_arg_is_iso8601_utc(execute_calls) -> bool:
+    """Return True if any captured execute() arg parses as a UTC ISO-8601 datetime."""
+    for _sql, args in execute_calls:
+        for a in args:
+            for cand in _candidate_strings(a):
+                if _looks_like_utc_iso8601(cand):
+                    return True
+    return False
+
+
+def _candidate_strings(value):
+    if isinstance(value, str):
+        yield value
+        return
+    if isinstance(value, dict):
+        for v in value.values():
+            yield from _candidate_strings(v)
+        return
+    if isinstance(value, (list, tuple)):
+        for v in value:
+            yield from _candidate_strings(v)
+
+
+def _looks_like_utc_iso8601(s: str) -> bool:
+    if not isinstance(s, str) or len(s) < 19:
+        return False
+    try:
+        # Accept '...Z' or explicit UTC offset.
+        normalised = s.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(normalised)
+    except ValueError:
+        return False
+    if dt.tzinfo is None:
+        return False
+    return dt.utcoffset() == timedelta(0)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# WSN-S1: first stale tick notifies once and persists watermark
+# ═══════════════════════════════════════════════════════════════════════════
+@pytest.mark.asyncio
+async def test_wsn_s1_first_stale_tick_notifies_once_and_persists_watermark(monkeypatch):
+    pool = _FakePool(rows=[_make_stale_row("REQ-stuck-1", stale_for_sec=2400)])
+    _patch_pool(monkeypatch, pool)
+    _patch_settings(monkeypatch, enabled=True, threshold_sec=1800, telegram_url="")
+    obs_calls = _patch_obs_record_event(monkeypatch)
+
+    with structlog.testing.capture_logs() as log_records:
+        result = await watchdog._notify_stale_escalated_tick()
+
+    # Return shape contract.
+    assert isinstance(result, dict), \
+        f"WSN-S1: tick MUST return a dict, got {type(result).__name__}"
+    assert "checked" in result and "notified" in result, \
+        f"WSN-S1: return dict MUST have 'checked' and 'notified' keys, got {result!r}"
+    assert result["notified"] == 1, \
+        f"WSN-S1: exactly one REQ should be notified, got {result!r}"
+
+    # Exactly one obs.record_event call with kind=watchdog_stuck_notify and the req_id.
+    assert len(obs_calls) == 1, (
+        f"WSN-S1: exactly one obs.record_event call MUST be made, "
+        f"got {len(obs_calls)} calls: {obs_calls!r}"
+    )
+    args, kwargs = obs_calls[0]
+    flat = list(args) + list(kwargs.values())
+    assert any("watchdog_stuck_notify" == _stringify(v) or
+               "watchdog_stuck_notify" in _stringify(v) for v in flat), (
+        f"WSN-S1: obs.record_event call MUST include kind='watchdog_stuck_notify', "
+        f"got args={args!r} kwargs={kwargs!r}"
+    )
+    assert any("REQ-stuck-1" in _stringify(v) for v in flat), (
+        f"WSN-S1: obs.record_event call MUST include the matching req_id, "
+        f"got args={args!r} kwargs={kwargs!r}"
+    )
+
+    # log.warning event named 'watchdog.stuck_notify' (NOT the .telegram_failed variant).
+    notify_logs = [r for r in log_records
+                   if r.get("event") == "watchdog.stuck_notify"
+                   and r.get("log_level") in ("warning", "warn")]
+    assert notify_logs, (
+        f"WSN-S1: a log.warning event named 'watchdog.stuck_notify' MUST be recorded; "
+        f"captured events: {[r.get('event') for r in log_records]!r}"
+    )
+
+    # Body string MUST start with '⏰ ' and contain the REQ id — search every
+    # captured surface (obs extras, log fields) since spec doesn't fix the carrier.
+    surfaces: list[str] = []
+    for r in log_records:
+        for v in r.values():
+            surfaces.append(_stringify(v))
+    for call in obs_calls:
+        for v in _flatten_call_args(call):
+            surfaces.append(_stringify(v))
+    assert any(s.startswith("⏰ ") and "REQ-stuck-1" in s for s in surfaces), (
+        "WSN-S1: a body string starting with '⏰ ' and containing the REQ id MUST "
+        f"appear in obs extras or log fields; surfaces: {surfaces!r}"
+    )
+
+    # Watermark persisted as UTC ISO-8601 — at least one execute() arg must be one.
+    assert pool.execute_calls, (
+        "WSN-S1: watchdog MUST persist context.stuck_notified_at via pool.execute(); "
+        "no execute() calls captured"
+    )
+    assert _any_execute_arg_is_iso8601_utc(pool.execute_calls), (
+        f"WSN-S1: persisted stuck_notified_at MUST be a UTC ISO-8601 string; "
+        f"captured execute() args: {[c[1] for c in pool.execute_calls]!r}"
+    )
+    assert _any_arg_contains(pool.execute_calls, "REQ-stuck-1"), (
+        "WSN-S1: persistence call MUST scope to the REQ id 'REQ-stuck-1'; "
+        f"captured execute() args: {[c[1] for c in pool.execute_calls]!r}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# WSN-S2: second tick within same stale window is suppressed
+# ═══════════════════════════════════════════════════════════════════════════
+@pytest.mark.asyncio
+async def test_wsn_s2_second_tick_in_same_window_is_suppressed(monkeypatch):
+    # Row already has a watermark >= updated_at (current ESCALATED window
+    # already notified). Use a watermark strictly newer than updated_at.
+    row = _make_stale_row("REQ-stuck-2", stale_for_sec=2400)
+    row["context"]["stuck_notified_at"] = (
+        row["updated_at"] + timedelta(seconds=10)
+    ).isoformat()
+    pool = _FakePool(rows=[row])
+    _patch_pool(monkeypatch, pool)
+    _patch_settings(
+        monkeypatch, enabled=True, threshold_sec=1800,
+        telegram_url="https://api.telegram.example/bot/test",
+    )
+    obs_calls = _patch_obs_record_event(monkeypatch)
+
+    posted: list = []
+
+    class _SpyClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, *a, **kw):
+            posted.append((a, kw))
+
+            class _R:
+                status_code = 200
+
+                def raise_for_status(self_inner):
+                    return None
+            return _R()
+
+    monkeypatch.setattr("orchestrator.watchdog.httpx.AsyncClient", _SpyClient)
+
+    result = await watchdog._notify_stale_escalated_tick()
+
+    assert obs_calls == [], (
+        f"WSN-S2: zero obs.record_event calls MUST be made, "
+        f"got {len(obs_calls)}: {obs_calls!r}"
+    )
+    assert posted == [], (
+        f"WSN-S2: zero HTTP POSTs to the telegram URL MUST occur, got {posted!r}"
+    )
+    assert isinstance(result, dict) and "checked" in result and "notified" in result, (
+        f"WSN-S2: return MUST be dict with 'checked'/'notified' keys, got {result!r}"
+    )
+    assert result["checked"] >= 1, (
+        f"WSN-S2: 'checked' MUST be >= 1 (the row was scanned), got {result!r}"
+    )
+    assert result["notified"] == 0, (
+        f"WSN-S2: 'notified' MUST be 0 (suppressed by watermark), got {result!r}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# WSN-S3: telegram POST is best-effort and never raises
+# ═══════════════════════════════════════════════════════════════════════════
+@pytest.mark.asyncio
+async def test_wsn_s3_telegram_post_failure_is_swallowed(monkeypatch):
+    pool = _FakePool(rows=[_make_stale_row("REQ-stuck-3", stale_for_sec=2400)])
+    _patch_pool(monkeypatch, pool)
+    _patch_settings(
+        monkeypatch, enabled=True, threshold_sec=1800,
+        telegram_url="https://api.telegram.example/bot/test/sendMessage",
+    )
+    obs_calls = _patch_obs_record_event(monkeypatch)
+    _patch_httpx_to_raise(monkeypatch)
+
+    with structlog.testing.capture_logs() as log_records:
+        # Tick MUST NOT raise — even though httpx POST raises ConnectError.
+        result = await watchdog._notify_stale_escalated_tick()
+
+    assert isinstance(result, dict), (
+        f"WSN-S3: tick MUST still return a dict on telegram failure, got {result!r}"
+    )
+
+    # In-DB notification is the source of truth → obs.record_event still called once.
+    assert len(obs_calls) == 1, (
+        f"WSN-S3: obs.record_event MUST still be invoked exactly once "
+        f"despite telegram failure, got {len(obs_calls)}: {obs_calls!r}"
+    )
+
+    # Watermark MUST still be persisted (telegram is opportunistic, no retry).
+    assert pool.execute_calls, (
+        "WSN-S3: watermark MUST still be persisted via pool.execute() "
+        "despite telegram failure; no execute() calls captured"
+    )
+    assert _any_execute_arg_is_iso8601_utc(pool.execute_calls), (
+        "WSN-S3: persisted stuck_notified_at MUST be a UTC ISO-8601 string "
+        f"even on telegram failure; got: {[c[1] for c in pool.execute_calls]!r}"
+    )
+
+    # A 'watchdog.stuck_notify.telegram_failed' log.warning event MUST be recorded.
+    failed_logs = [r for r in log_records
+                   if r.get("event") == "watchdog.stuck_notify.telegram_failed"
+                   and r.get("log_level") in ("warning", "warn")]
+    assert failed_logs, (
+        "WSN-S3: a log.warning event named 'watchdog.stuck_notify.telegram_failed' "
+        f"MUST be recorded; captured: {[r.get('event') for r in log_records]!r}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# WSN-S4: disabled flag short-circuits the tick
+# ═══════════════════════════════════════════════════════════════════════════
+@pytest.mark.asyncio
+async def test_wsn_s4_disabled_flag_short_circuits(monkeypatch):
+    # Row would otherwise qualify (stale, no watermark).
+    pool = _FakePool(rows=[_make_stale_row("REQ-stuck-4", stale_for_sec=99999)])
+    _patch_pool(monkeypatch, pool)
+    _patch_settings(monkeypatch, enabled=False, threshold_sec=1800, telegram_url="")
+    obs_calls = _patch_obs_record_event(monkeypatch)
+
+    result = await watchdog._notify_stale_escalated_tick()
+
+    assert result == {"checked": 0, "notified": 0}, (
+        f"WSN-S4: disabled tick MUST return exactly "
+        f"{{'checked': 0, 'notified': 0}}, got {result!r}"
+    )
+    assert pool.fetch_calls == [], (
+        f"WSN-S4: pool.fetch MUST NOT be called when disabled, "
+        f"got {len(pool.fetch_calls)} calls"
+    )
+    assert obs_calls == [], (
+        f"WSN-S4: obs.record_event MUST NOT be called when disabled, "
+        f"got {obs_calls!r}"
+    )

--- a/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
+++ b/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
@@ -173,10 +173,15 @@ def _stringify(value) -> str:
 
 
 def _any_arg_contains(calls, needle: str) -> bool:
+    """Search for `needle` in any captured call.
+
+    Works for both obs.record_event-style calls (`(args, kwargs)` tuples)
+    and pool.execute-style calls (`(sql, args)` tuples) by stringifying
+    every nested element.
+    """
     for call in calls:
-        for v in _flatten_call_args(call):
-            if needle in _stringify(v):
-                return True
+        if needle in _stringify(call):
+            return True
     return False
 
 

--- a/orchestrator/tests/test_watchdog_stuck_notify.py
+++ b/orchestrator/tests/test_watchdog_stuck_notify.py
@@ -1,0 +1,223 @@
+"""REQ-feat-stuck-notify-378-v2-1777866642 unit tests for
+`watchdog._notify_stale_escalated_tick`.
+
+Covers spec scenarios WSN-S1..WSN-S4 + the format helper.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+
+from orchestrator import watchdog
+
+
+# ─── Fake pool: records fetch SQL + execute calls ─────────────────────────
+@dataclass
+class FakePool:
+    rows: list = field(default_factory=list)
+    fetch_calls: list = field(default_factory=list)
+    execute_calls: list = field(default_factory=list)
+
+    async def fetch(self, sql, *args):
+        self.fetch_calls.append((sql, args))
+        return self.rows
+
+    async def execute(self, sql, *args):
+        self.execute_calls.append((sql, args))
+        return None
+
+
+def _esc_row(req_id="REQ-1", project_id="proj-1", stuck_sec=2400, ctx=None,
+             updated_offset_sec=2400):
+    """Mimic the asyncpg row shape returned by the SELECT in
+    `_notify_stale_escalated_tick` (req_id / project_id / context / updated_at /
+    stuck_sec)."""
+    return {
+        "req_id": req_id,
+        "project_id": project_id,
+        "context": json.dumps(ctx or {}),
+        "updated_at": datetime.now(UTC) - timedelta(seconds=updated_offset_sec),
+        "stuck_sec": stuck_sec,
+    }
+
+
+def _patch_pool(monkeypatch, pool):
+    monkeypatch.setattr("orchestrator.watchdog.db.get_pool", lambda: pool)
+
+
+def _patch_obs(monkeypatch):
+    calls: list = []
+
+    async def fake_record(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr("orchestrator.watchdog.observability.record_event", fake_record)
+    return calls
+
+
+def _patch_telegram(monkeypatch, *, raise_exc: Exception | None = None):
+    posts: list = []
+
+    async def fake_post(url, text):
+        posts.append((url, text))
+        if raise_exc:
+            raise raise_exc
+        return True
+
+    monkeypatch.setattr("orchestrator.watchdog._post_telegram_notify", fake_post)
+    return posts
+
+
+# ─── format helper (prefix contract) ──────────────────────────────────────
+def test_format_stuck_notify_text_starts_with_clock_emoji():
+    text = watchdog._format_stuck_notify_text("REQ-foo", 1900, "ESCALATED")
+    assert text.startswith("⏰ "), "dashboards rely on this prefix to string-match"
+    assert "REQ-foo" in text
+    assert "31min" in text  # 1900 // 60
+
+
+# ─── WSN-S1: first stale tick notifies once and persists watermark ────────
+@pytest.mark.asyncio
+async def test_wsn_s1_first_stale_tick_notifies_and_persists(monkeypatch):
+    monkeypatch.setattr(watchdog.settings, "escalated_stale_notify_enabled", True)
+    monkeypatch.setattr(watchdog.settings, "escalated_stale_threshold_sec", 1800)
+    monkeypatch.setattr(watchdog.settings, "escalated_stale_telegram_url", "")
+
+    pool = FakePool(rows=[_esc_row(req_id="REQ-1", stuck_sec=2400, ctx={})])
+    _patch_pool(monkeypatch, pool)
+    obs_calls = _patch_obs(monkeypatch)
+
+    result = await watchdog._notify_stale_escalated_tick()
+
+    assert result == {"checked": 1, "notified": 1}
+    assert len(obs_calls) == 1
+    assert obs_calls[0]["kind"] == "watchdog_stuck_notify"
+    assert obs_calls[0]["req_id"] == "REQ-1"
+    assert obs_calls[0]["error_msg"].startswith("⏰ ")
+    assert "REQ-1" in obs_calls[0]["error_msg"]
+
+    # watermark persisted via update_context (UPDATE req_state ... context = context || $2::jsonb)
+    update_calls = [c for c in pool.execute_calls if "UPDATE req_state" in c[0]]
+    assert len(update_calls) == 1
+    _sql, args = update_calls[0]
+    assert args[0] == "REQ-1"
+    persisted = json.loads(args[1])
+    assert "stuck_notified_at" in persisted
+    # round-trip: must parse back as ISO datetime
+    datetime.fromisoformat(persisted["stuck_notified_at"])
+
+
+# ─── WSN-S2: second tick within same stale window is suppressed ───────────
+@pytest.mark.asyncio
+async def test_wsn_s2_existing_watermark_suppresses_second_notify(monkeypatch):
+    monkeypatch.setattr(watchdog.settings, "escalated_stale_notify_enabled", True)
+    monkeypatch.setattr(watchdog.settings, "escalated_stale_threshold_sec", 1800)
+    monkeypatch.setattr(watchdog.settings, "escalated_stale_telegram_url",
+                        "https://hook.example.test/")
+
+    # watermark set 1min ago, updated_at 40min ago → watermark > updated_at → skip
+    watermark = (datetime.now(UTC) - timedelta(seconds=60)).isoformat()
+    pool = FakePool(rows=[_esc_row(
+        req_id="REQ-1", stuck_sec=2400,
+        updated_offset_sec=2400,
+        ctx={"stuck_notified_at": watermark},
+    )])
+    _patch_pool(monkeypatch, pool)
+    obs_calls = _patch_obs(monkeypatch)
+    posts = _patch_telegram(monkeypatch)
+
+    result = await watchdog._notify_stale_escalated_tick()
+
+    assert result == {"checked": 1, "notified": 0}
+    assert obs_calls == []
+    assert posts == []
+    # no UPDATE req_state on suppressed row
+    assert [c for c in pool.execute_calls if "UPDATE req_state" in c[0]] == []
+
+
+# ─── WSN-S3: telegram POST is best-effort and never raises ────────────────
+@pytest.mark.asyncio
+async def test_wsn_s3_telegram_failure_does_not_raise(monkeypatch):
+    monkeypatch.setattr(watchdog.settings, "escalated_stale_notify_enabled", True)
+    monkeypatch.setattr(watchdog.settings, "escalated_stale_threshold_sec", 1800)
+    monkeypatch.setattr(watchdog.settings, "escalated_stale_telegram_url",
+                        "https://hook.example.test/")
+
+    pool = FakePool(rows=[_esc_row(req_id="REQ-2", stuck_sec=2400, ctx={})])
+    _patch_pool(monkeypatch, pool)
+    obs_calls = _patch_obs(monkeypatch)
+
+    # _post_telegram_notify itself swallows; route the underlying httpx call to raise
+    # so we exercise the real best-effort path.
+    async def boom(*a, **kw):
+        raise httpx.ConnectError("DNS down")
+
+    class FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def post(self, *a, **kw):
+            await boom()
+
+    monkeypatch.setattr("orchestrator.watchdog.httpx.AsyncClient",
+                        lambda *a, **kw: FakeClient())
+
+    result = await watchdog._notify_stale_escalated_tick()
+
+    assert result == {"checked": 1, "notified": 1}
+    assert len(obs_calls) == 1
+    assert obs_calls[0]["req_id"] == "REQ-2"
+    # watermark still persisted (telegram failure must not block retry-suppression)
+    update_calls = [c for c in pool.execute_calls if "UPDATE req_state" in c[0]]
+    assert len(update_calls) == 1
+
+
+# ─── WSN-S4: disabled flag short-circuits the tick ────────────────────────
+@pytest.mark.asyncio
+async def test_wsn_s4_disabled_flag_short_circuits(monkeypatch):
+    monkeypatch.setattr(watchdog.settings, "escalated_stale_notify_enabled", False)
+
+    pool = FakePool(rows=[_esc_row(req_id="REQ-X", ctx={})])
+    _patch_pool(monkeypatch, pool)
+    obs_calls = _patch_obs(monkeypatch)
+
+    result = await watchdog._notify_stale_escalated_tick()
+
+    assert result == {"checked": 0, "notified": 0}
+    # pool.fetch must not be called when disabled
+    assert pool.fetch_calls == []
+    assert obs_calls == []
+
+
+# ─── extra: stale watermark (older than updated_at) still notifies ────────
+@pytest.mark.asyncio
+async def test_stale_watermark_below_updated_at_notifies_again(monkeypatch):
+    """Re-escalate: REQ left ESCALATED then re-entered → updated_at jumped → old
+    watermark < updated_at → tick must notify again."""
+    monkeypatch.setattr(watchdog.settings, "escalated_stale_notify_enabled", True)
+    monkeypatch.setattr(watchdog.settings, "escalated_stale_threshold_sec", 1800)
+    monkeypatch.setattr(watchdog.settings, "escalated_stale_telegram_url", "")
+
+    # watermark from a previous ESCALATED period (older than current updated_at)
+    old_watermark = (datetime.now(UTC) - timedelta(seconds=10000)).isoformat()
+    pool = FakePool(rows=[_esc_row(
+        req_id="REQ-3", stuck_sec=2400, updated_offset_sec=2400,
+        ctx={"stuck_notified_at": old_watermark},
+    )])
+    _patch_pool(monkeypatch, pool)
+    obs_calls = _patch_obs(monkeypatch)
+
+    result = await watchdog._notify_stale_escalated_tick()
+
+    assert result == {"checked": 1, "notified": 1}
+    assert len(obs_calls) == 1


### PR DESCRIPTION
## Why

REQ 进 ESCALATED 后等人 resume，没人盯就**永久卡**。issue #378 实证：v5 卡 30min 才被发现是 router 静默 drop。已有的 `_mark_abandoned_escalated_reqs` sweep 是 7 天太晚；watchdog escalate 路径只可能开 GH incident issue（如配 `gh_incident_repo`），不主动 nudge 操作员。

## What

`watchdog._notify_stale_escalated_tick`，搭 `_sync_stuck_sub_agent_statuses_tick` 同 5-tick (~5min) 周期跑：

- SQL 选 `state='escalated' AND updated_at < NOW - escalated_stale_threshold_sec`
- per-row：若 `context.stuck_notified_at >= req_state.updated_at` → 跳过（同段 ESCALATED 期已通知）
- 否则 emit 三件事：
  - `obs.record_event(kind="watchdog_stuck_notify", req_id=..., extras={...})`
  - `log.warning("watchdog.stuck_notify", text=...)`
  - 若 `escalated_stale_telegram_url` 配了，POST `{"text": "..."}` 到该 URL（best-effort，5s timeout，失败不阻塞）
- 写 `context.stuck_notified_at = now()` watermark 防重发

REQ resume → 推进 → 再 escalate 时 `updated_at` 跳到新时刻，watermark 自动失效，新一轮 stale 又能通知一次。

通知文本固定 prefix `"⏰ "` 让 Loki / dashboards 能 string-match。

### 新配置

- `escalated_stale_notify_enabled: bool = True`
- `escalated_stale_threshold_sec: int = 1800` (30min, issue #378 提议值)
- `escalated_stale_telegram_url: str = ""` (空 = 不外推；helm `if` 守门)

## Test plan

- [x] `tests/test_watchdog_stuck_notify.py` 6 tests covering WSN-S1..S4 + format helper + re-escalate watermark reset
- [x] `make ci-lint` 全绿
- [x] `make ci-unit-test`：watchdog 套件 53/53 通过；其它 31 个失败是 baseline pre-existing（已 stash 验证非本 PR 引入）
- [x] `openspec validate REQ-feat-stuck-notify-378-v2-1777866642` 通过
- [x] `check-scenario-refs.sh` 通过 (827 scenarios indexed)

## Out of scope

- 多 channel notify (Slack / 飞书)：v2 只 1 个 webhook URL，通用 webhook 形态用户自己 nginx redirect 桥
- 重复通知 / 升级路径（每 N 小时再 nudge）：issue #378 没要求；7 天 abandoned-by-user sweep 是长 tail 兜底
- GH issue 上贴 comment：`gh_incident.py` 的 escalate 时开 issue 已覆盖该用例，本 PR 不动

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-feat-stuck-notify-378-v2-1777866642\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/elshw6uy)