### PR TITLE
fix(rbac): add persistentvolumeclaims/status to runner-mgr Role

### DIFF
--- a/orchestrator/helm/templates/runner-rbac.yaml
+++ b/orchestrator/helm/templates/runner-rbac.yaml
@@ -29,7 +29,7 @@ rules:
     # websocket exec handshake 是 GET，纯 create 不够（M1/M2 sisyphus checker 直 exec runner pod）
     verbs: ["create", "get"]
   - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
+    resources: ["persistentvolumeclaims", "persistentvolumeclaims/status"]
     verbs: ["get", "list", "watch", "create", "delete", "patch"]
   - apiGroups: [""]
     resources: ["events"]


### PR DESCRIPTION
## Summary

- `create_accept` → `k8s_runner.get_runner_status` calls `read_namespaced_persistent_volume_claim_status` (the `/status` subresource)
- The current Role only grants `get` on `persistentvolumeclaims`, not the `/status` subresource — 403 Forbidden
- Fix: add `persistentvolumeclaims/status` to the resources list

**Already patched live** via `kubectl patch role` to unblock running REQs.

## Test plan

- [ ] `create_accept` completes without 403 on PVC status check
- [ ] Helm chart redeploy applies the RBAC fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)