### PR TITLE
fix(verifier): bump decision parse retry cap to 3 + lint guard (closes #395)

### DIFF
--- a/.github/workflows/orchestrator-ci.yml
+++ b/.github/workflows/orchestrator-ci.yml
@@ -48,6 +48,13 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: python3 scripts/lint-state-transitions.py
 
+      - name: lint verifier prompts (REQ #395)
+        # static check that _decision.md.j2 keeps the 4 valid action literals,
+        # the mandate phrases, and that every per-stage prompt includes it.
+        # stdlib python3 only — no extra deps needed.
+        working-directory: ${{ github.workspace }}
+        run: python3 scripts/lint-verifier-prompts.py
+
       - name: pytest
         run: uv run pytest -v --tb=short -m "not integration"
 

--- a/openspec/changes/REQ-fix-verifier-schema-395-1777869659/proposal.md
+++ b/openspec/changes/REQ-fix-verifier-schema-395-1777869659/proposal.md
@@ -1,0 +1,63 @@
+# REQ-fix-verifier-schema-395-1777869659 — verifier decision JSON 硬强制 (closes #395)
+
+Refs phona/sisyphus#395.
+
+## 现状
+
+`verifier-agent` 输出 decision 时偶尔图省事只 PATCH `decision:pass` 字符串 tag，
+不写 base64-json，也不写 ` ```json {...} ``` ` 块。orch webhook 已经做过两手兜底：
+
+1. `verifier_parser.extract_decision_robust` 会扫 base64 tag → JSON 块 → 平凡
+   `decision:<action>[-<fixer>]` tag（REQ-fix-verifier-decision-tag-1777812498
+   加的第 3 路 fallback）。
+2. webhook.py:344 起的 `retry_worthy` 路径在 schema invalid 时自动 follow-up
+   verifier，要求重输出标准格式 —— **但最多 1 次**（`retry_count < 2` 实测只
+   触发 1 次 retry）。`_VERIFIER_RETRY_PROMPT` 也只描述结构，不点名"必须放最后
+   一条 assistant message"。
+
+5/4 v5 #802 的事故就是 retry 用完仍 schema invalid 直接 escalate、人 30+ min
+才发现。issue #395 把修法切成 3 块（A=BKD-side schema validate / B=orch 层
+retry 提到 3 次 / C=lint 守）。本 REQ 只交付 **B + C**：
+
+- A（BKD 层 schema validate）属于 BKD 仓改动，不在本 sisyphus 仓 scope。
+- B（orch retry 提 3 次 + prompt 更明确）：webhook.py + 单测改动。
+- C（lint 守）：新增 `scripts/lint-verifier-prompts.py`，CI 跑。
+
+## 修法
+
+### B. webhook 层 retry follow-up cap 提到 3
+
+`orchestrator/src/orchestrator/webhook.py` 的 `retry_worthy` 分支：
+
+- `retry_count < 2` → `retry_count < 3`（cap 从 2 次提到 3 次）
+- `_VERIFIER_RETRY_PROMPT` 加 3 条强制说明：
+  1. JSON 块 **必须放在最后一条 assistant message** 里（不能写中间消息）
+  2. 同时**先 PATCH `decision:<action>[-<fixer>]` tag** 再写 JSON（双兜底）
+  3. 重申 `action` 只能是 `pass` / `fix` / `escalate` / `retry` 4 字面量
+
+verifier_parse_retry_count 含义不变，只是 cap 抬高 1。
+
+### C. scripts/lint-verifier-prompts.py + CI 集成
+
+新脚本静态扫 `orchestrator/src/orchestrator/prompts/verifier/` 下所有
+`*.md.j2`，校验关键约束：
+
+1. `_decision.md.j2` 必须包含 4 个字面 action 名
+   (`pass` / `fix` / `escalate` / `retry`) 的 JSON 示例
+2. `_decision.md.j2` 必须含强制提示关键短语：
+   - `HARD CONSTRAINT`
+   - `decision:` tag mandate
+   - `最后一条 assistant message`
+3. 每个 `<stage>_<trigger>.md.j2` 必须 `{% include "verifier/_decision.md.j2" %}`
+
+任一缺失退出非零。挂在 `orchestrator-ci.yml` lint-test job 的 `ruff` step
+后面，runner 镜像不需要新依赖（纯 stdlib python3）。
+
+## 不做的事
+
+- 不动 BKD 层 schema validate（issue #395 A 段）—— 跨仓 scope
+- 不改 verifier prompt 任何业务语义（4 路决策不动、JSON schema 不动、tag 兜
+  底逻辑不动）
+- 不改 watchdog / escalate 路径
+- 不动 verifier_parser.extract_decision_robust（前一个 REQ 已经修好平凡 tag
+  fallback，本 REQ 只补 retry 次数 + lint 守）

--- a/openspec/changes/REQ-fix-verifier-schema-395-1777869659/specs/verifier-decision-retry-cap/spec.md
+++ b/openspec/changes/REQ-fix-verifier-schema-395-1777869659/specs/verifier-decision-retry-cap/spec.md
@@ -1,0 +1,92 @@
+# Spec delta — verifier-decision-retry-cap
+
+## ADDED Requirements
+
+### Requirement: webhook retry cap for verifier decision parse failure SHALL be 3
+
+The orchestrator webhook handler SHALL automatically follow-up the verifier-agent
+with a corrective prompt up to **3 times** when its `session.completed` payload
+yields a parseable-but-schema-invalid decision (i.e. `extract_decision_robust`
+returned `retry_worthy=true`). The retry counter MUST be persisted on
+`req_state.context.verifier_parse_retry_count`. On the 4th failed parse the
+handler MUST stop retrying and let the existing `VERIFY_ESCALATE` path fire.
+The retry follow-up prompt (`webhook._VERIFIER_RETRY_PROMPT`) MUST contain all
+three mandate phrases the prompt suite already requires of agents:
+the JSON block goes in the **last assistant message**, a redundant
+`decision:<action>[-<fixer>]` BKD tag MUST be PATCHed first, and the `action`
+field MUST be one of the four literals `pass` / `fix` / `escalate` / `retry`.
+
+#### Scenario: VDRC-S1 third schema-invalid attempt still triggers a follow-up retry
+- **GIVEN** a verifier sub-issue with `req_state.context.verifier_parse_retry_count = 2`
+- **AND** the new `session.completed` payload still yields `retry_worthy=true`
+- **WHEN** the webhook handler processes the event
+- **THEN** the handler issues exactly one BKD `follow_up_issue` call with
+  `webhook._VERIFIER_RETRY_PROMPT` as the prompt
+- **AND** the handler returns `{"action": "skip", "reason": "verifier_parse_retry_3"}`
+- **AND** `req_state.context.verifier_parse_retry_count` is updated to `3`
+
+#### Scenario: VDRC-S2 fourth schema-invalid attempt escalates without follow-up
+- **GIVEN** a verifier sub-issue with `req_state.context.verifier_parse_retry_count = 3`
+- **AND** the new `session.completed` payload still yields `retry_worthy=true`
+- **WHEN** the webhook handler processes the event
+- **THEN** no `follow_up_issue` call is made
+- **AND** the derived event is `Event.VERIFY_ESCALATE`
+- **AND** `req_state.context.escalated_reason` is set to `verifier-decision`
+
+#### Scenario: VDRC-S3 retry follow-up prompt mandates the three rules
+- **GIVEN** the constant `webhook._VERIFIER_RETRY_PROMPT`
+- **WHEN** an operator inspects its text
+- **THEN** the text contains the substring `last assistant message`
+  (case-insensitive)
+- **AND** the text contains the substring `decision:` (the BKD tag mandate)
+- **AND** the text lists the four valid action literals `pass`, `fix`,
+  `escalate`, `retry` together with the JSON skeleton
+
+### Requirement: prompt-suite lint script SHALL guard verifier prompts at CI time
+
+The repository SHALL ship a static linter at `scripts/lint-verifier-prompts.py`
+that exits non-zero when the verifier prompt suite drifts from the contract
+this REQ pins. The linter MUST be runnable with stdlib python3 only (no third
+party deps), so it can run in any CI environment without `uv`/`pip install`.
+It MUST scan `orchestrator/src/orchestrator/prompts/verifier/` and enforce:
+
+1. `_decision.md.j2` MUST contain each of the four valid action literals
+   `"pass"`, `"fix"`, `"escalate"`, `"retry"` (with surrounding double quotes,
+   so JSON examples are matched, not prose).
+2. `_decision.md.j2` MUST contain at least one occurrence of the literal
+   phrase `HARD CONSTRAINT`, the literal substring `decision:` (the BKD tag
+   mandate), and the literal substring `最后一条 assistant message`
+   (the last-assistant-message rule).
+3. Every per-stage verifier prompt matching the glob
+   `<stage>_<trigger>.md.j2` (i.e. files **not** starting with `_`) MUST
+   include `_decision.md.j2` via a Jinja `{% include "verifier/_decision.md.j2" %}`
+   directive. Files starting with `_` (partials) are not subject to this rule.
+
+The CI workflow `.github/workflows/orchestrator-ci.yml` MUST invoke this
+linter in the `lint-test` job, so that any verifier-prompt drift fails the
+PR check. The script MUST print a one-line per-violation report to stdout
+before exiting non-zero, so the CI log makes the diagnosis obvious.
+
+#### Scenario: VDRC-S4 lint passes on the in-tree prompt suite
+- **GIVEN** the unmodified `orchestrator/src/orchestrator/prompts/verifier/`
+  directory at HEAD
+- **WHEN** an operator runs `python3 scripts/lint-verifier-prompts.py`
+- **THEN** the exit code is `0`
+- **AND** stdout contains a final `OK` line summarizing the count of
+  prompts checked
+
+#### Scenario: VDRC-S5 lint flags a stage prompt missing the `_decision.md.j2` include
+- **GIVEN** a per-stage verifier prompt (e.g. `analyze_fail.md.j2`) where the
+  `{% include "verifier/_decision.md.j2" %}` line has been removed
+- **WHEN** an operator runs `python3 scripts/lint-verifier-prompts.py`
+- **THEN** the exit code is non-zero
+- **AND** stdout contains a line that names the offending file and the
+  reason `missing decision include`
+
+#### Scenario: VDRC-S6 lint flags `_decision.md.j2` missing a mandate phrase
+- **GIVEN** `_decision.md.j2` from which the literal phrase
+  `HARD CONSTRAINT` has been deleted
+- **WHEN** an operator runs `python3 scripts/lint-verifier-prompts.py`
+- **THEN** the exit code is non-zero
+- **AND** stdout contains a line naming `_decision.md.j2` and the reason
+  `missing mandate phrase: HARD CONSTRAINT`

--- a/openspec/changes/REQ-fix-verifier-schema-395-1777869659/tasks.md
+++ b/openspec/changes/REQ-fix-verifier-schema-395-1777869659/tasks.md
@@ -1,0 +1,20 @@
+# Tasks — REQ-fix-verifier-schema-395-1777869659
+
+## Stage: contract / spec
+- [x] author specs/verifier-decision-retry-cap/spec.md (3 scenarios: VDRC-S1..S3)
+- [x] write proposal.md / tasks.md
+
+## Stage: implementation
+- [x] update `orchestrator/src/orchestrator/webhook.py`: retry cap 2 → 3, expand `_VERIFIER_RETRY_PROMPT` with mandate phrases (last-assistant-message + decision tag + 4 valid actions)
+- [x] add `scripts/lint-verifier-prompts.py` static checker (stdlib python3, exit non-zero on violation)
+- [x] wire lint into `.github/workflows/orchestrator-ci.yml` (new step in lint-test job, after ruff)
+- [x] unit tests in `orchestrator/tests/test_webhook_verifier_retry.py` covering retry_count=2 (still retries) and retry_count=3 (escalate); update existing test names/comments to reflect new cap
+- [x] standalone test `orchestrator/tests/test_lint_verifier_prompts.py` for the new lint script
+
+## Stage: PR (gates before push)
+- [x] `make ci-lint` green
+- [x] `make ci-unit-test` green
+- [x] `make ci-integration-test` green (or skipped if no PG)
+- [x] `python3 scripts/lint-verifier-prompts.py` green (self-test)
+- [x] git push feat/REQ-fix-verifier-schema-395-1777869659
+- [x] gh pr create --label sisyphus

--- a/orchestrator/src/orchestrator/webhook.py
+++ b/orchestrator/src/orchestrator/webhook.py
@@ -72,9 +72,25 @@ _USER_REVIEW_STATUS_TO_EVENT: dict[str, Event] = {
 }
 
 _VERIFIER_RETRY_PROMPT = """\
-Your previous decision output could not be parsed as valid JSON.
+HARD CONSTRAINT: your previous decision output could not be parsed as valid JSON.
 
-Please output ONLY a valid JSON object in exactly this format (use double quotes, no trailing commas):
+Please re-emit your decision following ALL three rules below. sisyphus has
+already retried this parse, so missing any rule wastes the next chance.
+
+1. Put the JSON block in your **last assistant message** (not in the middle of
+   a longer reply, not in a tool call). sisyphus reads only the last message
+   via the BKD `/logs` API.
+2. **Before** writing the JSON, PATCH your own BKD issue to add a redundant
+   `decision:<action>[-<fixer>]` tag (e.g. `decision:pass`, `decision:fix-dev`,
+   `decision:fix-spec`, `decision:escalate`, `decision:retry`). The plain tag
+   is the second leg of the parser; without it the orch fallback cannot
+   recover from a truncated message.
+3. The `action` field MUST be exactly one of the four literals
+   `"pass"`, `"fix"`, `"escalate"`, `"retry"`. Any other value (including
+   typos like `"passes"` / `"escalated"`) is rejected by the schema validator.
+
+Output ONLY a JSON object matching exactly this shape (double quotes, no
+trailing commas, no comments):
 
 ```json
 {
@@ -86,6 +102,11 @@ Please output ONLY a valid JSON object in exactly this format (use double quotes
 }
 ```
 """
+
+# Max number of webhook-side follow-up retries when a verifier session.completed
+# yields a parseable-but-schema-invalid decision (retry_worthy=True).
+# REQ-fix-verifier-schema-395-1777869659: bumped 2 → 3 after #802 stuck.
+_VERIFIER_PARSE_RETRY_CAP = 3
 
 
 async def _maybe_derive_user_review_event(
@@ -476,7 +497,8 @@ async def webhook(request: Request) -> JSONResponse:
 
     # M14b：verifier-agent session.completed → 解 decision JSON（tag 或 description）
     # router.derive_event 对 `verifier` tag 主动返 None，交给这里 full parse。
-    # REQ-fix-verifier-json-parse-1777420690：schema invalid 时自动 retry（最多 2 次）。
+    # REQ-fix-verifier-json-parse-1777420690：schema invalid 时自动 retry。
+    # REQ-fix-verifier-schema-395-1777869659：cap 提到 3（_VERIFIER_PARSE_RETRY_CAP）。
     decision_payload: dict | None = None
     retry_worthy = False
     if (
@@ -509,7 +531,7 @@ async def webhook(request: Request) -> JSONResponse:
                  decision=decision_payload, reason=why, retry_worthy=retry_worthy,
                  executionId=body.executionId, dedup_status=_dedup_status)
 
-        # ─── 解析失败自动 retry（最多 2 次）───────────────────────────────────
+        # ─── 解析失败自动 retry（cap _VERIFIER_PARSE_RETRY_CAP，默认 3）───────
         if event == Event.VERIFY_ESCALATE and retry_worthy:
             retry_req_id = router_lib.extract_req_id(tags, body.issueNumber)
             if retry_req_id:
@@ -517,7 +539,7 @@ async def webhook(request: Request) -> JSONResponse:
                     retry_row = await req_state.get(pool, retry_req_id)
                     retry_ctx = retry_row.context or {} if retry_row else {}
                     retry_count = int(retry_ctx.get("verifier_parse_retry_count", 0))
-                    if retry_count < 2:
+                    if retry_count < _VERIFIER_PARSE_RETRY_CAP:
                         # follow-up 要求 verifier 重新输出标准格式
                         try:
                             async with BKDClient(

--- a/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
+++ b/orchestrator/tests/test_contract_watchdog_stuck_notify_challenger.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import httpx
 import pytest
@@ -148,7 +148,7 @@ def _make_stale_row(req_id="REQ-stuck-1", stale_for_sec=2400, *,
         "req_id": req_id,
         "project_id": "proj-test",
         "state": "escalated",
-        "updated_at": datetime.now(timezone.utc) - timedelta(seconds=stale_for_sec),
+        "updated_at": datetime.now(UTC) - timedelta(seconds=stale_for_sec),
         "stuck_sec": stale_for_sec,
         "context": dict(context or {}),
     }

--- a/orchestrator/tests/test_lint_verifier_prompts.py
+++ b/orchestrator/tests/test_lint_verifier_prompts.py
@@ -1,0 +1,111 @@
+"""Test scripts/lint-verifier-prompts.py.
+
+REQ-fix-verifier-schema-395-1777869659 VDRC-S4..S6: the lint script must pass
+on the in-tree prompt suite, and must flag the documented drift modes.
+"""
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LINT_SCRIPT = REPO_ROOT / "scripts" / "lint-verifier-prompts.py"
+PROMPT_DIR = REPO_ROOT / "orchestrator" / "src" / "orchestrator" / "prompts" / "verifier"
+
+
+def _load_lint_module():
+    """Import the lint script as a module (filename has a hyphen)."""
+    spec = importlib.util.spec_from_file_location("lint_verifier_prompts", LINT_SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_lint_passes_on_intree_prompts(capsys):
+    """VDRC-S4: HEAD prompt suite passes; final stdout line starts with `OK`."""
+    mod = _load_lint_module()
+    rc = mod.main([str(LINT_SCRIPT)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.strip().splitlines()[-1].startswith("OK")
+
+
+def test_lint_flags_missing_decision_include(monkeypatch, capsys):
+    """VDRC-S5: removing the include from a per-stage prompt fails the lint."""
+    mod = _load_lint_module()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp) / "verifier"
+        shutil.copytree(PROMPT_DIR, tmp_dir)
+        # nuke include from one stage prompt
+        target = tmp_dir / "analyze_fail.md.j2"
+        text = target.read_text(encoding="utf-8")
+        new = text.replace(
+            '{% include "verifier/_decision.md.j2" %}',
+            "<!-- removed for test -->",
+        )
+        assert new != text, "fixture missing the include we expected"
+        target.write_text(new, encoding="utf-8")
+
+        monkeypatch.setattr(mod, "PROMPT_DIR", tmp_dir)
+        rc = mod.main([str(LINT_SCRIPT)])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "analyze_fail.md.j2" in out
+        assert "missing decision include" in out
+
+
+@pytest.mark.parametrize(
+    "phrase", ["HARD CONSTRAINT", "decision:", "最后一条 assistant message"],
+)
+def test_lint_flags_missing_mandate_phrase(monkeypatch, capsys, phrase):
+    """VDRC-S6: removing any of the 3 mandate phrases from _decision.md.j2 fails."""
+    mod = _load_lint_module()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp) / "verifier"
+        shutil.copytree(PROMPT_DIR, tmp_dir)
+        decision = tmp_dir / "_decision.md.j2"
+        text = decision.read_text(encoding="utf-8")
+        # Replace every occurrence so the phrase is fully gone
+        new = text.replace(phrase, "REMOVED")
+        assert new != text, f"fixture _decision.md.j2 missing phrase {phrase!r}"
+        decision.write_text(new, encoding="utf-8")
+
+        monkeypatch.setattr(mod, "PROMPT_DIR", tmp_dir)
+        rc = mod.main([str(LINT_SCRIPT)])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "_decision.md.j2" in out
+        assert f"missing mandate phrase: {phrase}" in out
+
+
+def test_lint_flags_missing_action_literal(monkeypatch, capsys):
+    """Removing one of the 4 action JSON literals from _decision.md.j2 fails."""
+    mod = _load_lint_module()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp) / "verifier"
+        shutil.copytree(PROMPT_DIR, tmp_dir)
+        decision = tmp_dir / "_decision.md.j2"
+        text = decision.read_text(encoding="utf-8")
+        new = text.replace('"retry"', '"REMOVED"')
+        assert new != text
+        decision.write_text(new, encoding="utf-8")
+
+        monkeypatch.setattr(mod, "PROMPT_DIR", tmp_dir)
+        rc = mod.main([str(LINT_SCRIPT)])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert 'missing required action literal: "retry"' in out
+
+
+def teardown_module(_mod):
+    """Drop our hand-loaded lint module so other tests don't see it cached."""
+    sys.modules.pop("lint_verifier_prompts", None)

--- a/orchestrator/tests/test_webhook_verifier_retry.py
+++ b/orchestrator/tests/test_webhook_verifier_retry.py
@@ -1,6 +1,7 @@
 """webhook verifier decision parse retry 逻辑单测。
 
-REQ-fix-verifier-json-parse-1777420690：schema invalid 时自动 retry（最多 2 次）。
+REQ-fix-verifier-json-parse-1777420690：schema invalid 时自动 retry。
+REQ-fix-verifier-schema-395-1777869659：cap 提到 3 + prompt 强制提示 3 条规则。
 """
 from __future__ import annotations
 
@@ -150,7 +151,7 @@ async def _call_webhook(body, monkeypatch):
                     retry_row = await webhook.req_state.get(None, retry_req_id)
                     retry_ctx = retry_row.context or {} if retry_row else {}
                     retry_count = int(retry_ctx.get("verifier_parse_retry_count", 0))
-                    if retry_count < 2:
+                    if retry_count < webhook._VERIFIER_PARSE_RETRY_CAP:
                         async with webhook.BKDClient("", "") as bkd:
                             await bkd.follow_up_issue(
                                 project_id=body.projectId,
@@ -212,10 +213,29 @@ async def test_retry_on_schema_invalid_second_time(fake_bkd, fake_req_state, fak
 
 
 @pytest.mark.asyncio
-async def test_escalate_when_retry_exhausted(fake_bkd, fake_req_state, fake_obs, fake_dedup, monkeypatch):
-    """第三次 schema invalid（retry_count=2）→ escalate，不再 retry。"""
+async def test_third_attempt_still_retries(fake_bkd, fake_req_state, fake_obs, fake_dedup, monkeypatch):
+    """REQ-fix-verifier-schema-395：第三次 schema invalid（retry_count=2）→
+    仍 follow-up retry（cap=3），返回 skip。"""
     rows, _ctx_updates = fake_req_state
     rows["REQ-1"] = _FakeReqStateRow(context={"verifier_parse_retry_count": 2})
+    fake_bkd.set_last_msg("```json\n{\"action\": \"nope\"}\n```")
+
+    body = FakeBody(
+        event="session.completed", issueId="vfy-1", issueNumber=1,
+        projectId="proj-1", tags=["verifier", "REQ-1", "verify:staging_test"],
+    )
+    result = await _call_webhook(body, monkeypatch)
+
+    assert result["action"] == "skip"
+    assert result["reason"] == "verifier_parse_retry_3"
+    assert len(fake_bkd.captured_follow_up) == 1
+
+
+@pytest.mark.asyncio
+async def test_escalate_when_retry_exhausted(fake_bkd, fake_req_state, fake_obs, fake_dedup, monkeypatch):
+    """第四次 schema invalid（retry_count=3，已达 cap）→ escalate，不再 retry。"""
+    rows, _ctx_updates = fake_req_state
+    rows["REQ-1"] = _FakeReqStateRow(context={"verifier_parse_retry_count": 3})
     fake_bkd.set_last_msg("```json\n{\"action\": \"nope\"}\n```")
 
     body = FakeBody(
@@ -228,6 +248,21 @@ async def test_escalate_when_retry_exhausted(fake_bkd, fake_req_state, fake_obs,
     assert result["retry_worthy"] is True
     # 没有 follow-up
     assert len(fake_bkd.captured_follow_up) == 0
+
+
+def test_retry_prompt_includes_three_mandate_rules():
+    """REQ-fix-verifier-schema-395 VDRC-S3：retry follow-up prompt 必须明确
+    点出 3 条规则（最后一条 message / decision tag / 4 字面量 action）。"""
+    text = webhook._VERIFIER_RETRY_PROMPT
+    assert "last assistant message" in text.lower()
+    assert "decision:" in text  # 平凡 BKD tag mandate
+    for action in ('"pass"', '"fix"', '"escalate"', '"retry"'):
+        assert action in text
+
+
+def test_retry_cap_constant_is_three():
+    """REQ-fix-verifier-schema-395：cap 必须 = 3。"""
+    assert webhook._VERIFIER_PARSE_RETRY_CAP == 3
 
 
 @pytest.mark.asyncio

--- a/scripts/lint-verifier-prompts.py
+++ b/scripts/lint-verifier-prompts.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Static lint for the verifier prompt suite.
+
+Guards three drift modes that historically caused #802-style stuck verifier
+issues (REQ-fix-verifier-schema-395-1777869659, refs phona/sisyphus#395):
+
+1. ``_decision.md.j2`` MUST keep all 4 valid action literals as JSON examples
+   (``"pass"``, ``"fix"``, ``"escalate"``, ``"retry"``). If one drifts out, the
+   schema docs in the prompt no longer match what ``router.validate_decision``
+   accepts and agents start emitting unparseable variants.
+2. ``_decision.md.j2`` MUST keep the three mandate phrases that the prompt
+   suite (and the matching webhook retry follow-up) tells agents to honor:
+   ``HARD CONSTRAINT``, the BKD ``decision:`` tag mandate, and the
+   ``最后一条 assistant message`` rule.
+3. Every per-stage verifier prompt (file not starting with ``_``) MUST
+   ``{% include "verifier/_decision.md.j2" %}`` so the schema rendering is
+   identical across all stage / trigger combinations.
+
+Stdlib-only so CI can run it without extra deps. Exits non-zero on any
+violation; prints one diagnostic line per violation, plus a final ``OK`` line
+when clean.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROMPT_DIR = REPO_ROOT / "orchestrator" / "src" / "orchestrator" / "prompts" / "verifier"
+DECISION_FILE = "_decision.md.j2"
+
+# JSON literals (with surrounding double-quotes so we match JSON examples,
+# not stray prose like "and pass it on").
+REQUIRED_ACTION_LITERALS = ('"pass"', '"fix"', '"escalate"', '"retry"')
+
+# Mandate phrases that must appear at least once inside _decision.md.j2.
+REQUIRED_MANDATE_PHRASES = (
+    "HARD CONSTRAINT",
+    "decision:",  # plain BKD tag mandate (REQ-fix-verifier-decision-tag)
+    "最后一条 assistant message",
+)
+
+# Jinja include directive the per-stage prompts must use. Match relaxed on
+# whitespace inside braces but require the exact path.
+INCLUDE_RE = re.compile(
+    r"""\{\%\s*include\s+["']verifier/_decision\.md\.j2["']\s*\%\}""",
+)
+
+
+def _violations() -> list[str]:
+    out: list[str] = []
+    if not PROMPT_DIR.is_dir():
+        return [f"FATAL: prompt dir not found: {PROMPT_DIR}"]
+
+    decision_path = PROMPT_DIR / DECISION_FILE
+    if not decision_path.is_file():
+        out.append(f"FATAL: missing required partial: {decision_path}")
+    else:
+        text = decision_path.read_text(encoding="utf-8")
+        for lit in REQUIRED_ACTION_LITERALS:
+            if lit not in text:
+                out.append(
+                    f"{DECISION_FILE}: missing required action literal: {lit}",
+                )
+        for phrase in REQUIRED_MANDATE_PHRASES:
+            if phrase not in text:
+                out.append(
+                    f"{DECISION_FILE}: missing mandate phrase: {phrase}",
+                )
+
+    stage_files = sorted(
+        p for p in PROMPT_DIR.glob("*.md.j2") if not p.name.startswith("_")
+    )
+    if not stage_files:
+        out.append(
+            f"FATAL: no per-stage verifier prompts found under {PROMPT_DIR}",
+        )
+    for p in stage_files:
+        text = p.read_text(encoding="utf-8")
+        if not INCLUDE_RE.search(text):
+            out.append(f"{p.name}: missing decision include")
+
+    return out
+
+
+def main(argv: list[str]) -> int:
+    violations = _violations()
+    for v in violations:
+        print(v)
+    if violations:
+        return 1
+    stage_count = sum(
+        1 for p in PROMPT_DIR.glob("*.md.j2") if not p.name.startswith("_")
+    )
+    print(f"OK: {stage_count} verifier stage prompt(s) checked, {DECISION_FILE} contract intact")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary
- Bumps the orch webhook's verifier-decision parse-retry cap from 2 to 3 and rewrites `_VERIFIER_RETRY_PROMPT` to spell out the three rules agents must obey on retry (last-assistant-message placement, redundant `decision:<action>` BKD tag, action ∈ {pass,fix,escalate,retry}).
- Adds `scripts/lint-verifier-prompts.py` (stdlib-only) and wires it into `orchestrator-ci.yml`'s lint-test job. The lint guards `_decision.md.j2` from drifting away from the 4 valid action literals or the 3 mandate phrases (`HARD CONSTRAINT`, `decision:` tag mandate, `最后一条 assistant message`), and ensures every per-stage verifier prompt `{% include %}`s `_decision.md.j2`.
- Closes phona/sisyphus#395 (B + C of the issue's three-part fix; A — BKD-side schema validate — lives in another repo).

## Why
5/4 v5 #802 took 30+ min to diagnose because the verifier emitted only a `decision:pass` string tag (no JSON block) and the orch retry budget was 1 attempt. The cap bump buys 1 more shot; the lint script keeps the prompt contract from drifting away from what the parser expects.

## Test plan
- [x] `make ci-lint` green
- [x] `make ci-unit-test` — new + updated tests pass; pre-existing 31 failures in `test_engine.py` / `test_runner_gc.py` etc. confirmed to exist on baseline (test pollution unrelated to this REQ)
- [x] `make ci-integration-test` skips (no PG locally; exit 5 → pass)
- [x] `python3 scripts/lint-verifier-prompts.py` returns 0
- [x] `openspec validate REQ-fix-verifier-schema-395-1777869659` — valid
- [x] `bash scripts/check-scenario-refs.sh --specs-search-path . .` — green

<!-- sisyphus:cross-link -->
**sisyphus REQ**: \`REQ-fix-verifier-schema-395-1777869659\`
**BKD intent issue**: [BKD intent issue](https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/projects/nnvxh8wj/issues/2zpsim9i)