### PR TITLE
feat(np-demo4): NodePort + make endpoint + no-wait (BC1/BC2/BC3)

### DIFF
--- a/openspec/changes/REQ-np-demo4-1779013770/proposal.md
+++ b/openspec/changes/REQ-np-demo4-1779013770/proposal.md
@@ -1,0 +1,42 @@
+# REQ-np-demo4-1779013770: NodePort + make endpoint + no-wait demo
+
+## 问题
+
+需要在零业务面积下端到端 smoke 一次 sisyphus 完整管道，同时向 testkit/httpx
+提供三项面向 K8s 接受测试的能力：
+
+1. **BC1 – NodePort URL 构造**：runner 在集群内通过 NodePort 访问服务时需要
+   `http://<nodeIP>:<nodePort>` 格式的 URL；目前无标准辅助函数，消费方各写一行
+   `fmt.Sprintf`，不利于统一。
+2. **BC2 – make endpoint 动态发现**：接受测试环境 URL 不固定（NodePort 随部署变化），
+   业务仓已有 `make endpoint` Makefile target 输出当前 URL；testkit 应能调用该
+   target 并直接建立 HTTPClient，避免消费方手写 `exec.Command` + `TrimSpace`。
+3. **BC3 – no-wait POST**：callboard `/api/v1/callboard/device/bind_code` 等异步
+   触发类接口只要求服务器收到请求即返回，客户端不应阻塞等待响应体；testkit 缺少
+   fire-and-forget 语义的 POST 方法，消费方只能用完整 `Post` 再丢弃响应体。
+
+## 方案
+
+### testkit/httpx 新增三项能力
+
+| 文件 | 新增内容 |
+|---|---|
+| `testkit/httpx/nodeport.go` | `NodePortURL(nodeIP string, nodePort int) string` |
+| `testkit/httpx/make_endpoint.go` | `NewServiceClientFromMake(tb, makeTarget, dir string, opts ...Option) *HTTPClient` |
+| `testkit/httpx/client.go` | `(c *HTTPClient) PostNoWait(tb, path string, body any, headers ...map[string]string) int` |
+
+### orchestrator/_pipeline_marker.py
+
+追加 `NP_DEMO4_REQ: str = "REQ-np-demo4-1779013770"` 与既有三条常量共存，
+无生产路径 import，无副作用。
+
+## 取舍
+
+- **为什么 NodePortURL 不支持 HTTPS**：接受环境内网无 TLS，硬编码 `http://` 降低
+  消费方出错面积；需要 HTTPS 的场景可直接 `NewServiceClient`。
+- **为什么 NewServiceClientFromMake 接受 dir 参数**：`make` 需要在含 Makefile 的
+  目录执行；`dir=""` 默认为 `"."`（调用方当前目录），测试可传 `t.TempDir()`。
+- **为什么 PostNoWait 返回 int（status code）而非 void**：调用方通常需要确认服务
+  已收到请求（2xx），返回状态码比完全静默更有用；不读响应体即满足"不等待"语义。
+- **为什么不新建 httpx 子包**：三个新增都是 HTTPClient / URL 工具，与现有 httpx
+  内聚，无需新包。

