### PR TITLE
feat(orch): router decode-fail telemetry (closes #372)

### DIFF
--- a/openspec/changes/REQ-feat-router-telemetry-v3-1777866642/proposal.md
+++ b/openspec/changes/REQ-feat-router-telemetry-v3-1777866642/proposal.md
@@ -1,0 +1,57 @@
+# REQ-feat-router-telemetry-v3-1777866642 — router decode-fail telemetry (3-signal emit)
+
+Closes phona/sisyphus#372.
+
+## 现状
+
+`webhook._derive_verifier_event` 解析 `session.completed` from a verifier
+sub-issue 时若 `extract_decision_robust` 拿不到合规 decision JSON / tag，会
+返回 `VERIFY_ESCALATE`。webhook 当前对该路径的可观测信号只有：
+
+1. **`log.info("webhook.verifier.decision", ...)`** — INFO 级，被 ops loki
+   noise 淹没。
+2. **`obs.record_event("verifier.decision.parse_retry_exhausted", ...)`** —
+   仅在 retry 用尽分支写入；retry_worthy=False（首轮无 decision 文本）路径
+   完全无 obs 记录。
+3. **`statusId=review`** push 到 BKD —— 用户能在 BKD UI "review" 列看到
+   issue，但 *为什么* 进 review 完全不可见，需要拉源码 / 手 base64 decode 才
+   能定位 router 在抱怨啥。
+
+5/4 v5 dogfood 实测：verifier emit 不合规 `decision:pass` 字符串 tag → router
+解析失败 → REQ ESCALATED 状态无 transition → **静默吞掉，零 BKD 反馈、零
+queryable obs、零 warning 级 log**。30 分钟后才有人意识到流水线卡住。
+
+## 修法（3 路 emit，互相兜底）
+
+`router.derive_verifier_event` 返回 `VERIFY_ESCALATE` + `reason` 时，webhook
+在确认 *不再 retry* 的终态点（retry_worthy=False 直接 escalate / retry 用尽
+escalate）emit 三处信号：
+
+1. **`stage_runs` 写一行 decode-fail event** —
+   `stage="router_decode_fail"` / `outcome="silent_drop"` /
+   `fail_reason=reason` / `context={"issue_id", "raw_tags", "verifier_stage"}`。
+   复用既有 `stage_runs` schema，无新表 / 新列。
+   Metabase 看板新查询可 `WHERE stage='router_decode_fail'` 一眼出列表。
+
+2. **BKD verifier issue 加 tag + description 警告块** —
+   PATCH 该 issue tags 追加 `router-decode-fail`，再 PATCH description
+   追加格式化警告块（reason / 期望格式 / 实际 tags / 操作建议）。
+   tag 是稳定信号（BKD `Issue` 一定有 `tags` 字段）；description PATCH 是
+   best-effort（如果 BKD 版本不支持 description 更新就退化成 warning log）。
+
+3. **`log.warning("router.decode_fail", ...)`** — WARNING 级结构化日志，loki
+   alerting 可订阅。
+
+三路任一落地都能让"卡住 30 分钟"压到"看 BKD 看板秒懂"。
+
+## 不做的事
+
+- **不新建 migration** — 复用 `stage_runs.context::jsonb`（既有，0016 加的）
+  装 `issue_id` / `raw_tags`，不引入 `0017_router_decode_fail.sql`。
+- **不在 retry-not-yet-exhausted 路径 emit** — 那条路径会走 follow_up 让
+  agent 重输出，先给 agent 自救机会；只在终态 escalate 才 emit 三路信号。
+- **不改 router.py** — telemetry 完全在 webhook 调用路径上，router 仍是纯
+  解析层。
+- **不引入新 Event / 新 ReqState** — `VERIFY_ESCALATE` 走原 transition，
+  telemetry 只是 side-effect。
+- **不动 watchdog / GC** — 跟 escalate / resume 路径正交。

--- a/openspec/changes/REQ-feat-router-telemetry-v3-1777866642/specs/router-decode-fail-telemetry/spec.md
+++ b/openspec/changes/REQ-feat-router-telemetry-v3-1777866642/specs/router-decode-fail-telemetry/spec.md
@@ -1,0 +1,65 @@
+# Spec delta — router-decode-fail-telemetry
+
+## ADDED Requirements
+
+### Requirement: webhook SHALL persist a stage_runs row on terminal verifier decode-fail
+
+The orchestrator MUST insert a closed `stage_runs` row recording the
+decode-fail event whenever `webhook` receives a `session.completed` from a
+verifier sub-issue and `router.derive_verifier_event_with_retry_info`
+ultimately returns `Event.VERIFY_ESCALATE` with a non-empty `reason` (i.e.
+the agent will not be auto-retried — either `retry_worthy=False` initially,
+or the per-REQ retry counter has already reached the cap). The row SHALL
+set `stage="router_decode_fail"`, `outcome="silent_drop"`, and `fail_reason`
+to the router reason string, and `context` SHALL be a JSON object that
+contains at minimum `issue_id` (the BKD verifier issue id), `raw_tags` (the
+tags array seen at decode time), and `verifier_stage` (the stage parsed from
+the `verify:` tag, or `"unknown"` when absent). The row MUST be self-closing
+(`started_at` equal to `ended_at` modulo clock drift) so that downstream
+stage_runs queries do not treat it as an open-ended run. Insert failure (DB
+hiccup) MUST be caught and logged at WARNING; it MUST NOT abort the
+surrounding webhook flow.
+
+#### Scenario: RDFT-S1 stage_runs row written when no decision JSON is found
+- **GIVEN** a `session.completed` from a verifier issue tagged `["verifier", "verify:staging_test", "REQ-x"]`
+- **AND** `extract_decision_robust` returns `decision=None` with `retry_worthy=False`
+- **WHEN** the webhook processes the event
+- **THEN** exactly one `stage_runs` row is inserted with `stage="router_decode_fail"`, `outcome="silent_drop"`, `fail_reason` matching the router reason string (e.g. starts with `"no decision JSON"`)
+- **AND** the row's `context` JSON contains `issue_id`, `raw_tags` (a list including `"verifier"`), and `verifier_stage="staging_test"`
+- **AND** the row is closed (`ended_at` is not null)
+
+### Requirement: webhook SHALL surface decode-fail on the BKD verifier issue
+
+On terminal verifier decode-fail, the orchestrator MUST best-effort PATCH the
+BKD verifier issue with two visible signals: (a) append a `router-decode-fail`
+tag to the issue's `tags` (additive, preserving all existing tags via the
+`GET → merge → PATCH` convention used elsewhere in this codebase), and (b)
+attempt to append a human-readable warning block to the issue `description`
+that includes the router `reason`, the expected decision-tag formats, the raw
+tags observed at decode time, and an operator hint on how to recover (manual
+PATCH of a `decision:<action>` tag, or follow-up that re-emits the JSON
+block). Either step's failure (BKD down, version that does not support
+description update) MUST be isolated by try/except and logged at WARNING; the
+remaining signals (stage_runs row, log.warning) MUST still fire.
+
+#### Scenario: RDFT-S2 BKD issue gets `router-decode-fail` tag and warning text appended
+- **GIVEN** a verifier `session.completed` whose decision parse ultimately escalates with reason `"invalid decision: invalid action: 'pass'"`
+- **WHEN** the webhook calls `_emit_decode_fail_telemetry` for that issue
+- **THEN** the BKD client receives exactly one `update_issue` call carrying both `tags` (the previous tags plus `"router-decode-fail"`, no duplicates) and `description` (a string containing the literal `router decode 失败` plus the router reason verbatim)
+- **AND** when the BKD `update_issue` call raises, the function still returns normally (does not propagate the exception out of the webhook handler) and the in-memory log captures a WARNING with key `router.decode_fail.bkd_patch_failed`
+
+### Requirement: webhook SHALL log decode-fail at WARNING level with structured fields
+
+The orchestrator MUST emit a single `log.warning` with event key
+`router.decode_fail` for every terminal decode-fail. The log call SHALL bind
+at least `issue_id`, `req_id`, `stage`, `reason`, and `raw_tags` so that
+loki / structlog consumers can route on each independently. The log MUST fire
+*before* any best-effort downstream call (stage_runs insert / BKD PATCH) so
+that even a hard exception in those paths still leaves the WARNING line in
+the log stream.
+
+#### Scenario: RDFT-S3 WARNING log line emitted with full context
+- **GIVEN** a verifier session.completed that fails decode with reason `"no decision JSON found in tag or description"`
+- **WHEN** `_emit_decode_fail_telemetry` runs for that event
+- **THEN** the structlog stream contains exactly one entry at level WARNING with event `"router.decode_fail"`
+- **AND** that entry binds `issue_id`, `req_id`, `stage`, `reason`, and `raw_tags` keys, where `reason` matches the router reason verbatim and `raw_tags` is the original tags list

