### PR TITLE
fix(admin): rename event= kwarg in emit log (structlog collision)

### DIFF
--- a/orchestrator/src/orchestrator/admin.py
+++ b/orchestrator/src/orchestrator/admin.py
@@ -102,7 +102,7 @@ async def emit_event(
     if row is None:
         raise HTTPException(status_code=404, detail=f"req {req_id} not found")
 
-    log.warning("admin.emit", req_id=req_id, event=body.event, from_state=row.state.value)
+    log.warning("admin.emit", req_id=req_id, bkd_event=body.event, from_state=row.state.value)
     fake = _FakeBody(req_id, row.project_id)
     tags = await _fetch_intent_tags(req_id, row.project_id, row.context)
     return await engine.step(


### PR DESCRIPTION
## Summary

- `POST /admin/req/{id}/emit` returns 500 Internal Server Error
- Root cause: `log.warning("admin.emit", ..., event=body.event, ...)` — structlog uses `event` as the positional message key, so passing `event=` as kwargs causes `TypeError: got multiple values for argument 'event'`
- Fix: rename to `bkd_event=body.event`

## Test plan

- [ ] `POST /admin/req/{req_id}/emit {"event": "intent.accept"}` returns 200 after deploy
- [ ] Logs show `bkd_event=...` field correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)