--- a/openspec/changes/REQ-np-demo4-1779013770/specs/np-demo4/spec.md
+++ b/openspec/changes/REQ-np-demo4-1779013770/specs/np-demo4/spec.md
@@ -1,0 +1,97 @@
+## ADDED Requirements
+
+### Requirement: testkit/httpx MUST 提供 NodePort URL 构造函数
+
+The package `testkit/httpx` SHALL expose a package-level function `NodePortURL`
+with signature `func NodePortURL(nodeIP string, nodePort int) string`. The
+function MUST return a string of the form `http://<nodeIP>:<nodePort>` where
+`<nodeIP>` is the `nodeIP` argument and `<nodePort>` is the decimal representation
+of the `nodePort` argument. The function MUST NOT make network calls, start
+goroutines, or produce side effects of any kind.
+
+#### Scenario: BC1 NodePortURL constructs correct http URL
+
+- **GIVEN** any non-empty string `nodeIP` and any positive integer `nodePort`
+- **WHEN** the caller invokes `httpx.NodePortURL(nodeIP, nodePort)`
+- **THEN** the return value equals `fmt.Sprintf("http://%s:%d", nodeIP, nodePort)`
+  with no trailing slash, no scheme other than `http`, and no network activity
+  as a side effect
+
+---
+
+### Requirement: testkit/httpx MUST 提供 make endpoint 动态发现工厂
+
+The package `testkit/httpx` SHALL expose a function `NewServiceClientFromMake`
+with signature
+`func NewServiceClientFromMake(tb testing.TB, makeTarget, dir string, opts ...Option) *HTTPClient`.
+The function MUST invoke `make <makeTarget>` as a subprocess with its working
+directory set to `dir` (or `"."` when `dir` is the empty string). It MUST
+trim leading and trailing whitespace from the subprocess stdout and use the
+result as the `baseURL` for a new `HTTPClient` constructed via `NewServiceClient`.
+If the `make` invocation exits with a non-zero status, the function MUST call
+`tb.Fatalf` and not return an `*HTTPClient`.
+
+#### Scenario: BC2 NewServiceClientFromMake uses make output as base URL
+
+- **GIVEN** a directory `dir` that contains a `Makefile` with target
+  `endpoint` that prints a well-formed URL (e.g., `http://10.0.0.1:30080`)
+  followed by a newline
+- **WHEN** the caller invokes `httpx.NewServiceClientFromMake(t, "endpoint", dir)`
+- **THEN** the returned `*HTTPClient` has its base URL set to
+  `"http://10.0.0.1:30080"` (whitespace stripped) and can send HTTP requests
+  to that base
+
+---
+
+### Requirement: testkit/httpx HTTPClient MUST 提供 no-wait POST 方法
+
+The type `httpx.HTTPClient` SHALL expose a method `PostNoWait` with signature
+`func (c *HTTPClient) PostNoWait(tb testing.TB, path string, body any, headers ...map[string]string) int`.
+The method MUST send a POST request to `c.baseURL + path` with the same
+auth-header and persistent-header logic as `Post`, serialise `body` to JSON
+when non-nil, and return the HTTP response status code. The method MUST close
+the response body immediately after reading the status code without reading any
+response bytes, satisfying fire-and-forget semantics for async trigger endpoints
+such as `/api/v1/callboard/device/bind_code`. If the request fails at the
+transport layer, the method MUST call `tb.Fatalf`.
+
+#### Scenario: BC3 PostNoWait sends request and returns status without reading body
+
+- **GIVEN** an HTTP server that accepts POST on `/trigger`, records receipt,
+  and returns HTTP 202 with a non-empty body
+- **WHEN** the caller invokes `client.PostNoWait(t, "/trigger", payload)`
+- **THEN** the return value is `202`, the server has received exactly one POST
+  request, and the test does not block waiting for the response body to be read
+
+---
+
+### Requirement: _pipeline_marker 模块 MUST 提供 np-demo4 验证常量
+
+The module at `orchestrator/src/orchestrator/_pipeline_marker.py` SHALL expose
+a module-level string attribute named `NP_DEMO4_REQ`. The attribute MUST hold
+the literal string `"REQ-np-demo4-1779013770"`. It MUST coexist with
+`PIPELINE_VALIDATION_REQ`, `PIPELINE_VALIDATION_REQ_V3`, and
+`SMOKE_PIPELINE_V3_REQ` without modifying any of them. The module MUST NOT
+import `NP_DEMO4_REQ` anywhere in the production code path (engine / router /
+actions / checkers / store).
+
+#### Scenario: NPD4-S1 module exposes NP_DEMO4_REQ without side effects
+
+- **GIVEN** a fresh Python interpreter with `orchestrator/src` on `sys.path`
+- **WHEN** `importlib.import_module("orchestrator._pipeline_marker")` is called
+- **THEN** the module object exposes `NP_DEMO4_REQ` and no log line, network
+  call, or filesystem write is observable as a side effect
+
+#### Scenario: NPD4-S2 NP_DEMO4_REQ is str matching REQ-np-demo4 pattern
+
+- **GIVEN** the module `orchestrator._pipeline_marker` has been imported
+- **WHEN** `NP_DEMO4_REQ` is read from the module
+- **THEN** the value is a `str` instance matching `^REQ-np-demo4-\d+$`
+
+#### Scenario: NPD4-S3 all four pipeline-marker constants coexist unchanged
+
+- **GIVEN** `orchestrator._pipeline_marker` imported
+- **WHEN** the test reads all four constants
+- **THEN** `PIPELINE_VALIDATION_REQ`, `PIPELINE_VALIDATION_REQ_V3`, and
+  `SMOKE_PIPELINE_V3_REQ` retain their original literal values and `NP_DEMO4_REQ`
+  equals `"REQ-np-demo4-1779013770"`

--- a/orchestrator/src/orchestrator/_pipeline_marker.py
+++ b/orchestrator/src/orchestrator/_pipeline_marker.py
@@ -13,3 +13,4 @@ from __future__ import annotations
 PIPELINE_VALIDATION_REQ: str = "REQ-validate-fresh-pipeline-1777123726"
 PIPELINE_VALIDATION_REQ_V3: str = "REQ-validate-fresh-3-1777132879"
 SMOKE_PIPELINE_V3_REQ: str = "REQ-smoke-pipeline-v3-1777806694"
