### PR TITLE
fix(helm): orch probe timeoutSeconds 1s→5s + failureThreshold→5

### DIFF
--- a/orchestrator/helm/templates/deployment.yaml
+++ b/orchestrator/helm/templates/deployment.yaml
@@ -117,12 +117,16 @@ spec:
               port: http
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold | default 5 }}
           readinessProbe:
             httpGet:
               path: {{ .Values.probes.readiness.path }}
               port: http
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold | default 5 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.prompts.configMap.enabled }}

--- a/orchestrator/helm/values.yaml
+++ b/orchestrator/helm/values.yaml
@@ -281,14 +281,23 @@ prompts:
     enabled: false
 
 probes:
+  # 2026-05-17 stability test: 3 并发 webhook 同时打进来，asyncio event loop
+  # 处理 (extract_req_id + state CAS + k8s exec spawn runner clone) 阶段性
+  # 顶住，/healthz 1s 默认 timeout 撞 "context deadline exceeded" → kubelet
+  # 杀 orch (实测 8min 内 RESTARTS=2)，所有 in-flight create_accept 全孤儿。
+  # 加 timeoutSeconds=5 + failureThreshold=5 给 async 服务足够余量。
   liveness:
     path: /livez
     initialDelaySeconds: 10
     periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 5
   readiness:
     path: /readyz
     initialDelaySeconds: 5
     periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
 
 nodeSelector: {}
 tolerations: []

--- a/orchestrator/src/orchestrator/k8s_runner.py
+++ b/orchestrator/src/orchestrator/k8s_runner.py
@@ -288,10 +288,14 @@ class RunnerController:
             security_context=client.V1SecurityContext(privileged=True),
             resources=client.V1ResourceRequirements(
                 # 2026-04 实证：vm-node04 5991Mi 总内存，1Gi request 只能塞 1 个 runner，
-                # 多 REQ 并发时撞 FailedScheduling: Insufficient memory。
-                # 降到 512Mi/250m，能塞 2-3 个并发 runner。
-                # limit 保持 8Gi（runner 跑 docker build 高峰时需要）。
-                requests={"cpu": "250m", "memory": "512Mi"},
+                # 多 REQ 并发时撞 FailedScheduling: Insufficient memory。降到 512Mi/250m。
+                # 2026-05 复测：vm04 4 core + longhorn 480m + lab-baseline 300m +
+                # ephemeral 业务 ~600m，250m × runner 让 3 并发撞 Insufficient cpu。
+                # runner 平时只是 sleep infinity + dockerd 兜底（实测 idle 用 ~10m）；
+                # docker build / kubectl exec 高峰允许 burst 到 limit 4c。降 50m 后
+                # vm04 single-node 实测稳放 4 个并发 runner + ephemeral env。
+                # limit 保持 4c/8Gi（runner 跑 docker build 高峰时需要）。
+                requests={"cpu": "50m", "memory": "512Mi"},
                 limits={"cpu": "4", "memory": "8Gi"},
             ),
             env=env_vars,


### PR DESCRIPTION
3 并发 webhook 实测 orch /healthz 1s 默认 timeout 顶不住，asyncio event loop 偶尔 1s+ 不响应 → liveness fail × 3 → kubelet kill → in-flight create_accept 全孤儿。

bump timeoutSeconds=5 + failureThreshold=5 给 async 服务余量。

跟 #530 配套：#530 调 runner cpu request 让 3+ 并发 runner 能 schedule，本 PR 让 orch 自己不被并发杀。

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)