### PR TITLE
fix(create_accept): _resolve_source_repo honors source-repo tag (closes #439)

### DIFF
--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -282,6 +282,16 @@ async def _read_source_manifest(rc, req_id: str, source_basename: str) -> Manife
         "fi"
     )
     result = await rc.exec_in_runner(req_id, command=cmd, timeout_sec=_TIMEOUT_MANIFEST_READ_SEC)
+    log.warning(
+        "create_accept.manifest_probe_debug",
+        req_id=req_id,
+        source=source_basename,
+        path=path,
+        exit_code=result.exit_code,
+        stdout_len=len(result.stdout or ""),
+        stdout_head=(result.stdout or "")[:400],
+        stderr_head=(result.stderr or "")[:200],
+    )
     if result.exit_code != 0:
         # probe failure (kubectl exec hiccup, broken shell, etc.) — fall back
         # to legacy single-layer path rather than escalating: an existing

--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import json
 import shlex
 import time
+from collections.abc import Iterable
 
 import structlog
 
@@ -44,7 +45,7 @@ from ..prompts import render
 from ..state import Event
 from ..store import db, req_state, stage_runs
 from . import register, short_title
-from ._clone import ensure_runner_with_clone
+from ._clone import _extract_source_repo_tags, ensure_runner_with_clone
 from ._integration_resolver import resolve_integration_dir
 from ._skip import skip_if_enabled
 
@@ -779,7 +780,7 @@ async def create_accept(*, body, req_id, tags, ctx):
     # REQs typically have one entry; multi-repo REQs declare the source first
     # by convention (sisyphus-clone-repos.sh order). Fall back to integration
     # resolver scan when ctx is empty.
-    source_repo, source_basename = _resolve_source_repo(ctx)
+    source_repo, source_basename = _resolve_source_repo(ctx, tags)
 
     # If we can't identify a source repo from ctx, take the legacy single-layer
     # path which uses the integration resolver to pick a directory.
@@ -846,13 +847,27 @@ async def create_accept(*, body, req_id, tags, ctx):
     )
 
 
-def _resolve_source_repo(ctx: dict | None) -> tuple[str, str | None]:
-    """Best-effort identify the source repo full name + basename from ctx.
+def _resolve_source_repo(
+    ctx: dict | None, tags: Iterable[str] | None = None,
+) -> tuple[str, str | None]:
+    """Best-effort identify the source repo full name + basename.
 
-    Returns (full_name, basename); when ctx lacks the info, returns (`unknown`,
-    None) and caller falls through to the legacy resolver.
+    Layer priority（mirror _clone.resolve_repos #362）：
+      1. tags `source-repo:<owner>/<repo>` —— per-REQ explicit override
+      2. ctx.cloned_repos[0]
+      3. ctx.intake_finalized_intent.involved_repos[0] / ctx.involved_repos[0]
+      4. settings.default_involved_repos[0]
+
+    Returns (full_name, basename); when all layers are empty, returns
+    (`unknown`, None) and caller falls through to the legacy resolver.
     """
     ctx = ctx or {}
+    # Layer 1: source-repo tag wins —— admin/resume 时 ctx 可能被清空但 tag 还在
+    src_tags = _extract_source_repo_tags(tags) if tags is not None else []
+    if src_tags:
+        first = src_tags[0]
+        if isinstance(first, str) and "/" in first:
+            return first, first.split("/", 1)[1]
     cloned = ctx.get("cloned_repos") or []
     if cloned:
         first = cloned[0]


### PR DESCRIPTION
## 现象 (#439)

phase5 forgot-password REQ 多次 attempt 都 \`create_accept.single_layer reason=\"no manifest\"\` 走 single-layer fallback → BACKEND_ENDPOINT 注不进 → \`make accept-env-up\` 炸。

## 根因（debug log #440 暴露）

\`\`\`
\"path\": \"/workspace/source/sisyphus/.sisyphus/env.yaml\"
\"stdout\": \"__MANIFEST_MISSING__\"
\`\`\`

orch 在 \`sisyphus\` 子目录找 manifest，**不是真 source \`ttpos-flutter\`**。原因：

- \`_resolve_source_repo(ctx)\` 只看 ctx
- admin/resume 时 ctx 经常空（cloned_repos / involved_repos 都 None）
- → fallback \`settings.default_involved_repos[0] = \"phona/sisyphus\"\`
- → basename \`sisyphus\` → 找错路径 → MANIFEST_MISSING → single_layer

REQ-fix-orch-source-repo-tag-1777824479 (#362) 已为 \`_clone.resolve_repos\` 加了 \`source-repo:\` tag 最高优先层，但 \`_resolve_source_repo\` **没同步**——仍只信 ctx。

## 修法

\`_resolve_source_repo\` mirror \`_clone.resolve_repos\` 的 layer 顺序：
1. tags \`source-repo:<owner>/<repo>\` —— 最高优先
2. ctx.cloned_repos[0]
3. ctx.intake_finalized_intent.involved_repos / ctx.involved_repos
4. settings.default_involved_repos

调用点 create_accept 已有 \`tags\` 入参，传进去就行。

## 验证

merge → image build → helm upgrade → admin/resume phase5 → 期望 \`manifest_probe_debug path=/workspace/source/ttpos-flutter/...\` + \`__MANIFEST_FOUND__\` + \`multi_layer_start\` event → BACKEND_ENDPOINT 注入成功 → atomic MCP 实战。

## 范围

- 仅 \`_resolve_source_repo\` 加 tags 入参 + layer 1
- debug log (\`manifest_probe_debug\`) 暂留下个 PR 删

Closes #439
Refs #362