+NP_DEMO4_REQ: str = "REQ-np-demo4-1779013770"

--- a/orchestrator/tests/test_contract_np_demo4.py
+++ b/orchestrator/tests/test_contract_np_demo4.py
@@ -1,0 +1,41 @@
+"""Contract tests for REQ-np-demo4-1779013770.
+
+Black/white-box behavioral contracts derived from:
+  openspec/changes/REQ-np-demo4-1779013770/specs/np-demo4/spec.md
+
+Scenarios covered:
+  NPD4-S1   module exposes NP_DEMO4_REQ without side effects
+  NPD4-S2   NP_DEMO4_REQ is a str matching ^REQ-np-demo4-\\d+$
+  NPD4-S3   all four pipeline-marker constants coexist with expected literal values
+"""
+from __future__ import annotations
+
+import importlib
+import re
+
+NPD4_PATTERN = re.compile(r"^REQ-np-demo4-\d+$")
+
+
+def test_npd4_s1_module_exposes_np_demo4_req() -> None:
+    mod = importlib.import_module("orchestrator._pipeline_marker")
+    assert mod is not None
+    assert hasattr(mod, "NP_DEMO4_REQ")
+
+
+def test_npd4_s2_constant_is_str_and_matches_pattern() -> None:
+    from orchestrator import _pipeline_marker
+
+    value = _pipeline_marker.NP_DEMO4_REQ
+    assert isinstance(value, str)
+    assert NPD4_PATTERN.match(value), (
+        f"NP_DEMO4_REQ={value!r} does not match {NPD4_PATTERN.pattern}"
+    )
+
+
+def test_npd4_s3_all_four_constants_coexist() -> None:
+    from orchestrator import _pipeline_marker
+
+    assert _pipeline_marker.PIPELINE_VALIDATION_REQ == "REQ-validate-fresh-pipeline-1777123726"
+    assert _pipeline_marker.PIPELINE_VALIDATION_REQ_V3 == "REQ-validate-fresh-3-1777132879"
+    assert _pipeline_marker.SMOKE_PIPELINE_V3_REQ == "REQ-smoke-pipeline-v3-1777806694"
+    assert _pipeline_marker.NP_DEMO4_REQ == "REQ-np-demo4-1779013770"

--- a/testkit/httpx/client.go
+++ b/testkit/httpx/client.go
@@ -100,6 +100,38 @@ func (c *HTTPClient) Delete(tb testing.TB, path string, body any, headers ...map
 	return c.doRequest(tb, req, headers...)
 }
 
+// PostNoWait sends a POST request and returns the HTTP status code without
+// reading the response body. Use for async trigger endpoints that return
+// immediately (fire-and-forget semantics); the server receives the full
+// request but the client does not block on a potentially large response.
+func (c *HTTPClient) PostNoWait(tb testing.TB, path string, body any, headers ...map[string]string) int {
+	tb.Helper()
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+path, jsonReader(tb, body))
+	if err != nil {
+		tb.Fatalf("failed to create PostNoWait request: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
+	}
+	for key, value := range c.headers {
+		req.Header.Set(key, value)
+	}
+	for _, h := range headers {
+		for key, value := range h {
+			req.Header.Set(key, value)
+		}
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		tb.Fatalf("PostNoWait request failed: %v", err)
+	}
+	resp.Body.Close()
+	return resp.StatusCode
+}
+
 // DoRequest performs a request with explicit method, path, optional JSON body, and extra headers.
 func (c *HTTPClient) DoRequest(tb testing.TB, method, path string, body any, headers map[string]string) *HTTPResponse {
 	tb.Helper()

--- a/testkit/httpx/make_endpoint.go
+++ b/testkit/httpx/make_endpoint.go
@@ -1,0 +1,28 @@
+package httpx
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// NewServiceClientFromMake runs `make <makeTarget>` in dir (defaults to "." when
+// empty), trims stdout, and returns an HTTPClient whose base URL is the output.
+// Calls tb.Fatalf if make exits non-zero or produces empty output.
+func NewServiceClientFromMake(tb testing.TB, makeTarget, dir string, opts ...Option) *HTTPClient {
+	tb.Helper()
+	if dir == "" {
+		dir = "."
+	}
+	cmd := exec.Command("make", makeTarget)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		tb.Fatalf("make %s in %s failed: %v", makeTarget, dir, err)
+	}
+	url := strings.TrimSpace(string(out))
+	if url == "" {
+		tb.Fatalf("make %s in %s produced empty output", makeTarget, dir)
+	}
+	return NewServiceClient(url, opts...)
+}

