### PR TITLE
fix(escalate): drop session-failed cleanup_runner; let runner_gc tend (closes #473)

### DIFF
--- a/orchestrator/src/orchestrator/actions/escalate.py
+++ b/orchestrator/src/orchestrator/actions/escalate.py
@@ -462,11 +462,19 @@ async def escalate(*, body, req_id, tags, ctx):
     await req_state.update_context(pool, req_id, ctx_patch)
 
     # SESSION_FAILED 类路径下 transition 是 self-loop（state 没动），需手动 CAS 推到
-    # ESCALATED 并清 runner。
+    # ESCALATED。
     # 触发源：BKD 真发的 session.failed webhook，或 watchdog 内部 emit Event.SESSION_FAILED
     # （body.event="watchdog.stuck"）。
     # 其他事件路径（如 INTAKE_FAIL / PR_CI_TIMEOUT / VERIFY_ESCALATE）的 transition
     # 已在 state.py 写死 next_state=ESCALATED，engine 已经做过 CAS + cleanup，这里跳过。
+    #
+    # 不主动清 runner pod（issue #473）：watchdog 5min 阈值跟 BKD agent 真挂没握手，
+    # 经常误判 stuck；我们这边一删 pod 就跟 late result:pass 撞 race（state 进 next
+    # stage 时 pod 已 404，下游 stage exec 失败再 escalate）。改由 runner_gc 兜底：
+    #   - state 留在 ESCALATED → runner_gc 下一 tick 看到 terminal 清 pod
+    #   - BKD agent late result:pass 推下一 stage → state 离开 ESCALATED 进 non-terminal
+    #     → runner_gc 永远不动它，pod 留给下一 stage exec
+    #   - PVC 默认 retain N 天，stage 入口 ensure_runner_alive 幂等 lazy recreate
     is_session_failed_path = body.event in _SESSION_END_SIGNALS
     if is_session_failed_path:
         row = await req_state.get(pool, req_id)
@@ -476,19 +484,10 @@ async def escalate(*, body, req_id, tags, ctx):
                 Event.SESSION_FAILED, "escalate",
             )
             if advanced:
-                # 手动清 runner（engine 没自动清，因为 transition 是 self-loop 看不出 terminal）
-                try:
-                    rc = k8s_runner.get_controller()
-                    await rc.cleanup_runner(req_id, retain_pvc=True)
-                    log.info("escalate.runner_cleaned", req_id=req_id)
-                except Exception as e:
-                    log.warning("escalate.runner_cleanup_failed",
-                                req_id=req_id, error=str(e))
                 # REQ-bkd-hitl-end-to-end-loop-1777273753：engine.step 看本次
                 # transition 是 self-loop（cur=cur），不会触发它的终态 sync
                 # block；所以这条 self-loop 路径要 escalate 自己 PATCH BKD
