### PR TITLE
fix(create_accept): _branch_exists_on_remote URL missing @ between token and host

### DIFF
--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -349,7 +349,7 @@ async def _branch_exists_on_remote(
     propagates as False (fail-closed; caller will fall back through the R6
     chain).
     """
-    url = f"https://x-access-token:${{GH_TOKEN}}/github.com/{repo_full_name}.git"
+    url = f"https://x-access-token:${{GH_TOKEN}}@github.com/{repo_full_name}.git"
     cmd = f"git ls-remote --heads {url} {shlex.quote(branch)} | head -n1"
     try:
         result = await rc.exec_in_runner(req_id, command=cmd, timeout_sec=_TIMEOUT_BRANCH_CHECK_SEC)


### PR DESCRIPTION
## Bug

\`\`\`python
url = f\"https://x-access-token:\${{GH_TOKEN}}/github.com/{repo_full_name}.git\"
                                                  ↑ 应是 @ 不是 /
\`\`\`

URL 缺 \`@\` → 当 \`x-access-token:\${GH_TOKEN}\` 整串被 git 当 host：parser 把 \`x-access-token\` 当 host，\`\${GH_TOKEN}\` 当 port → connection fail → \`git ls-remote\` 非 0 → return False。

效果：cross-repo accept REQ 的所有 \`_branch_exists_on_remote\` 调用都 false，导致 same_name 同名分支识别不出（即使存在），class fallback 候选分支也识别不出 → \`branch_resolution_failed\` 整层 multi_layer 推不动。

## 复现

phase5 forgot-password REQ：ttpos-flutter \`needs: ZonEaseTech/ttpos-server-go\`，feat 同名分支两边都已推：

\`\`\`
$ git ls-remote ... ZonEaseTech/ttpos-server-go.git feat/REQ-REQ-phase5-forgot-password-1777940891
651abb2aa...  refs/heads/feat/REQ-REQ-phase5-forgot-password-1777940891
\`\`\`

但 orch 在 runner pod 跑同 ls-remote 用错误 URL → fail → 'branch_resolution_failed for ZonEaseTech/ttpos-server-go class=develop'。

## 修

加 \`@\`。

Refs phona/sisyphus#439（同 stack）