### PR TITLE
feat(accept): PR-driven dispatch endpoint + prompt hook 拆分

### DIFF
--- a/orchestrator/src/orchestrator/actions/create_accept.py
+++ b/orchestrator/src/orchestrator/actions/create_accept.py
@@ -524,6 +524,33 @@ async def _dispatch_accept_agent(
             project_id=proj, ctx=ctx, accept_issue_id=issue.id,
         )
         pr_urls_dict = (ctx or {}).get("pr_urls") or {}
+
+        # 装 prompt hook list（参考 memory:feedback_prompt_pluggable_via_filename_convention）。
+        # 主 prompt 的 {% for _hook in enabled_prompt_hooks %} loop 按 list 顺序 include
+        # _shared/hooks/<hook>.md.j2。inputs/ 提供"喂什么"，drivers/ 提供"怎么打"。
+        # 文件按目录分类是给人看的，list 是扁平字符串路径（不上 PromptHook 抽象）。
+        #
+        # ⚠️ 全局 settings.enabled_prompt_hooks（mcp_preflight / precheck /
+        # self_issue_constraint 三条 fail-fast）必须前置，stage-local 追加 inputs +
+        # driver。直接传 enabled_prompt_hooks kwarg 会覆盖 Jinja2 globals 那份默认值
+        # (prompts/__init__.py:46)，导致 fail-fast 全丢。
+        pr_url = (ctx or {}).get("pr_url") or ""
+        linked_issue_url = (ctx or {}).get("linked_issue_url") or ""
+        hooks: list[str] = list(settings.enabled_prompt_hooks)
+        if pr_url:
+            # PR-driven 路径（GHA dispatch / 全链路均适用）：PR 在就一并装 linked_issue，
+            # linked_issue hook 内部处理 linked_issue_url 空的场景（从 PR body 抠 Closes #N）。
+            hooks.append("inputs/pr_context")
+            hooks.append("inputs/linked_issue")
+        else:
+            # 没 PR ctx → 走全链路 spec.md（analyze 阶段产物）兜底。
+            hooks.append("inputs/spec_md")
+        # driver: thanatos pod 在 → mobile/redroid 路径；否则黑盒 curl/grpcurl。
+        if thanatos_pod:
+            hooks.append("drivers/thanatos_mcp")
+        else:
+            hooks.append("drivers/direct_curl")
+
         prompt = render(
             "accept.md.j2",
             req_id=req_id,
@@ -539,6 +566,10 @@ async def _dispatch_accept_agent(
             thanatos_skill_repo=thanatos_skill_repo,
             bkd_entry_links=bkd_entry_links,
             pr_urls=pr_urls_dict,
+            # 新增：prompt hook 机制 + PR-driven 输入
+            enabled_prompt_hooks=hooks,
+            pr_url=pr_url,
+            linked_issue_url=linked_issue_url,
         )
         await bkd.follow_up_issue(project_id=proj, issue_id=issue.id, prompt=prompt)
         await bkd.update_issue(project_id=proj, issue_id=issue.id, status_id="working")

--- a/orchestrator/src/orchestrator/admin.py
+++ b/orchestrator/src/orchestrator/admin.py
@@ -931,3 +931,117 @@ async def accept_env_gc_status() -> dict:
     orchestrator 重启前为 {last: null}。
     """
     return {"last": accept_env_gc.get_last_result()}
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Accept-only dispatch（dogfood 期 PR-driven 入口）
+#
+# 业务侧 CI（ttpos-ci 之类）build 完镜像后，直接 POST 这里：跳前面 6 段
+# (intake/analyze/spec/dev/staging/pr-ci-watch) 直入 ACCEPT_RUNNING，
+# 复用 state.py:137 的 (INIT, INTENT_ACCEPT) → ACCEPT_RUNNING transition。
+# 不新增 event 不新增 state，纯把现有 intent.accept 通路串到 HTTP。
+#
+# accept-agent 拿到的 ctx 已经带 pr_url / linked_issue_url / image_tags /
+# pr_urls，prompt hook（_shared/hooks/inputs/{pr_context,linked_issue}）直接消费。
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class AcceptDispatchReq(BaseModel):
+    """ttpos-ci → sisyphus PR-driven 验收触发 payload。
+
+    image_tag 是 ttpos-ci `scripts/ci-build.sh` 算出来的最终 tag（pr-N-sha 类）；
+    runner pod 里 ttpos-server-go 的 `make accept-env-up` 读 SISYPHUS_IMAGE_TAGS
+    env 做 helm --set image.tag override。
+    """
+
+    pr_url: str
+    pr_number: int
+    image_tag: str
+    source_repo: str
+    branch: str
+    linked_issue_url: str = ""
+    project_id: str = "nnvxh8wj"
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "pr_url": "https://github.com/ZonEaseTech/ttpos-server-go/pull/892",
+                "pr_number": 892,
+                "image_tag": "pr-892-abc1234",
+                "source_repo": "ttpos-server-go",
+                "branch": "feat/shop-auto-settle",
+                "linked_issue_url": "",
+                "project_id": "nnvxh8wj",
+            },
+        },
+    }
+
+
+@admin.post(
+    "/req/dispatch-accept",
+    tags=["accept-dispatch"],
+    summary="PR-driven accept dispatch (业务仓 CI 全绿后触发)",
+)
+async def dispatch_accept(
+    req: AcceptDispatchReq,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    """业务仓 CI 全绿后派一条 accept-only REQ。
+
+    不走前置 intake/analyze/dev/...，直接 INIT --INTENT_ACCEPT--> ACCEPT_RUNNING，
+    复用 create_accept 全套机械流（env-up / agent / teardown / report）。
+
+    同步返回 req_id（验收异步跑），调用方靠 BKD issue 或 Metabase 看进度。
+    """
+    _verify_token(authorization)
+
+    req_id = f"REQ-pr{req.pr_number}-{int(datetime.now(UTC).timestamp())}"
+    ctx: dict = {
+        "pr_url": req.pr_url,
+        "linked_issue_url": req.linked_issue_url,
+        "image_tags": {req.source_repo: req.image_tag},
+        "branch": req.branch,
+        "source_repo": req.source_repo,
+        # pr_acceptance_comment.md.j2 走 ctx.pr_urls dict 贴 PR 管理 comment
+        "pr_urls": {req.source_repo: req.pr_url},
+        # 给 inputs/* hook 标识本次 REQ 由 GHA 直派（没 BKD intent issue）
+        "intent_source": "gha-dispatch",
+    }
+
+    pool = db.get_pool()
+    await req_state.insert_init(pool, req_id, req.project_id, context=ctx)
+
+    fake = _FakeBody(req_id, req.project_id)
+    # GHA dispatch 没真 BKD intent issue，给 create_accept._dispatch_accept_agent
+    # 的 parent-id: tag 一个占位（功能上只是装饰，不影响 accept-agent 跑）。
+    fake.issueId = f"gha-dispatch-{req_id}"
+
+    log.warning(
+        "admin.dispatch_accept",
+        req_id=req_id,
+        pr_url=req.pr_url,
+        image_tag=req.image_tag,
+        source_repo=req.source_repo,
+    )
+
+    result = await engine.step(
+        pool,
+        body=fake,
+        req_id=req_id,
+        project_id=req.project_id,
+        tags=[
+            "intent:accept",
+            f"pr:{req.source_repo}#{req.pr_number}",
+            "source:gha-dispatch",
+        ],
+        cur_state=ReqState.INIT,
+        ctx=ctx,
+        event=Event.INTENT_ACCEPT,
+    )
+
+    return {
+        "req_id": req_id,
+        "pr_url": req.pr_url,
+        "state": "ACCEPT_RUNNING",
+        "engine_result": result,
+    }

--- a/orchestrator/src/orchestrator/prompts/_shared/hooks/drivers/direct_curl.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/hooks/drivers/direct_curl.md.j2
@@ -1,0 +1,65 @@
+## 驱动：直 curl / grpcurl（黑盒打 endpoint）
+
+工具集：`curl` / `grpcurl` / `jq` —— sisyphus runner pod 内全有。
+
+### Step D0: 健康检查
+
+```bash
+POD=runner-{{ req_id | lower }}
+NS=sisyphus-runners
+
+if ! kubectl -n $NS exec $POD -- curl -sf "{{ endpoint }}/healthz" > /dev/null; then
+  echo "BLOCKED: endpoint {{ endpoint }}/healthz unreachable"
+  exit 1
+fi
+echo "endpoint healthy: {{ endpoint }}"
+```
+
+`/healthz` 不存在时换 `/`、`/ready`、`/version` 探一遍；都不响应 → BLOCKED。
+
+### Step D1: 跑每个验收点（来自 inputs 推出来的 checklist）
+
+模板（HTTP API）：
+
+```bash
+kubectl -n $NS exec $POD -- curl -sfi -X <METHOD> \
+  '{{ endpoint }}<path>' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <test-jwt-if-needed>' \
+  -d '<body>' \
+  | head -c 1024   # body 截 1KB 防爆 evidence
+```
+
+模板（gRPC）：
+
+```bash
+# 先列服务（要 server reflection 开着）
+kubectl -n $NS exec $POD -- grpcurl -plaintext <host>:<port> list
+
+# 调方法
+kubectl -n $NS exec $POD -- grpcurl -plaintext \
+  -d '<json>' <host>:<port> <pkg>.<Service>/<Method>
+```
+
+### Step D2: evidence 记录
+
+每个验收点至少存：
+
+- 请求 cmd（脱敏 token）
+- 响应 body（≤1KB）
+- HTTP code / gRPC code
+- 判定依据（一句话："返回 200 且 body.status=ok"）
+
+### Step D3: 跨点串联
+
+如果验收点 V2 依赖 V1 副作用（V1 创建资源 → V2 查询同一资源），把 V1 响应里的 id 存本地变量给 V2 用。**不要每次重新造数据**，那样测不到幂等 / 状态变更。
+
+### Step D4: 镜像核对（防 SISYPHUS_IMAGE_TAGS 注入失败）
+
+```bash
+# /version 不存在就跳过；存在则核对 tag = ctx 里发来的 image_tag
+kubectl -n $NS exec $POD -- curl -sf "{{ endpoint }}/version" 2>/dev/null \
+  | jq -r '.image_tag // .version // empty' || echo "(no /version endpoint)"
+```
+
+如果 endpoint 暴露版本信息且 tag 跟本次 dispatch 的 image_tag 不匹配 → 大概率是 helm install 没正确注入 image override，**报 BLOCKED**，避免 silent pass（用旧码跑了一遍）。

--- a/orchestrator/src/orchestrator/prompts/_shared/hooks/drivers/thanatos_mcp.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/hooks/drivers/thanatos_mcp.md.j2
@@ -1,0 +1,101 @@
+## 驱动：thanatos atomic MCP（mobile / redroid 路径）
+
+> 业务仓 `accept-env-up` 起了 thanatos pod，**走 atomic MCP**。直 curl 路径见 `drivers/direct_curl` hook。
+
+### Step T0: 拉起 thanatos MCP server + 锚定产品知识基线（强制）
+
+thanatos MCP server 在 thanatos pod 中以 stdio 方式运行：
+
+```bash
+kubectl -n {{ thanatos_namespace }} exec -i {{ thanatos_pod }} -- python -m thanatos.server
+```
+
+工具一览：
+
+| 工具 | 用途 |
+|---|---|
+| `preflight(endpoint)` | 一次性绑定 redroid endpoint（host:port），必须最先调 |
+| `recall(skill_path, intent[, tags])` | 检索业务仓 `.thanatos/` 产品知识（anchors / flows / pitfalls / contracts / glossary）|
+| `observe()` | 当前 uiautomator dump tree（含元素 text / content-desc / resource-id / bounds）|
+| `screenshot()` | base64 PNG 截图 |
+| `tap(name)` | 点击文本 / content-desc / resource-id 模糊匹配的首个元素 |
+| `type(name, text)` | 在命名字段输入 text |
+| `wait(ms)` | 直接 sleep |
+| `wait_for_text(text, timeout_ms)` | 轮询直到 text 出现或超时 |
+| `current_page()` | 当前前台 `{package, activity}` |
+| `find(name)` | 单元素快照（debug） |
+
+**第一件事（不可省）**：调 `recall` 至少一次，锚定本仓产品基线。理由：
+不调 recall = 每次重新探索 element 命名 / 业务流程 → 验收风格漂移、设计意图丢失。
+仓里 `.thanatos/anchors.md` / `flows.md` / `pitfalls.md` 维护着 widget 别名 + 流程 + 已知坑，
+**就是用来防漂移的**，必须先看。
+
+```text
+# 推荐 recall 顺序（按当前 REQ 调整 intent）
+recall(skill_path="/workspace/source/{{ thanatos_skill_repo }}/.thanatos/skill.yaml",
+       intent="<feature> screen widgets")
+recall(skill_path=..., intent="<feature> flow steps")
+recall(skill_path=..., intent="known pitfalls", tags=["<feature>"])
+```
+
+跑完拿到 element 别名 / 流程要点 / 历史坑，记下来当下面单步验收的字典。
+
+### Step T1: preflight + 验证 endpoint
+
+```bash
+POD=runner-{{ req_id | lower }}
+NS=sisyphus-runners
+
+# lab endpoint reachable
+kubectl -n $NS exec $POD -- curl -sf "{{ endpoint }}/healthz" || {
+  echo "BLOCKED: endpoint {{ endpoint }} unreachable" >&2; exit 1; }
+```
+
+通过 thanatos MCP 调一次 `preflight`（绑定 redroid 给后续 atomic 工具用）。endpoint 形式
+取决于业务仓 `.sisyphus/env.yaml` 的 `emits.endpoint` —— 一般是 `<redroid_host>:5554` /
+`<redroid_host>:5555`。
+
+```text
+preflight(endpoint="<redroid host:port>")
+```
+
+返回 `{ok: true, a11y_node_count: N}` 才能进下一步。失败先看 lab 是否真起、APK 是否
+真装上（`pm list packages | grep -q <package>`）。
+
+### Step T2: 单步驱动 + 视觉 / 结构判定（每个验收点一遍）
+
+对每个验收点循环：
+
+1. **回到入口态**（如必要）：用 `current_page` 检查；不在期望 activity 就 `tap` 回首页
+   或重启 app（`adb shell am start -n <pkg>/.MainActivity`，可通过 thanatos pod exec 跑）
+2. **GIVEN**：把每条 GIVEN 翻译成"建立前置态"的 atomic 调用（多数情况 GIVEN 已经满足
+   = 启动后默认在某 page，调 `current_page` / `observe` 确认即可；不满足就 tap/type 凑齐）
+3. **WHEN**：把动作翻译成 atomic 调用（`tap("Forgot password")` / `type("用户名", "...")`）。
+   有异步 UI 变化用 `wait_for_text` 不要硬 `wait`
+4. **THEN**：判结果 ——
+   - 优先 `screenshot()` + LLM 看图判（流程对不对、样式对不对、有没有错误提示）
+   - 或 `observe()` 拿 dom，看目标元素是否存在 / 文本是否含期望串
+   - 或 `current_page()` 确认导航到位
+5. **每步留 evidence**：每个验收点至少 1 张关键截图 + 关键 dom 片段
+6. **判 verdict**：`pass` / `fail`，fail 写清楚 reason（"snackbar 没出现" / "样式异常 — 按钮叠在
+   输入框上方" / "tap 后 current_page 没切" 等）
+
+**单步原则**：每次 1 个 atomic call，看返回再决定下一步。**禁止盲写**一长串
+`tap` 调用不看中间状态 —— 那等于退化回 batch 模式。
+
+### Step T3: 报告补充段（thanatos 专属，主 prompt 不变量之外）
+
+主 prompt 的 verdict / source / evidence / notes 之外，追加：
+
+```markdown
+## Recall used
+- anchors.md: 命中 N 条（element 命名字典）
+- flows.md: 命中 M 条（业务流程）
+- pitfalls.md: 命中 K 条（已知坑）
+```
+
+### Step T4: 硬约束（thanatos 路径专属）
+
+- **不构建 APK / 不重装 / 不重启 app**：accept-env-up 已经把 build (GH workflow) + install (adb) + launch (am start) 都做完。**禁止跑 `flutter pub get` / `gradle` / `adb install` / 任何源码构建**
+- **强制 recall**：先 recall 后 act —— 不 recall = 验收基线漂移
+- **单步**：1 个 atomic call → 看结果 → 决定下一步，不要盲写一长串

--- a/orchestrator/src/orchestrator/prompts/_shared/hooks/inputs/linked_issue.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/hooks/inputs/linked_issue.md.j2
@@ -1,0 +1,32 @@
+## 输入源：关联 Issue
+
+{% if linked_issue_url %}
+显式传入：**{{ linked_issue_url }}**
+
+```bash
+gh issue view {{ linked_issue_url }} --json title,body,labels \
+  | jq -r '"## Issue Title:\n\(.title)\n\n## Issue Body:\n\(.body)"'
+```
+{% else %}
+未显式传入，从 PR body 自己抠（已在 pr_context hook 跑过 `gh pr view` 留下 /tmp/pr_context.json）：
+
+```bash
+ISSUE_NUM=$(jq -r '.body' /tmp/pr_context.json 2>/dev/null \
+  | grep -oE '(Closes|Refs|Fixes|closes|refs|fixes) #[0-9]+' \
+  | head -1 | grep -oE '[0-9]+')
+
+if [ -n "$ISSUE_NUM" ]; then
+  # PR repo 推断（pr_url 形如 https://github.com/<owner>/<repo>/pull/N）
+  PR_REPO=$(echo "{{ pr_url }}" | sed -E 's|https://github.com/([^/]+/[^/]+)/pull/.*|\1|')
+  gh issue view --repo "$PR_REPO" "$ISSUE_NUM" --json title,body \
+    | jq -r '"## Issue Title:\n\(.title)\n\n## Issue Body:\n\(.body)"'
+else
+  echo "(PR body 没引用 Closes/Refs/Fixes #N，跳过 issue 上下文)"
+fi
+```
+{% endif %}
+
+对比 PR 是否真的实现了 issue 描述的需求。**特别注意**：
+
+- issue 提到、但 PR diff 里没体现的需求点 → 大概率漏实现，**加进 checklist 单独验**
+- PR 实现了、但 issue 没要的额外行为 → 可能是 over-spec，标 notes 提示 reviewer

--- a/orchestrator/src/orchestrator/prompts/_shared/hooks/inputs/pr_context.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/hooks/inputs/pr_context.md.j2
@@ -1,0 +1,29 @@
+## 输入源：PR
+
+本次验收基于 PR：**{{ pr_url }}**
+
+**先跑（必跑）**：
+
+```bash
+# PR 元数据 + body（含验收点描述）
+gh pr view {{ pr_url }} --json title,body,labels,files,additions,deletions \
+  | tee /tmp/pr_context.json \
+  | jq -r '"## PR Title:\n\(.title)\n\n## PR Body:\n\(.body)\n\n## Files changed:\n\(.files | map("- \(.path) (+\(.additions)/-\(.deletions))") | join("\n"))"'
+
+# diff 头 500 行（看核心 endpoint / handler / schema 变化）
+gh pr diff {{ pr_url }} | head -500 > /tmp/pr_diff.txt
+echo "(diff 已存 /tmp/pr_diff.txt)"
+```
+
+从 PR 标题 / 描述 / diff / 改动文件列表里推断：
+
+- 这次改了什么功能（核心动词 + 名词）
+- 影响哪些 endpoint（diff 里 route / handler 路径）
+- 有没有数据库 schema / 配置变更
+- PR 描述里有没有显式的「验收点」清单（# 验收 / # Acceptance / 中文「验收点」段落）
+- PR body 里 `Closes #N` / `Refs #N` / `Fixes #N` 关联了哪些 issue（下面 linked_issue hook 会用）
+
+把推断结果写下来当下面 driver 阶段的 checklist —— V1/V2/V3 命名你自己起，每条要能追溯到 PR 哪一段。
+
+> ⚠️ **PR body 信息不足时怎么办**：不要瞎编验收点。如果 PR body / diff / files 加起来推不出能验的东西，
+> 直接报 BLOCKED，verdict=BLOCKED，notes 说明"PR 描述不充分，无法推出验收 checklist"。这比硬编 verdict=PASS 强 10 倍。

--- a/orchestrator/src/orchestrator/prompts/_shared/hooks/inputs/spec_md.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/hooks/inputs/spec_md.md.j2
@@ -1,0 +1,19 @@
+## 输入源：spec.md (legacy / 全链路场景)
+
+```bash
+POD=runner-{{ req_id | lower }}
+NS=sisyphus-runners
+
+SPEC_PATH=$(kubectl -n $NS exec $POD -- bash -c \
+  "ls /workspace/source/*/openspec/changes/{{ req_id }}/specs/*/spec.md 2>/dev/null | head -1")
+if [ -z "$SPEC_PATH" ]; then
+  echo "(no spec.md found, skipping spec input)"
+else
+  echo "## spec.md: $SPEC_PATH"
+  kubectl -n $NS exec $POD -- cat "$SPEC_PATH"
+fi
+```
+
+按 `#### Scenario: <id> <desc>` 切块，每块含 GIVEN / WHEN / THEN。**每个 scenario 当一个独立验收点**。
+
+> 跟 `inputs/pr_context` 共存时：spec.md 是 analyze 阶段产物，**最权威**；PR 描述是落地后视角，二者一致 → checklist 二选一即可；不一致 → 标 notes 提示。

--- a/orchestrator/src/orchestrator/prompts/accept.md.j2
+++ b/orchestrator/src/orchestrator/prompts/accept.md.j2
@@ -13,8 +13,7 @@
 
 ─────────
 
-## 验收 (ACCEPT / AI-QA) — atomic-MCP era
-AGENT_ROLE=accept-agent
+## 验收 — AGENT_ROLE=accept-agent
 REQ={{ req_id }}
 ENDPOINT={{ endpoint }}
 NAMESPACE={{ namespace }}
@@ -29,237 +28,61 @@ THANATOS_SKILL_REPO={{ thanatos_skill_repo or '<unset>' }}
 
 ## 你的职责
 
-sisyphus 已经：
-- 在 `$NAMESPACE` 跑 `make accept-env-up`，lab 已拉起
-- 拿到 lab endpoint（上面 `$ENDPOINT`）
-{% if thanatos_pod %}
-- 业务仓 `accept-env-up` 起了 thanatos pod（`$THANATOS_POD`，`$THANATOS_NAMESPACE`）
-- **APK 已构建（GH workflow）+ 装到 redroid + `am start` 启动 MainActivity**。app 此刻已经在 redroid 跑，preflight / observe 直接出图。
-{% endif %}
+sisyphus 已经在 `$NAMESPACE` 跑完 `make accept-env-up`，lab 拉起、endpoint 就绪。**你做验收**：
 
-你要做的：**逐条**跑 spec.md 里 `#### Scenario:` 块定义的验收用例 —— 自己看 GIVEN/WHEN/THEN
-用自然语言推断意图，**单步**调 thanatos atomic MCP（observe / tap / type / screenshot ...）
-驱动 redroid，看截图 + dom 判每条 scenario pass/fail。
-
-> 🚫 **不要重新构建 APK**。不要跑 `flutter pub get` / `gradle assembleDebug` / `melos`
-> / 任何源码构建命令。不要重装 APK（不调 `adb install`）。不要重启 app（除非 atomic
-> MCP 流确实卡死，且记录原因）。accept-env-up 已经把"build → install → launch"全做完，
-> agent 只剩"用 atomic MCP 驱动现有 app 跑 spec scenario"这一段。重新构建 = 浪费 10-20min
-> + 跟 sisyphus 已交付的环境基线脱钩，是 anti-pattern。
-
-> ⚠️ **不再有 thanatos DSL 解析**。spec scenario 是给你（人 / agent）读的验收契约，
-> 不是 thanatos 直接 regex parse 的指令。是否实现了 scenario 描述的行为，**你来判**。
+1. 从上面 **inputs** hook 注入的上下文（PR / linked issue / spec.md）里推出"该验什么" —— 一份 checklist，V1/V2/V3 命名自己起
+2. 用上面 **drivers** hook 注入的工具集（curl/grpcurl 或 thanatos atomic MCP）打 `$ENDPOINT`
+3. 一条一条验完，每条判 verdict + 留 evidence
+4. 写报告，贴 PR comment，打 tag
 
 不管环境。跑完不清，sisyphus 会调 `accept-env-down`。
 
 ---
-{% if thanatos_pod %}
-## 步骤（thanatos atomic MCP 路径）
 
-> 业务仓 accept-env-up 起了 thanatos pod，**走 atomic MCP**。直 curl 路径只在 thanatos
-> 没起的 fallback 模式跑。
-
-### Step 0: 拉起 thanatos MCP server + 锚定产品知识基线（强制）
-
-thanatos MCP server 在 thanatos pod 中以 stdio 方式运行：
-
-```bash
-kubectl -n {{ thanatos_namespace }} exec -i {{ thanatos_pod }} -- python -m thanatos.server
-```
-
-工具一览：
-
-| 工具 | 用途 |
-|---|---|
-| `preflight(endpoint)` | 一次性绑定 redroid endpoint（host:port），必须最先调 |
-| `recall(skill_path, intent[, tags])` | 检索业务仓 `.thanatos/` 产品知识（anchors / flows / pitfalls / contracts / glossary）|
-| `observe()` | 当前 uiautomator dump tree（含元素 text / content-desc / resource-id / bounds）|
-| `screenshot()` | base64 PNG 截图 |
-| `tap(name)` | 点击文本 / content-desc / resource-id 模糊匹配的首个元素 |
-| `type(name, text)` | 在命名字段输入 text |
-| `wait(ms)` | 直接 sleep |
-| `wait_for_text(text, timeout_ms)` | 轮询直到 text 出现或超时 |
-| `current_page()` | 当前前台 `{package, activity}` |
-| `find(name)` | 单元素快照（debug） |
-
-**第一件事（不可省）**：调 `recall` 至少一次，锚定本仓产品基线。理由：
-不调 recall = 每次重新探索 element 命名 / 业务流程 → 验收风格漂移、设计意图丢失。
-仓里 `.thanatos/anchors.md` / `flows.md` / `pitfalls.md` 维护着 widget 别名 + 流程 + 已知坑，
-**就是用来防漂移的**，必须先看。
-
-```text
-# 推荐 recall 顺序（按当前 REQ 调整 intent）
-recall(skill_path="/workspace/source/{{ thanatos_skill_repo }}/.thanatos/skill.yaml",
-       intent="<feature> screen widgets")
-recall(skill_path=..., intent="<feature> flow steps")
-recall(skill_path=..., intent="known pitfalls", tags=["<feature>"])
-```
-
-跑完拿到 element 别名 / 流程要点 / 历史坑，记下来当下面单步验收的字典。
-
-### Step 1: preflight + 验证 endpoint
-
-```bash
-POD=runner-{{ req_id | lower }}
-NS=sisyphus-runners
-
-# lab endpoint reachable
-kubectl -n $NS exec $POD -- curl -sf "{{ endpoint }}/healthz" || {
-  echo "FAIL: endpoint {{ endpoint }} unreachable" >&2; exit 1; }
-```
-
-通过 thanatos MCP 调一次 `preflight`（绑定 redroid 给后续 atomic 工具用）。endpoint 形式
-取决于业务仓 `.sisyphus/env.yaml` 的 `emits.endpoint` —— 一般是 `<redroid_host>:5554` /
-`<redroid_host>:5555`。
-
-```text
-preflight(endpoint="<redroid host:port>")
-```
-
-返回 `{ok: true, a11y_node_count: N}` 才能进 Step 2。失败先看 lab 是否真起、APK 是否
-真装上（`pm list packages | grep -q <package>`）。
-
-### Step 2: 解析 spec.md 路径 + 抽出 scenario 列表
-
-```bash
-SPEC_PATH=$(kubectl -n $NS exec $POD -- bash -c \
-  "ls /workspace/source/{{ thanatos_skill_repo }}/openspec/changes/{{ req_id }}/specs/*/spec.md 2>/dev/null | head -1")
-[ -n "$SPEC_PATH" ] || { echo "FAIL: no spec.md found" >&2; exit 1; }
-
-kubectl -n $NS exec $POD -- cat "$SPEC_PATH"
-```
-
-读出来后，按 `#### Scenario: <id> <desc>` 切块，每块含 GIVEN/WHEN/THEN 步骤。**逐条验收**。
-
-### Step 3: 单步驱动 + 视觉 / 结构判定（每个 scenario 一遍）
-
-对每个 scenario 循环：
-
-1. **回到入口态**（如必要）：用 `current_page` 检查；不在期望 activity 就 `tap` 回首页
-   或重启 app（`adb shell am start -n <pkg>/.MainActivity`，可通过 thanatos pod exec 跑）
-2. **GIVEN**：把每条 GIVEN 翻译成"建立前置态"的 atomic 调用（多数情况 GIVEN 已经满足
-   = 启动后默认在某 page，调 `current_page` / `observe` 确认即可；不满足就 tap/type 凑齐）
-3. **WHEN**：把动作翻译成 atomic 调用（`tap("Forgot password")` / `type("用户名", "...")`）。
-   有异步 UI 变化用 `wait_for_text` 不要硬 `wait`
-4. **THEN**：判结果 ——
-   - 优先 `screenshot()` + LLM 看图判（流程对不对、样式对不对、有没有错误提示）
-   - 或 `observe()` 拿 dom，看目标元素是否存在 / 文本是否含期望串
-   - 或 `current_page()` 确认导航到位
-5. **每步留 evidence**：每个 scenario 至少 1 张关键截图 + 关键 dom 片段
-6. **判 verdict**：`pass` / `fail`，fail 写清楚 reason（"snackbar 没出现" / "样式异常 — 按钮叠在
-   输入框上方" / "tap 后 current_page 没切" 等）
-
-**单步原则**：每次 1 个 atomic call，看返回再决定下一步。**禁止盲写**一长串
-`tap` 调用不看中间状态 —— 那等于退化回 batch 模式。
-
-### Step 4: 报告
-
-在本 issue follow-up 追加：
-
-```markdown
-## Accept Result (atomic MCP)
-
-### {{ req_id }}-S1: <短描述>
-- verdict: PASS
-- evidence: <screenshot ref / inline base64 / dom snippet>
-- notes: <可选>
-
-### {{ req_id }}-S2: <短描述>
-- verdict: FAIL
-- reason: snackbar "即将上线" 没出现 (wait_for_text timeout 5000ms)
-- evidence: <screenshot 链接>
-
-## Recall used
-- anchors.md: 命中 N 条（element 命名字典）
-- flows.md: 命中 M 条（业务流程）
-- pitfalls.md: 命中 K 条（已知坑）
-```
-
-verdict 三态：`PASS` / `FAIL` / `BLOCKED`（前置态都建不起来 / preflight 失败 → BLOCKED，
-区分于 FAIL）。
-
-### Step 5: 贴 PR 管理 comment（含 BKD 反向控制通道入口）
-
-⚠️ 这一步**必须用 BKD Coder workspace 的 `gh` CLI 执行**（你跑在 Coder 里有现成的
-`gh auth`）—— sisyphus orchestrator / runner pod **不写 GH**（架构契约）。
-{% include "_shared/pr_acceptance_comment.md.j2" %}
-
-### Step 6: 贴 tag + move review
-
-- 全过：tags = `[accept, {{ req_id }}, result:pass]`, statusId=review
-- 任一 FAIL / BLOCKED：tags = `[accept, {{ req_id }}, result:fail]`, statusId=review
-
-{% else %}
-## 步骤（直 curl 路径 — fallback / sisyphus self-accept）
-
-> 业务仓 accept-env-up 没起 thanatos pod（或 sisyphus 自家 self-accept compose
-> 路径），accept-agent 直接读 spec + curl endpoint 跑 scenario。
-
-### Step 1: 验证 endpoint
-
-```bash
-POD=runner-{{ req_id | lower }}
-NS=sisyphus-runners
-
-kubectl -n $NS exec $POD -- curl -sf "{{ endpoint }}/healthz"
-if [ $? -ne 0 ]; then
-  exit 1
-fi
-```
-
-### Step 2: 读 Acceptance Scenario
-
-从 runner 的 /workspace/source/<repo>/openspec 读各仓 spec：
-
-```bash
-kubectl -n $NS exec $POD -- bash -c \
-  "cat /workspace/source/*/openspec/changes/{{ req_id }}/specs/*/spec.md"
-```
-
-找出所有 `#### Scenario: <id> <desc>` block（GIVEN / WHEN / THEN）。
-
-### Step 3: 跑每个 scenario
-
-对 `{{ endpoint }}` 做 curl / gRPC 等，按 GIVEN→WHEN→THEN 验证。
-
-```bash
-kubectl -n $NS exec $POD -- bash -c \
-  "curl -sf -X POST '{{ endpoint }}/api/feature' -d '{...}' | jq .status"
-```
-
-记录：pass/fail + evidence（response / logs / side-effects）。
-
-### Step 4: 报告
+## 报告格式（统一）
 
 在本 issue follow-up 追加：
 
 ```markdown
 ## Accept Result
 
-- {{ req_id }}-S1: PASS — curl 200, response body correct
-- {{ req_id }}-S2: FAIL — curl 500, error: xxx
+### {{ req_id }}-V<n>: <短描述>
+- verdict: PASS | FAIL | BLOCKED
+- source: <来自哪个 input: pr_context (PR 第 N 段) / linked_issue (#issue 第 N 段) / spec.md S<n>>
+- evidence: <运行证据，driver 决定形态 — curl 响应 / screenshot ref / dom 片段>
+- notes: <可选；driver 专属补充段也走这里>
 ```
 
-### Step 5: 贴 PR 管理 comment（含 BKD 反向控制通道入口）
+verdict 三态：
 
-⚠️ 这一步**必须用 BKD Coder workspace 的 `gh` CLI 执行**。
-{% include "_shared/pr_acceptance_comment.md.j2" %}
+- **PASS**：验收点行为符合 PR / issue 描述
+- **FAIL**：行为偏离 PR / issue 描述（写清楚怎么偏）
+- **BLOCKED**：前置条件不满足（endpoint 不通 / 输入信号都没有 / 推不出 checklist）
 
-### Step 6: 贴 tag + move review
+> ⚠️ **不要 silent pass**：推不出验收点就老老实实标 BLOCKED；半懂不懂就 FAIL；不要把所有都标 PASS 走过场。FAIL/BLOCKED 比假 PASS 有用 10 倍。
 
-- 全过：tags = `[accept, {{ req_id }}, result:pass]`, statusId=review
-- 任一失败：tags = `[accept, {{ req_id }}, result:fail]`, statusId=review
-{% endif %}
+driver hook 里有专属补充段（如 thanatos 的 `## Recall used`），直接追加在最后即可。
 
 ---
 
-## 硬约束
+## 收尾
 
-- **不部署 lab**：sisyphus 搞好的
-- **不清 lab**：sisyphus 会做
-- **不构建 APK / 不重装 / 不重启 app**：accept-env-up 已经把 build (GH workflow) + install (adb) + launch (am start) 都做完。**禁止跑 `flutter pub get` / `gradle` / `adb install` / 任何源码构建**。app 已在 redroid 上跑，直接 preflight + observe + tap/type 验。
-- **不改业务代码**：只读 + (curl | thanatos atomic MCP)
-- **真实 endpoint**：不 mock
-- **强制 recall**：thanatos 路径下，先 recall 后 act —— 不 recall = 验收基线漂移
-- **单步**：1 个 atomic call → 看结果 → 决定下一步，不要盲写一长串
-- **update-issue** 要指本 accept issue（不是 SOURCE_ISSUE）
+### 贴 PR 管理 comment（含 BKD 反向控制通道入口）
+
+⚠️ 这一步**必须用 BKD Coder workspace 的 `gh` CLI 执行**（你跑在 Coder 里有现成的 `gh auth`）—— sisyphus orchestrator / runner pod **不写 GH**（架构契约 §8）。
+
+{% include "_shared/pr_acceptance_comment.md.j2" %}
+
+### 贴 tag + move review
+
+- 全过 → tags = `[accept, {{ req_id }}, result:pass]`, statusId=review
+- 任一非 PASS → tags = `[accept, {{ req_id }}, result:fail]`, statusId=review
+
+---
+
+## 硬约束（不变量）
+
+- **不部署 lab / 不清 lab / 不改业务代码**：sisyphus 做 env-up + env-down，agent 只验
+- **真实 endpoint，不 mock**
+- **update-issue 指本 accept issue**（不是 SOURCE_ISSUE）
+- **driver 专属约束**（mobile / 单步原则等）见 drivers/ 对应 hook 段

--- a/orchestrator/tests/test_contract_prompts_repo_agnostic_challenger.py
+++ b/orchestrator/tests/test_contract_prompts_repo_agnostic_challenger.py
@@ -171,14 +171,20 @@ def test_pra_s5_no_feature_a_prefix_in_prompts() -> None:
 # ---------------------------------------------------------------------------
 
 def test_pra_s6_accept_instructs_scenario_heading_match() -> None:
-    """PRA-S6: accept.md.j2 must instruct the agent to find acceptance scenarios
-    via `#### Scenario:` heading match (the same pattern as check-scenario-refs.sh),
-    not via a hardcoded `FEATURE-A` prefix."""
-    text = _read("accept.md.j2")
-    assert "#### Scenario:" in text, (
-        "PRA-S6 FAILED: accept.md.j2 does not reference `#### Scenario:` as the\n"
-        "discriminator for finding acceptance scenario blocks. The instruction in\n"
-        "Step 2 must direct the agent to enumerate every block whose heading matches\n"
+    """PRA-S6: accept-stage prompt material must instruct the agent to find
+    acceptance scenarios via `#### Scenario:` heading match (the same pattern as
+    check-scenario-refs.sh), not via a hardcoded `FEATURE-A` prefix.
+
+    Material = accept.md.j2 itself + the spec.md input hook it composes when
+    spec.md is present (post hook-refactor in feat/accept-dispatch-endpoint, the
+    heading-match instruction lives in `_shared/hooks/inputs/spec_md.md.j2`;
+    main prompt stays driver/input agnostic by design)."""
+    bundle = _read("accept.md.j2") + "\n" + _read("_shared/hooks/inputs/spec_md.md.j2")
+    assert "#### Scenario:" in bundle, (
+        "PRA-S6 FAILED: neither accept.md.j2 nor its spec_md input hook\n"
+        "(_shared/hooks/inputs/spec_md.md.j2) references `#### Scenario:` as the\n"
+        "discriminator for finding acceptance scenario blocks. At least one of them\n"
+        "must direct the agent to enumerate every block whose heading matches\n"
         "`#### Scenario:` (neutral, per spec requirement PRA-S6)."
     )
 

--- a/orchestrator/uv.lock
+++ b/orchestrator/uv.lock
@@ -944,6 +944,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1210,6 +1222,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-httpx" },
+    { name = "pytest-randomly" },
     { name = "ruff" },
 ]
 
@@ -1218,6 +1231,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-httpx" },
+    { name = "pytest-randomly" },
     { name = "ruff" },
 ]
 
@@ -1237,6 +1251,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.32" },
+    { name = "pytest-randomly", marker = "extra == 'dev'", specifier = ">=3.15" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7" },
     { name = "structlog", specifier = ">=24.4" },
@@ -1250,6 +1265,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-httpx", specifier = ">=0.32" },
+    { name = "pytest-randomly", specifier = ">=3.15" },
     { name = "ruff", specifier = ">=0.15.11" },
 ]
 


### PR DESCRIPTION
## 目的

dogfood 期把 sisyphus accept stage 抠出独立可触发，不依赖前面 7 段（intake/analyze/spec/dev/staging/pr-ci-watch），保留未来回归全链路的零迁移路径。

## 数据流

```
业务仓 PR → ttpos-ci CI build images push GHCR → 末步 curl POST /admin/req/dispatch-accept
  → sisyphus 复用 (INIT, INTENT_ACCEPT) → ACCEPT_RUNNING transition
  → create_accept exec runner pod 调 ttpos-server-go `make accept-env-up`
  → accept-env-up 自包含 clone arch-lab + helm install + endpoint JSON
  → 派 BKD accept-agent（PR-driven prompt: pr_context + linked_issue + direct_curl）
  → agent 黑盒打 endpoint 跑验收 → 写报告 + 贴 PR comment
  → make accept-env-down 拆 lab
```

## 改动归属

- **本 PR (sisyphus)**：admin endpoint + prompt 拆 hook + create_accept ctx 装配
- 配套 ttpos-server-go PR：https://github.com/ZonEaseTech/ttpos-server-go/pull/new/feat/accept-env-up（accept-env.mk）
- ttpos-arch-lab：**0 改动**（用现有 VALUES_EXTRA 入口接 image override）
- ttpos-ci：调用方加 final job 调本 endpoint（user 把控）

## 改动总览

| 文件 | 改动 |
|---|---|
| ``admin.py`` | +96 ← 新增 ``POST /admin/req/dispatch-accept`` + OpenAPI example + tag |
| ``actions/create_accept.py`` | +31 ← 装 hooks list（全局默认 + stage-local 追加，不覆盖） |
| ``prompts/accept.md.j2`` | -174 ← 瘦身（删两份重复的 step 段，提炼为 hook） |
| ``prompts/_shared/hooks/inputs/pr_context.md.j2`` | +29 🆕 |
| ``prompts/_shared/hooks/inputs/linked_issue.md.j2`` | +32 🆕 |
| ``prompts/_shared/hooks/inputs/spec_md.md.j2`` | +19 🆕 |
| ``prompts/_shared/hooks/drivers/direct_curl.md.j2`` | +65 🆕 |
| ``prompts/_shared/hooks/drivers/thanatos_mcp.md.j2`` | +101 🆕 |
| ``tests/test_contract_prompts_repo_agnostic_challenger.py`` | PRA-S6 合约迁移 |

净 +218 行。

## 关键设计点

1. **复用现有 transition** ``state.py:137`` ``(INIT, INTENT_ACCEPT) → ACCEPT_RUNNING``，0 新增 event/state
2. **hooks list 不覆盖全局默认** —— ``mcp_preflight`` / ``precheck`` / ``self_issue_constraint`` 三条 fail-fast 保留
3. **prompt 自动按 ctx 选 input**：有 ``pr_url`` → PR-driven；没 → spec_md 兜底
4. **driver 自动选**：``thanatos_pod`` 在 → mobile；不在 → direct_curl
5. **合约迁移**：PRA-S6 spec heading 判别从主 prompt 搬到 ``inputs/spec_md.md.j2``，合约测试同步扩展断言范围

## OpenAPI

部署后 ``https://<sisyphus-domain>/docs`` 看 **accept-dispatch** section 拿 contract，``Try it out`` 直接能用（带 example payload）。

## ttpos-ci 端 contract

```http
POST /admin/req/dispatch-accept
Authorization: Bearer <SISYPHUS_ADMIN_TOKEN>
Content-Type: application/json

{
  "pr_url":           "https://github.com/ZonEaseTech/ttpos-server-go/pull/892",
  "pr_number":        892,
  "image_tag":        "pr-892-abc1234",
  "source_repo":      "ttpos-server-go",
  "branch":           "feat/x",
  "linked_issue_url": "",
  "project_id":       "nnvxh8wj"
}
```

## 测试

- ✅ 2341 个单元 / contract test 通过（本机可跑的全部）
- ⏭ 跳过 13 个 DB integration + 3 个 make-dep contract test（本机环境缺 PG / make，CI 会跑）
- ✅ Python ``py_compile`` + Jinja2 syntax 通过

## 推迟下一轮

verifier-agent 接 fail 3 路决策 / mobile thanatos 实跑 / silent-pass 自动告警 / 手动 CLI 入口 / 多 image_tag loop / sisyphus OpenAPI metadata 整治（B/C/SecurityScheme/分组）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)