### PR TITLE
fix(accept-dispatch): derive owner/repo from pr_url for `pr:` tag

### DIFF
--- a/orchestrator/src/orchestrator/admin.py
+++ b/orchestrator/src/orchestrator/admin.py
@@ -995,6 +995,19 @@ async def dispatch_accept(
     """
     _verify_token(authorization)
 
+    # 从 pr_url 抠 owner/repo slug（intent_tags._PR_TAG_RE 期望 pr:owner/repo#N
+    # 格式，create_accept.py 入口处 extract_pr_tag 校验，缺 owner 直接 fail-fast，
+    # closes #400）。payload 的 source_repo 字段可能只是 repo basename
+    # (ttpos-server-go) 也可能已经是 owner/repo，统一从 pr_url 抠最稳。
+    try:
+        owner_repo = req.pr_url.split("github.com/", 1)[1].rsplit("/pull/", 1)[0]
+        assert "/" in owner_repo, "owner_repo missing slash"
+    except (IndexError, AssertionError) as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"pr_url malformed (expect https://github.com/<owner>/<repo>/pull/N): {req.pr_url}",
+        ) from e
+
     req_id = f"REQ-pr{req.pr_number}-{int(datetime.now(UTC).timestamp())}"
     ctx: dict = {
         "pr_url": req.pr_url,
@@ -1031,7 +1044,7 @@ async def dispatch_accept(
         project_id=req.project_id,
         tags=[
             "intent:accept",
-            f"pr:{req.source_repo}#{req.pr_number}",
+            f"pr:{owner_repo}#{req.pr_number}",
             "source:gha-dispatch",
         ],
         cur_state=ReqState.INIT,

--- a/orchestrator/tests/test_admin.py
+++ b/orchestrator/tests/test_admin.py
@@ -1138,3 +1138,74 @@ def test_admin_route_table_runner_resume_renamed():
     # bare /resume 绑 state-level resume_req（不是 resume_runner）
     assert paths_to_endpoint.get("/admin/req/{req_id}/resume") is resume_req
     assert paths_to_endpoint.get("/admin/req/{req_id}/resume") is not resume_runner
+
+
+# ─── dispatch-accept smoke ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_accept_tag_includes_owner_repo_from_pr_url(monkeypatch):
+    """dispatch-accept 必须把 pr_url 抠成 owner/repo 拼 `pr:owner/repo#N` tag，
+    否则 create_accept.py 入口的 extract_pr_tag fail-fast 把 REQ 直接 escalate
+    （smoke test live cluster 实证）。"""
+    from orchestrator import admin as admin_mod
+    from orchestrator.admin import AcceptDispatchReq, dispatch_accept
+
+    monkeypatch.setattr(admin_mod, "_verify_token", lambda x: None)
+
+    class FakePool:
+        async def execute(self, *a, **kw): return None
+    monkeypatch.setattr("orchestrator.admin.db.get_pool", lambda: FakePool())
+
+    async def fake_insert_init(*a, **kw): return None
+    monkeypatch.setattr("orchestrator.admin.req_state.insert_init", fake_insert_init)
+
+    captured: dict = {}
+
+    async def fake_step(pool, *, body, req_id, project_id, tags, cur_state, ctx, event, depth=0):
+        captured["tags"] = tags
+        captured["ctx"] = ctx
+        captured["event"] = event
+        return {"action": "noop"}
+
+    monkeypatch.setattr("orchestrator.admin.engine.step", fake_step)
+
+    req = AcceptDispatchReq(
+        pr_url="https://github.com/ZonEaseTech/ttpos-server-go/pull/892",
+        pr_number=892,
+        image_tag="pr-892-abc",
+        source_repo="ttpos-server-go",     # basename 形式（payload 常态）
+        branch="feat/x",
+    )
+    result = await dispatch_accept(req, authorization="Bearer x")
+
+    assert result["state"] == "ACCEPT_RUNNING"
+    # 关键断言：tag 含 owner/repo 形式，不能漏 owner
+    pr_tags = [t for t in captured["tags"] if t.startswith("pr:")]
+    assert pr_tags == ["pr:ZonEaseTech/ttpos-server-go#892"], (
+        f"expected `pr:ZonEaseTech/ttpos-server-go#892`, got {pr_tags}; "
+        "create_accept.py extract_pr_tag 会因为缺 owner 直接 fail-fast escalate"
+    )
+    assert captured["event"].value == "intent.accept"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_accept_rejects_malformed_pr_url(monkeypatch):
+    """pr_url 不符合 github.com/<owner>/<repo>/pull/N 形式 → 400，
+    不要静默落 REQ 让它跑到 create_accept 才 fail。"""
+    from orchestrator import admin as admin_mod
+    from orchestrator.admin import AcceptDispatchReq, dispatch_accept
+
+    monkeypatch.setattr(admin_mod, "_verify_token", lambda x: None)
+
+    req = AcceptDispatchReq(
+        pr_url="https://example.com/not-a-pr",
+        pr_number=1,
+        image_tag="t",
+        source_repo="r",
+        branch="b",
+    )
+    with pytest.raises(HTTPException) as ei:
+        await dispatch_accept(req, authorization="Bearer x")
+    assert ei.value.status_code == 400
+    assert "pr_url malformed" in ei.value.detail


### PR DESCRIPTION
## 现象

PR #479 merge 后 live smoke test (vm-node04) 跑 ``POST /admin/req/dispatch-accept``：

```json
{
  "req_id": "REQ-pr9999-1778576537",
  "state": "ACCEPT_RUNNING",
  "engine_result": {
    "action": "create_accept",
    "result": {
      "emit": "accept-env-up.fail",
      "reason": "intent:accept requires a pr:owner/repo#N tag to specify the PR"
    },
    "chained": {
      "action": "escalate",
      "next_state": "escalated"
    }
  }
}
```

入口跑通了（HTTP 200 / req_state insert / engine.step 触发），但 ``create_accept`` 立刻 fail-fast 把 REQ chain escalate。

## 根因

``admin.py:1034`` 拼 tag 时 ``f"pr:{req.source_repo}#{req.pr_number}"`` —— ``source_repo`` 字段是 basename (``ttpos-server-go``)，缺 owner，不匹配 ``intent_tags._PR_TAG_RE`` 期望的 ``pr:owner/repo#N`` 格式（PR #400 引入的 fail-fast）。

## 修法

从 ``pr_url``（一定有，且 payload 必填）抠 owner/repo：

```
https://github.com/ZonEaseTech/ttpos-server-go/pull/9999
                   └────── owner/repo ──────┘   └pr_number┘
```

拼成 ``pr:ZonEaseTech/ttpos-server-go#9999``，匹配 regex。

``pr_url`` 形式非法 → 400 直接 reject，不放进 state machine 让它流程内 fail（入口层 reject vs 内部 escalate 语义更清晰）。

## 测试覆盖

新加两个 unit test：

- ``test_dispatch_accept_tag_includes_owner_repo_from_pr_url`` mock engine.step 截取 tags，断言 ``pr:ZonEaseTech/ttpos-server-go#892``
- ``test_dispatch_accept_rejects_malformed_pr_url`` 断言畸形 pr_url 返 ``HTTPException(400, "pr_url malformed")``

这两条 ``pytest tests/test_admin.py -k dispatch_accept`` 全过；70 个 admin + accept 相关测试 0 回归。

## 反思

PR #479 没写 endpoint 单元测试导致此问题。本次补上后，dispatch endpoint 行为 contract 进入测试 net。

🤖 Generated with [Claude Code](https://claude.com/claude-code)