### PR TITLE
debug(create_accept): log manifest_probe stdout/exit_code for #439 diagnosis

### DIFF
--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -282,6 +282,16 @@ async def _read_source_manifest(rc, req_id: str, source_basename: str) -> Manife
         "fi"
     )
     result = await rc.exec_in_runner(req_id, command=cmd, timeout_sec=_TIMEOUT_MANIFEST_READ_SEC)
+    log.warning(
+        "create_accept.manifest_probe_debug",
+        req_id=req_id,
+        source=source_basename,
+        path=path,
+        exit_code=result.exit_code,
+        stdout_len=len(result.stdout or ""),
+        stdout_head=(result.stdout or "")[:400],
+        stderr_head=(result.stderr or "")[:200],
+    )
     if result.exit_code != 0:
         # probe failure (kubectl exec hiccup, broken shell, etc.) — fall back
         # to legacy single-layer path rather than escalating: an existing


### PR DESCRIPTION
诊断 phona/sisyphus#439：phase5 forgot-password REQ accept 3 attempts 都 'no manifest' fallback single-layer，但 PVC 直查 file 在场，orch 同 bash command exec 返回 __MANIFEST_FOUND__。需看 orch 实际 result.stdout/exit_code 才能定根因。

加一行 log.warning('create_accept.manifest_probe_debug', ...) 输出 stdout_head / exit_code / stderr_head，无行为改动。诊断完 revert。

merge → CI build → helm upgrade orch → admin/resume → log 出根因。