### PR TITLE
fix(accept prompt): tag PATCH 要 GET merge, 别覆盖 orch 注入的 tag

### DIFF
--- a/orchestrator/src/orchestrator/prompts/_shared/hooks/drivers/direct_curl.md.j2
+++ b/orchestrator/src/orchestrator/prompts/_shared/hooks/drivers/direct_curl.md.j2
@@ -44,15 +44,21 @@ if ! kubectl -n $NS get secret golden-credentials >/dev/null 2>&1; then
 fi
 
 # 2. 抠某 role creds 换 token
-role=cashier   # 按 scenario 需要换 admin/kiosk/tablet/kitchen 等
+role=shop   # 按 scenario 需要换 shop/cashier/kiosk/tablet/kitchen 等
 creds=$(kubectl -n $NS get secret golden-credentials -o jsonpath="{.data.$role}" | base64 -d)
-login_url=$(jq -r .login_url <<<"$creds")
-body=$(jq -c '{username,password}' <<<"$creds")
+# NS 占位符 sed 替换 (secret 模板里写 'main-api.NS.svc.cluster.local')
+login_url=$(jq -r .login_url <<<"$creds" | sed "s/\.NS\./.${NS}./")
+# login body: 业务 spec 决定字段集; ttpos shop 要 username/password/code/device_id
+body=$(jq -c '{username,password,code,device_id}' <<<"$creds")
+
+# extra_headers (业务约定 header, 如 ttpos shop login 需要 CLIENT-VERSION 走 SaasLogin 路径)
+extra_headers=$(jq -r '.extra_headers // {} | to_entries | map("-H \"\(.key): \(.value)\"") | join(" ")' <<<"$creds")
 
 POD=runner-{{ req_id | lower }}
 RUNNER_NS=sisyphus-runners
-token=$(kubectl -n $RUNNER_NS exec $POD -- curl -sS -X POST "$login_url" \
-        -H 'Content-Type: application/json' -d "$body" \
+# eval 让 extra_headers 里的 -H 字符串展开 (静态 secret 内容, 非注入面)
+token=$(eval "kubectl -n $RUNNER_NS exec $POD -- curl -sS -X POST '$login_url' \
+        -H 'Content-Type: application/json' $extra_headers -d '$body'" \
         | jq -r '.data.token // .data.access_token // empty')
 [ -z "$token" ] && { echo "BLOCKED: login failed for role=$role"; exit 1; }
 echo "got token for role=$role first8=${token:0:8}..."

--- a/orchestrator/src/orchestrator/prompts/accept.md.j2
+++ b/orchestrator/src/orchestrator/prompts/accept.md.j2
@@ -97,8 +97,29 @@ gh api -X POST "repos/<owner>/<repo>/statuses/{{ head_sha }}" \
 
 ### 贴 tag + move review
 
-- 全过 → tags = `[accept, {{ req_id }}, result:pass]`, statusId=review
-- 任一非 PASS → tags = `[accept, {{ req_id }}, result:fail]`, statusId=review
+⚠️ **BKD PATCH tags 是 replace 不是 append** — 必须先 GET 现有 tags merge 再 PATCH，
+否则会覆盖掉 sisyphus orch 注入的 `sisyphus` / `parent-id:...` / `pr:...` 等关键 tag,
+orch 找不到 REQ 对应关系会触发 watchdog escalate (实测撞过 issue 93qvxv11)。
+
+正确做法 (bash 示例):
+```bash
+PROJECT=nnvxh8wj
+MY=$(basename $PWD)
+RESULT=pass   # 或 fail
+# 1. GET 现有 tags
+current=$(curl -sS "http://localhost:3000/api/projects/$PROJECT/issues/$MY" | jq -r '.tags // [] | @json')
+# 2. 删旧 result:* (防累加), 加新 result, accept, REQ 兜底
+new=$(jq -nc --argjson cur "$current" --arg req '{{ req_id }}' --arg res "result:$RESULT" \
+  '$cur | map(select(startswith("result:")|not)) | . + ["accept", $req, $res] | unique')
+# 3. PATCH 写回
+curl -sS -X PATCH "http://localhost:3000/api/projects/$PROJECT/issues/$MY" \
+  -H 'content-type: application/json' \
+  -d "$(jq -nc --argjson tags "$new" '{tags: $tags, statusId: "review"}')"
+```
+
+- 全过 → 加 `result:pass`
+- 任一非 PASS → 加 `result:fail`
+- statusId 始终 `review`(orch watchdog 看 tag 决定 ack/fix/escalate, 不看 status)
 
 ---
 


### PR DESCRIPTION
## 现象

issue 93qvxv11 (REQ-pr364-1779096885 accept-agent): 
- agent 跑通 PASS
- 但 tags 只剩 `[result:pass]`, orch 注入的 `[sisyphus, parent-id:..., pr:..., accept, REQ-...]` 全丢

orch watchdog 找不到 REQ 对应关系 → 当 stuck 478s → escalate auto_resume。

## Root cause

`accept.md.j2` 收尾段说 `tags = [accept, REQ-x, result:pass]`, agent 用 BKD PATCH tags 覆盖式写, 把 orch 之前注入的关键 tag 全冲掉 (BKD PATCH tags 是 replace 不是 append)。

## 修

prompt 改成显式 GET → merge → PATCH 三步, 给 bash 示例:

```bash
current=$(curl ... | jq '.tags')
new=$(jq --argjson cur "$current" '$cur + ["accept", "REQ-x", "result:pass"] | unique')
curl PATCH ... -d '{"tags": $new}'
```

## 影响

之前 fjjv3imz / 8kyie9qq 没撞这个 bug 是因为 agent 那两次替换式写时碰巧包了所有 orch 注入的 tag。**行为靠 agent 自觉**, 改 prompt 显式 require 才稳。