### PR TITLE
feat(golden_cow): accept-agent 凭证目录走 golden-credentials secret

### DIFF
--- a/docs/golden-cow.md
+++ b/docs/golden-cow.md
@@ -61,6 +61,59 @@ helm_extra_sets_from_secret: [...]
 
 **文件不存在或 `enabled: false`** → orch 跳过 setup，旧 accept 流程不受影响（向后兼容）。
 
+### 4.1 测试账号目录 (`golden-credentials` secret)
+
+凭证跟 snapshot **同源**：golden VolumeSnapshot 物化了一组 seed 测试用户 (mysql.user 表)。
+谁创 snapshot 就 know 用了哪些账号 → catalog 自然归 snapshot owner (sisyphus golden_cow) 管。
+设计哲学：跟"snapshot 数据走 VolumeSnapshot 跨 ns import" 完全对齐 — "snapshot 凭证目录"
+走 K8s Secret 跨 ns copy。
+
+#### 4.1.1 secret 结构
+
+namespace: `sisyphus` (或 spec.copy_secrets 的 from_ns)
+name: `golden-credentials`
+data (per role 一个 key):
+
+```json
+{
+  "cashier": {
+    "login_url": "http://main-api.NS.svc.cluster.local:8080/api/v1/cashier/login",
+    "username": "test_cashier@example.com",
+    "password": "<plain>"
+  },
+  "kiosk":  {...},
+  "tablet": {...},
+  "admin":  {...}
+}
+```
+
+`NS` 是字面占位符 — accept-agent 拿到 secret 后 sed 替换成 per-REQ ns 名再 curl。
+
+#### 4.1.2 创建命令 (snapshot owner 一次性)
+
+```bash
+kubectl -n sisyphus create secret generic golden-credentials \
+  --from-literal=cashier='{"login_url":"http://main-api.NS.svc.cluster.local:8080/api/v1/cashier/login","username":"test_cashier@example.com","password":"<pw>"}' \
+  --from-literal=kiosk='{"login_url":"http://main-api.NS.svc.cluster.local:8080/api/v1/kiosk/login","username":"test_kiosk@example.com","password":"<pw>"}'
+```
+
+更新方式: `kubectl -n sisyphus edit secret golden-credentials` (base64 decode 改 key value)。
+建议跟 golden snapshot 同时更新 (新 snapshot 用了不同 seed user 时配套换 creds)。
+
+#### 4.1.3 secret 缺失时行为
+
+`copy_secrets[*].optional=true` (本 secret 默认): 源 secret 不存在 → log warn 跳过, **不阻断 setup**。
+- noAuth scenario REQ: 不受影响, 正常跑
+- auth scenario REQ: drivers/direct_curl.md.j2 Step DA 检测到本 ns 没 `golden-credentials` →
+  agent 自动标 BLOCKED 不 silent pass
+
+#### 4.1.4 跟 driver hook 配套
+
+`prompts/_shared/hooks/drivers/direct_curl.md.j2` Step DA 给 agent 模板:
+- `kubectl -n $NS get secret golden-credentials -o jsonpath='{.data.<role>}' | base64 -d`
+- 抠 `login_url` / `username` / `password` curl 换 `Bearer token`
+- 后续 Step D1 scenario 模板用 `-H "Authorization: Bearer $token"`
+
 ## 5. 集成点
 
 `actions/create_accept.py` 在 runner exec `make accept-env-up` 之前调一次：

--- a/orchestrator/config/golden-cow.example.yaml
+++ b/orchestrator/config/golden-cow.example.yaml
@@ -54,6 +54,25 @@ copy_secrets:
     # 走 adopt 不报冲突
     helm_release_name: ttpos-arch-lab
 
