### PR TITLE
feat(accept): wire ttpos-ci image-publish status → SISYPHUS_IMAGE_TAGS env (closes #474)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -685,3 +685,84 @@ api-tag-management-spec.md。**不立 issue**——等 5 条 ttpos REQ 跑通 + 
 全套落地后启动。心智依据：dispatch-contract.md §0.1 (envelope vs letter)。
 
 撞够 3 次 C 类 tag 引发的故障再考虑立 issue。
+
+## 2026-05-06 06:09Z REQ-kiosk-log-cleanup-dogfood-1778045291 全链跑通到 staging-test 撞新 race
+**A 方案验证铁证**: 05:44:27 clone.exec source="ctx.intake_finalized_intent.involved_repos" repos=[ZonEaseTech/ttpos-flutter] —— PR #471/#472 dispatch-contract + FinalizedIntent 严校验链路真跑通，#464/#466 footgun 在新链路下天然消失（不走 helm fallback）。
+
+**新撞洞 (1 次)**: watchdog stuck (5min) → escalate.runner_cleaned 删 pod，但 BKD agent 后来 result:pass → ESCALATED → next-stage transition (challenger.pass → DEV_CROSS_CHECK → STAGING_TEST)，下游 stage exec runner pod → 404 → precheck:runner-pod-not-found → verifier escalate。
+
+根因：`watchdog → engine.step(Event.SESSION_FAILED) → escalate.cleanup_runner` 中间没 PATCH BKD cancel session，sisyphus 跟 BKD agent 不握手；BKD agent 不知自己被判死继续跑。escalate.py:482 假设"escalate = pod 没用"，但 ESCALATED → next-stage resume 路径不会重起 pod。
+
+修法候选（不修，记录）：
+- (A) state.py: ESCALATED → next-stage transition 强制重 ensure_runner
+- (B) escalate.py: 不立即删 pod，30s grace period 看 result tag 后到没
+- (C) watchdog: PATCH BKD cancel session 等真 session.failed 再 escalate
+- (D) 调 watchdog stuck 阈值 5min → 15min（治标）
+
+按 §15.2 第 1 次撞 → log + skip 不立 issue，撞够 3 次再 review。dogfood 进 §15.1 派下一条 ttpos REQ 循环。
+
+## 2026-05-06 06:48Z REQ admin resume 后到 accept-running 撞 vm04 evict + mid-action interrupt
+**追加进展**：admin resume 路径走通后 REQ 06:33:52 → pr-ci-running，06:35:53 pr-ci.pass → accept-running ✅（PR #206 GH CI 真绿）。
+
+**新撞故障 (1 次)**：vm04 节点 ephemeral-storage 阈值告警 → kubelet evict orch + metabase；create_accept action 跑到一半（state CAS 推到 accept-running 但 BKD agent 没起 / accept_issue_id 没落 ctx）→ orch 重启后 watchdog 找不到 accept sub-issue → 每 60s 报 watchdog.missing_issue_id 干瞪眼。
+
+根因：sisyphus action 不是原子的，state CAS + 副作用（起 BKD agent / 落 ctx 字段）非事务性，evict 在中间撞 → state 与 ctx 不一致。watchdog 没机制识别"state 推进了但 sub-issue 没起 = action 中断"，只会找现有 issue_id 轮。
+
+修法候选（不修，记录）：
+- (A) action 写 ctx fields 跟 state CAS 同事务（state machine 抽象层动）
+- (B) watchdog 加一条规则：state in (accept-running / staging-test-running / ...) 且 ctx 里对应 issue_id 缺 → 自动 reset 重派
+- (C) admin endpoint 加 reset-action（user 触发重派）
+- (D) infra 层：vm04 节点磁盘扩容 / ephemeral-storage 阈值调高 / orch 加 restart policy
+
+**dogfood 验证完成度**: 80% (intake/analyze/spec/challenger/dev-cross/staging/pr-ci-watch 全跑过 + admin resume 路径走通；accept stage 因 evict 没真跑到)。
+
+按 §15.2 第 1 次撞 → log + skip。下一步：派下一条 ttpos REQ 继续 §15.1 操作循环。
+
+## 2026-05-06 07:30Z REQ-kiosk-log-cleanup-dogfood 验证完整收官（pipeline 100% 验过）
+
+**两轮 admin resume 后 accept stage 真起跑**：
+- 1st resume (06:33Z): staging-test.pass → pr-ci-running → pr-ci.pass → accept-running → vm04 evict mid-action
+- 2nd resume (07:29Z): force_escalate + resume(action=pass,stage=pr_ci) → 重做 create_accept → accept-env-up 真 invoke → fail "UPGRADE FAILED: another operation in progress" (failed_layer: ZonEaseTech/ttpos-server-go)
+
+**accept-env-up.fail 真因**：lab helm release 状态残留（前面两次 evict + mid-action interrupt 让 helm install 卡 in-progress 没清理）。不是 sisyphus pipeline bug，是 lab infra cleanup 问题。
+
+**Dogfood 验证目标完成度 = 100%（结构）**：sisyphus pipeline 9 个 stage 全部真触达：intake / analyze / artifact-check / spec-lint / challenger / dev-cross-check / staging-test / pr-ci-watch / **accept (create_accept invoke + accept-env-up real run)**。
+
+**待手动清**: 卡住的 helm release `ttpos-server-go-acceptance-...` 之类。helm history -n <ns> + helm rollback / uninstall。运维操作，不影响下条 dogfood REQ。
+
+**今日 dogfood 拿到的两条架构铁证**：
+1. PR #471/#472 dispatch-contract + FinalizedIntent 真跑通：05:44:27 clone.exec source=ctx.intake_finalized_intent.involved_repos —— #464/#466 footgun 在新链路下天然消失
+2. admin endpoint resume 体系完整可用（runner-resume + force_escalate + resume action=pass stage=*）—— playbook §16.2 表格那条 ❌ "L5 缺 admin token" 实际错了，token 是 webhook_token 直接复用
+
+**今日撞 footgun 三种 (各 1 次)**：
+- watchdog/escalate race (BKD agent late result:pass vs 删 pod)
+- vm04 ephemeral-storage evict (kubelet eviction + sisyphus runner_gc disk_pressure 因 RBAC 缺 nodes:list 永久禁用)
+- create_accept mid-action interrupt + helm release 状态残留
+
+按 §15.2 全部 1-2 次 → log + skip，不立 issue。下次 dogfood 派 REQ 前手动清 helm 残留。
+
+## 2026-05-06 08:40Z lab chart image tag 接入契约（dispatch-contract 衍生）
+**用户提出策略（dogfood Round-X 暴露）**:
+1. **涉及的仓库（intent.repos 里）**：lab 起来时用该仓 PR-CI 跑出的镜像（含 PR / commit SHA tag）
+2. **没涉及的仓库**：用基线分支（base_branches 或 chart default）的最新镜像
+
+**现状 gap**：
+- sisyphus 侧：create_accept 起 helm install 不传 image tag override；intent.repos 信息没用到
+- lab chart 侧（ttpos-server-go/ttpos-scripts/accept-minimal-values.yaml）：8 处 hardcode `tag: test-feat-pack-develop`（ad-hoc 分支特定 tag），不是基线分支 auto-build tag
+- 结果：dogfood REQ 改 ttpos-flutter（不涉及 server-go），lab 起 server-go 拉 stale image，撞 server-go 业务侧的旧 bug（RocketMQ DNS error 已在 feat/pack-develop-hwt fix 但 tag 没更新）
+
+**修法（不在本次 dogfood，挂这里）**：
+- sisyphus 侧：actions/create_accept.py 渲 helm install 时按 intent.repos + base_branches 算 image tag override，传 `--set <repo>.image.tag=...`
+- lab chart 侧：业务仓 accept-minimal-values.yaml 改用基线分支自动 build tag (`develop-latest` / `develop-{sha}` / immutable digest)，不 hardcode ad-hoc tag
+- 最优雅：lab chart 完全不写 tag default，sisyphus 强制传 → 错位时 fail-fast 不 silent
+
+**关联**: dispatch-contract.md (intent.repos 用法扩展) + integration-contracts.md (lab chart image tag 契约新章节)。等 5 条 ttpos REQ 跑通 + envelope/letter tag cleanup 一起做，**不立 issue**。
+
+**RESOLVED 2026-05-06 ~10Z**：promote 到 #474。实证发现 ttpos-ci/ci-go.yml 早就把 image-publish 设计成 PR-CI 一个 check（commit `db24441`），image_tag 通过 commit status `CI / image-publish` 的 description 写出。落地为单点改动：
+- pr_ci_watch.py 加 commit statuses API 路径（之前只看 check-runs，过早判绿是隐藏 bug）
+- 抽 image-publish description → CheckResult.extras.image_tags
+- create_pr_ci_watch 写 ctx.image_tags
+- create_accept.py 注入 SISYPHUS_IMAGE_TAGS env
+- integration-contracts §11 加章节 + accept-env.mk 样板
+
+业务仓 dispatch.yml / ttpos-ci 改动归零；sisyphus runner PAT 不动。完整顺向兼容（业务仓没接 image-publish job → 自动 fallback chart default）。

--- a/docs/dispatch-contract.md
+++ b/docs/dispatch-contract.md
@@ -207,7 +207,7 @@ pydantic 在入口处 enforce schema，失败回 422 让 agent 重试。
 
 | 字段 | 谁读 | 用来做啥 |
 |---|---|---|
-| `repos` | runner pod entrypoint / `_clone.py` | clone 这些仓 |
+| `repos` | runner pod entrypoint / `_clone.py` / pr_ci_watch / accept image-tag 解析 | clone 这些仓；轮 PR-CI；accept 阶段按这个 list 拼 `SISYPHUS_IMAGE_TAGS` (见 [integration-contracts.md §11](integration-contracts.md)) |
 | `base_branches` | runner pod entrypoint / `_clone.py` | per-repo `git checkout` |
 | `business_behavior` / `data_constraints` / `edge_cases` / `do_not_touch` | analyze / challenger / verifier prompts | 业务理解 + 写 spec + 写 test |
 | `acceptance` | accept stage agent / verifier | 验收命令 + pass 判定 |

--- a/docs/integration-contracts.md
+++ b/docs/integration-contracts.md
@@ -403,6 +403,7 @@ orchestrator 在 `kubectl exec` 进 runner pod 跑命令时注入：
 | `SISYPHUS_REQ_ID` | 所有 stage | 形如 `REQ-29`，业务 Makefile 拼 namespace / 标签 |
 | `SISYPHUS_STAGE` | accept-env-up / accept-env-down | `accept-env-up` / `accept-teardown`，给 Makefile 区分阶段 |
 | `SISYPHUS_NAMESPACE` | accept 阶段 | `accept-<req-id-lowercase>`，专给 helm `-n` 用 |
+| `SISYPHUS_IMAGE_TAGS` | accept 阶段（pr-ci 全绿且 ttpos-ci `CI / image-publish` 写过 tag 时）| JSON dict `{"<owner>/<repo>": "<image_tag>", ...}`；业务仓 `accept-env-up` 转 helm `--set <chart>.image.tag=...`。空 → fallback chart default。详见 §11 |
 | `SISYPHUS_RUNNER=1` | runner 镜像内置 | 让脚本能判"我在 sisyphus runner 里" |
 
 **约定**：业务 Makefile 应只依赖上面这些 env；不要假设额外的 `KUBECONFIG` / 凭据 —— 那些是 runner 镜像 / aissh 提供的 ambient context。
@@ -648,3 +649,81 @@ patch 方式及验证步骤见 §1c.2。
 ```
 
 **误判信号**：clone 报 `Write access not granted` 但你只想读——见 §1c.3，往往是 read 权限缺，不是 write。
+
+## 11. lab chart image tag 契约（closes #474）
+
+### 11.1 问题域
+
+accept stage 起 lab 时，每个涉及仓应该用**该仓 PR-CI 跑出的镜像**（含 PR head SHA）；没涉及的仓用基线分支镜像。业务仓 `accept-minimal-values.yaml` 不应 hardcode ad-hoc tag —— 那种 hardcode 让某仓 fix 后镜像 stale，dogfood 撞旧 bug。
+
+### 11.2 契约位置（信号源 → 注入）
+
+```
+ttpos-ci/.github/workflows/ci-go.yml （image-publish job, ttpos-ci@db24441）
+  ↓ docker buildx push ghcr.io/<repo>:<REQ-id>-sha-<8>
+  ↓ createCommitStatus → 业务仓 PR head SHA 上写
+       context     = "CI / image-publish"
+       state       = "success"
+       description = "ghcr.io/<repo>:<REQ-id>-sha-<8>"   ← 这就是 image_tag
+
+sisyphus pr_ci_watch checker
+  ↓ GET /repos/<repo>/commits/<sha>/statuses          ← #474 新加的轮询路径
+  ↓ 找 context == "CI / image-publish" && state == "success"，抠 description
+  ↓ CheckResult.extras = {"image_tags": {"<owner>/<repo>": "<tag>", ...}}
+
+create_pr_ci_watch action
+  ↓ result.passed && result.extras → ctx.image_tags 持久化
+
+create_accept action（env-up 入口）
+  ↓ ctx.image_tags → SISYPHUS_IMAGE_TAGS env (JSON dict)
+  ↓ kubectl exec runner: `make accept-env-up` with env
+
+业务仓 accept-env.mk
+  ↓ jq 从 SISYPHUS_IMAGE_TAGS 抽自己关心的 key
+  ↓ helm upgrade --install ... --set <chart>.image.tag=<image_tag>
+```
+
+### 11.3 业务仓 `accept-env-up` 接 env 的最小样板
+
+```makefile
+# accept-env.mk
+.PHONY: accept-env-up
+
+# 从 SISYPHUS_IMAGE_TAGS（JSON dict）抽本仓 image_tag；缺则空（落 chart default）
+THIS_REPO_FULL := $(shell git -C $(CURDIR) remote get-url origin | sed -E 's|.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$$|\1|')
+THIS_IMAGE_TAG := $(shell echo '$(SISYPHUS_IMAGE_TAGS)' | jq -r --arg k '$(THIS_REPO_FULL)' '.[$$k] // empty' 2>/dev/null)
+
+accept-env-up:
+	@echo "🚀 accept-env-up: $(SISYPHUS_NAMESPACE) (image_tag=$(THIS_IMAGE_TAG))"
+	@cd $(ARCH_LAB_DIR) && \
+	  IMAGE_TAG_ARGS=""; \
+	  if [ -n "$(THIS_IMAGE_TAG)" ]; then \
+	    # tag 含 registry/repo:tag —— 拆成 image + tag 两段给 helm（chart 决定 key）
+	    image_part="$${THIS_IMAGE_TAG%:*}"; tag_part="$${THIS_IMAGE_TAG##*:}"; \
+	    IMAGE_TAG_ARGS="--set ttposServerGo.image.repository=$$image_part --set ttposServerGo.image.tag=$$tag_part"; \
+	  fi; \
+	  helm upgrade --install $(SISYPHUS_NAMESPACE) charts/edge-lab \
+	    --namespace $(SISYPHUS_NAMESPACE) \
+	    -f $(CURDIR)/ttpos-scripts/accept-minimal-values.yaml \
+	    $$IMAGE_TAG_ARGS \
+	    --wait --timeout 15m
+	@printf '{"endpoint":"http://%s.svc.cluster.local:8080","namespace":"%s"}\n' \
+	  "$(SISYPHUS_NAMESPACE)" "$(SISYPHUS_NAMESPACE)"
+```
+
+**说明**：
+- `THIS_REPO_FULL` 用 `git remote get-url` 抽 `<owner>/<repo>`，跟 sisyphus 注入的 JSON key 对齐
+- `SISYPHUS_IMAGE_TAGS` 空 / jq 抽不到 → `THIS_IMAGE_TAG` 为空 → 不传 `--set`，chart default 兜底
+- chart `values.yaml` 应 **不写** `image.tag` 默认值，或写一个安全的基线分支 immutable digest（不写 `latest` / ad-hoc 分支 tag）—— 让 sisyphus 错位时 fail-fast 而不是 silent 撞 stale image
+
+### 11.4 兼容性
+
+- pr_ci_watch 兼容业务仓**还没接** ttpos-ci 路（无 `CI / image-publish` status）：image_tag 抽不到 → ctx.image_tags 缺 → SISYPHUS_IMAGE_TAGS env 不注入 → `accept-env-up` 走 chart default
+- 业务仓**还没接** image_tag override 的 accept-env-up：env 注入了但 Makefile 不读，等于 noop
+- 双向都 graceful，**不强制原子升级**
+
+### 11.5 涉/未涉仓的覆盖说明
+
+当前实现**只覆盖涉及仓**（intent.repos 列里那些）：pr_ci_watch 拿到的是该 REQ 涉及仓的 PR head SHA 上写的 image_tag。**未涉及仓的基线分支 image_tag 不在本契约范围**，由业务仓 chart 的 default 值兜底（recommendation：写基线分支 immutable digest，不要 floating tag）。
+
+如果未来要 sisyphus 主动为未涉及仓解析基线 SHA + 探测对应 image_tag，开新 issue 议；现在 dogfood 用涉及仓覆盖已经修了 #474 的核心痛点。

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -48,6 +48,7 @@ addopts = "-p no:randomly"
 markers = [
     "integration: integration tests (selected by `make ci-integration-test`; excluded by `make ci-unit-test`)",
     "no_stub_self_heal: opt-out conftest autouse stub of `ensure_runner_alive` (REQ-fix-runner-self-heal-394)",
+    "no_stub_commit_statuses: opt-out conftest autouse stub of `/commits/{sha}/statuses` API (closes #474; tests that supply their own statuses mock)",
 ]
 
 [tool.ruff]

--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -52,6 +52,23 @@ from ._skip import skip_if_enabled
 log = structlog.get_logger(__name__)
 
 _TIMEOUT_ENV_UP_SEC = 1800  # 30 min: helm install + wait ready + APK GHA build poll (5-10min) + download + adb install
+
+
+def _image_tags_env(ctx: dict | None) -> dict[str, str]:
+    """closes #474: 把 ctx.image_tags（pr_ci_watch 从 commit status
+    `CI / image-publish` 抠出来的 per-repo image_tag）拼成 JSON env，让业务仓
+    accept-env-up Makefile target 转 `helm --set <repo>.image.tag=...`
+    （契约 `SISYPHUS_IMAGE_TAGS`，docs/sisyphus-integration.md §4 +
+    docs/integration-contracts.md §11）。
+
+    空 dict / 缺字段 → 返 {}，不注入 env，业务仓 chart 落 default tag（兼容期，
+    业务仓还没接 image-publish job 时也别炸）。
+    """
+    image_tags = (ctx or {}).get("image_tags")
+    if not isinstance(image_tags, dict) or not image_tags:
+        return {}
+    # owner/repo key 形式跟 pr_ci_watch 输出对齐；业务仓自己 jq 抽 basename
+    return {"SISYPHUS_IMAGE_TAGS": json.dumps(image_tags, sort_keys=True)}
 _TIMEOUT_LITE_SEC = 1800   # 30 min for up × N + sleep + smoke × N + down × N
 _TIMEOUT_MANIFEST_READ_SEC = 30  # cat .sisyphus/env.yaml on runner
 _TIMEOUT_BRANCH_CHECK_SEC = 60   # git ls-remote per needs repo
@@ -650,6 +667,7 @@ async def _run_legacy_single_layer(*, req_id: str, ctx, body, tags, rc, namespac
         "SISYPHUS_REQ_ID": req_id,
         "SISYPHUS_STAGE": "accept-env-up",
         "SISYPHUS_NAMESPACE": namespace,
+        **_image_tags_env(ctx),
     }
     try:
         result = await rc.exec_in_runner(
@@ -965,6 +983,7 @@ async def _run_multi_layer_with_cache(
         "SISYPHUS_REQ_ID": req_id,
         "SISYPHUS_STAGE": "accept-env-up",
         "SISYPHUS_NAMESPACE": namespace,
+        **_image_tags_env(ctx),
     }
     source_branch = (ctx or {}).get("branch") or f"feat/{req_id}"
     dir_map = cross_repo_env.workspace_dir_map(topo)

--- a/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/actions/create_pr_ci_watch.py
@@ -224,6 +224,22 @@ async def _run_checker(*, req_id: str, ctx: dict) -> dict:
     pool = db.get_pool()
     await artifact_checks.insert_check(pool, req_id, "pr-ci-watch", result)
 
+    # closes #474: pr_ci_watch 把每仓 image_tag（从 commit status
+    # `CI / image-publish` 的 description 抠出来）通过 result.extras 透出，
+    # 这里写 ctx.image_tags 让 create_accept 拼 SISYPHUS_IMAGE_TAGS env 喂
+    # 业务仓 chart。空 / None 不写 —— 业务仓还没接 image-publish job 的
+    # 兼容期沉默跳过，accept-env-up 会落到 chart default tag。
+    if result.passed and result.extras:
+        image_tags = result.extras.get("image_tags") if isinstance(result.extras, dict) else None
+        if isinstance(image_tags, dict) and image_tags:
+            try:
+                await req_state.update_context(pool, req_id, {"image_tags": image_tags})
+                log.info("create_pr_ci_watch.image_tags_persisted",
+                         req_id=req_id, repos=list(image_tags.keys()))
+            except Exception as e:
+                log.warning("create_pr_ci_watch.image_tags_persist_failed",
+                            req_id=req_id, error=str(e))
+
     if result.exit_code == 124:
         emit = Event.PR_CI_TIMEOUT
     elif result.passed:

--- a/orchestrator/src/orchestrator/checkers/_types.py
+++ b/orchestrator/src/orchestrator/checkers/_types.py
@@ -31,3 +31,9 @@ class CheckResult:
     cmd: str
     reason: str | None = None
     attempts: int = 1
+    # 给 checker 透出额外的结构化信号，让上游 action 把数据写 ctx；engine /
+    # artifact_checks / verifier 不读这字段。pr_ci_watch 用它带回每仓
+    # `image_tags`（commit status `CI / image-publish` 的 description 字段
+    # 解析得来，accept stage 通过 SISYPHUS_IMAGE_TAGS env 喂给业务仓 chart，
+    # 见 docs/integration-contracts.md §11、closes #474）。
+    extras: dict | None = None

--- a/orchestrator/src/orchestrator/checkers/pr_ci_watch.py
+++ b/orchestrator/src/orchestrator/checkers/pr_ci_watch.py
@@ -27,9 +27,15 @@ GH API:
 - GET /repos/{owner}/{repo}/pulls?head={owner}:{branch}&state=open  → open PR（含 head.sha）
 - GET /repos/{owner}/{repo}/pulls?head={owner}:{branch}&state=closed → closed/merged PR
 - GET /repos/{owner}/{repo}/commits/{sha}/check-runs                 → check_runs[]
+- GET /repos/{owner}/{repo}/commits/{sha}/statuses                   → statuses[]
+  （commit statuses，给 PAT-only ci 系统用——ttpos-ci 用 createCommitStatus 写
+  `CI / lint`, `CI / unit-test`, `CI / integration-test`, `CI / sonarqube`,
+  `CI / image-publish`，详见 commit ttpos-ci@db24441；statuses 跟 check-runs
+  合并判绿，image-publish 的 description 字段是 image_tag，extras 透出供 accept
+  注入 SISYPHUS_IMAGE_TAGS env。closes #474）
 
 退出码：
-- 0   = 全绿（所有 repo 的 check-run completed 且 conclusion 友好）
+- 0   = 全绿（所有 repo 的 check-run/status 都 completed 且 conclusion 友好）
 - 1   = 至少一个失败
 - 124 = 超时
 """
@@ -59,6 +65,13 @@ _FAIL_CONCLUSIONS = {"failure", "cancelled", "timed_out", "action_required", "st
 # 别的 slug（如 "anthropic-claude" / 第三方 review bot）属于 review-only signal。
 # 用于检测假阳性 pass：全绿但全是 review-only check-run（GHA 一次没跑）。
 _GHA_APP_SLUG = "github-actions"
+
+# ttpos-ci/.github/workflows/ci-go.yml 的 image-publish job 用 createCommitStatus
+# 写入业务仓 PR 的 commit status；description 字段直接放 image_tag 字符串
+# （`ghcr.io/<repo>:<REQ-id>-sha-<8>`）。pr_ci_watch 全绿时拿这个值塞进
+# extras['image_tags'] 给 create_accept 写 ctx → SISYPHUS_IMAGE_TAGS env。
+# 见 ttpos-ci@db24441 + docs/integration-contracts.md §11。
+_IMAGE_PUBLISH_STATUS_CONTEXT = "CI / image-publish"
 
 
 @dataclass
@@ -196,17 +209,35 @@ async def watch_pr_ci(
                     stderr_tail="", duration_sec=time.monotonic() - start, cmd=_cmd_label(),
                 )
 
-            # Fetch check-runs for non-terminal repos
+            # Fetch check-runs + commit statuses for non-terminal repos.
+            # 两路信号合并：check-runs（GHA workflow 自己写的）+ statuses
+            # （PAT-only 系统如 ttpos-ci 写的）—— ttpos-ci 的
+            # `CI / lint`, `CI / unit-test`, `CI / integration-test`,
+            # `CI / sonarqube`, `CI / image-publish` 都在 statuses 一侧，必须
+            # 一并轮才不会过早判绿（closes #474 隐藏 bug：以前只看
+            # check-runs，"Dispatch CI" 一发出 dispatch event 就 success，
+            # ttpos-ci 还没跑完就 PR_CI_PASS）。
             api_error = None
             for state in states:
                 if state.terminal_verdict is not None:
                     continue
                 try:
-                    per_repo_runs[state.repo] = await _get_check_runs(client, state.repo, state.sha)
+                    runs = await _get_check_runs(client, state.repo, state.sha)
                 except httpx.HTTPError as e:
                     api_error = (state.repo, e)
                     log.warning("checker.pr_ci_watch.api_error",
                                 repo=state.repo, sha=state.sha[:8], error=str(e))
+                    continue
+                # statuses 是辅路：仓没接 statuses-based CI（如 ttpos-ci）时
+                # API 也合法地返空数组；偶发 HTTP 抖动不应阻塞 check-runs 主路。
+                # → 失败静默降级为空 list，verdict 仍以 check-runs 为准。
+                statuses: list[dict] = []
+                try:
+                    statuses = await _get_commit_statuses(client, state.repo, state.sha)
+                except httpx.HTTPError as e:
+                    log.warning("checker.pr_ci_watch.statuses_api_error",
+                                repo=state.repo, sha=state.sha[:8], error=str(e))
+                per_repo_runs[state.repo] = runs + _statuses_to_runs(statuses)
 
             if api_error and time.monotonic() >= deadline:
                 repo, e = api_error
@@ -264,10 +295,31 @@ async def watch_pr_ci(
                     else f"{state.repo}: {_summarize(per_repo_runs.get(state.repo, []))}"
                     for state in states
                 ]
+                # 抽 ttpos-ci image-publish 的 image_tag。pass 时 PR-CI 全绿，每个非
+                # merged 的 repo 应该都有 success 的 `CI / image-publish` status；
+                # 没有 → log warning 但不阻塞 pass（业务仓还没接 image-publish job 的
+                # 兼容期）。merged repo 走的是 PR 已合并的早期 terminal 路径，没轮
+                # statuses，跳过。
+                image_tags: dict[str, str] = {}
+                for state in states:
+                    if state.terminal_verdict == "pass":
+                        continue  # merged，没 statuses 可读
+                    tag = _extract_image_tag(per_repo_runs.get(state.repo, []))
+                    if tag:
+                        image_tags[state.repo] = tag
+                    else:
+                        log.warning(
+                            "checker.pr_ci_watch.image_tag_missing",
+                            repo=state.repo, sha=state.sha[:8],
+                            note="PR all-green but `CI / image-publish` status absent or empty description "
+                                 "— accept stage will fall back to chart default tag",
+                        )
+                extras = {"image_tags": image_tags} if image_tags else None
                 return CheckResult(
                     passed=True, exit_code=0,
                     stdout_tail=" | ".join(parts)[:_TAIL],
                     stderr_tail="", duration_sec=time.monotonic() - start, cmd=_cmd_label(),
+                    extras=extras,
                 )
 
             if time.monotonic() + poll_interval_sec >= deadline:
@@ -322,6 +374,72 @@ async def _get_check_runs(client: httpx.AsyncClient, repo: str, sha: str) -> lis
     r = await client.get(f"/repos/{repo}/commits/{sha}/check-runs", params={"per_page": 100})
     r.raise_for_status()
     return r.json().get("check_runs", [])
+
+
+async def _get_commit_statuses(client: httpx.AsyncClient, repo: str, sha: str) -> list[dict]:
+    """GET /repos/{repo}/commits/{sha}/statuses。
+
+    GitHub commit-statuses API（legacy）跟 check-runs 是两套独立信号；ttpos-ci
+    用 PAT 写 statuses（PAT 不能写 check-runs），所以 sisyphus 必须两路都拉
+    才看得到 ttpos-ci 的 lint / unit / integration / sonarqube / image-publish
+    五个 status。
+    """
+    r = await client.get(f"/repos/{repo}/commits/{sha}/statuses", params={"per_page": 100})
+    r.raise_for_status()
+    return r.json() if isinstance(r.json(), list) else []
+
+
+def _statuses_to_runs(statuses: list[dict]) -> list[dict]:
+    """commit status → check-run shape，让 _classify 一并处理。
+
+    每个 status 视作一条 GHA check-run：
+      state=success  → status=completed, conclusion=success
+      state=failure / error → status=completed, conclusion=failure
+      state=pending  → status=in_progress, conclusion=None
+    `app.slug` 强制设 github-actions —— ttpos-ci 走 PAT 写的 statuses 在语义上
+    就是 PR-CI 信号，不算 review-only bot；no-gha 假阳性判定不应误伤。
+    `_status_description` 是私字段，留给 _extract_image_tag 提 image-publish 的 image_tag。
+    """
+    out: list[dict] = []
+    for s in statuses or []:
+        state = s.get("state", "pending")
+        if state in ("failure", "error"):
+            status_field = "completed"
+            conclusion = "failure"
+        elif state == "success":
+            status_field = "completed"
+            conclusion = "success"
+        else:  # pending / unknown
+            status_field = "in_progress"
+            conclusion = None
+        out.append({
+            "name": s.get("context", "?"),
+            "status": status_field,
+            "conclusion": conclusion,
+            "app": {"slug": _GHA_APP_SLUG},
+            "_status_description": s.get("description"),
+        })
+    return out
+
+
+def _extract_image_tag(runs: list[dict]) -> str | None:
+    """从 runs（含 status_to_runs 注入的条目）里抓 CI / image-publish 的 description。
+
+    description 是 ttpos-ci/.github/workflows/ci-go.yml image-publish job 写
+    回去的 image_tag 字符串。只在 status=completed && conclusion=success
+    时认；否则跳过。
+    """
+    for r in runs:
+        if r.get("name") != _IMAGE_PUBLISH_STATUS_CONTEXT:
+            continue
+        if r.get("status") != "completed":
+            continue
+        if r.get("conclusion") != "success":
+            continue
+        desc = r.get("_status_description")
+        if isinstance(desc, str) and desc.strip():
+            return desc.strip()
+    return None
 
 
 # ── verdict 计算 ─────────────────────────────────────────────────────────

--- a/orchestrator/tests/conftest.py
+++ b/orchestrator/tests/conftest.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import re
 from unittest.mock import AsyncMock
 
 import pytest
@@ -33,3 +34,28 @@ def _stub_ensure_runner_alive(request, monkeypatch):
         return
     for target in _SELF_HEAL_PATCH_TARGETS:
         monkeypatch.setattr(target, AsyncMock(return_value=True))
+
+
+# closes #474: pr_ci_watch 现在双路拉 check-runs + commit statuses。已有
+# pr_ci_watch 测试只 mock 了 check-runs；statuses 默认空数组兜底，让现存测试
+# 不用挨个改，专门测 statuses / image_tag 的新测试自己 add_response 覆写。
+#
+# 不写 `httpx_mock` 进 fixture signature —— pytest-httpx 的 httpx_mock 是
+# request-scoped lazy fixture，autouse fixture 强引用会让它**所有 test** 都
+# 激活 httpx 拦截，破坏只用 monkeypatch / 不沾 HTTP 的纯逻辑测试。这里走 dynamic
+# request.getfixturevalue 仅在 test 自己已请求 httpx_mock 时才 inject。
+@pytest.fixture(autouse=True)
+def _default_empty_commit_statuses(request):
+    if "no_stub_commit_statuses" in request.keywords:
+        return
+    if "httpx_mock" not in request.fixturenames:
+        return
+    httpx_mock = request.getfixturevalue("httpx_mock")
+    httpx_mock.add_response(
+        url=re.compile(
+            r"^https://api\.github\.com/repos/[^/]+/[^/]+/commits/.+/statuses(\?.*)?$"
+        ),
+        json=[],
+        is_reusable=True,
+        is_optional=True,
+    )

--- a/orchestrator/tests/test_checkers_pr_ci_watch.py
+++ b/orchestrator/tests/test_checkers_pr_ci_watch.py
@@ -630,3 +630,195 @@ async def test_watch_pr_ci_review_only_check_runs_treated_as_fail(
     assert "no-gha-checks-ran" in result.stdout_tail
     # 露出实际跑了啥（review-only bot 真身），便于人工 / verifier 一眼判
     assert "claude-review" in result.stdout_tail
+
+
+# ── #474: commit statuses 路径 + image_tag extras ─────────────────────────────
+
+def _status(context: str, state: str = "success", description: str = "") -> dict:
+    """模拟 GitHub commit statuses API 单条返回。"""
+    return {"context": context, "state": state, "description": description}
+
+
+def test_statuses_to_runs_maps_states_correctly():
+    """status state 映射到 check-run 形态：success/failure/pending 各一条。"""
+    runs = pr_ci_watch._statuses_to_runs([
+        _status("CI / lint", "success"),
+        _status("CI / unit-test", "failure", "boom"),
+        _status("CI / integration-test", "pending"),
+        _status("CI / sonarqube", "error", "config bad"),
+    ])
+    by_name = {r["name"]: r for r in runs}
+    assert by_name["CI / lint"]["status"] == "completed"
+    assert by_name["CI / lint"]["conclusion"] == "success"
+    assert by_name["CI / unit-test"]["conclusion"] == "failure"
+    assert by_name["CI / integration-test"]["status"] == "in_progress"
+    assert by_name["CI / integration-test"]["conclusion"] is None
+    # error 也走 failure（避免落到 review-only bot 误判）
+    assert by_name["CI / sonarqube"]["conclusion"] == "failure"
+    # 全部强标 GHA-equivalent，不会被 no-gha 假阳性误伤
+    assert all(r["app"]["slug"] == "github-actions" for r in runs)
+
+
+def test_extract_image_tag_picks_image_publish_description():
+    """description 字段就是 image_tag；其它 status 跳过。"""
+    runs = pr_ci_watch._statuses_to_runs([
+        _status("CI / lint", "success"),
+        _status("CI / image-publish", "success",
+                "ghcr.io/phona/ttpos-server-go:REQ-1-sha-deadbee1"),
+    ])
+    assert pr_ci_watch._extract_image_tag(runs) == \
+        "ghcr.io/phona/ttpos-server-go:REQ-1-sha-deadbee1"
+
+
+def test_extract_image_tag_returns_none_when_image_publish_pending():
+    """image-publish 还 pending → 不抠（会撞旧 description）。"""
+    runs = pr_ci_watch._statuses_to_runs([
+        _status("CI / image-publish", "pending"),
+    ])
+    assert pr_ci_watch._extract_image_tag(runs) is None
+
+
+def test_extract_image_tag_returns_none_when_image_publish_failed():
+    """image-publish failure 时 description 是 'Image publish failure' 之类，跳过。"""
+    runs = pr_ci_watch._statuses_to_runs([
+        _status("CI / image-publish", "failure", "Image publish failure"),
+    ])
+    assert pr_ci_watch._extract_image_tag(runs) is None
+
+
+def test_extract_image_tag_returns_none_when_image_publish_absent():
+    """业务仓没接 image-publish job → 安全返 None。"""
+    runs = pr_ci_watch._statuses_to_runs([
+        _status("CI / lint", "success"),
+        _status("CI / unit-test", "success"),
+    ])
+    assert pr_ci_watch._extract_image_tag(runs) is None
+
+
+@pytest.mark.no_stub_commit_statuses
+@pytest.mark.asyncio
+async def test_watch_pr_ci_pending_status_holds_back_pass(httpx_mock, monkeypatch):
+    """check-runs 全绿但 statuses 里 image-publish 还 pending → verdict=pending 不应判 pass。"""
+    monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+    repo = patch_pr_lookup(monkeypatch)
+
+    async def fast_sleep(_):
+        return None
+    monkeypatch.setattr(pr_ci_watch.asyncio, "sleep", fast_sleep)
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/commits/"
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/check-runs?per_page=100",
+        json=_runs_payload(_run("Dispatch CI")),
+        is_reusable=True,
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/commits/"
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/statuses?per_page=100",
+        json=[
+            _status("CI / lint", "success"),
+            _status("CI / image-publish", "pending"),
+        ],
+        is_reusable=True,
+    )
+
+    result = await pr_ci_watch.watch_pr_ci(
+        "REQ-9", "feat/REQ-9", poll_interval_sec=0, timeout_sec=0, repos=[repo],
+    )
+
+    # statuses pending → 整体 pending → 超时 124（不会过早判 PR_CI_PASS）
+    assert result.passed is False
+    assert result.exit_code == 124
+
+
+@pytest.mark.no_stub_commit_statuses
+@pytest.mark.asyncio
+async def test_watch_pr_ci_passes_with_image_tag_extras(httpx_mock, monkeypatch):
+    """check-runs + statuses 全绿，image-publish description 抠出 image_tag 进 extras。"""
+    monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+    repo = patch_pr_lookup(monkeypatch)
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/commits/"
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/check-runs?per_page=100",
+        json=_runs_payload(_run("Dispatch CI")),
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/commits/"
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/statuses?per_page=100",
+        json=[
+            _status("CI / lint", "success"),
+            _status("CI / unit-test", "success"),
+            _status("CI / integration-test", "success"),
+            _status("CI / sonarqube", "success"),
+            _status("CI / image-publish", "success",
+                    "ghcr.io/phona/ubox-crosser:REQ-9-sha-deadbeef"),
+        ],
+    )
+
+    result = await pr_ci_watch.watch_pr_ci(
+        "REQ-9", "feat/REQ-9", poll_interval_sec=1, timeout_sec=60, repos=[repo],
+    )
+
+    assert result.passed is True
+    assert result.exit_code == 0
+    assert result.extras == {
+        "image_tags": {
+            "phona/ubox-crosser": "ghcr.io/phona/ubox-crosser:REQ-9-sha-deadbeef",
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_watch_pr_ci_passes_without_image_tag_when_status_absent(
+    httpx_mock, monkeypatch,
+):
+    """业务仓还没接 image-publish job → pass 但 extras 缺 image_tags（accept fall back chart default）。"""
+    monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+    repo = patch_pr_lookup(monkeypatch)
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/commits/"
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/check-runs?per_page=100",
+        json=_runs_payload(_run("lint")),
+    )
+    # statuses 由 conftest 默认 fixture 兜底空数组；这里不再 add_response
+
+    result = await pr_ci_watch.watch_pr_ci(
+        "REQ-9", "feat/REQ-9", poll_interval_sec=1, timeout_sec=60, repos=[repo],
+    )
+
+    assert result.passed is True
+    assert result.exit_code == 0
+    # extras 是 None：image_tags 为空 dict 时不构造 extras
+    assert result.extras is None
+
+
+@pytest.mark.no_stub_commit_statuses
+@pytest.mark.asyncio
+async def test_watch_pr_ci_status_failure_breaks_pass(httpx_mock, monkeypatch):
+    """check-runs 全绿但 statuses 有 failure（如 ttpos-ci 的 sonarqube 红） → 整体 fail。"""
+    monkeypatch.setattr(pr_ci_watch.settings, "github_token", "ghp_xxx")
+    repo = patch_pr_lookup(monkeypatch)
+
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/commits/"
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/check-runs?per_page=100",
+        json=_runs_payload(_run("Dispatch CI")),
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/phona/ubox-crosser/commits/"
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/statuses?per_page=100",
+        json=[
+            _status("CI / lint", "success"),
+            _status("CI / sonarqube", "failure", "Coverage below threshold"),
+        ],
+    )
+
+    result = await pr_ci_watch.watch_pr_ci(
+        "REQ-9", "feat/REQ-9", poll_interval_sec=1, timeout_sec=60, repos=[repo],
+    )
+
+    assert result.passed is False
+    assert result.exit_code == 1
+    assert "CI / sonarqube=failure" in result.stdout_tail


### PR DESCRIPTION
## TL;DR

closes #474. ttpos-ci 早就把 `image-publish` 设计成 PR-CI 的一个 commit status check（`db24441`），image_tag 就在 `CI / image-publish` 的 `description` 字段。sisyphus 这边只缺读取通道——本 PR 加上，并把 image_tag 通过 `SISYPHUS_IMAGE_TAGS` env 喂给业务仓 `accept-env-up`，让 lab chart 不再 hardcode tag。

## 变更链路

\`\`\`
ttpos-ci/ci-go.yml image-publish job (db24441)
  ↓ docker buildx push ghcr.io/<repo>:<REQ-id>-sha-<8>
  ↓ createCommitStatus → 业务仓 PR head SHA
       context     = "CI / image-publish"
       description = "ghcr.io/<repo>:<REQ-id>-sha-<8>"   ← image_tag

sisyphus pr_ci_watch checker  ← 本 PR 加 statuses API 路径
  ↓ extras = {"image_tags": {<owner/repo>: <tag>}}

create_pr_ci_watch action  ← 本 PR 写 ctx.image_tags
  ↓
create_accept action  ← 本 PR 注入 SISYPHUS_IMAGE_TAGS env
  ↓
业务仓 accept-env.mk → helm --set <chart>.image.tag=...
\`\`\`

## 顺带修了的隐藏 bug

\`pr_ci_watch\` 之前**只看 check-runs**——业务仓 \`dispatch.yml\` 一发出 \`repository_dispatch\` event 就 success（产生 \`Dispatch CI\` check-run），ttpos-ci 那边的 lint/unit/integration/sonarqube/image-publish **还没跑完** sisyphus 已判 \`PR_CI_PASS\`。本 PR 把 commit statuses（PAT-only ci 系统写的）也并入判绿信号，pending 时不放过，failure 时整体 fail。

## 兼容性

- 业务仓**没接** image-publish job：\`image_tag\` 抠不到 → ctx 不写 → env 不注入 → chart default 兜底 ✅
- 业务仓**没接** \`SISYPHUS_IMAGE_TAGS\` 接收逻辑：env 注入但 Makefile 不读 → noop ✅
- statuses API 抖动：静默降级为空数组，verdict 仍以 check-runs 为准 ✅

## 不动的东西

- 状态机 / verifier / checker structure / prompt / router
- runner PAT scope（仍 contents:read）
- 业务仓 \`dispatch.yml\` / ttpos-ci workflows

## 文件改动

| 文件 | 改动 |
|---|---|
| \`checkers/pr_ci_watch.py\` | 加 \`_get_commit_statuses\` / \`_statuses_to_runs\` / \`_extract_image_tag\`；轮询循环合并两路；pass 时 \`extras={'image_tags':...}\` |
| \`checkers/_types.py\` | \`CheckResult\` 加可选 \`extras\` 字段（向后兼容） |
| \`actions/create_pr_ci_watch.py\` | \`result.passed && extras.image_tags\` → \`update_context({'image_tags': ...})\` |
| \`actions/create_accept.py\` | 加 \`_image_tags_env\` helper；env-up 两路（legacy single-layer + multi-layer）都注入 \`SISYPHUS_IMAGE_TAGS\` |
| \`docs/integration-contracts.md\` | §11 加 image-tag 契约章节 + accept-env.mk 样板；§5 表把 \`SISYPHUS_IMAGE_TAGS\` env 列入 |
| \`docs/dispatch-contract.md\` | §3.1 \`repos\` 字段消费方加 accept image-tag 解析 |
| \`tests/test_checkers_pr_ci_watch.py\` | 8 个新 test 覆盖 statuses-to-runs 映射 / image-tag 抠取 / pending 不过早绿 / failure 整体红 / pass 写 extras / 业务仓没接 image-publish 兼容 |
| \`tests/conftest.py\` | autouse fixture 给现存 test 兜底空 statuses（动态 \`request.fixturenames\` 检查，不强占非 httpx 测试）|
| \`pyproject.toml\` | 注册 \`no_stub_commit_statuses\` marker |
| \`BACKLOG.md\` | RESOLVED 注 |

## 验证

- \`pytest tests/test_checkers_pr_ci_watch.py tests/test_actions_create_pr_ci_watch.py tests/test_create_accept_*.py\` 共 75 个 test 全绿
- \`ruff check\` 全绿
- 全量 pytest 跟 main 同基线（49 fail / 32 error 全部预存在，与本 PR 无关）

## Follow-up（不在本 PR）

业务仓 \`accept-env.mk\` 接 \`SISYPHUS_IMAGE_TAGS\` env 的实现——属于业务仓 PR，docs/integration-contracts.md §11.3 给了 ~10 行样板。

🤖 Generated with [Claude Code](https://claude.com/claude-code)