--- a/testkit/httpx/make_endpoint_test.go
+++ b/testkit/httpx/make_endpoint_test.go
@@ -1,0 +1,58 @@
+package httpx_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/phona/sisyphus/testkit/httpx"
+)
+
+// TestNewServiceClientFromMake_BC2 verifies that NewServiceClientFromMake
+// runs `make <target>` in the given dir, strips whitespace from stdout, and
+// uses the result as the base URL for the returned HTTPClient.
+func TestNewServiceClientFromMake_BC2(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"code":0,"message":"ok","data":null}`))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	makefile := filepath.Join(dir, "Makefile")
+	content := "endpoint:\n\t@echo " + srv.URL + "\n"
+	if err := os.WriteFile(makefile, []byte(content), 0o644); err != nil {
+		t.Fatalf("write Makefile: %v", err)
+	}
+
+	client := httpx.NewServiceClientFromMake(t, "endpoint", dir)
+	resp := client.Get(t, "/")
+	resp.AssertOK(t)
+}
+
+// TestPostNoWait_BC3 verifies that PostNoWait sends the request, returns the
+// status code, and does not block on the response body.
+func TestPostNoWait_BC3(t *testing.T) {
+	received := make(chan struct{}, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received <- struct{}{}
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte(`{"code":0,"message":"accepted","data":null}`))
+	}))
+	defer srv.Close()
+
+	client := httpx.NewServiceClient(srv.URL)
+	status := client.PostNoWait(t, "/trigger", map[string]string{"action": "bind"})
+
+	if status != http.StatusAccepted {
+		t.Fatalf("PostNoWait returned status %d, want %d", status, http.StatusAccepted)
+	}
+	select {
+	case <-received:
+	default:
+		t.Fatal("server did not receive the POST request")
+	}
+}

--- a/testkit/httpx/nodeport.go
+++ b/testkit/httpx/nodeport.go
@@ -1,0 +1,10 @@
+package httpx
+
+import "fmt"
+
+// NodePortURL constructs an HTTP URL for a Kubernetes NodePort service.
+// Use when the runner must reach a service exposed via NodePort from outside
+// the cluster (or from a node that differs from the service's pod node).
+func NodePortURL(nodeIP string, nodePort int) string {
+	return fmt.Sprintf("http://%s:%d", nodeIP, nodePort)
+}

--- a/testkit/httpx/nodeport_test.go
+++ b/testkit/httpx/nodeport_test.go
@@ -1,0 +1,26 @@
+package httpx_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/phona/sisyphus/testkit/httpx"
+)
+
+func TestNodePortURL_BC1(t *testing.T) {
+	cases := []struct {
+		nodeIP   string
+		nodePort int
+	}{
+		{"10.0.0.1", 30080},
+		{"192.168.1.100", 31000},
+		{"127.0.0.1", 30000},
+	}
+	for _, tc := range cases {
+		want := fmt.Sprintf("http://%s:%d", tc.nodeIP, tc.nodePort)
+		got := httpx.NodePortURL(tc.nodeIP, tc.nodePort)
+		if got != want {
+			t.Errorf("NodePortURL(%q, %d) = %q, want %q", tc.nodeIP, tc.nodePort, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **BC1** – `testkit/httpx.NodePortURL(nodeIP, nodePort)`: constructs `http://<nodeIP>:<nodePort>` for K8s NodePort service access
- **BC2** – `testkit/httpx.NewServiceClientFromMake(tb, makeTarget, dir)`: runs `make <target>`, strips stdout, creates HTTPClient — lets accept tests discover endpoint URLs dynamically via the business repo's `Makefile`
- **BC3** – `testkit/httpx.HTTPClient.PostNoWait(tb, path, body)`: sends POST, closes response body immediately, returns status code — fire-and-forget semantics for async trigger endpoints like `/api/v1/callboard/device/bind_code`
- **pipeline marker**: adds `NP_DEMO4_REQ = "REQ-np-demo4-1779013770"` to `_pipeline_marker.py`, coexisting with the three existing constants

## Test plan

- [x] `go test ./httpx/... -run TestNodePortURL_BC1` — PASS
- [x] `go test ./httpx/... -run TestNewServiceClientFromMake_BC2` — PASS (temp-dir Makefile stub)
- [x] `go test ./httpx/... -run TestPostNoWait_BC3` — PASS (httptest server, channel receipt check)
- [x] `go test ./...` full testkit suite — all PASS
- [x] `make test-no-business-leak` — OK (no ttpos/callboard names in testkit source)
- [x] `pytest tests/test_contract_np_demo4.py` — NPD4-S1/S2/S3 all PASS

Closes REQ-np-demo4-1779013770

🤖 Generated with [Claude Code](https://claude.com/claude-code)