--- a/openspec/changes/REQ-feat-router-telemetry-v3-1777866642/tasks.md
+++ b/openspec/changes/REQ-feat-router-telemetry-v3-1777866642/tasks.md
@@ -1,0 +1,18 @@
+# Tasks — REQ-feat-router-telemetry-v3-1777866642
+
+## Stage: contract / spec
+- [x] author specs/router-decode-fail-telemetry/spec.md (3 scenarios: RDFT-S1..S3)
+- [x] write proposal.md / tasks.md
+
+## Stage: implementation
+- [x] add `insert_decode_fail` helper in `orchestrator/src/orchestrator/store/stage_runs.py` writing one closed `stage_runs` row (`stage="router_decode_fail"`, `outcome="silent_drop"`, context with `issue_id` / `raw_tags` / `verifier_stage`)
+- [x] add `_emit_decode_fail_telemetry` in `orchestrator/src/orchestrator/webhook.py` performing the 3 emit signals (stage_runs row + BKD tag/description PATCH + log.warning), each best-effort with isolated try/except so any single failure does not block the others
+- [x] wire `_emit_decode_fail_telemetry` at every terminal verifier decode-fail point (retry_worthy=False direct escalate; retry exhausted escalate); leave the retry follow_up path untouched (agent gets its self-correction window first)
+- [x] add unit tests in `orchestrator/tests/test_webhook_decode_fail_telemetry.py` covering the 3 emit points across both terminal paths
+
+## Stage: PR (gates before push)
+- [x] `make ci-lint` green
+- [x] `make ci-unit-test` green
+- [x] `make ci-integration-test` green (or skipped if no PG)
+- [x] git push feat/REQ-feat-router-telemetry-v3-1777866642
+- [x] gh pr create --label sisyphus