+  # golden 数据快照同源的"测试账号目录" — 跟 mysql/mariadb snapshot 一起属于
+  # snapshot owner (sisyphus golden_cow) 管理面。结构 (per role):
+  #   { username: ..., password: ..., login_url: ... }
+  # accept-agent 在 per-REQ ns 里 `kubectl get secret golden-credentials` 自取,
+  # drivers/direct_curl.md.j2 Step DA 模板按 role 换 token。
+  #
+  # optional=true: secret 不存在 (404) 时只 log warn 不阻断 setup —
+  # noAuth scenario REQ 仍可跑; auth scenario 在 driver hook 里自动 BLOCKED。
+  #
+  # 创建方式 (snapshot owner 手动一次):
+  #   kubectl -n sisyphus create secret generic golden-credentials \
+  #     --from-literal=cashier='{"login_url":"http://main-api.NS.svc:8080/api/v1/cashier/login","username":"test_cashier@example.com","password":"<pw>"}' \
+  #     --from-literal=kiosk='{"login_url":"...","username":"...","password":"..."}'
+  #
+  # 备注: NS 是占位符, agent 拿到 secret 后 sed 替换成本 REQ 的 namespace 再 curl。
+  - name: golden-credentials
+    from_ns: sisyphus
+    optional: true
+
 # ── 从复制进来的 secret 读 key, 翻译成 helm --set ───────────────────────
 # chart 默认 erpnext.mariadb.rootPassword 是 "testroot"，但 golden snapshot
 # 里 mariadb.user 表用的是 baseline 真密码。chart 模板渲染 Secret 时用

