### PR TITLE
feat(intake): wire FinalizedIntent.model_validate into extractor (PR #471 §2.4 step 1)

### DIFF
--- a/orchestrator/src/orchestrator/router.py
+++ b/orchestrator/src/orchestrator/router.py
@@ -14,6 +14,9 @@ import json
 import re
 from collections.abc import Iterable
 
+from pydantic import ValidationError
+
+from .schemas.intent import FinalizedIntent
 from .state import Event
 from .verifier_parser import extract_decision_robust
 
@@ -183,53 +186,75 @@ def extract_decision_from_issue(
     return result.decision
 
 
-_REQUIRED_INTAKE_FIELDS = frozenset({
-    "involved_repos", "business_behavior", "data_constraints",
-    "edge_cases", "do_not_touch", "acceptance",
-})
+def _validate_intent_dict(data: object) -> dict | None:
+    """跑 FinalizedIntent.model_validate；通过返 by_alias dict（兼容下游
+    `involved_repos` 字段访问），失败 log debug 后返 None。
+
+    PR #471 §2.3 A 方案：A 方案在调用方（webhook）把 None 翻成 INTAKE_FAIL
+    强 escalate；本函数只负责"提取 + 严校验"，不直接 escalate。
+    """
+    if not isinstance(data, dict):
+        return None
+    try:
+        intent = FinalizedIntent.model_validate(data)
+    except ValidationError as e:
+        log.debug(
+            "extract_intake_finalized_intent.schema_invalid",
+            errors=e.errors(include_url=False),
+            keys=sorted(data.keys()),
+        )
+        return None
+    # by_alias=True → 输出 `involved_repos` 而不是 `repos`，兼容
+    # _clone.py / start_analyze_with_finalized_intent.py 现有字段访问。
+    # exclude_defaults=True → 没声明的 base_branches 不输出空 dict，
+    # 跟原 dict 形状保持向后兼容（避免下游消费方撞到意外字段）。
+    return intent.model_dump(by_alias=True, exclude_defaults=True)
 
 
 def extract_intake_finalized_intent(text: str | None) -> dict | None:
     """从 intake-agent 最后一条 message 提取 finalized intent JSON。
 
     3 层 fallback：json codeblock / plain codeblock / bare braces with key field。
-    必须含 6 个 required 字段，否则返 None。
+    提取到的 dict 走 FinalizedIntent.model_validate 严校验，schema 不合法返 None。
+
+    Schema：参见 `orchestrator.schemas.intent.FinalizedIntent` /
+    `docs/dispatch-contract.md` §3。
     """
     if not text:
         return None
-
-    def _valid(data: object) -> bool:
-        return isinstance(data, dict) and _REQUIRED_INTAKE_FIELDS.issubset(data.keys())
 
     # 1. ```json ... ``` 代码块（推荐，最稳）
     blocks = re.findall(r"```json\s*(\{.*?\})\s*```", text, flags=re.DOTALL)
     for blk in reversed(blocks):
         try:
             data = json.loads(blk)
-            if _valid(data):
-                return data
         except Exception:
             continue
+        validated = _validate_intent_dict(data)
+        if validated is not None:
+            return validated
 
     # 2. ``` ... ``` 无 lang 标代码块
     blocks = re.findall(r"```\s*(\{.*?\})\s*```", text, flags=re.DOTALL)
     for blk in reversed(blocks):
         try:
             data = json.loads(blk)
-            if _valid(data):
-                return data
         except Exception:
             continue
+        validated = _validate_intent_dict(data)
+        if validated is not None:
+            return validated
 
     # 3. bare braces 含 "involved_repos" 关键字
     candidates = re.findall(r"\{[^{}]*\"involved_repos\"[^{}]*\}", text, flags=re.DOTALL)
     for blk in reversed(candidates):
         try:
             data = json.loads(blk)
-            if _valid(data):
-                return data
         except Exception:
             continue
+        validated = _validate_intent_dict(data)
+        if validated is not None:
+            return validated
 
     return None
 

--- a/orchestrator/tests/test_intake.py
+++ b/orchestrator/tests/test_intake.py
@@ -77,6 +77,40 @@ def test_extract_none_on_empty():
     assert extract_intake_finalized_intent("no json here") is None
 
 
+# ─── 1b. FinalizedIntent 严校验（PR #471 §2.3 A 方案接通）──────────────────────
+
+def test_extract_rejects_extra_field():
+    """FinalizedIntent.extra=forbid → 6 字段以外的字段 = schema 漂移 → None"""
+    bad = {**_VALID_INTENT, "unexpected_field": "oops"}
+    text = f"```json\n{json.dumps(bad)}\n```"
+    assert extract_intake_finalized_intent(text) is None
+
+
+def test_extract_rejects_bad_repo_format():
+    """repos 必须 'owner/repo' 格式"""
+    bad = {**_VALID_INTENT, "involved_repos": ["just-name-no-slash"]}
+    text = f"```json\n{json.dumps(bad)}\n```"
+    assert extract_intake_finalized_intent(text) is None
+
+
+def test_extract_rejects_unknown_base_branch_key():
+    """base_branches 的 key 必须是 repos 里某一项的 basename"""
+    bad = {**_VALID_INTENT, "base_branches": {"unknown-repo": "main"}}
+    text = f"```json\n{json.dumps(bad)}\n```"
+    assert extract_intake_finalized_intent(text) is None
+
+
+def test_extract_accepts_base_branches():
+    """新字段 base_branches 选填，合法时透传"""
+    good = {**_VALID_INTENT, "base_branches": {"repo-a": "feat/develop"}}
+    text = f"```json\n{json.dumps(good)}\n```"
+    got = extract_intake_finalized_intent(text)
+    assert got is not None
+    assert got["base_branches"] == {"repo-a": "feat/develop"}
+    # 兼容 alias：下游读 involved_repos
+    assert got["involved_repos"] == ["owner/repo-a"]
+
+
 # ─── 2. router routing ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## TL;DR

执行 [docs/dispatch-contract.md](https://github.com/phona/sisyphus/blob/main/docs/dispatch-contract.md) §2.4 follow-up 第 1 步（A 方案接通）：把 intake-agent 输出的 finalized intent 从 "6 字段必填 issubset" 升级为 **pydantic FinalizedIntent.model_validate 严校验**。

## 改动

| 文件 | 变更 |
|---|---|
| `orchestrator/src/orchestrator/router.py` | 加 `_validate_intent_dict()` helper（pydantic + log debug error 细节 + by_alias 兼容下游）；3 层正则 fallback 全接入；删 `_REQUIRED_INTAKE_FIELDS` 常量（FinalizedIntent 接管真相） |
| `orchestrator/tests/test_intake.py` | 加 4 新 test：extra forbid / repo 格式 / base_branches key 引用 / happy 透传 base_branches |

## 行为变化

intake-agent 输出 silent None 升级为 schema 严校验：现在会捕到的错：
- `extra` 字段（schema 漂移防御）
- `involved_repos` 项格式错（必须 `owner/repo`）
- `base_branches` key 引用 repos 里不存在的 basename
- 字段类型错

捕到时 `log.debug` 含 pydantic `ValidationError` 详情，方便诊断（不再 silent）。
下游 `_clone.py` / `start_analyze_with_finalized_intent.py` 字段访问**完全不动**（`by_alias=True` 输出 `involved_repos` 兼容名）。

## 测试

- 25 原有 `test_intake` 全过
- 加 4 新 test 覆盖严校验路径
- 全套 **2376 passed**（13 PG-required tests skip，跟本改动无关）

## Follow-up（§2.4 余下 3 步）

后续 PR 一步一推：
- step 2: `start_analyze` 加 issue body intent block 提取（analyze 直入路径）
- step 3: `_clone.py` / `_resolve_source_repo` 砍 4 层 fallback
- step 4: 移除 helm `default_*` 字段读取代码

Refs PR #471, #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)