### PR TITLE
fix(orch tests): _readyz_harness mock leak causing 31-test isolation failure (closes #364)

### DIFF
--- a/openspec/changes/REQ-fix-test-isolation-364-1777867646/proposal.md
+++ b/openspec/changes/REQ-fix-test-isolation-364-1777867646/proposal.md
@@ -1,0 +1,87 @@
+# Proposal: 修 orch test suite isolation pollution（31 fail in deterministic order）
+
+## Problem
+
+`cd orchestrator && uv run pytest -m "not integration"` 全 suite 跑稳定 31 fail，
+但任何子集（单文件 / 几文件）跑都 pass：
+
+```
+$ uv run pytest tests/test_runner_gc.py
+13 passed in 1.08s
+
+$ uv run pytest -m "not integration"
+31 failed, 2234 passed
+```
+
+→ 经典 test isolation pollution：某个早跑的 test 改了 module-level 状态，没还原，
+后跑的 test 拿到污染状态崩。
+
+### 影响
+
+- CI `lint-test` job 永远红 → PR review 不能信 CI 状态
+- 每个 sisyphus self-dogfood PR 都看到这 31 fail，agent / 人都得分辨"我这 PR
+  真破了 test 还是只是继承 pre-existing"
+- verifier-agent 看 staging-test 红绿做 fix/escalate 决策时被误导
+- 实证 5/3：PR #363（fix-362）触发 10+ test fail → 我 + agent 都误判 regression
+  → 浪费时间循环讨论。最后跑 main full suite 也 31 fail 才确认 pre-existing
+
+### 根因（bisect 出来）
+
+唯一的 polluter 是 `tests/test_contract_readyz_namespaced_challenger.py` 里的
+`_readyz_harness` contextmanager。RZN-S3 路径同时叠了两个 patch 在同一目标：
+
+```python
+patches.append(patch.object(k8s_runner, "get_controller", side_effect=...))
+patches.append(patch("orchestrator.main.k8s_runner.get_controller", side_effect=...))
+```
+
+`orchestrator.main.k8s_runner` 通过 `from . import k8s_runner` 共享同一模块对象，
+两个 patch 指向同一 attribute。问题在 stop 顺序：
+
+1. patch1.start() 把 `k8s_runner.get_controller` 从 real_fn 换成 MagicMock₁
+2. patch2.start() 时"原值"读到的是 MagicMock₁（patch1 已替换），保存它
+3. finally 按 forward 顺序 stop：patch1.stop() → 还原成 real_fn ✓
+4. patch2.stop() → 还原成 patch2 保存的"原值" = MagicMock₁ ✗
+
+结果：测试结束后 `k8s_runner.get_controller` 永远停在 MagicMock₁，下游所有
+依赖它的 test 都拿到一个不抛 RuntimeError 也不返真 controller 的 mock，
+于是 31 个 test 集中崩在 runner_gc / engine cleanup / intent sync 链路。
+
+## Solution
+
+最小改动修 polluter：
+
+1. **删冗余 patch**：`patch.object(k8s_runner, "get_controller", ...)` 已经把目标
+   改了；`patch("orchestrator.main.k8s_runner.get_controller", ...)` 是多余的，
+   因为两条路径都解到同一个模块对象。
+2. **stop 反序**：嵌套 patch 用 LIFO 顺序还原，防御性写法（万一以后又叠多个 patch）。
+
+用 `--randomly-seed=N` 多 seed 跑 suite 还会暴露其他 latent isolation bug
+（与 #364 报告无关、深度更深的几处 module-level state leak）。**不在本 REQ
+scope 内**：本 REQ 只修 #364 报告的 deterministic-order 31 fail，让 main 的
+`make ci-unit-test` 重新可信；剩余 latent bug 单独立 follow-up issue 跟踪。
+
+## Why not 加 random-order 守
+
+#364 的"修法"列里写"CI 跑 `pytest --random-order` 让 isolation bug 早暴露"。
+本 REQ **加了 `pytest-randomly` 作为 dev dep**（需要时 `--randomly-seed=N`
+本地复现），但**不在 CI 默认开**——多 seed 跑会暴露与本 REQ 无关的额外
+isolation bug，强行打开会让 CI 红的更花哨，违反"fix one thing per REQ"。
+
+启用 random-order-default 留给 follow-up REQ，先把那批 latent bug 收掉再开。
+
+## Scope
+
+- `orchestrator/tests/test_contract_readyz_namespaced_challenger.py`
+  —— `_readyz_harness` 删冗余 patch + stop 反序
+- `orchestrator/pyproject.toml` —— 加 `pytest-randomly>=3.15` 到 dev deps
+  （`[project.optional-dependencies].dev` + `[dependency-groups].dev`）
+
+## Out of scope
+
+- random-order 默认开 / CI 改 `make ci-unit-test` 命令
+- 修其他 seed 下才出的 isolation bug（test_contract_escalate_pr_merged_override
+  / test_contract_gh_incident_per_repo / test_actions_smoke.test_teardown_*
+  在 seed=1 下 fail —— 单独 issue）
+- conftest.py 加 autouse 'leak guard'（防御性 fixture，未来 REQ 考虑）
+- 删 `_readyz_harness` 本身（contract test 形态保留）

--- a/openspec/changes/REQ-fix-test-isolation-364-1777867646/specs/test-isolation-readyz-harness/spec.md
+++ b/openspec/changes/REQ-fix-test-isolation-364-1777867646/specs/test-isolation-readyz-harness/spec.md
@@ -1,0 +1,51 @@
+# test-isolation-readyz-harness
+
+## ADDED Requirements
+
+### Requirement: _readyz_harness MUST NOT leak patched get_controller mock to subsequent tests
+
+`tests/test_contract_readyz_namespaced_challenger.py` 里的 `_readyz_harness`
+contextmanager 在 `raise_runtime_on_get_controller=True` 路径下 SHALL 只对
+`orchestrator.k8s_runner.get_controller` 这一个 attribute 应用一个 patch；
+当 contextmanager 退出时 `orchestrator.k8s_runner.get_controller` MUST 恢复
+为原始未被 patch 的实现，使后续 test 调用 `k8s_runner.set_controller(fake)`
++ `k8s_runner.get_controller()` 时 MUST 拿到 fake controller 本身、而不是
+被 leak 的 MagicMock。
+
+实现 MUST NOT 在同一个 attribute 上叠多个 patch（例如同时 patch
+`k8s_runner.get_controller` 和 `orchestrator.main.k8s_runner.get_controller`），
+因为这两条路径解到同一模块对象，叠 patch 后 stop 顺序错时会把后启动 patch 的
+"原值"还原成前一 patch 替换后的 mock，造成 mock 永久泄漏到下游全部 test。
+若 harness 出于防御性必须叠多个 patch，stop MUST 按反向顺序（LIFO）执行，
+保证最先启动的 patch 最后还原。
+
+#### Scenario: TIRH-S1 deterministic-order full suite passes after harness runs
+
+- **GIVEN** `orchestrator/tests/test_contract_readyz_namespaced_challenger.py::test_RZN_S3_controller_not_initialized_skipped_returns_200` 被运行
+- **AND** 紧随其后的同一 pytest session 跑 `tests/test_runner_gc.py::test_active_includes_inflight`
+- **WHEN** test_active_includes_inflight 的 `mock_controller` fixture 调
+  `k8s_runner.set_controller(fake)`，再 `await runner_gc.gc_once()`
+- **THEN** `runner_gc.gc_once` MUST 解析到 fake controller（而非 leak 的 MagicMock）
+- **AND** `fake.gc_orphan_pods.await_args` MUST NOT be None
+- **AND** test MUST pass，断言 `pod_keep == {"REQ-1","REQ-2","REQ-3"}` 通过
+
+#### Scenario: TIRH-S2 RZN-S3 contract assertion still passes
+
+- **GIVEN** `_readyz_harness(controller=None, raise_runtime_on_get_controller=True)` 被使用
+- **WHEN** harness body 内调 `_client().get("/readyz")`
+- **THEN** `k8s_runner.get_controller()` MUST 在 harness body 内抛
+  `RuntimeError("not init")`
+- **AND** `/readyz` 响应 MUST 是 HTTP 200，body `{"status": "ok"}`
+- **AND** RZN-S3 黑盒断言（status code 200 + body shape + `failed` 不含 "k8s"）
+  MUST 通过
+
+#### Scenario: TIRH-S3 harness exit restores original get_controller
+
+- **GIVEN** 进入 `_readyz_harness` 之前 `orchestrator.k8s_runner.get_controller`
+  是 sisyphus 源码定义的真实 function（非 mock）
+- **WHEN** `_readyz_harness(controller=None, raise_runtime_on_get_controller=True)`
+  context 退出（无论 body 是否抛异常）
+- **THEN** `orchestrator.k8s_runner.get_controller` MUST 重新等于原始真实 function
+- **AND** 调用 `k8s_runner.get_controller()` 在 `_controller is None` 时
+  MUST 抛 `RuntimeError`（来自源码原版 `get_controller`），错误消息以
+  `"RunnerController 未初始化"` 开头，**不是** `"not init"`（leak mock 的特征字符串）

--- a/openspec/changes/REQ-fix-test-isolation-364-1777867646/specs/test-isolation-readyz-harness/spec.md
+++ b/openspec/changes/REQ-fix-test-isolation-364-1777867646/specs/test-isolation-readyz-harness/spec.md
@@ -2,7 +2,7 @@
 
 ## ADDED Requirements
 
-### Requirement: _readyz_harness MUST NOT leak patched get_controller mock to subsequent tests
+### Requirement: _readyz_harness SHALL restore get_controller cleanly so it does not leak a mock to subsequent tests
 
 `tests/test_contract_readyz_namespaced_challenger.py` 里的 `_readyz_harness`
 contextmanager 在 `raise_runtime_on_get_controller=True` 路径下 SHALL 只对

--- a/openspec/changes/REQ-fix-test-isolation-364-1777867646/specs/test-isolation-readyz-harness/spec.md
+++ b/openspec/changes/REQ-fix-test-isolation-364-1777867646/specs/test-isolation-readyz-harness/spec.md
@@ -2,15 +2,16 @@
 
 ## ADDED Requirements
 
-### Requirement: _readyz_harness SHALL restore get_controller cleanly so it does not leak a mock to subsequent tests
+### Requirement: _readyz_harness SHALL restore get_controller cleanly
 
-`tests/test_contract_readyz_namespaced_challenger.py` 里的 `_readyz_harness`
-contextmanager 在 `raise_runtime_on_get_controller=True` 路径下 SHALL 只对
-`orchestrator.k8s_runner.get_controller` 这一个 attribute 应用一个 patch；
-当 contextmanager 退出时 `orchestrator.k8s_runner.get_controller` MUST 恢复
-为原始未被 patch 的实现，使后续 test 调用 `k8s_runner.set_controller(fake)`
-+ `k8s_runner.get_controller()` 时 MUST 拿到 fake controller 本身、而不是
-被 leak 的 MagicMock。
+The `_readyz_harness` contextmanager in
+`tests/test_contract_readyz_namespaced_challenger.py` SHALL apply at most one
+patch on the `orchestrator.k8s_runner.get_controller` attribute when
+`raise_runtime_on_get_controller=True`, and on contextmanager exit it MUST
+restore that attribute to the original implementation so subsequent tests in
+the same pytest session that call `k8s_runner.set_controller(fake)` and then
+`k8s_runner.get_controller()` MUST receive the fake controller instance —
+never a leaked MagicMock.
 
 实现 MUST NOT 在同一个 attribute 上叠多个 patch（例如同时 patch
 `k8s_runner.get_controller` 和 `orchestrator.main.k8s_runner.get_controller`），

--- a/openspec/changes/REQ-fix-test-isolation-364-1777867646/specs/test-isolation-readyz-harness/spec.md
+++ b/openspec/changes/REQ-fix-test-isolation-364-1777867646/specs/test-isolation-readyz-harness/spec.md
@@ -2,7 +2,7 @@
 
 ## ADDED Requirements
 
-### Requirement: _readyz_harness SHALL restore get_controller cleanly
+### Requirement: readyz harness SHALL restore get_controller cleanly
 
 The `_readyz_harness` contextmanager in
 `tests/test_contract_readyz_namespaced_challenger.py` SHALL apply at most one

--- a/openspec/changes/REQ-fix-test-isolation-364-1777867646/specs/test-isolation-readyz-harness/spec.md
+++ b/openspec/changes/REQ-fix-test-isolation-364-1777867646/specs/test-isolation-readyz-harness/spec.md
@@ -2,16 +2,18 @@
 
 ## ADDED Requirements
 
-### Requirement: readyz harness SHALL restore get_controller cleanly
+### Requirement: readyz harness restores get_controller cleanly
 
-The `_readyz_harness` contextmanager in
-`tests/test_contract_readyz_namespaced_challenger.py` SHALL apply at most one
-patch on the `orchestrator.k8s_runner.get_controller` attribute when
-`raise_runtime_on_get_controller=True`, and on contextmanager exit it MUST
-restore that attribute to the original implementation so subsequent tests in
-the same pytest session that call `k8s_runner.set_controller(fake)` and then
-`k8s_runner.get_controller()` MUST receive the fake controller instance —
-never a leaked MagicMock.
+The readyz harness contextmanager SHALL apply at most one patch on
+the get_controller attribute and MUST restore it on exit so subsequent
+tests receive the fake controller — never a leaked MagicMock.
+
+具体实现：`tests/test_contract_readyz_namespaced_challenger.py` 里的
+`_readyz_harness` 在 `raise_runtime_on_get_controller=True` 路径下只 patch
+`orchestrator.k8s_runner.get_controller` 这一个 attribute；contextmanager
+退出时该 attribute 恢复为源码原始 function，使后续 test 调
+`k8s_runner.set_controller(fake)` + `k8s_runner.get_controller()` 拿到
+fake controller 本身。
 
 实现 MUST NOT 在同一个 attribute 上叠多个 patch（例如同时 patch
 `k8s_runner.get_controller` 和 `orchestrator.main.k8s_runner.get_controller`），

--- a/openspec/changes/REQ-fix-test-isolation-364-1777867646/tasks.md
+++ b/openspec/changes/REQ-fix-test-isolation-364-1777867646/tasks.md
@@ -1,0 +1,38 @@
+# Tasks — REQ-fix-test-isolation-364-1777867646
+
+## Stage: spec
+- [x] author proposal.md（problem / root cause / scope）
+- [x] author specs/test-isolation-readyz-harness/spec.md（ADDED Requirement +
+      scenario for "harness MUST not leak get_controller mock"）
+
+## Stage: implementation
+- [x] orchestrator/tests/test_contract_readyz_namespaced_challenger.py
+      `_readyz_harness`：删 `patch("orchestrator.main.k8s_runner.get_controller", ...)`
+      冗余项，保留 `patch.object(k8s_runner, "get_controller", ...)` 单 patch
+- [x] orchestrator/tests/test_contract_readyz_namespaced_challenger.py
+      `_readyz_harness`：finally 块 stop 顺序改 LIFO（`reversed(patches)`）
+- [x] orchestrator/pyproject.toml：加 `pytest-randomly>=3.15`
+      到 `[project.optional-dependencies].dev` + `[dependency-groups].dev`
+
+## Stage: verification
+- [x] `uv run pytest -m "not integration" -p no:randomly` 全 suite 通过
+      （deterministic order，2265 passed / 1 skipped / 16 deselected）
+- [x] RZN-S1/S2/S3 三条 challenger contract 仍通过（黑盒断言不动）
+- [x] `--randomly-seed=N` 复现能力：dev 本地按需开 random-order 找 latent bug
+
+## Stage: PR（推之前必须全绿）
+- [x] git push feat/REQ-fix-test-isolation-364-1777867646
+- [ ] `make ci-lint` → 全绿（仅 lint 改动文件）
+- [ ] `make ci-unit-test` → 全绿（deterministic order）
+- [ ] `make ci-integration-test` → pass / 0-collect-skip
+- [ ] gh pr create + sisyphus label + cross-link footer
+
+## Out of scope（follow-up issue tracking）
+- [ ] 修 seed=1 下 fail 的 12 个 test：
+  - test_contract_escalate_pr_merged_override.py（4）
+  - test_contract_escalate_pr_merged_override_challenger.py（4）
+  - test_contract_gh_incident_per_repo.py（3）
+  - test_actions_smoke.py::test_teardown_skipped_when_accept_skipped（1）
+- [ ] CI 默认开 `pytest-randomly`（放在所有 latent leak 修完之后）
+- [ ] tests/conftest.py 加 autouse 'leak guard'（断言 module-level 状态在
+      test 后还是初始值），降低未来 isolation bug 复现成本

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
     "pytest-httpx>=0.32",
+    "pytest-randomly>=3.15",
     "ruff>=0.7",
     "mypy>=1.13",
 ]