--- a/orchestrator/src/orchestrator/store/stage_runs.py
+++ b/orchestrator/src/orchestrator/store/stage_runs.py
@@ -183,6 +183,44 @@ async def stamp_bkd_issue_id(
     return int(row["id"]) if row else None
 
 
+async def insert_decode_fail(
+    pool: asyncpg.Pool,
+    *,
+    req_id: str,
+    issue_id: str,
+    verifier_stage: str,
+    reason: str,
+    raw_tags: list[str],
+) -> int:
+    """Record a terminal verifier decode-fail event as a closed stage_runs row.
+
+    Used by webhook when `derive_verifier_event` returns VERIFY_ESCALATE
+    on a path that will not be auto-retried (either retry_worthy=False or
+    retry budget exhausted). The row is self-closing — started_at == ended_at
+    — because this is a discrete failure event, not an in-flight stage. It
+    surfaces in observability (Q15-style queries) so operators can spot the
+    silent-drop class of failures without grepping orch logs.
+    """
+    now = datetime.now(UTC)
+    context = {
+        "issue_id": issue_id,
+        "raw_tags": list(raw_tags or []),
+        "verifier_stage": verifier_stage,
+    }
+    row = await pool.fetchrow(
+        """
+        INSERT INTO stage_runs
+            (req_id, stage, agent_type, started_at, ended_at,
+             outcome, fail_reason, duration_sec, context)
+        VALUES ($1, 'router_decode_fail', 'router', $2, $2,
+                'silent_drop', $3, 0.0, $4::jsonb)
+        RETURNING id
+        """,
+        req_id, now, reason, json.dumps(context),
+    )
+    return int(row["id"])
+
+
 async def stamp_bkd_session_id(
     pool: asyncpg.Pool,
     req_id: str,

--- a/orchestrator/src/orchestrator/webhook.py
+++ b/orchestrator/src/orchestrator/webhook.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import hmac
+from datetime import UTC, datetime
 from typing import Any
 
 import structlog
@@ -145,6 +146,96 @@ async def _maybe_derive_user_review_event(
         status_id=new_status, derived_event=new_event.value,
     )
     return new_event
+
+
+_DECODE_FAIL_TAG = "router-decode-fail"
+
+_DECODE_FAIL_NOTE_TEMPLATE = (
+    "---\n"
+    "⚠️ sisyphus router decode 失败 ({timestamp}):\n"
+    "  reason: {reason}\n"
+    "  期望格式: tag `decision:<urlsafe-base64-json>` / `decision:<action>[-<fixer>]` "
+    "或 logs 含 ```json {{...}} ``` 块\n"
+    "  实际 tags: {raw_tags}\n"
+    "  操作建议: PATCH 加合规 decision tag，或 follow-up agent 重输出标准 JSON 块\n"
+)
+
+
+async def _emit_decode_fail_telemetry(
+    *,
+    pool: Any,
+    project_id: str,
+    issue_id: str,
+    req_id: str | None,
+    verifier_stage: str,
+    reason: str,
+    raw_tags: list[str],
+) -> None:
+    """3 emit signals for a terminal verifier decode-fail (closes #372).
+
+    Order matters: log.warning fires first, *before* any network / DB call,
+    so a hard exception below still leaves a loki-visible breadcrumb. Each
+    downstream emit is wrapped in its own try/except so a single failing
+    sink does not silence the others.
+    """
+    log.warning(
+        "router.decode_fail",
+        issue_id=issue_id, req_id=req_id, stage=verifier_stage,
+        reason=reason, raw_tags=list(raw_tags or []),
+    )
+
+    if req_id:
+        try:
+            await stage_runs.insert_decode_fail(
+                pool,
+                req_id=req_id, issue_id=issue_id,
+                verifier_stage=verifier_stage, reason=reason,
+                raw_tags=list(raw_tags or []),
+            )
+        except Exception as e:
+            log.warning(
+                "router.decode_fail.stage_runs_failed",
+                req_id=req_id, issue_id=issue_id, error=str(e),
+            )
+
+    note = _DECODE_FAIL_NOTE_TEMPLATE.format(
+        timestamp=datetime.now(UTC).isoformat(),
+        reason=reason,
+        raw_tags=list(raw_tags or []),
+    )
+    try:
+        async with BKDClient(settings.bkd_base_url, settings.bkd_token) as bkd:
+            issue = await bkd.get_issue(project_id, issue_id)
+            new_tags = list(dict.fromkeys([*(issue.tags or []), _DECODE_FAIL_TAG]))
+            new_desc = (
+                (issue.description or "").rstrip() + "\n" + note
+                if issue.description
+                else note
+            )
+            await bkd.update_issue(
+                project_id=project_id, issue_id=issue_id,
+                tags=new_tags, description=new_desc,
+            )
+    except Exception as e:
+        log.warning(
+            "router.decode_fail.bkd_patch_failed",
+            issue_id=issue_id, error=str(e),
+        )
+
+    try:
+        await obs.record_event(
+            "router.decode_fail",
+            req_id=req_id, issue_id=issue_id,
+            extras={
+                "stage": verifier_stage, "reason": reason,
+                "raw_tags": list(raw_tags or []),
+            },
+        )
+    except Exception as e:
+        log.warning(
+            "router.decode_fail.obs_record_failed",
+            req_id=req_id, issue_id=issue_id, error=str(e),
+        )
 
 
 async def _push_upstream_status(project_id: str, issue_id: str, status_id: str) -> None:
@@ -405,6 +496,25 @@ async def webhook(request: Request) -> JSONResponse:
                 req_id=retry_req_id,
                 issue_id=body.issueId,
                 extras={"reason": why},
+            )
+
+        # ─── 终态 decode-fail telemetry（closes #372）──────────────────────
+        # 走到这里有两条路径：
+        #   (a) retry_worthy=False —— 首轮就找不到 decision JSON，无 retry 机会
+        #   (b) retry_worthy=True 且 retry 次数耗尽
+        # 两条都意味着 agent 不会再被自动唤醒重写 decision，REQ 即将进
+        # ESCALATED。emit 3 路信号让"静默吞掉"现象（issue #372）变成
+        # stage_runs / BKD UI / log.warning 三方都能看见的失败事件。
+        if event == Event.VERIFY_ESCALATE and why:
+            decode_req_id = router_lib.extract_req_id(tags, body.issueNumber)
+            await _emit_decode_fail_telemetry(
+                pool=pool,
+                project_id=body.projectId,
+                issue_id=body.issueId,
+                req_id=decode_req_id,
+                verifier_stage=router_lib._stage_from_tags(tags) or "unknown",
+                reason=why,
+                raw_tags=tags,
             )
 
     # INTAKE_PASS：扫所有 assistant-messages 找 finalized intent JSON

--- a/orchestrator/tests/test_contract_router_decode_fail_telemetry_challenger.py
+++ b/orchestrator/tests/test_contract_router_decode_fail_telemetry_challenger.py
@@ -20,7 +20,6 @@ Scenarios covered:
 from __future__ import annotations
 
 import json
-import logging
 from typing import Any
 
 
@@ -314,8 +313,8 @@ async def test_rdft_s3_warning_log_with_structured_fields(monkeypatch):
     reason, raw_tags. The warning MUST fire BEFORE any best-effort downstream
     emit so a hard exception in those paths still leaves the line in the stream.
     """
-    from orchestrator import webhook
     import orchestrator.store.stage_runs as sr_mod
+    from orchestrator import webhook
 
     captured: list[dict[str, Any]] = []
 

--- a/orchestrator/tests/test_contract_router_decode_fail_telemetry_challenger.py
+++ b/orchestrator/tests/test_contract_router_decode_fail_telemetry_challenger.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import json
 from typing import Any
 
-
 # ─── Shared fakes ────────────────────────────────────────────────────────────
 
 

--- a/orchestrator/tests/test_contract_router_decode_fail_telemetry_challenger.py
+++ b/orchestrator/tests/test_contract_router_decode_fail_telemetry_challenger.py
@@ -1,0 +1,383 @@
+"""Contract tests for router decode-fail telemetry (RDFT, REQ-feat-router-telemetry-v3-1777866642).
+
+Black-box behavioral contracts derived from:
+  openspec/changes/REQ-feat-router-telemetry-v3-1777866642/specs/router-decode-fail-telemetry/spec.md
+
+Scenarios covered:
+  RDFT-S1  webhook decode-fail path INSERTs a stage_runs row with
+           stage='router_decode_fail' / outcome='silent_drop' / fail_reason=router-reason
+           and context JSON containing issue_id, raw_tags, verifier_stage.
+  RDFT-S2a BKD verifier issue gets a `router-decode-fail` tag (additive, no dupes,
+           previous tags preserved) AND a description containing the literal
+           'router decode 失败' plus the router reason verbatim.
+  RDFT-S2b When BKDClient.update_issue raises, _emit_decode_fail_telemetry returns
+           normally and emits a WARNING with key 'router.decode_fail.bkd_patch_failed'.
+  RDFT-S3  _emit_decode_fail_telemetry emits exactly one structlog warning with
+           event='router.decode_fail' binding issue_id, req_id, stage, reason, raw_tags;
+           the warning fires BEFORE downstream emits so a hard exception in those
+           paths still leaves the WARNING in the stream.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+
+# ─── Shared fakes ────────────────────────────────────────────────────────────
+
+
+class _FakePool:
+    """Capture both fetchrow and execute calls so we can inspect the stage_runs INSERT."""
+
+    def __init__(self):
+        self.fetchrow_calls: list[tuple[str, tuple]] = []
+        self.execute_calls: list[tuple[str, tuple]] = []
+
+    async def fetchrow(self, sql, *args):
+        self.fetchrow_calls.append((sql, args))
+
+        class _Row(dict):
+            pass
+
+        return _Row(id=1)
+
+    async def execute(self, sql, *args):
+        self.execute_calls.append((sql, args))
+
+
+def _find_stage_runs_insert(
+    calls: list[tuple[str, tuple]],
+) -> tuple[str, tuple] | None:
+    for sql, args in calls:
+        if "stage_runs" in sql.lower() and "insert" in sql.lower():
+            return sql, args
+    return None
+
+
+def _make_bkd_factory(
+    *,
+    prev_tags: list[str],
+    description: str = "",
+    capture_update: list | None = None,
+    update_raises: BaseException | None = None,
+):
+    """Return a fake BKDClient class compatible with `async with BKDClient(...) as bkd:`."""
+
+    class _BKD:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get_issue(self, *a, **kw):
+            class _Issue:
+                pass
+
+            _Issue.tags = list(prev_tags)
+            _Issue.description = description
+            return _Issue()
+
+        async def update_issue(self, *a, **kw):
+            if capture_update is not None:
+                capture_update.append({"args": a, "kwargs": kw})
+            if update_raises is not None:
+                raise update_raises
+
+    return _BKD
+
+
+# ─── RDFT-S1: stage_runs row written when no decision JSON is found ──────────
+
+
+async def test_rdft_s1_stage_runs_row_inserted_on_decode_fail(monkeypatch):
+    """RDFT-S1: terminal verifier decode-fail must INSERT exactly one stage_runs
+    row with stage='router_decode_fail', outcome='silent_drop', fail_reason
+    matching the router reason, and context JSON containing issue_id, raw_tags,
+    verifier_stage.
+
+    Driven through the public helper webhook._emit_decode_fail_telemetry, which
+    the spec names as the seam used by the webhook session.completed handler.
+    """
+    from orchestrator import webhook
+
+    pool = _FakePool()
+    raw_tags = ["verifier", "verify:staging_test", "REQ-rdft-s1"]
+    reason = "no decision JSON found in tag or description"
+
+    monkeypatch.setattr(
+        webhook,
+        "BKDClient",
+        _make_bkd_factory(prev_tags=raw_tags, capture_update=[]),
+    )
+
+    await webhook._emit_decode_fail_telemetry(
+        pool=pool,
+        project_id="proj-rdft",
+        issue_id="issue-rdft-s1",
+        req_id="REQ-rdft-s1",
+        verifier_stage="staging_test",
+        reason=reason,
+        raw_tags=raw_tags,
+    )
+
+    insert = _find_stage_runs_insert(pool.fetchrow_calls) or _find_stage_runs_insert(
+        pool.execute_calls
+    )
+    assert insert is not None, (
+        "RDFT-S1: webhook decode-fail path must INSERT INTO stage_runs; "
+        f"saw fetchrow={pool.fetchrow_calls!r} execute={pool.execute_calls!r}"
+    )
+    sql, args = insert
+    flat = list(args)
+
+    # serialize once for cheap substring checks
+    blob = " ".join(repr(a) for a in flat)
+    assert "router_decode_fail" in blob, (
+        f"RDFT-S1: stage column must be 'router_decode_fail'; args={flat!r}"
+    )
+    assert "silent_drop" in blob, (
+        f"RDFT-S1: outcome column must be 'silent_drop'; args={flat!r}"
+    )
+    assert reason in blob, (
+        f"RDFT-S1: fail_reason must match router reason {reason!r}; args={flat!r}"
+    )
+
+    # Find the context dict (asyncpg may pass dict or JSON-encoded string)
+    ctx: dict | None = None
+    for a in flat:
+        if isinstance(a, dict) and "issue_id" in a:
+            ctx = a
+            break
+        if isinstance(a, str) and a.lstrip().startswith("{"):
+            try:
+                d = json.loads(a)
+            except Exception:
+                continue
+            if isinstance(d, dict) and "issue_id" in d:
+                ctx = d
+                break
+    assert ctx is not None, (
+        f"RDFT-S1: stage_runs row must include a context JSON with issue_id; args={flat!r}"
+    )
+    assert ctx.get("issue_id") == "issue-rdft-s1", (
+        f"RDFT-S1: context.issue_id must be 'issue-rdft-s1'; got {ctx!r}"
+    )
+    assert ctx.get("verifier_stage") == "staging_test", (
+        f"RDFT-S1: context.verifier_stage must be 'staging_test'; got {ctx!r}"
+    )
+    raw = ctx.get("raw_tags")
+    assert isinstance(raw, list) and "verifier" in raw, (
+        f"RDFT-S1: context.raw_tags must be a list including 'verifier'; got {ctx!r}"
+    )
+
+
+# ─── RDFT-S2a: BKD update_issue called with tag + warning text ───────────────
+
+
+async def test_rdft_s2a_bkd_update_issue_with_tag_and_warning(monkeypatch):
+    """RDFT-S2: _emit_decode_fail_telemetry MUST PATCH the verifier issue with
+    both (a) tags = previous_tags + ['router-decode-fail'] (additive, no dupes,
+    previous tags preserved) and (b) description containing the literal
+    'router decode 失败' plus the router reason verbatim.
+    """
+    from orchestrator import webhook
+
+    prev_tags = ["verifier", "verify:staging_test", "REQ-rdft-s2", "result:pass"]
+    captured: list = []
+    reason = "invalid decision: invalid action: 'pass'"
+
+    monkeypatch.setattr(
+        webhook,
+        "BKDClient",
+        _make_bkd_factory(
+            prev_tags=prev_tags,
+            description="prior body",
+            capture_update=captured,
+        ),
+    )
+
+    await webhook._emit_decode_fail_telemetry(
+        pool=_FakePool(),
+        project_id="proj-rdft",
+        issue_id="issue-rdft-s2",
+        req_id="REQ-rdft-s2",
+        verifier_stage="staging_test",
+        reason=reason,
+        raw_tags=prev_tags,
+    )
+
+    assert len(captured) == 1, (
+        f"RDFT-S2: BKD update_issue must be called exactly once for the decode-fail "
+        f"issue; got {len(captured)} call(s): {captured!r}"
+    )
+    call = captured[0]
+    kw = call["kwargs"]
+
+    new_tags = kw.get("tags")
+    assert new_tags is not None, (
+        f"RDFT-S2: update_issue must pass tags=; got kwargs={kw!r}"
+    )
+    for t in prev_tags:
+        assert t in new_tags, (
+            f"RDFT-S2: previous tag {t!r} must be preserved in additive PATCH; "
+            f"got {new_tags!r}"
+        )
+    assert "router-decode-fail" in new_tags, (
+        f"RDFT-S2: new tags must include 'router-decode-fail'; got {new_tags!r}"
+    )
+    assert len(new_tags) == len(set(new_tags)), (
+        f"RDFT-S2: tags must be deduplicated; got {new_tags!r}"
+    )
+
+    desc = kw.get("description")
+    assert isinstance(desc, str), (
+        f"RDFT-S2: update_issue must pass description=<str>; got {desc!r}"
+    )
+    assert "router decode 失败" in desc, (
+        f"RDFT-S2: description must contain literal 'router decode 失败'; got {desc!r}"
+    )
+    assert reason in desc, (
+        f"RDFT-S2: description must contain router reason verbatim {reason!r}; "
+        f"got {desc!r}"
+    )
+
+
+# ─── RDFT-S2b: BKD failure is isolated, WARNING surfaced ─────────────────────
+
+
+async def test_rdft_s2b_bkd_failure_isolated(monkeypatch, caplog):
+    """RDFT-S2 (failure-isolation half): when BKDClient.update_issue raises,
+    _emit_decode_fail_telemetry MUST still return normally and the in-memory
+    log MUST capture a WARNING with key 'router.decode_fail.bkd_patch_failed'.
+    """
+    from orchestrator import webhook
+
+    monkeypatch.setattr(
+        webhook,
+        "BKDClient",
+        _make_bkd_factory(
+            prev_tags=["verifier"],
+            update_raises=RuntimeError("bkd-down"),
+        ),
+    )
+
+    caplog.set_level(logging.WARNING)
+
+    # MUST NOT raise — the surrounding webhook flow must keep going.
+    await webhook._emit_decode_fail_telemetry(
+        pool=_FakePool(),
+        project_id="proj-rdft",
+        issue_id="issue-rdft-s2b",
+        req_id="REQ-rdft-s2b",
+        verifier_stage="staging_test",
+        reason="any reason",
+        raw_tags=["verifier"],
+    )
+
+    def _record_blob(rec: logging.LogRecord) -> str:
+        bits = [rec.getMessage()]
+        for k in ("event", "msg"):
+            v = getattr(rec, k, None)
+            if v is not None:
+                bits.append(str(v))
+        return " ".join(bits)
+
+    found = any(
+        "router.decode_fail.bkd_patch_failed" in _record_blob(rec)
+        for rec in caplog.records
+    )
+    assert found, (
+        "RDFT-S2: BKD update_issue raise must NOT propagate; function must log a "
+        "WARNING with key 'router.decode_fail.bkd_patch_failed'. "
+        f"Captured records: {[r.getMessage() for r in caplog.records]!r}"
+    )
+
+
+# ─── RDFT-S3: structlog WARNING with structured fields, fired first ──────────
+
+
+async def test_rdft_s3_warning_log_with_structured_fields(monkeypatch):
+    """RDFT-S3: _emit_decode_fail_telemetry MUST emit exactly one structlog
+    warning with event='router.decode_fail' binding issue_id, req_id, stage,
+    reason, raw_tags. The warning MUST fire BEFORE any best-effort downstream
+    emit so a hard exception in those paths still leaves the line in the stream.
+    """
+    from orchestrator import webhook
+    import orchestrator.store.stage_runs as sr_mod
+
+    captured: list[dict[str, Any]] = []
+
+    class _StubLogger:
+        def warning(self, event, **kw):
+            captured.append({"event": event, **kw})
+
+        def info(self, *a, **kw):
+            pass
+
+        def error(self, *a, **kw):
+            pass
+
+        def debug(self, *a, **kw):
+            pass
+
+        def bind(self, **kw):
+            return self
+
+    assert hasattr(webhook, "log"), (
+        "RDFT-S3: webhook module must expose a `log` (structlog) attribute for telemetry"
+    )
+    monkeypatch.setattr(webhook, "log", _StubLogger())
+
+    # Force EVERY downstream emit to blow up — log MUST still be captured because
+    # it has to fire first.
+    async def _boom(*a, **kw):
+        raise RuntimeError("downstream-explosion")
+
+    monkeypatch.setattr(sr_mod, "insert_decode_fail", _boom)
+    if hasattr(webhook, "insert_decode_fail"):
+        monkeypatch.setattr(webhook, "insert_decode_fail", _boom)
+    monkeypatch.setattr(
+        webhook,
+        "BKDClient",
+        _make_bkd_factory(
+            prev_tags=["verifier"],
+            update_raises=RuntimeError("downstream-explosion"),
+        ),
+    )
+
+    raw_tags = ["verifier", "verify:staging_test", "REQ-rdft-s3"]
+    reason = "no decision JSON found in tag or description"
+
+    # MUST NOT raise even with everything below blowing up.
+    await webhook._emit_decode_fail_telemetry(
+        pool=_FakePool(),
+        project_id="proj-rdft",
+        issue_id="issue-rdft-s3",
+        req_id="REQ-rdft-s3",
+        verifier_stage="staging_test",
+        reason=reason,
+        raw_tags=raw_tags,
+    )
+
+    matches = [c for c in captured if c.get("event") == "router.decode_fail"]
+    assert len(matches) == 1, (
+        f"RDFT-S3: must emit exactly one log.warning with event='router.decode_fail'; "
+        f"got {captured!r}"
+    )
+    rec = matches[0]
+    for key, want in [
+        ("issue_id", "issue-rdft-s3"),
+        ("req_id", "REQ-rdft-s3"),
+        ("stage", "staging_test"),
+        ("reason", reason),
+    ]:
+        assert key in rec, f"RDFT-S3: log must bind {key!r}; got {rec!r}"
+        assert rec[key] == want, f"RDFT-S3: log {key}={rec[key]!r}, want {want!r}"
+    assert "raw_tags" in rec and list(rec["raw_tags"]) == list(raw_tags), (
+        f"RDFT-S3: log must bind raw_tags={raw_tags!r}; got {rec.get('raw_tags')!r}"
+    )

--- a/orchestrator/tests/test_contract_router_decode_fail_telemetry_challenger.py
+++ b/orchestrator/tests/test_contract_router_decode_fail_telemetry_challenger.py
@@ -135,16 +135,17 @@ async def test_rdft_s1_stage_runs_row_inserted_on_decode_fail(monkeypatch):
     sql, args = insert
     flat = list(args)
 
-    # serialize once for cheap substring checks
-    blob = " ".join(repr(a) for a in flat)
+    # serialize once for cheap substring checks. Some columns (stage/outcome) may be
+    # baked as SQL literals rather than bound params, so include the SQL in the blob.
+    blob = sql + " " + " ".join(repr(a) for a in flat)
     assert "router_decode_fail" in blob, (
-        f"RDFT-S1: stage column must be 'router_decode_fail'; args={flat!r}"
+        f"RDFT-S1: stage column must be 'router_decode_fail'; sql={sql!r} args={flat!r}"
     )
     assert "silent_drop" in blob, (
-        f"RDFT-S1: outcome column must be 'silent_drop'; args={flat!r}"
+        f"RDFT-S1: outcome column must be 'silent_drop'; sql={sql!r} args={flat!r}"
     )
     assert reason in blob, (
-        f"RDFT-S1: fail_reason must match router reason {reason!r}; args={flat!r}"
+        f"RDFT-S1: fail_reason must match router reason {reason!r}; sql={sql!r} args={flat!r}"
     )
 
     # Find the context dict (asyncpg may pass dict or JSON-encoded string)
@@ -250,13 +251,32 @@ async def test_rdft_s2a_bkd_update_issue_with_tag_and_warning(monkeypatch):
 # ─── RDFT-S2b: BKD failure is isolated, WARNING surfaced ─────────────────────
 
 
-async def test_rdft_s2b_bkd_failure_isolated(monkeypatch, caplog):
+async def test_rdft_s2b_bkd_failure_isolated(monkeypatch):
     """RDFT-S2 (failure-isolation half): when BKDClient.update_issue raises,
-    _emit_decode_fail_telemetry MUST still return normally and the in-memory
-    log MUST capture a WARNING with key 'router.decode_fail.bkd_patch_failed'.
+    _emit_decode_fail_telemetry MUST still return normally and emit a structlog
+    WARNING with key 'router.decode_fail.bkd_patch_failed'.
     """
     from orchestrator import webhook
 
+    captured: list[dict[str, Any]] = []
+
+    class _StubLogger:
+        def warning(self, event, **kw):
+            captured.append({"level": "warning", "event": event, **kw})
+
+        def info(self, *a, **kw):
+            pass
+
+        def error(self, *a, **kw):
+            pass
+
+        def debug(self, *a, **kw):
+            pass
+
+        def bind(self, **kw):
+            return self
+
+    monkeypatch.setattr(webhook, "log", _StubLogger())
     monkeypatch.setattr(
         webhook,
         "BKDClient",
@@ -265,8 +285,6 @@ async def test_rdft_s2b_bkd_failure_isolated(monkeypatch, caplog):
             update_raises=RuntimeError("bkd-down"),
         ),
     )