--- a/orchestrator/src/orchestrator/golden_cow.py
+++ b/orchestrator/src/orchestrator/golden_cow.py
@@ -80,11 +80,16 @@ class SecretCopy:
     annotations，让随后 helm install 把这个已存在 secret 当作 "已 adopted"
     的 release 资源 (不然 helm install 报 "cannot be imported into the
     current release"，因 chart 渲染同名 Secret 跟我们复制的冲突)。
+
+    `optional=true` 时源 secret 不存在 (404) 只 log warn 跳过, 不阻断 setup。
+    用于按需 secret (如 golden-credentials 凭证目录, 业务仓里不存在时也允许
+    跑 noAuth 端点的验收 scenario)。
     """
     name: str
     from_ns: str
     helm_release_name: str = ""      # 业务侧 helm install 用的 release 名
     helm_release_namespace: str = ""  # = ephemeral ns 本身 (空则用 req_ns)
+    optional: bool = False           # 源 secret 不存在时是否容忍跳过
 
 
 @dataclass
@@ -367,8 +372,17 @@ async def _copy_secret(req_ns: str, sc: SecretCopy) -> dict[str, bytes]:
 
     可选打上 helm ownership 让随后 helm install 把它当 "release-owned" 资源
     (chart 模板渲染同名 Secret 时不会冲突 — helm 走 3-way merge 而非 reject)。
+
+    `sc.optional=True` 时源 secret 不存在 (404) 只 log warn 返空 dict, 不抛。
     """
-    src = await _k8s(_core_v1.read_namespaced_secret, name=sc.name, namespace=sc.from_ns)
+    try:
+        src = await _k8s(_core_v1.read_namespaced_secret, name=sc.name, namespace=sc.from_ns)
+    except ApiException as e:
+        if e.status == 404 and sc.optional:
+            logger.warning("golden_cow: optional secret %s missing in %s, skipped",
+                           sc.name, sc.from_ns)
+            return {}
+        raise
     meta = client.V1ObjectMeta(name=sc.name)
     if sc.helm_release_name:
         # helm 看到这俩 ann + 1 label = 当 release 已 own 此资源, 不报 import 冲突

--- a/orchestrator/src/orchestrator/prompts/_shared/hooks/drivers/direct_curl.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/hooks/drivers/direct_curl.md.j2
@@ -17,6 +17,47 @@ echo "endpoint healthy: {{ endpoint }}"
 
 `/healthz` 不存在时换 `/`、`/ready`、`/version` 探一遍；都不响应 → BLOCKED。
 
+### Step DA: 拿 token（只在 scenario 需要 auth 时跑）
+
+per-REQ ns 里 sisyphus `golden_cow.setup_ephemeral_ns` 会**可选**复制
+`golden-credentials` Secret 进来，含 golden snapshot 同源的测试账号。结构：
+
+```json
+{
+  "<role>": {
+    "login_url": "http://main-api.<ns>.svc.cluster.local:8080/api/v1/<role>/login",
+    "username": "test_<role>@example.com",
+    "password": "<test-pw>"
+  },
+  "...": {...}
+}
+```
+
+获取 token 模板（同一 secret 多 role 各换各的）：
+
+```bash
+NS=accept-req-{{ req_id | lower }}
+# 1. 先看 secret 在不在 (optional, 不在就只能跑 noAuth 端点)
+if ! kubectl -n $NS get secret golden-credentials >/dev/null 2>&1; then
+  echo "BLOCKED: golden-credentials secret missing, can't run auth-required scenarios"
+  # 仅 noAuth scenario 时不算 BLOCKED, 跳过 Step DA 直接 D1
+fi
+
+# 2. 抠某 role creds 换 token
+role=cashier   # 按 scenario 需要换 admin/kiosk/tablet/kitchen 等
+creds=$(kubectl -n $NS get secret golden-credentials -o jsonpath="{.data.$role}" | base64 -d)
+login_url=$(jq -r .login_url <<<"$creds")
+body=$(jq -c '{username,password}' <<<"$creds")
+
+POD=runner-{{ req_id | lower }}
+RUNNER_NS=sisyphus-runners
+token=$(kubectl -n $RUNNER_NS exec $POD -- curl -sS -X POST "$login_url" \
+        -H 'Content-Type: application/json' -d "$body" \
+        | jq -r '.data.token // .data.access_token // empty')
+[ -z "$token" ] && { echo "BLOCKED: login failed for role=$role"; exit 1; }
+echo "got token for role=$role (len=${#token})"
+```
+
 ### Step D1: 跑每个验收点（来自 inputs 推出来的 checklist）
 
 模板（HTTP API）：
@@ -25,10 +66,12 @@ echo "endpoint healthy: {{ endpoint }}"
 kubectl -n $NS exec $POD -- curl -sfi -X <METHOD> \
   '{{ endpoint }}<path>' \
   -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <test-jwt-if-needed>' \
+  -H "Authorization: Bearer $token" \
   -d '<body>' \
   | head -c 1024   # body 截 1KB 防爆 evidence
 ```
+
+> `$token` 来自 Step DA。noAuth 端点忽略 `-H Authorization` 整行。
 
 模板（gRPC）：
 

--- a/orchestrator/tests/test_create_accept_minimal.py
+++ b/orchestrator/tests/test_create_accept_minimal.py
@@ -11,14 +11,14 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = pytest.mark.skip(
-    reason="v0.3-lite fallback removed (PR #547); rewrite tests for child-agent dispatch path"
-)
-
 from orchestrator.actions import create_accept as mod
 from orchestrator.actions._integration_resolver import ResolveResult
 from orchestrator.k8s_runner import ExecResult
 from orchestrator.state import Event
+
+pytestmark = pytest.mark.skip(
+    reason="v0.3-lite fallback removed (PR #547); rewrite tests for child-agent dispatch path"
+)
 
 # ─── Fakes ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
凭证跟存储 snapshot 同源同管 (sisyphus golden_cow), 不引入新管理面. SecretCopy.optional 字段让 secret 缺席不阻断 setup. drivers/direct_curl.md.j2 加 Step DA token 获取模板. docs 加完整契约防 LLM 下次又编新机制.

待 snapshot owner 手动创 sisyphus/golden-credentials secret 填入当前 snapshot 对应的 seed test users 后, 在生产 spec yaml 加 entry 激活。

🤖 Generated with [Claude Code](https://claude.com/claude-code)