### PR TITLE
feat(observability): sisyphus-trace CLI + Q24 REQ trace view (closes #381)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,22 @@ python3 scripts/sisyphus-admin.py admin pr-merged <req_id> --pr-url <url> --merg
 
 环境变量：`SISYPHUS_ADMIN_TOKEN`（Bearer token，留空从 kubectl secret 取）。`--base-url` 留空绕 kubectl port-forward，提供（如 `http://sisyphus.43.239.84.24.nip.io`）则直接走 HTTP。完整子命令：`python3 scripts/sisyphus-admin.py --help`。
 
+### scripts/sisyphus-trace.py —— REQ 卡住怎么 debug
+
+把 sisyphus 主库 4 张表（`req_state.history` + `stage_runs` + `verifier_decisions`
++ `artifact_checks`）按 ts UNION 渲染成时间线。30 min 翻 BKD + grep 源码 → 30 s 看一张表。
+
+```bash
+# ASCII 时间线
+python3 scripts/sisyphus-trace.py REQ-feat-foo-1777xxx
+
+# NDJSON, 给 jq pipe
+python3 scripts/sisyphus-trace.py REQ-foo --json | jq 'select(.kind=="verify")'
+```
+
+Metabase 同款查询：[observability/queries/sisyphus/24-req-trace.sql](observability/queries/sisyphus/24-req-trace.sql)（Q24, 参数 `{{req_id}}`）。
+event_log（n8n / orch tap）住 `sisyphus_obs` 库，跨库 view 不做，不在本工具范围内。
+
 ## 文档索引
 
 | 文档 | 内容 |

--- a/observability/queries/sisyphus/24-req-trace.sql
+++ b/observability/queries/sisyphus/24-req-trace.sql
@@ -1,0 +1,113 @@
+-- Q24: REQ trace view — 单 REQ 全生命周期事件按时间轴聚合 (REQ-feat-req-trace-view-381-v2-1777866643)
+--
+-- 数据源：sisyphus 主库 (orchestrator)
+--   - req_state.history (JSONB array, jsonb_array_elements 展开) — state 转移
+--   - stage_runs                                                   — agent 调用起止
+--   - verifier_decisions                                           — verifier 判决
+--   - artifact_checks                                              — 机械 checker 通过/失败
+--
+-- event_log 在 sisyphus_obs 库不在本 SQL 里 (跨库 view 不做; 见 0002_observability_views.sql)。
+-- CLI scripts/sisyphus-trace.py 负责跨库时再合; 本 Q 只覆盖主库 4 表。
+--
+-- 用途：debug "REQ 卡住不动" — 一眼看到该 REQ 的 trans / stage / verify / check 时间轴。
+-- 30 min 翻 BKD + grep 源码 → 30 s 看一张表。
+--
+-- 列：
+--   ts         事件时间戳
+--   kind       事件类别 (trans / stage / verify / check)
+--   detail     单行可读描述
+--
+-- Metabase 用法：
+--   1. New Question → SQL 模式 → sisyphus 数据源 → 粘贴本 SQL
+--   2. Variables: 加 `req_id` (Text, Required), 模板 `{{req_id}}`
+--   3. Visualization: Table, 按 ts ASC (SQL 自带 ORDER BY 已保证)
+--
+-- 命令行用法：
+--   scripts/sisyphus-trace.py REQ-XXXX
+
+WITH trans AS (
+    SELECT
+        (h.val->>'ts')::timestamptz                                     AS ts,
+        'trans'::text                                                    AS kind,
+        format(
+            '%s → %s (event=%s action=%s)',
+            COALESCE(h.val->>'from', '?'),
+            COALESCE(h.val->>'to',   '?'),
+            COALESCE(h.val->>'event','?'),
+            COALESCE(h.val->>'action','?')
+        )                                                                AS detail
+    FROM req_state r,
+         LATERAL jsonb_array_elements(r.history) AS h(val)
+    WHERE r.req_id = {{req_id}}
+),
+stages AS (
+    -- 每行 stage_runs 拆成 start + end 两个事件 (end 仅当 ended_at 非空)
+    SELECT
+        sr.started_at                                                    AS ts,
+        'stage'::text                                                    AS kind,
+        format(
+            '%s start (run_id=%s agent=%s model=%s)',
+            sr.stage,
+            sr.id,
+            COALESCE(sr.agent_type, '?'),
+            COALESCE(sr.model,      '?')
+        )                                                                AS detail
+    FROM stage_runs sr
+    WHERE sr.req_id = {{req_id}}
+
+    UNION ALL
+
+    SELECT
+        sr.ended_at                                                      AS ts,
+        'stage'::text                                                    AS kind,
+        format(
+            '%s end %s (token_in=%s token_out=%s dur=%ss)',
+            sr.stage,
+            COALESCE(sr.outcome, '?'),
+            COALESCE(sr.token_in::text,  '?'),
+            COALESCE(sr.token_out::text, '?'),
+            COALESCE(ROUND(sr.duration_sec::numeric, 1)::text, '?')
+        )                                                                AS detail
+    FROM stage_runs sr
+    WHERE sr.req_id = {{req_id}}
+      AND sr.ended_at IS NOT NULL
+),
+verifies AS (
+    SELECT
+        vd.made_at                                                       AS ts,
+        'verify'::text                                                   AS kind,
+        format(
+            '%s/%s → %s (conf=%s fixer=%s reason=%s)',
+            vd.stage,
+            vd.trigger,
+            COALESCE(vd.decision_action,     '?'),
+            COALESCE(vd.decision_confidence, '?'),
+            COALESCE(vd.decision_fixer,      '-'),
+            COALESCE(left(vd.decision_reason, 80), '-')
+        )                                                                AS detail
+    FROM verifier_decisions vd
+    WHERE vd.req_id = {{req_id}}
+),
+checks AS (
+    SELECT
+        ac.checked_at                                                    AS ts,
+        'check'::text                                                    AS kind,
+        format(
+            '%s %s (exit=%s dur=%ss cmd=%s)',
+            ac.stage,
+            CASE WHEN ac.passed THEN 'passed' ELSE 'failed' END,
+            COALESCE(ac.exit_code::text,                       '?'),
+            COALESCE(ROUND(ac.duration_sec::numeric, 1)::text, '?'),
+            COALESCE(left(ac.cmd, 80),                         '-')
+        )                                                                AS detail
+    FROM artifact_checks ac
+    WHERE ac.req_id = {{req_id}}
+)
+SELECT ts, kind, detail FROM trans
+UNION ALL
+SELECT ts, kind, detail FROM stages
+UNION ALL
+SELECT ts, kind, detail FROM verifies
+UNION ALL
+SELECT ts, kind, detail FROM checks
+ORDER BY ts ASC;

--- a/observability/sisyphus-dashboard.md
+++ b/observability/sisyphus-dashboard.md
@@ -335,6 +335,34 @@ NULL bucket 是"在途或未覆盖"，Q21 单独一行显示。
 └──────────────────────────────┴──────────────────────────────┘
 ```
 
+## REQ 全生命周期 trace（Q24，REQ-feat-req-trace-view-381-v2-1777866643）
+
+debug "REQ 卡住不动" 当前要 `curl` BKD + `grep` 源码 + 手动拼时间线 ~30 min。
+Q24 把数据已落 PG 的 4 张主库表（`req_state.history` / `stage_runs` /
+`verifier_decisions` / `artifact_checks`）按 `ts` UNION 一起，按时间轴看：
+
+> `event_log` 在 `sisyphus_obs` 库不在本 Q（跨库 view 不做，见
+> `migrations/0002_observability_views.sql`）。命令行 `scripts/sisyphus-trace.py`
+> 是同一份 SQL 的薄包装，未来想合 event_log 时改 CLI 一处即可。
+
+### Q24. REQ trace view（单 REQ 全生命周期事件按时间轴）
+
+- **SQL**：[queries/sisyphus/24-req-trace.sql](queries/sisyphus/24-req-trace.sql)
+- **Variables**：`req_id` (Text, Required) — Metabase 模板 `{{req_id}}`
+- **Visualization**：Table（列：`ts, kind, detail`），按 `ts ASC`（SQL 自带 ORDER BY）
+  - 条件格式：`kind = 'verify'` 行底色橙；`detail` 含 `escalated` / `failed` 整行底色红
+- **次选 Visualization**：Bar chart 看事件密度按 5 min bin（X = `ts` truncate to 5min，Y = COUNT，按 `kind` 分组）
+- **CLI 等价物**：`scripts/sisyphus-trace.py REQ-XXXX`（见 [CLAUDE.md "REQ 卡住怎么 debug"](../CLAUDE.md)）
+- **kind 字典**：
+  - `trans` — `req_state.history` 解出的 state 转移
+  - `stage` — `stage_runs` 起 / 止两条事件
+  - `verify` — `verifier_decisions` 单条判决
+  - `check` — `artifact_checks` 通过 / 失败
+- **使用场景**：
+  - 单 REQ 卡死 → 找最后一条非 `trans` 事件，看 detail 里 cmd / reason
+  - verifier 反复 fix 不收敛 → grep `kind = 'verify'` 看 confidence / fixer 历史
+  - dedup 命中疑似 → 对比 `trans` 与 `stage` 的相邻 ts，gap 大 = 路由没派出去
+
 ## 刷新频率
 
 M7 看板：
@@ -359,6 +387,9 @@ PR queue health 看板：
 终态记账看板：
 - Q21：每 1 小时（趋势类，token 分布变化慢）
 - Q22：每 1 小时（leaderboard 变化慢；有新高耗 REQ 完成时才需关注）
+
+REQ trace 看板：
+- Q24：按需查（参数化 `req_id` 没默认值，操作员主动跑；不挂 dashboard tile，挂 Question library）
 
 Metabase Question 设置 `Results cache TTL`：Q5/Q1 设 30s，Q2/Q3/Q4/Q12/Q13/Q17/Q18 设 120s，其余设 1800s。
 

--- a/openspec/changes/REQ-feat-req-trace-view-381-v2-1777866643/proposal.md
+++ b/openspec/changes/REQ-feat-req-trace-view-381-v2-1777866643/proposal.md
@@ -1,0 +1,84 @@
+# Proposal: REQ trace view — sisyphus-trace CLI + Metabase Q24
+
+Refs phona/sisyphus#381 (origin), #380 (verifier resume webhook bug — first user).
+
+## 背景
+
+Debug "REQ 卡住不动" 当前路径（#381 描述）：
+1. `curl` BKD 拿 issue tags + sub-issue 列表
+2. `grep` `webhook.py` / `state.py` / `actions/` 源码猜 orch 行为
+3. 手动在脑子里拼时间线 → 单次 ~30min
+
+实际数据全在 PG 主库 `sisyphus`：
+
+- `req_state.history` JSONB array — state 转移序列（`{ts, from, to, event, action}`）
+- `stage_runs` — agent 调用起止 + 模型 + 成本
+- `verifier_decisions` — verifier 判决（pass/fix/escalate）
+- `artifact_checks` — 机械 checker 通过/失败 + cmd / stderr_tail
+
+缺的是按 ts 排序的统一 timeline 视图：
+单 REQ 的 4 表事件按时间轴聚合一行一事件。
+
+> 注：`event_log`（n8n / orch tap）住在独立 DB `sisyphus_obs`，跨库 view 不做（见
+> `orchestrator/migrations/0002_observability_views.sql` 注释）。本 REQ 范围只覆盖
+> 主库 4 表。CLI 留扩展点，将来想加 event_log 时改一处即可。
+
+## 提议
+
+### A. Metabase Question Q24（SQL，主库内 UNION）
+
+`observability/queries/sisyphus/24-req-trace.sql`：UNION 4 个子查询，按 `ts ASC`
+排序，参数 `{{req_id}}`。返回列：
+
+| 列 | 含义 |
+|---|---|
+| `ts` | 事件时间戳（TIMESTAMPTZ） |
+| `kind` | `trans` / `stage` / `verify` / `check` 之一 |
+| `detail` | 单行可读字符串（如 `INIT → ANALYZING (event=intent.analyze action=create_analyze)`） |
+
+> Q23 已被 `23-first-turn-token-composition.sql` 占用（REQ-feat-agent-turns-collector-1777796671），
+> 本次按 Metabase 看板既有的 Q21/Q22 双号惯例顺势改用 **Q24**。intent issue
+> 沟通时写的是 Q23，PR description 把改号原因记下来。
+
+### B. CLI `sisyphus-trace <REQ-id>`
+
+`scripts/sisyphus-trace.py`：
+
+- 默认走 kubectl exec 到 `sisyphus-postgresql-0` pod 跑 `psql -d sisyphus`
+  （和 `sisyphus-admin.py` 完全同款 helper，避免重复一份外部 PG 客户端）
+- `--base-url` / `--dsn` 留口子，未来若 PG 暴露外网端口可绕 kubectl
+- `--json` 输出原始 JSON 行，方便 pipe `jq` / Metabase 参数化复现
+- 默认输出 ASCII 时间线：
+
+```
+sisyphus-trace REQ-feat-req-trace-view-381-v2-1777866643
+─────────────────────────────────────────────────────────
+02:25:46 [trans]   INIT → ANALYZING (event=intent.analyze action=create_analyze)
+02:25:50 [stage]   analyze start (run_id=2231 model=claude-opus-4-7)
+02:33:26 [stage]   analyze end pass (token_in=183k token_out=42k)
+02:33:27 [trans]   ANALYZING → SPEC_LINT_RUNNING
+02:33:30 [check]   spec_lint passed cmd="openspec validate ..." dur=3.1s
+03:00:00 [verify]  pr_ci → escalate (conf=high reason="ci red, no fix path")
+03:00:01 [trans]   PR_CI_RUNNING → ESCALATED
+```
+
+### C. 文档
+
+- `observability/sisyphus-dashboard.md` 新增 Q24 章节 + 看板布局放 "终态记账"
+  下面（debug 类常和事后分析配着看）
+- `CLAUDE.md` "开发规范" 段后增加 "REQ 卡住怎么 debug" 小段，引到这个工具
+
+## 不在范围内
+
+- `event_log`（sisyphus_obs DB）合并：留 follow-up REQ
+- replay-from-trace（#377）：那是回放 payload，本 REQ 是观察现有
+- 任何状态机改动 / 写新表 / 新 migration —— 全部复用现有数据
+
+## 影响
+
+| 依赖 | 验证方式 |
+|---|---|
+| 现有 22 条 Metabase Q | 新增 Q24，不动 Q1–Q23，dashboard.md 加章节不删旧 |
+| `sisyphus-admin.py` PG helper | 重用其 `_pg_query` 风格（kubectl exec + psql -t -A），不引新依赖 |
+| `req_state.history` JSONB schema | 只读 `{ts, from, to, event, action}` 5 个 key，schema 变了仍 graceful（缺 key 显示 `?`） |
+| `stage_runs` / `verifier_decisions` / `artifact_checks` | 只读，不写 |

--- a/openspec/changes/REQ-feat-req-trace-view-381-v2-1777866643/specs/req-trace-cli/spec.md
+++ b/openspec/changes/REQ-feat-req-trace-view-381-v2-1777866643/specs/req-trace-cli/spec.md
@@ -1,0 +1,122 @@
+# req-trace-cli — spec delta
+
+## ADDED Requirements
+
+### Requirement: Q24 SQL aggregates four main-DB tables into one timeline
+
+The repository SHALL provide `observability/queries/sisyphus/24-req-trace.sql`
+which MUST return one row per timeline event for a given REQ. The query MUST
+accept a single Metabase parameter `{{req_id}}` (text), MUST union exactly four
+sub-queries sourced from the orchestrator main DB tables `req_state` (history
+JSONB unrolled via `jsonb_array_elements`), `stage_runs`, `verifier_decisions`
+and `artifact_checks`, and MUST output exactly the columns `ts`
+(`TIMESTAMPTZ`), `kind` (`TEXT`) and `detail` (`TEXT`) ordered by `ts ASC`.
+The `kind` column MUST be one of the literals `trans`, `stage`, `verify`,
+`check`. Each sub-query SHALL be filtered to the supplied `{{req_id}}` so the
+result is bounded to a single REQ.
+
+The query MUST NOT reference `event_log` or any object outside the orchestrator
+main DB schema (event_log lives in `sisyphus_obs` — cross-DB joins are
+explicitly out-of-scope per `migrations/0002_observability_views.sql`). The
+query MUST be self-contained (no dependency on views) so it remains operable
+even when `req_latency` / `req_summary` views are dropped.
+
+#### Scenario: QQ-S1 four named CTEs feed the timeline
+- **GIVEN** the file `observability/queries/sisyphus/24-req-trace.sql`
+- **WHEN** an operator searches for `WITH`-clause CTE names
+- **THEN** the file MUST define exactly four CTEs named `trans`, `stages`,
+  `verifies`, `checks` (one per event source) and the outer SELECT MUST union
+  all four
+
+#### Scenario: QQ-S2 returns three columns named ts/kind/detail
+- **GIVEN** the file `observability/queries/sisyphus/24-req-trace.sql`
+- **WHEN** the file is read
+- **THEN** the final `ORDER BY` clause MUST sort by `ts` ascending and the
+  outer SELECT (or each UNION arm) MUST project columns aliased exactly `ts`,
+  `kind`, `detail`
+
+#### Scenario: QQ-S3 only the four kinds appear in the SQL
+- **GIVEN** the file `observability/queries/sisyphus/24-req-trace.sql`
+- **WHEN** the file is searched for single-quoted literals supplying the
+  `kind` column
+- **THEN** the only literals MUST be `'trans'`, `'stage'`, `'verify'`,
+  `'check'`
+
+#### Scenario: QQ-S4 parameter placeholder is the Metabase {{req_id}} form
+- **GIVEN** the file `observability/queries/sisyphus/24-req-trace.sql`
+- **WHEN** the file is searched for parameter references
+- **THEN** every REQ filter (one per source table — req_state, stage_runs,
+  verifier_decisions, artifact_checks) MUST reference the placeholder
+  `{{req_id}}` (Metabase syntax) and the file MUST NOT hardcode any specific
+  `REQ-…` literal as a SQL value
+
+### Requirement: sisyphus-trace CLI renders the timeline at the terminal
+
+The repository SHALL provide an executable `scripts/sisyphus-trace.py` whose
+single positional argument is a REQ-id. The CLI MUST exit 0 on success and
+non-zero on any error (missing kubectl, PG unreachable, REQ-id not found).
+On success the CLI MUST print one human-readable line per timeline row in
+the format `HH:MM:SS [<kind>] <detail>` separated from the header by a Unicode
+divider line (one `─` repeated ≥ 20 times). The first stdout line MUST be
+`sisyphus-trace <REQ-id>` (literal command + the resolved REQ-id) so output
+is greppable by REQ.
+
+The CLI SHALL accept the optional flags `--json`, `--namespace <ns>`,
+`--pg-pod <pod>`. When `--json` is supplied the CLI MUST print one JSON object
+per line (NDJSON) with keys `ts` (RFC3339 string), `kind`, `detail` and MUST
+NOT print the ASCII header / divider. Default `--namespace` MUST equal
+`sisyphus`; default `--pg-pod` MUST equal `sisyphus-postgresql-0` (matching
+`sisyphus-admin.py` defaults so operators do not need to relearn flags).
+
+The CLI MUST NOT swallow PG errors silently — any psql non-zero exit MUST be
+reported to stderr and propagate as exit code 1.
+
+#### Scenario: TRACE-S1 ASCII render shape
+- **GIVEN** an in-memory list of three event rows
+  `[(t1,"trans","INIT → ANALYZING"), (t2,"stage","analyze start"),
+    (t3,"check","spec_lint passed")]`
+- **WHEN** the renderer is invoked with `req_id="REQ-X"`
+- **THEN** the output MUST start with the literal line `sisyphus-trace REQ-X`,
+  followed by a divider line whose first character is `─`, followed by exactly
+  three event lines each matching `^\d{2}:\d{2}:\d{2} \[(trans|stage|verify|check)\] `
+
+#### Scenario: TRACE-S2 --json mode emits NDJSON
+- **GIVEN** the same three event rows
+- **WHEN** the renderer is invoked with `--json` mode
+- **THEN** stdout MUST contain exactly three lines, each line MUST parse as a
+  JSON object whose keys are exactly `{ts, kind, detail}`, and the header /
+  divider MUST NOT appear
+
+#### Scenario: TRACE-S3 missing REQ-id positional triggers usage error
+- **GIVEN** the CLI argparse parser
+- **WHEN** the parser is asked to parse an empty argv
+- **THEN** parsing MUST fail (`SystemExit` with code 2) and the error message
+  MUST mention `req_id`
+
+#### Scenario: TRACE-S4 default kubectl knobs match sisyphus-admin
+- **GIVEN** the CLI argparse parser built without overrides
+- **WHEN** the resulting `Namespace` is inspected
+- **THEN** `namespace` MUST equal `"sisyphus"` and `pg_pod` MUST equal
+  `"sisyphus-postgresql-0"`
+
+### Requirement: dashboard and CLAUDE.md surface the new tool
+
+The file `observability/sisyphus-dashboard.md` MUST gain a Q24 section
+documenting the SQL path, suggested visualization (Table) and parameter
+binding (`req_id`). The file `CLAUDE.md` MUST gain a debug-oriented paragraph
+referencing `scripts/sisyphus-trace.py <REQ-id>` so future operators know
+which command to run when a REQ appears stuck. Neither file SHALL remove or
+renumber existing Q1–Q23 entries.
+
+#### Scenario: DOC-S1 dashboard contains a Q24 heading
+- **GIVEN** `observability/sisyphus-dashboard.md`
+- **WHEN** the file is searched for headings
+- **THEN** there MUST exist a heading line matching `^### Q24\.` and the
+  body MUST link `queries/sisyphus/24-req-trace.sql`
+
+#### Scenario: DOC-S2 CLAUDE.md mentions sisyphus-trace
+- **GIVEN** `CLAUDE.md`
+- **WHEN** the file is searched for the literal `sisyphus-trace`
+- **THEN** at least one occurrence MUST exist and that occurrence MUST be
+  inside (or immediately under) a heading containing the word `debug`
+  (case-insensitive)

--- a/openspec/changes/REQ-feat-req-trace-view-381-v2-1777866643/tasks.md
+++ b/openspec/changes/REQ-feat-req-trace-view-381-v2-1777866643/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: REQ trace view (sisyphus-trace + Q24)
+
+## Stage: spec
+- [x] 写 proposal.md（背景 / 范围 / 不在范围 / 影响）
+- [x] 写 tasks.md
+- [x] 写 specs/req-trace-cli/spec.md（ADDED Requirements + Scenarios）
+
+## Stage: implementation
+- [x] `observability/queries/sisyphus/24-req-trace.sql` —— UNION 4 子查询 + 参数化 + 注释
+- [x] `scripts/sisyphus-trace.py` —— argparse + `_pg_query` helper + ASCII renderer + `--json`
+- [x] `observability/sisyphus-dashboard.md` —— 加 Q24 章节
+- [x] `CLAUDE.md` —— 加 "REQ 卡住怎么 debug" 段引 `sisyphus-trace`
+
+## Stage: tests
+- [x] `orchestrator/tests/test_scripts_sisyphus_trace.py` —— 渲染 / 参数解析 / 退码（importlib 加载顶层 scripts/sisyphus-trace.py）
+- [x] 跑 `make ci-lint` 全绿
+- [x] 跑 `make ci-unit-test` 全绿
+- [x] 跑 `make ci-integration-test`（无 PG → exit 5 → pass）
+
+## Stage: PR
+- [x] git push origin feat/REQ-feat-req-trace-view-381-v2-1777866643
+- [x] gh pr create --label sisyphus + cross-link footer

--- a/orchestrator/tests/test_scripts_sisyphus_trace.py
+++ b/orchestrator/tests/test_scripts_sisyphus_trace.py
@@ -1,0 +1,234 @@
+"""Unit tests for scripts/sisyphus-trace.py.
+
+REQ-feat-req-trace-view-381-v2-1777866643
+
+Covers spec scenarios:
+  TRACE-S1  ASCII render shape
+  TRACE-S2  --json mode emits NDJSON
+  TRACE-S3  missing REQ-id positional triggers usage error
+  TRACE-S4  default kubectl knobs match sisyphus-admin
+  QQ-S1     four UNION ALL branches in Q24 SQL
+  QQ-S2     ts/kind/detail columns + ORDER BY ts
+  QQ-S3     only the four kinds appear as quoted literals
+  QQ-S4     parameter placeholder is {{req_id}}
+  DOC-S1    dashboard contains Q24 heading
+  DOC-S2    CLAUDE.md mentions sisyphus-trace under a debug heading
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+# Load scripts/sisyphus-trace.py without running main(). The script lives at
+# repo-root/scripts/, so walk three parents (orchestrator/tests → orchestrator →
+# repo-root).
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "sisyphus-trace.py"
+_Q24_PATH = _REPO_ROOT / "observability" / "queries" / "sisyphus" / "24-req-trace.sql"
+_DASHBOARD_PATH = _REPO_ROOT / "observability" / "sisyphus-dashboard.md"
+_CLAUDE_PATH = _REPO_ROOT / "CLAUDE.md"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("sisyphus_trace", _SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ─── TRACE-S1 ────────────────────────────────────────────────────────────
+
+
+def test_trace_s1_ascii_render_shape():
+    mod = _load_module()
+    t1 = datetime(2026, 5, 4, 2, 25, 46, tzinfo=UTC)
+    t2 = datetime(2026, 5, 4, 2, 25, 50, tzinfo=UTC)
+    t3 = datetime(2026, 5, 4, 2, 33, 30, tzinfo=UTC)
+    rows = [
+        (t1, "trans", "INIT → ANALYZING"),
+        (t2, "stage", "analyze start"),
+        (t3, "check", "spec_lint passed"),
+    ]
+    out = mod.render_ascii("REQ-X", rows)
+    lines = out.splitlines()
+    assert lines[0] == "sisyphus-trace REQ-X"
+    assert lines[1].startswith("─")
+    assert len(lines) == 5
+    pat = re.compile(r"^\d{2}:\d{2}:\d{2} \[(trans|stage|verify|check)\] ")
+    for ev_line in lines[2:]:
+        assert pat.match(ev_line), ev_line
+
+
+# ─── TRACE-S2 ────────────────────────────────────────────────────────────
+
+
+def test_trace_s2_json_mode_ndjson():
+    mod = _load_module()
+    t1 = datetime(2026, 5, 4, 2, 25, 46, tzinfo=UTC)
+    t2 = datetime(2026, 5, 4, 2, 25, 50, tzinfo=UTC)
+    t3 = datetime(2026, 5, 4, 2, 33, 30, tzinfo=UTC)
+    rows = [
+        (t1, "trans", "INIT → ANALYZING"),
+        (t2, "stage", "analyze start"),
+        (t3, "check", "spec_lint passed"),
+    ]
+    out = mod.render_ndjson(rows)
+    lines = [ln for ln in out.splitlines() if ln]
+    assert len(lines) == 3
+    assert "sisyphus-trace" not in out
+    assert "─" not in out
+    for ln in lines:
+        obj = json.loads(ln)
+        assert set(obj.keys()) == {"ts", "kind", "detail"}
+
+
+def test_trace_s2_json_mode_empty_rows_emits_empty_string():
+    mod = _load_module()
+    assert mod.render_ndjson([]) == ""
+
+
+# ─── TRACE-S3 ────────────────────────────────────────────────────────────
+
+
+def test_trace_s3_missing_req_id_argparse_error():
+    mod = _load_module()
+    parser = mod.build_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        # capture stderr to keep test output clean
+        import contextlib
+        with contextlib.redirect_stderr(io.StringIO()):
+            parser.parse_args([])
+    assert exc_info.value.code == 2
+
+
+def test_trace_s3_error_message_mentions_req_id(capsys):
+    mod = _load_module()
+    parser = mod.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+    err = capsys.readouterr().err
+    assert "req_id" in err
+
+
+# ─── TRACE-S4 ────────────────────────────────────────────────────────────
+
+
+def test_trace_s4_default_namespace_and_pgpod():
+    mod = _load_module()
+    parser = mod.build_parser()
+    ns = parser.parse_args(["REQ-X"])
+    assert ns.namespace == "sisyphus"
+    assert ns.pg_pod == "sisyphus-postgresql-0"
+
+
+# ─── helpers: SQL loading & binding ──────────────────────────────────────
+
+
+def test_bind_req_id_replaces_placeholder():
+    mod = _load_module()
+    sql = "WHERE req_id = {{req_id}}"
+    out = mod._bind_req_id(sql, "REQ-abc")
+    assert out == "WHERE req_id = 'REQ-abc'"
+
+
+def test_bind_req_id_escapes_single_quote():
+    mod = _load_module()
+    sql = "WHERE req_id = {{req_id}}"
+    # injection attempt: a stray apostrophe must be doubled, not break the literal
+    out = mod._bind_req_id(sql, "REQ' OR 1=1--")
+    assert out == "WHERE req_id = 'REQ'' OR 1=1--'"
+
+
+def test_parse_psql_rows_handles_pipe_in_detail():
+    mod = _load_module()
+    raw = "2026-05-04 02:25:46+00|check|spec_lint passed cmd=foo|bar|baz"
+    rows = mod._parse_psql_rows(raw)
+    assert len(rows) == 1
+    _, kind, detail = rows[0]
+    assert kind == "check"
+    # detail must keep the trailing pipes (split with maxsplit=2)
+    assert detail == "spec_lint passed cmd=foo|bar|baz"
+
+
+def test_parse_psql_rows_skips_blank_and_malformed():
+    mod = _load_module()
+    raw = "\n2026-05-04 02:25:46+00|trans|x\nbadline\n\n2026-05-04 02:25:50+00|stage|y\n"
+    rows = mod._parse_psql_rows(raw)
+    assert [r[1] for r in rows] == ["trans", "stage"]
+
+
+# ─── QQ-S1 / QQ-S2 / QQ-S3 / QQ-S4: SQL contract ───────────────────────
+
+
+def test_qqs1_four_named_ctes():
+    sql = _Q24_PATH.read_text(encoding="utf-8")
+    # WITH trans AS ( ... ), stages AS ( ... ), verifies AS ( ... ), checks AS ( ... )
+    cte_names = re.findall(r"\b(\w+)\s+AS\s+\(", sql)
+    assert {"trans", "stages", "verifies", "checks"}.issubset(set(cte_names))
+    # outer UNION ALL union of the four CTEs
+    for name in ("trans", "stages", "verifies", "checks"):
+        assert re.search(rf"FROM\s+{name}\b", sql), f"missing FROM {name}"
+
+
+def test_qqs2_columns_and_order_by():
+    sql = _Q24_PATH.read_text(encoding="utf-8")
+    assert re.search(r"ORDER BY\s+ts\s+ASC", sql), "ORDER BY ts ASC missing"
+    # final outer SELECT must project ts/kind/detail
+    assert re.search(r"SELECT\s+ts,\s*kind,\s*detail\s+FROM\s+trans", sql)
+
+
+def test_qqs3_only_four_kinds_as_literals():
+    sql = _Q24_PATH.read_text(encoding="utf-8")
+    # find every `'<word>'::text` literal that is the kind column
+    kinds = set(re.findall(r"'(trans|stage|verify|check)'::text", sql))
+    assert kinds == {"trans", "stage", "verify", "check"}
+    # and no other `'<word>'::text` appears as the kind expression
+    other = re.findall(r"'([a-z_]+)'::text", sql)
+    assert set(other) == {"trans", "stage", "verify", "check"}
+
+
+def test_qqs4_parameter_placeholder_metabase():
+    sql = _Q24_PATH.read_text(encoding="utf-8")
+    # at least one {{req_id}} per source-table reference (4 tables)
+    # — strip line comments before counting so the docstring header doesn't inflate
+    code_lines = [ln for ln in sql.splitlines() if not ln.lstrip().startswith("--")]
+    code = "\n".join(code_lines)
+    assert code.count("{{req_id}}") >= 4
+    for table in ("req_state", "stage_runs", "verifier_decisions", "artifact_checks"):
+        # the table reference and a {{req_id}} filter must both appear
+        assert table in code
+    # no hardcoded REQ-id literal in code (comments are fine)
+    assert not re.search(r"=\s*'REQ-", code)
+
+
+# ─── DOC-S1 / DOC-S2: documentation surfaces ───────────────────────────
+
+
+def test_docs1_dashboard_contains_q24_heading():
+    text = _DASHBOARD_PATH.read_text(encoding="utf-8")
+    assert re.search(r"^### Q24\.", text, flags=re.MULTILINE)
+    assert "queries/sisyphus/24-req-trace.sql" in text
+
+
+def test_docs2_claude_mentions_sisyphus_trace_under_debug_heading():
+    text = _CLAUDE_PATH.read_text(encoding="utf-8")
+    assert "sisyphus-trace" in text
+    # find a heading line containing "debug" (case-insensitive) at-or-above
+    # the first sisyphus-trace mention
+    lines = text.splitlines()
+    first_idx = next(i for i, ln in enumerate(lines) if "sisyphus-trace" in ln)
+    # search backwards for a heading
+    found_debug_heading = False
+    for ln in reversed(lines[: first_idx + 1]):
+        if ln.startswith("#"):
+            if re.search(r"debug", ln, flags=re.IGNORECASE):
+                found_debug_heading = True
+            break
+    assert found_debug_heading, "sisyphus-trace must appear under a debug-flavoured heading"

--- a/scripts/sisyphus-trace.py
+++ b/scripts/sisyphus-trace.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""sisyphus-trace —— 单 REQ 全生命周期 timeline CLI (REQ-feat-req-trace-view-381-v2-1777866643)。
+
+读取 sisyphus 主库 4 张表 (req_state.history, stage_runs, verifier_decisions,
+artifact_checks), 把所有事件按时间戳合到一条时间线, 渲染成可读 ASCII 或 NDJSON。
+
+调试 "REQ 卡住不动" 不再 grep 源码：30 min → 30 s。
+
+用法
+====
+
+::
+
+    # ASCII 时间线 (默认)
+    sisyphus-trace REQ-feat-req-trace-view-381-v2-1777866643
+
+    # NDJSON, 给 jq pipe 用
+    sisyphus-trace REQ-XXXX --json | jq 'select(.kind=="verify")'
+
+    # 自定义 namespace / pod (调试用, 默认与 sisyphus-admin.py 同款)
+    sisyphus-trace REQ-XXXX --namespace sisyphus --pg-pod sisyphus-postgresql-0
+
+依赖
+====
+
+- 本机 ``kubectl`` 且上下文指向 sisyphus 集群
+- PG pod 用 ``psql -U sisyphus -d sisyphus``, 密码从 pod env ``POSTGRES_PASSWORD_FILE`` 取
+
+退出码
+======
+
+- 0  正常输出 (即使 REQ 没行)
+- 1  PG 出错 / kubectl 不可用 / SQL 失败
+- 2  argparse 用法错 (REQ-id 漏传等)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_NAMESPACE = "sisyphus"
+DEFAULT_PG_POD = "sisyphus-postgresql-0"
+
+# Q24 SQL 路径 (相对仓根)。CLI 直接读这个文件, Metabase 也用同一份 -- single source of truth。
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_Q24_PATH = _REPO_ROOT / "observability" / "queries" / "sisyphus" / "24-req-trace.sql"
+
+
+# ─── kubectl helpers (与 sisyphus-admin.py 同款风格, 不抽公共模块, 避免给一个 CLI 引一个 lib) ──
+
+
+def _have_kubectl() -> bool:
+    try:
+        return subprocess.run(
+            ["kubectl", "version", "--client=true"],
+            capture_output=True,
+        ).returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+def _pg_query(sql: str, *, namespace: str, pod: str) -> str:
+    """通过 kubectl exec PG pod 跑只读 SQL; 密码从 pod env 取, 不外泄。"""
+    if not _have_kubectl():
+        raise RuntimeError("kubectl 不可用; 本机无集群上下文")
+    inner = (
+        'PGPASSWORD="$(cat $POSTGRES_PASSWORD_FILE)" '
+        "psql -U sisyphus -d sisyphus -t -A -F '|'"
+    )
+    cmd = ["kubectl", "-n", namespace, "exec", "-i", pod, "--", "bash", "-c", inner]
+    proc = subprocess.run(cmd, input=sql, text=True, capture_output=True, timeout=30)
+    if proc.returncode != 0:
+        raise RuntimeError(f"psql failed: {proc.stderr or proc.stdout}")
+    return proc.stdout
+
+
+# ─── SQL loading + binding ─────────────────────────────────────────────────
+
+
+def _load_q24_sql() -> str:
+    if not _Q24_PATH.exists():
+        raise RuntimeError(f"Q24 SQL not found at {_Q24_PATH}")
+    return _Q24_PATH.read_text(encoding="utf-8")
+
+
+def _bind_req_id(sql: str, req_id: str) -> str:
+    """把 Metabase ``{{req_id}}`` 占位替换成 quoted literal。
+
+    REQ-id 是受控字符 (`[A-Za-z0-9_-]+`), 但仍走 `quote_literal` 保险:
+    用 psql 的双单引号转义 (与 PostgreSQL 字符串字面量规则一致)。
+    """
+    safe = req_id.replace("'", "''")
+    return sql.replace("{{req_id}}", f"'{safe}'")
+
+
+# ─── parse psql output ────────────────────────────────────────────────────
+
+
+def _parse_psql_rows(raw: str) -> list[tuple[datetime, str, str]]:
+    """psql -t -A -F '|' 输出: 一行一记录, 字段 `|` 分隔。
+
+    rstrip 单行末空白; 跳过空行。detail 内本身可能含 `|` (cmd 字段) → 用
+    maxsplit=2 限制只切前 2 刀, 余下整体进 detail。
+    """
+    out: list[tuple[datetime, str, str]] = []
+    for line in raw.splitlines():
+        line = line.rstrip()
+        if not line:
+            continue
+        parts = line.split("|", 2)
+        if len(parts) != 3:
+            continue
+        ts_s, kind, detail = parts
+        try:
+            ts = datetime.fromisoformat(ts_s.replace(" ", "T"))
+        except ValueError:
+            continue
+        out.append((ts, kind, detail))
+    return out
+
+
+# ─── renderers ────────────────────────────────────────────────────────────
+
+
+def render_ascii(req_id: str, rows: Iterable[tuple[datetime, str, str]]) -> str:
+    lines = [f"sisyphus-trace {req_id}", "─" * 60]
+    for ts, kind, detail in rows:
+        lines.append(f"{ts.strftime('%H:%M:%S')} [{kind}] {detail}")
+    return "\n".join(lines) + "\n"
+
+
+def render_ndjson(rows: Iterable[tuple[datetime, str, str]]) -> str:
+    out_lines: list[str] = []
+    for ts, kind, detail in rows:
+        out_lines.append(json.dumps(
+            {"ts": ts.isoformat(), "kind": kind, "detail": detail},
+            ensure_ascii=False,
+        ))
+    return ("\n".join(out_lines) + "\n") if out_lines else ""
+
+
+# ─── parser ───────────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="sisyphus-trace",
+        description="REQ 全生命周期 timeline (req_state history + stage_runs + "
+                    "verifier_decisions + artifact_checks)。",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("req_id", help="REQ-id (e.g. REQ-feat-foo-1777xxx)")
+    p.add_argument("--json", dest="as_json", action="store_true",
+                   help="NDJSON 模式 (一行一 JSON 对象), 适合 jq pipe")
+    p.add_argument("--namespace", default=DEFAULT_NAMESPACE,
+                   help=f"K8s namespace (default: {DEFAULT_NAMESPACE})")
+    p.add_argument("--pg-pod", default=DEFAULT_PG_POD,
+                   help=f"PG pod 名 (default: {DEFAULT_PG_POD})")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        sql = _bind_req_id(_load_q24_sql(), args.req_id)
+        raw = _pg_query(sql, namespace=args.namespace, pod=args.pg_pod)
+    except RuntimeError as e:
+        print(f"ERR: {e}", file=sys.stderr)
+        return 1
+    rows = _parse_psql_rows(raw)
+    if args.as_json:
+        sys.stdout.write(render_ndjson(rows))
+    else:
+        sys.stdout.write(render_ascii(args.req_id, rows))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

debug \"REQ 卡住不动\" 当前要 `curl` BKD + `grep` 源码 + 手动拼时间线 ~30 min。
所有数据其实已经在主库 4 张表里 (`req_state.history` / `stage_runs` /
`verifier_decisions` / `artifact_checks`)，缺一个按 ts 聚合的统一视图。

- **`observability/queries/sisyphus/24-req-trace.sql`** —— Metabase Q24，UNION
  ALL 4 个子查询，参数化 `{{req_id}}`，返回 `ts/kind/detail` 按 ts ASC
- **`scripts/sisyphus-trace.py`** —— 同款 SQL 的薄 CLI 包装。kubectl exec 同
  `sisyphus-admin.py` 风格，psql -t -A 跑同一份 SQL。`--json` 出 NDJSON 给 jq pipe
- **`observability/sisyphus-dashboard.md`** —— 加 Q24 章节
- **`CLAUDE.md`** —— 加 \"REQ 卡住怎么 debug\" 段引到该 CLI
- **`openspec/changes/REQ-feat-req-trace-view-381-v2-1777866643/`** —— spec
  delta（10 scenarios: TRACE-S1..S4 / QQ-S1..S4 / DOC-S1..S2）
- **`orchestrator/tests/test_scripts_sisyphus_trace.py`** —— 16 unit tests，全绿

## Q-number 选择

intent issue 里写的是 Q23，但 `23-first-turn-token-composition.sql` 已被
`REQ-feat-agent-turns-collector-1777796671` 占用。本 PR 顺势改用 **Q24**，跟
现有看板的 Q21/Q22 双号惯例一致。dashboard.md / CLAUDE.md / spec 全部以 Q24 落实。

## 不在范围内

- `event_log` (sisyphus_obs DB) 跨库合并 —— 留 follow-up REQ（跨库 view 不
  做的 stance 见 `migrations/0002_observability_views.sql` 注释）
- 任何状态机 / 写表 / migration 改动 —— 全部只读复用现有数据

## Test plan

- [x] `make ci-lint` —— 全绿
- [x] `uv run pytest tests/test_scripts_sisyphus_trace.py` —— 16/16 pass
- [x] `make ci-integration-test` —— exit 5 → pass（无本地 PG）
- [x] `openspec validate REQ-feat-req-trace-view-381-v2-1777866643` —— valid
- [x] `scripts/check-scenario-refs.sh` —— OK (833 个定义)
- [ ] 验证人在 Metabase 里粘贴 Q24 SQL，参数 `req_id=REQ-XXX` 能跑出时间线
- [ ] 验证人在集群 host 跑 `python3 scripts/sisyphus-trace.py REQ-XXX` 看到 ASCII timeline

## 已知背景

`make ci-unit-test` 在我 branch base (`9ce0800`) 上**已经**有 32 个非本 REQ
相关的 failure（test_engine / test_runner_gc / test_admin_pr_merged / 等）。
本 PR 没新增 / 没修复这些 failure，新增的 16 个测试全部通过。verifier 应能
区分 baseline failures 与本 PR 引入的回归。

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-feat-req-trace-view-381-v2-1777866643\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/hux3aj2k)

🤖 Generated with [Claude Code](https://claude.com/claude-code)