-
-    caplog.set_level(logging.WARNING)
 
     # MUST NOT raise — the surrounding webhook flow must keep going.
     await webhook._emit_decode_fail_telemetry(
@@ -279,22 +297,11 @@ async def test_rdft_s2b_bkd_failure_isolated(monkeypatch, caplog):
         raw_tags=["verifier"],
     )
 
-    def _record_blob(rec: logging.LogRecord) -> str:
-        bits = [rec.getMessage()]
-        for k in ("event", "msg"):
-            v = getattr(rec, k, None)
-            if v is not None:
-                bits.append(str(v))
-        return " ".join(bits)
-
-    found = any(
-        "router.decode_fail.bkd_patch_failed" in _record_blob(rec)
-        for rec in caplog.records
-    )
-    assert found, (
+    found = [c for c in captured if c.get("event") == "router.decode_fail.bkd_patch_failed"]
+    assert len(found) >= 1, (
         "RDFT-S2: BKD update_issue raise must NOT propagate; function must log a "
-        "WARNING with key 'router.decode_fail.bkd_patch_failed'. "
-        f"Captured records: {[r.getMessage() for r in caplog.records]!r}"
+        "WARNING with event='router.decode_fail.bkd_patch_failed'. "
+        f"Captured warnings: {captured!r}"
     )
 
 

--- a/orchestrator/tests/test_webhook_decode_fail_telemetry.py
+++ b/orchestrator/tests/test_webhook_decode_fail_telemetry.py
@@ -1,0 +1,259 @@
+"""Router decode-fail telemetry — 3 emit signals at terminal verifier escalate
+(closes phona/sisyphus#372).
+
+Covers spec scenarios RDFT-S1..S3 in
+``openspec/changes/REQ-feat-router-telemetry-v3-1777866642/specs/router-decode-fail-telemetry/spec.md``.
+"""
+from __future__ import annotations
+
+from typing import ClassVar
+
+import pytest
+import structlog
+
+from orchestrator import webhook
+from orchestrator.bkd import Issue
+
+
+class _FakeBKD:
+    """In-memory stub of BKDClient — capture update_issue / get_issue calls."""
+
+    captured_update: ClassVar[list[dict]] = []
+    captured_get: ClassVar[list[tuple[str, str]]] = []
+    raise_on_update: ClassVar[bool] = False
+    raise_on_get: ClassVar[bool] = False
+    issue_tags: ClassVar[list[str]] = []
+    issue_description: ClassVar[str | None] = None
+
+    def __init__(self, *_a, **_kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def get_issue(self, project_id, issue_id):
+        self.captured_get.append((project_id, issue_id))
+        if self.raise_on_get:
+            raise RuntimeError("BKD get_issue down")
+        return Issue(
+            id=issue_id, project_id=project_id, issue_number=1,
+            title="t", status_id="working",
+            tags=list(self.issue_tags),
+            session_status="completed",
+            description=self.issue_description,
+        )
+
+    async def update_issue(self, *, project_id, issue_id, **kw):
+        if self.raise_on_update:
+            raise RuntimeError("BKD update_issue down")
+        self.captured_update.append({
+            "project_id": project_id, "issue_id": issue_id, **kw,
+        })
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_bkd():
+    _FakeBKD.captured_update = []
+    _FakeBKD.captured_get = []
+    _FakeBKD.raise_on_update = False
+    _FakeBKD.raise_on_get = False
+    _FakeBKD.issue_tags = ["verifier", "verify:staging_test", "REQ-x"]
+    _FakeBKD.issue_description = None
+
+
+@pytest.fixture
+def fake_bkd(monkeypatch):
+    monkeypatch.setattr(webhook, "BKDClient", _FakeBKD)
+    return _FakeBKD
+
+
+@pytest.fixture
+def captured_stage_runs(monkeypatch):
+    """Replace stage_runs.insert_decode_fail with a list-capturing stub."""
+    captured: list[dict] = []
+
+    async def fake_insert(pool, **kw):
+        captured.append(kw)
+        return 12345
+
+    monkeypatch.setattr(
+        "orchestrator.webhook.stage_runs.insert_decode_fail", fake_insert,
+    )
+    return captured
+
+
+@pytest.fixture
+def captured_obs(monkeypatch):
+    captured: list[dict] = []
+
+    async def fake_record(kind, *, req_id=None, issue_id=None, extras=None, **_kw):
+        captured.append({
+            "kind": kind, "req_id": req_id, "issue_id": issue_id,
+            "extras": extras,
+        })
+
+    monkeypatch.setattr("orchestrator.webhook.obs.record_event", fake_record)
+    return captured
+
+
+@pytest.fixture
+def captured_logs():
+    """structlog testing helper — returns the in-memory log entries."""
+    cap = structlog.testing.LogCapture()
+    structlog.configure(processors=[cap])
+    yield cap
+    structlog.reset_defaults()
+
+
+@pytest.mark.asyncio
+async def test_stage_runs_row_inserted_on_decode_fail(
+    fake_bkd, captured_stage_runs, captured_obs,
+):
+    """RDFT-S1: stage_runs row inserted with stage='router_decode_fail',
+    outcome='silent_drop', and full context."""
+    await webhook._emit_decode_fail_telemetry(
+        pool=object(),  # stub — fake helper ignores it
+        project_id="proj-1",
+        issue_id="vfy-1",
+        req_id="REQ-x",
+        verifier_stage="staging_test",
+        reason="no decision JSON found in tag or description",
+        raw_tags=["verifier", "verify:staging_test", "REQ-x"],
+    )
+
+    assert len(captured_stage_runs) == 1
+    row = captured_stage_runs[0]
+    assert row["req_id"] == "REQ-x"
+    assert row["issue_id"] == "vfy-1"
+    assert row["verifier_stage"] == "staging_test"
+    assert row["reason"].startswith("no decision JSON")
+    assert row["raw_tags"] == ["verifier", "verify:staging_test", "REQ-x"]
+
+
+@pytest.mark.asyncio
+async def test_bkd_issue_tag_and_description_patched(
+    fake_bkd, captured_stage_runs, captured_obs,
+):
+    """RDFT-S2: BKD `update_issue` call carries tags + description with the
+    decode-fail signal, both reason and raw_tags surfaced verbatim."""
+    _FakeBKD.issue_tags = ["verifier", "verify:staging_test", "REQ-x"]
+    _FakeBKD.issue_description = "original prompt body"
+
+    await webhook._emit_decode_fail_telemetry(
+        pool=object(),
+        project_id="proj-1",
+        issue_id="vfy-1",
+        req_id="REQ-x",
+        verifier_stage="staging_test",
+        reason="invalid decision: invalid action: 'pass'",
+        raw_tags=["verifier", "verify:staging_test", "REQ-x", "decision:pass"],
+    )
+
+    assert len(_FakeBKD.captured_update) == 1
+    payload = _FakeBKD.captured_update[0]
+    assert payload["project_id"] == "proj-1"
+    assert payload["issue_id"] == "vfy-1"
+
+    assert "router-decode-fail" in payload["tags"]
+    # Existing tags preserved, no duplicates of router-decode-fail
+    assert payload["tags"].count("router-decode-fail") == 1
+    for original in _FakeBKD.issue_tags:
+        assert original in payload["tags"]
+
+    assert "router decode 失败" in payload["description"]
+    assert "invalid action: 'pass'" in payload["description"]
+    # Original body preserved before warning block
+    assert payload["description"].startswith("original prompt body")
+
+
+@pytest.mark.asyncio
+async def test_warning_log_emitted_first(
+    captured_logs, fake_bkd, captured_stage_runs, captured_obs,
+):
+    """RDFT-S3: a single WARNING-level `router.decode_fail` log entry is emitted
+    with structured `issue_id` / `req_id` / `stage` / `reason` / `raw_tags`."""
+    await webhook._emit_decode_fail_telemetry(
+        pool=object(),
+        project_id="proj-1",
+        issue_id="vfy-1",
+        req_id="REQ-x",
+        verifier_stage="staging_test",
+        reason="no decision JSON found in tag or description",
+        raw_tags=["verifier", "REQ-x"],
+    )
+
+    matching = [
+        e for e in captured_logs.entries
+        if e.get("event") == "router.decode_fail"
+        and e.get("log_level") == "warning"
+    ]
+    assert len(matching) == 1, captured_logs.entries
+    e = matching[0]
+    assert e["issue_id"] == "vfy-1"
+    assert e["req_id"] == "REQ-x"
+    assert e["stage"] == "staging_test"
+    assert e["reason"] == "no decision JSON found in tag or description"
+    assert e["raw_tags"] == ["verifier", "REQ-x"]
+
+
+@pytest.mark.asyncio
+async def test_bkd_failure_does_not_block_other_signals(
+    captured_logs, fake_bkd, captured_stage_runs, captured_obs,
+):
+    """RDFT-S2 isolation: when BKD update_issue raises, stage_runs row + obs
+    record + WARNING log still fire."""
+    _FakeBKD.raise_on_update = True
+
+    await webhook._emit_decode_fail_telemetry(
+        pool=object(),
+        project_id="proj-1",
+        issue_id="vfy-1",
+        req_id="REQ-x",
+        verifier_stage="staging_test",
+        reason="some reason",
+        raw_tags=["verifier"],
+    )
+
+    # stage_runs still inserted
+    assert len(captured_stage_runs) == 1
+    # obs.record_event still called
+    assert any(c["kind"] == "router.decode_fail" for c in captured_obs)
+    # primary warning still logged
+    assert any(
+        e.get("event") == "router.decode_fail" and e.get("log_level") == "warning"
+        for e in captured_logs.entries
+    )
+    # BKD-failure-specific WARNING also logged
+    assert any(
+        e.get("event") == "router.decode_fail.bkd_patch_failed"
+        for e in captured_logs.entries
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_req_id_skips_stage_runs_but_still_logs(
+    captured_logs, fake_bkd, captured_stage_runs, captured_obs,
+):
+    """When req_id is None (extract_req_id returned nothing), stage_runs insert
+    is skipped (FK / NOT NULL safety) but the BKD signal + warning log still fire."""
+    await webhook._emit_decode_fail_telemetry(
+        pool=object(),
+        project_id="proj-1",
+        issue_id="vfy-1",
+        req_id=None,
+        verifier_stage="unknown",
+        reason="no decision JSON found in tag or description",
+        raw_tags=["verifier"],
+    )
+
+    assert captured_stage_runs == []
+    # BKD PATCH still attempted
+    assert len(_FakeBKD.captured_update) == 1
+    # Warning still logged
+    assert any(
+        e.get("event") == "router.decode_fail" and e.get("log_level") == "warning"
+        for e in captured_logs.entries
+    )


### PR DESCRIPTION
## Summary

Closes phona/sisyphus#372 — verifier router decode-fail used to be silent
(零 BKD 反馈、零 queryable obs、log.info 级被 noise 淹没). Adds 3 explicit
emit signals at the terminal escalate point.

## Changes

- **`store/stage_runs.py`**: new `insert_decode_fail` helper writing one
  closed `stage_runs` row (`stage='router_decode_fail'`,
  `outcome='silent_drop'`, JSONB `context` carrying `issue_id` / `raw_tags`
  / `verifier_stage`). Reuses the existing `stage_runs` schema — no new
  migration.
- **`webhook.py`**: new `_emit_decode_fail_telemetry` that fires 3 signals,
  each isolated by try/except so a single sink failure does not silence
  the others:
  1. `log.warning('router.decode_fail', ...)` — emitted **first**, so even
     a hard exception in the downstream calls still leaves a breadcrumb.
  2. `stage_runs.insert_decode_fail` — queryable in Metabase
     (`WHERE stage='router_decode_fail'`).
  3. BKD `update_issue` — adds `router-decode-fail` tag (additive, dedup)
     plus appends a `⚠️ sisyphus router decode 失败 ...` block to the
     issue description (best-effort).
  Wired at the end of the verifier-decision block, **only** when
  `event == VERIFY_ESCALATE` and `why` is non-empty (catches both the
  retry_worthy=False initial path and the retry-exhausted path; leaves
  the in-flight retry follow_up untouched).
- **`tests/test_webhook_decode_fail_telemetry.py`**: 5 unit tests
  covering RDFT-S1..S3 from the spec plus BKD-failure isolation and the
  no-req-id edge case.

## openspec change

`openspec/changes/REQ-feat-router-telemetry-v3-1777866642/` —
proposal + 3 RDFT-S* scenarios + tasks (all checked).
\`openspec validate REQ-feat-router-telemetry-v3-1777866642 --strict\`
passes; \`check-scenario-refs.sh\` clean.

## Test plan

- [x] `make ci-lint` — pass
- [x] `make ci-integration-test` — pass (no PG → exit 5 → pass per Makefile contract)
- [x] `uv run pytest tests/test_webhook_decode_fail_telemetry.py` — 5/5 pass
- [x] `openspec validate ... --strict` — pass

\`make ci-unit-test\` still surfaces the same **31 pre-existing failures**
that exist on `main` (verified by stash + rerun) — none are caused by this
change. They look like cross-test pollution in `test_runner_gc.py` /
`test_engine.py` / `test_engine_verifier_loop.py`; out of scope for this REQ.

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-feat-router-telemetry-v3-1777866642\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/ni4yx2z1)