@@ -61,5 +62,6 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
     "pytest-httpx>=0.32",
+    "pytest-randomly>=3.15",
     "ruff>=0.15.11",
 ]

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -41,6 +41,10 @@ packages = ["src/orchestrator"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+# 默认禁掉 pytest-randomly：还有几处 latent isolation bug（独立 issue 跟踪），
+# 强行打开会让 CI 红，与本 REQ 的 #364 deterministic-order 修复无关。
+# 本地排查 leak 仍可 `uv run pytest --randomly-seed=N -p randomly` 临时开。
+addopts = "-p no:randomly"
 markers = [
     "integration: integration tests (selected by `make ci-integration-test`; excluded by `make ci-unit-test`)",
 ]

--- a/orchestrator/tests/test_contract_readyz_namespaced_challenger.py
+++ b/orchestrator/tests/test_contract_readyz_namespaced_challenger.py
@@ -136,16 +136,15 @@ def _readyz_harness(
     ]
 
     if raise_runtime_on_get_controller:
+        # 单 patch 即可：`orchestrator.main` 通过 `from . import k8s_runner` 共享同一
+        # 模块对象，patch 一次就同时改 main.k8s_runner.get_controller。
+        # 之前同时叠两个 patch.object 会让第二个 patch 在 start() 时把"原值"
+        # 记成第一个 patch 替换后的 MagicMock，stop() 顺序错时把 MagicMock
+        # 还原回去，污染整套件下游所有依赖 k8s_runner.get_controller 的 test。
         patches.append(
             patch.object(
                 k8s_runner,
                 "get_controller",
-                side_effect=RuntimeError("not init"),
-            )
-        )
-        patches.append(
-            patch(
-                "orchestrator.main.k8s_runner.get_controller",
                 side_effect=RuntimeError("not init"),
             )
         )
@@ -155,7 +154,9 @@ def _readyz_harness(
     try:
         yield
     finally:
-        for p in patches:
+        # LIFO 顺序 stop：嵌套 patch 必须按相反顺序还原，否则后启动的
+        # patch 会把"原值"恢复成前一个 patch 替换后的 mock。
+        for p in reversed(patches):
             try:
                 p.stop()
             except RuntimeError:


### PR DESCRIPTION
## Summary

修 `make ci-unit-test` 全 suite 跑稳定 31 fail（确定性顺序）的 root cause —— `tests/test_contract_readyz_namespaced_challenger.py::_readyz_harness` 在 RZN-S3 路径下叠了两个 patch 在同一个 `k8s_runner.get_controller` attribute 上，stop forward-order 时把第二个 patch 的"原值"还原成第一个 patch 替换后的 MagicMock，污染整 suite 下游所有依赖 `k8s_runner.get_controller` 的 test。

详细复盘 + scenario contract 见 `openspec/changes/REQ-fix-test-isolation-364-1777867646/`。

## Changes

- `orchestrator/tests/test_contract_readyz_namespaced_challenger.py` `_readyz_harness`
  - 删 `patch("orchestrator.main.k8s_runner.get_controller", ...)` 冗余项（同模块对象，单 patch 即可）
  - finally 块改 `reversed(patches)` LIFO 还原（防御性写法）
- `orchestrator/pyproject.toml`
  - 加 `pytest-randomly>=3.15` 到 `[project.optional-dependencies].dev` + `[dependency-groups].dev`（本地排查 leak 用）
  - `[tool.pytest.ini_options].addopts = "-p no:randomly"`：默认禁，本 REQ 不收 latent isolation bug，独立 follow-up issue 跟踪
- `openspec/changes/REQ-fix-test-isolation-364-1777867646/`
  - proposal.md + tasks.md + specs/test-isolation-readyz-harness/spec.md（TIRH-S1/S2/S3 scenario）

## Verification (全部本地通过)

- ✅ `openspec validate --type change REQ-fix-test-isolation-364-1777867646` —— valid
- ✅ `BASE_REV=$(git merge-base HEAD origin/main) make ci-lint` —— All checks passed
- ✅ `make ci-unit-test` —— 2265 passed, 1 skipped, 16 deselected（修前 31 fail）
- ✅ `make ci-integration-test` —— 0-collect → pass（PostgreSQL not reachable）
- ✅ RZN-S1/S2/S3 三条 challenger contract 仍通过（黑盒断言不动）
- ✅ TIRH-S3 verified: `k8s_runner.get_controller` 在 harness 退出后恢复原始 function（不再是 MagicMock）

## Out of scope (follow-up tracking)

- 修 `--randomly-seed=1` 下 fail 的 12 个 test (test_contract_escalate_pr_merged_override / test_contract_gh_incident_per_repo / test_actions_smoke.test_teardown_*) —— 单独 issue
- CI 默认开 `pytest-randomly` —— 待上面 latent leak 修完后开
- conftest.py autouse 'leak guard' —— 防御性 fixture，未来 REQ 评估

## Test plan

- [x] `cd orchestrator && uv run pytest -m "not integration"` 全 suite 全绿（确定性顺序）
- [x] `make ci-lint` / `make ci-unit-test` / `make ci-integration-test` 三 target 全绿
- [x] openspec validate 通过
- [ ] PR CI（GHA lint-test / staging-test）全绿
- [ ] sisyphus pipeline 后续 stage（spec_lint / dev_cross_check / staging_test / pr_ci_watch）全过

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-fix-test-isolation-364-1777867646\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/za4z8egw)