### PR TITLE
fix(chart/thanatos): set resources.limits to bound orphan-pod blast (closes #433)

### DIFF
--- a/deploy/charts/thanatos/values.yaml
+++ b/deploy/charts/thanatos/values.yaml
@@ -20,7 +20,11 @@ resources:
   requests:
     cpu: 200m
     memory: 256Mi
-  limits: {}
+  # 必设 limits 防 orphan pod 拖死 host（phona/sisyphus#433 实证：redroid 烧 CPU
+  # 18+h 把 vm-node04 cluster sshd / ingress / k3s API 全打死）。
+  limits:
+    cpu: "1"
+    memory: 512Mi
 
 service:
   # Debug only: kubectl port-forward + local mcp client. accept-agent reaches
@@ -43,6 +47,12 @@ redroid:
     requests:
       cpu: 500m
       memory: 1Gi
+    # redroid 跑 Android 完整系统（zygote64 / system_server / SystemUI / mediaserver
+    # 等持续 30-50% CPU），不限 = 8c VM 上单 orphan 就拖死 host（phona/sisyphus#433）。
+    # 2 CPU / 2Gi 给 boot 时峰值（~1.5 CPU / 1.5Gi 持续 30s）留余量。
+    limits:
+      cpu: "2"
+      memory: 2Gi
 
 # Pod-level options
 imagePullSecrets: []


### PR DESCRIPTION
## What

\`deploy/charts/thanatos/values.yaml\` 加 limits：

| 容器 | 之前 | 现在 |
|---|---|---|
| thanatos | requests 200m/256Mi, limits {} | + limits 1 CPU / 512Mi |
| redroid  | requests 500m/1Gi, 没 limits 字段 | + limits 2 CPU / 2Gi |

## Why

phona/sisyphus#433 实证：phase5b shortcut REQ 留 orphan thanatos+redroid pod 18h，redroid 内 Android 系统持续 30-50% CPU 没人拦 → 8c vm-node04 load avg 飙到 167 → sshd 拒连 / ingress 死 / k3s API timeout。删 orphan namespace 30s 内 load 1min 83→26 立证。

## Test

\`\`\`bash
helm template test deploy/charts/thanatos --set driver=adb --set image.tag=sha-test
\`\`\`

输出 verify：
- thanatos container limits: cpu 1 / memory 512Mi ✓
- redroid container limits: cpu 2 / memory 2Gi ✓

## Test plan

- [x] helm template 渲染 limits 字段正确
- [ ] CI: 全绿
- [ ] CD: deploy.yml helm upgrade（main merge 后）
- [ ] dogfood: 下次 thanatos chart 起 redroid 跑满 5h 不再拖死 host

## 不涉及

- orch accept-env GC（独立 issue 立后续）
- runtime 已跑的 thanatos chart（要 helm upgrade 才生效）

🤖 Generated with [Claude Code](https://claude.com/claude-code)