### PR TITLE
chore(helm): default agent_model to sonnet for dev/dogfood phase

### DIFF
--- a/orchestrator/helm/templates/configmap.yaml
+++ b/orchestrator/helm/templates/configmap.yaml
@@ -9,6 +9,9 @@ data:
   SISYPHUS_LOG_JSON: {{ .Values.env.log_json | quote }}
   SISYPHUS_BKD_BASE_URL: {{ .Values.env.bkd_base_url | quote }}
   SISYPHUS_WORKDIR_ROOT: {{ .Values.env.workdir_root | quote }}
+  {{- with .Values.env.agent_model }}
+  SISYPHUS_AGENT_MODEL: {{ . | quote }}
+  {{- end }}
   SISYPHUS_SKIP_ANALYZE: {{ .Values.env.skip_analyze | quote }}
   SISYPHUS_SKIP_SPEC: {{ .Values.env.skip_spec | quote }}
   SISYPHUS_SKIP_DEV: {{ .Values.env.skip_dev | quote }}

--- a/orchestrator/helm/values.yaml
+++ b/orchestrator/helm/values.yaml
@@ -86,6 +86,11 @@ env:
   log_json: true
   bkd_base_url: https://bkd-launcher--admin-jbcnet--weifashi.coder.tbc.5ok.co/api
   workdir_root: /var/sisyphus-ci
+
+  # ─── stage agent / verifier / fixer / pr-ci-watch sub-issue 默认 model ───
+  # 设计原则（CLAUDE.md "生产用最强模型"）默认 opus；dev/dogfood 阶段可降 sonnet 省 token。
+  # 留空走 config.py default (claude-opus-4-7[1m])
+  agent_model: claude-sonnet-4-6
   # 不存任何 project_id / repo_url —— project_id 来自 webhook，
   # repo_url 来自 agent 自己 `git remote get-url origin`
   # snapshot loop 排除已知死项目（每 5min 一次的 BKD list_issues 失败 noise）。


### PR DESCRIPTION
## Summary

dev/调试阶段 sisyphus 自 dogfood 用 opus 4.7 是 token 浪费（10+ REQ/晚 × Opus ~5 倍 sonnet 价 = 巨成本）。CLAUDE.md "生产用最强模型" 原则在生产部署再切回。

## Changes

- `orchestrator/helm/values.yaml`: 加 `env.agent_model: "claude-sonnet-4-6"`（留空则走 config.py default = opus）
- `orchestrator/helm/templates/configmap.yaml`: 条件渲染 `SISYPHUS_AGENT_MODEL`（with .Values.env.agent_model）

## 实证

5/4 凌晨手 `kubectl set env deploy/orch-sisyphus-orchestrator SISYPHUS_AGENT_MODEL=claude-sonnet-4-6` 临时切，本 PR 持久化到 helm，下次 helm upgrade 不 revert。

切回 Opus 只需 `agent_model: ""` 或删该行。

## Test plan

- [ ] helm upgrade 后 configmap 含 SISYPHUS_AGENT_MODEL=claude-sonnet-4-6
- [ ] orch 启动正常，新 sub-issue 用 sonnet