-                # intent issue 的 statusId="review"。同模式 await（escalate
-                # 已 await cleanup_runner，多一行简单清晰）。
+                # intent issue 的 statusId="review"。
                 try:
                     async with BKDClient(
                         settings.bkd_base_url, settings.bkd_token,

--- a/orchestrator/tests/test_intent_status_sync.py
+++ b/orchestrator/tests/test_intent_status_sync.py
@@ -307,6 +307,99 @@ async def test_hitl_s3_escalate_session_failed_self_loop_patches_intent_review(
 
 
 # ═══════════════════════════════════════════════════════════════════════
+# HITL-S3b (issue #473): SESSION_FAILED self-loop MUST NOT cleanup runner pod
+#
+# 防 watchdog stuck 误判删 pod → BKD agent late result:pass 推下一 stage 时
+# pod 已 404 race。runner_gc 兜底（state=ESCALATED 留着自然清，state 离开
+# ESCALATED 进 non-terminal 留 pod 给下一 stage exec）。
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_hitl_s3b_session_failed_self_loop_does_not_cleanup_runner(
+    monkeypatch, _isolated_actions, _mock_runner_controller,
+):
+    """issue #473：SESSION_FAILED 路径 escalate action 内**不再**主动 cleanup_runner.
+
+    BKD agent late result:pass 进来时 pod 还在，下一 stage exec 不撞 404。
+    真死的 REQ 由 runner_gc 兜底（state=ESCALATED → terminal → 下一 tick 清）。
+    """
+    from orchestrator.actions import escalate as escalate_mod
+
+    inst, _update_issue = _make_bkd_mock()
+
+    pool = _FakePool({
+        "REQ-1": _FakeReq(
+            state=ReqState.STAGING_TEST_RUNNING.value,
+            context={
+                "intent_issue_id": "abc123",
+                "auto_retry_count": 2,  # 真 escalate 分支（跳 retry 路径）
+            },
+        ),
+    })
+
+    monkeypatch.setattr(escalate_mod, "BKDClient", lambda *a, **kw: inst)
+    inst.merge_tags_and_update = AsyncMock(return_value=None)
+    monkeypatch.setattr(escalate_mod, "db", MagicMock())
+    monkeypatch.setattr(
+        escalate_mod, "_all_prs_merged_for_req",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr(
+        escalate_mod.gh_incident, "open_incident",
+        AsyncMock(return_value=None),
+    )
+
+    import orchestrator.store.req_state as rs_mod
+    saved = (rs_mod.cas_transition, rs_mod.update_context, rs_mod.get)
+
+    async def _fake_cas(_p, rid, expected, target, evt, action, context_patch=None):
+        r = pool.rows.get(rid)
+        if r is None or r.state != expected.value:
+            return False
+        r.state = target.value
+        return True
+
+    async def _fake_update_ctx(_p, rid, patch_d):
+        r = pool.rows.get(rid)
+        if r:
+            r.context.update(patch_d)
+
+    @dataclass
+    class _Row:
+        state: ReqState
+        context: dict
+
+    async def _fake_get(_p, rid):
+        r = pool.rows.get(rid)
+        if r is None:
+            return None
+        return _Row(state=ReqState(r.state), context=dict(r.context))
+
+    rs_mod.cas_transition = _fake_cas
+    rs_mod.update_context = _fake_update_ctx
+    rs_mod.get = _fake_get
+
+    body = type("B", (), {
+        "issueId": "abc123", "projectId": "proj-x",
+        "event": "watchdog.stuck",
+    })()
+
+    try:
+        await escalate_mod.escalate(
+            body=body, req_id="REQ-1",
+            tags=[], ctx=dict(pool.rows["REQ-1"].context),
+        )
+    finally:
+        rs_mod.cas_transition, rs_mod.update_context, rs_mod.get = saved
+
+    # state advanced to ESCALATED via manual CAS
+    assert pool.rows["REQ-1"].state == ReqState.ESCALATED.value
+    # ─── #473 contract：runner pod MUST NOT be cleaned up by escalate action ───
+    _mock_runner_controller.cleanup_runner.assert_not_awaited()
+
+
+# ═══════════════════════════════════════════════════════════════════════
 # HITL-S4: BKD PATCH failure → log warning, state machine continues
 # ═══════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## What

删掉 `escalate` action 内 SESSION_FAILED self-loop 路径主动 `cleanup_runner` 那 9 行，让 `runner_gc` 单点兜底 pod 生命周期。

Closes #473

## Why（race 时序）

```
06:06:38  challenger watchdog stuck 578s → escalating（BKD agent 实际还在跑）
06:06:40  escalate.runner_cleaned ← 删 pod ⚠️
06:06:40  BKD agent late result:pass 推到
06:06:40  router fire challenger.pass → ESCALATED → DEV_CROSS_CHECK → STAGING_TEST
06:08:17  staging-test exec runner pod → 404 not found → precheck fail
06:09:03  verifier 看到 precheck infra fail → escalate（再次）
```

watchdog 5min 阈值跟 BKD agent 真挂没握手，经常误判 stuck；escalate 一删 pod 就跟 BKD late result:pass 撞 race。dogfood Round-2026-05-06 单条 REQ 撞 5 次 admin resume。

## How

`runner_gc` 已经按 state 兜底（每 15min tick；只清 `state ∈ {done, escalated}` 的 pod），完整覆盖：

| 路径 | 现在 | 改后 |
|---|---|---|
| 真死的 REQ | escalate 同步删 pod | state 留 ESCALATED → runner_gc 下一 tick 清 |
| BKD late result:pass | pod 已 404 → 下游 stage 再 escalate ❌ | state 离开 ESCALATED 进 next stage → runner_gc 不动它 → pod 留着 ✅ |
| 主链 → DONE | `engine._cleanup_runner_on_terminal` 清（不动） | 不变 |
| PR-merged shortcut → DONE | `_apply_pr_merged_done_override` 清（不动） | 不变 |

## 代价

ESCALATED 后 pod 内存释放从 0s → 最多 15min（`runner_gc_interval_sec` 可调）。换来 race 消失 + 不需要补 BKD cancel 握手 + 不动 watchdog 阈值 + 不动 state.py。

## 安全网（已有，未动）

- `retain_pvc=True` 由 ESCALATED 状态自动决定，PVC 保 `pvc_retain_on_escalate_days` 天供 debug
- 每个 stage 入口（4 checker + start_*）的 `ensure_runner_alive` 幂等 lazy recreate（issue #394 自愈层）→ "pod 已删，PVC 还在，再 resume" 场景 workspace 不丢

## Tests

- 新增 `test_hitl_s3b_session_failed_self_loop_does_not_cleanup_runner` 锁定契约
- 全套 `test_intent_status_sync.py`（9）+ `test_engine_escalated_resume.py` + 两个 cleanup_runner contract tests 共 134 条全过
- 完整 unit suite 2416 条全过（13 失败均为本机无 PG 的 integration tests，与本改动无关）

🤖 Generated with [Claude Code](https://claude.com/claude-code)