### PR TITLE
fix(accept_env_gc): escalated 留 retention, accept pass 立删 ns (#572)

### DIFF
--- a/openspec/changes/REQ-accept-env-gc-1777377950/proposal.md
+++ b/openspec/changes/REQ-accept-env-gc-1777377950/proposal.md
@@ -26,13 +26,14 @@ accept 阶段通过 `make accept-env-up` 在 K8s cluster 上创建临时 namespa
 | 维度 | runner_gc | accept_env_gc |
 |---|---|---|
 | 扫描对象 | Pod + PVC（`sisyphus-runners` ns） | Namespace（`accept-req-*`，cluster-wide） |
-| 保留依据 | req_state 非终态 / escalated retention | req_state 非终态 |
+| 保留依据 | req_state 非终态 / escalated retention | req_state 非终态 / escalated retention |
 | 清理动作 | delete pod / delete pvc | delete namespace（级联删内部全部资源） |
 | 周期 | 15 min | 15 min（独立配置） |
-| 终态 | done / escalated | done / escalated（无 retention） |
+| 终态 | done 立即清 / escalated 留 retention | done 立即清 / escalated 留 retention |
 
-accept env namespace 不给人 debug 用（debug 用 runner pod + PVC），所以终态（done 和
-escalated）一律立即清，不留 retention 窗口。
+happy path（done）立即清，无 debug 价值；escalated 路径留
+`pvc_retain_on_escalate_days` 窗口供操作员 `kubectl describe/logs` 失败的 accept
+lab 现场（issue #572）。
 
 ### 实现要点
 
@@ -96,9 +97,10 @@ GC 在周期性 tick 中兜底任何漏网之鱼（K8s API 失败、orchestrator
   `sisyphus-runners` namespace 内的 Pod/PVC，accept env namespace 是 cluster-wide
   的，扫描维度不同。合进去让 runner_gc 职责不纯（同时要管 ns-level 资源）。独立模块
   可独立开关（`accept_env_gc_interval_sec=0` 关闭）。
-- **为什么 accept env 没有 retention** —— accept env 是临时 lab 部署，不给人 debug
-  用（runner pod 和 PVC 才是 debug 现场）。done 和 escalated 的 namespace 立即清不
-  丢任何有价值的状态。
+- **为什么 escalated 留 retention** —— 跟 runner_gc PVC 同窗口。escalated 多半是
+  accept 失败导致的，namespace 里的 pod logs / events / configmap 是第一手现场，
+  没了就只能事后猜。done 路径仍立即清，无 debug 价值。issue #572 的根因之一就是
+  之前 escalated 也立即清，操作员来不及看现场。
 - **为什么不通过 label 严格过滤** —— `list_accept_env_namespaces` 优先按
   `sisyphus/role=accept-env` label 过滤，fallback 到 `accept-req-*` prefix，兼容早期
   没打 label 的 namespace。

--- a/openspec/changes/REQ-accept-env-gc-1777377950/specs/accept-env-gc/spec.md
+++ b/openspec/changes/REQ-accept-env-gc-1777377950/specs/accept-env-gc/spec.md
@@ -5,11 +5,15 @@
 ### Requirement: accept_env_gc.gc_once SHALL scan all `accept-req-*` namespaces and delete those whose REQ is in a terminal state or absent from req_state
 
 The orchestrator SHALL expose `accept_env_gc.gc_once()` that reads all rows from
-`req_state`, computes a keep set of REQ ids whose `state` is NOT in
-`{done, escalated}` (non-terminal), lists all K8s namespaces matching
-`accept-req-*` via `RunnerController.list_accept_env_namespaces()`, and deletes
-(via `RunnerController.delete_namespace()`) every namespace whose extracted REQ id
-is NOT in the keep set. A namespace whose REQ id cannot be found in `req_state`
+`req_state`, computes a keep set comprising (a) every REQ whose `state` is NOT in
+`{done, escalated}` (non-terminal), AND (b) every `escalated` REQ whose
+`updated_at` is within the last `pvc_retain_on_escalate_days` days. It then lists
+all K8s namespaces matching `accept-req-*` via
+`RunnerController.list_accept_env_namespaces()`, and deletes (via
+`RunnerController.delete_namespace()`) every namespace whose extracted REQ id is
+NOT in the keep set. `done` REQs are deleted immediately (no retention — happy
+path has no debug value); `escalated` REQs retain their accept namespace for the
+retention window so operators can `kubectl describe/logs` the failed lab. A namespace whose REQ id cannot be found in `req_state`
 (orphan) SHALL also be deleted. The function MUST handle `ApiException(status=404)`
 from the delete call as a success (namespace already gone). The function MUST
 return a dict containing `cleaned_namespaces` (list of deleted ns names),
@@ -36,16 +40,26 @@ return a dict containing `cleaned_namespaces` (list of deleted ns names),
 - **AND** `cleaned_namespaces` MUST equal `["accept-req-1"]`
 - **AND** `kept_namespaces` MUST be empty
 
-#### Scenario: AEGC-S3 escalated REQ causes namespace deletion with no retention
+#### Scenario: AEGC-S3 escalated REQ keeps namespace within retention window
 
 - **GIVEN** a `req_state` row `REQ-1` state `escalated` with `updated_at` within
-  the default runner PVC retention window, AND the K8s controller lists namespace
+  the last `pvc_retain_on_escalate_days` days, AND the K8s controller lists
+  namespace `["accept-req-1"]`
+- **WHEN** `accept_env_gc.gc_once()` is awaited
+- **THEN** the namespace MUST be in `kept_namespaces` (NOT `cleaned_namespaces`)
+- **AND** `delete_namespace` MUST NOT be invoked for `accept-req-1`
+- **AND** the retention behavior MUST mirror `runner_gc` PVC retention so that
+  failed accept labs remain available for operator debug until the same window
+  expires (issue #572)
+
+#### Scenario: AEGC-S3b escalated REQ past retention is cleaned
+
+- **GIVEN** a `req_state` row `REQ-1` state `escalated` with `updated_at` older
+  than `pvc_retain_on_escalate_days` days, AND the K8s controller lists namespace
   `["accept-req-1"]`
 - **WHEN** `accept_env_gc.gc_once()` is awaited
 - **THEN** `delete_namespace("accept-req-1")` MUST be invoked exactly once
-- **AND** the namespace MUST be in `cleaned_namespaces` (NOT `kept_namespaces`)
-- **AND** the behavior MUST differ from runner_gc PVC retention, which would keep
-  the PVC for human debug; accept env namespace has no retention concept
+- **AND** the namespace MUST be in `cleaned_namespaces`
 
 #### Scenario: AEGC-S4 orphan namespace (no req_state row) is cleaned
 

--- a/orchestrator/src/orchestrator/accept_env_gc.py
+++ b/orchestrator/src/orchestrator/accept_env_gc.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import structlog
 from kubernetes.client import ApiException
@@ -50,10 +50,27 @@ def _parse_req_id_from_namespace(ns_name: str) -> str | None:
 
 
 async def _active_req_ids() -> set[str]:
-    """保留集 = 非终态 REQ（accept env 还在用）。"""
+    """保留集 = 非终态 + escalated 在 retention 内（给人排障）。
+
+    跟 runner_gc PVC keep set 同模型：done 立删（happy path 无 debug 价值），
+    escalated 保留 `pvc_retain_on_escalate_days` 天 —— accept 失败导致的 escalate
+    最需要 namespace + pod 现场，这窗口让人 kubectl describe/logs。过期由 GC 扫掉。
+    """
     pool = db.get_pool()
-    rows = await pool.fetch("SELECT req_id, state FROM req_state")
-    return {r["req_id"] for r in rows if r["state"] not in _TERMINAL_STATES}
+    rows = await pool.fetch("SELECT req_id, state, updated_at FROM req_state")
+    keep: set[str] = set()
+    now = datetime.now(UTC)
+    retention = timedelta(days=settings.pvc_retain_on_escalate_days)
+    for r in rows:
+        state = r["state"]
+        if state not in _TERMINAL_STATES:
+            keep.add(r["req_id"])
+            continue
+        if state == "escalated":
+            updated_at = r["updated_at"]
+            if updated_at and (now - updated_at) < retention:
+                keep.add(r["req_id"])
+    return keep
 
 
 async def gc_once() -> dict:

--- a/orchestrator/src/orchestrator/actions/teardown_accept_env.py
+++ b/orchestrator/src/orchestrator/actions/teardown_accept_env.py
@@ -16,6 +16,7 @@ import shlex
 import structlog
 
 from .. import cross_repo_env, k8s_runner
+from ..config import settings
 from ..state import Event
 from ..store import db, req_state
 from . import register
@@ -56,6 +57,7 @@ async def teardown_accept_env(*, body, req_id, tags, ctx):
     except RuntimeError as e:
         # runner controller 没初始化（本地 dev / kubeconfig 缺）—— 跳过清理
         log.warning("teardown.no_controller", req_id=req_id, error=str(e))
+        rc = None
     else:
         accept_layers = list((ctx or {}).get("accept_layers") or [])
         if len(accept_layers) > 1:
@@ -64,6 +66,25 @@ async def teardown_accept_env(*, body, req_id, tags, ctx):
             )
         else:
             env_down_ok = await _run_single_layer_teardown(rc, req_id=req_id)
+
+    # 3b. happy path（accept pass）立删 namespace —— helm uninstall 只清 release，
+    # ns 留下是 issue #572 的根。accept fail 留着给人排障，由 accept_env_gc 走
+    # retention 过期再清（跟 PVC 同窗口）。
+    if rc is not None and accept_result == "pass":
+        ns_name = f"accept-{req_id.lower()}"
+        try:
+            await rc.delete_namespace(ns_name)
+        except Exception as e:
+            log.warning("teardown.ns_delete_failed", req_id=req_id,
+                        namespace=ns_name, error=str(e))
+    elif accept_result == "fail":
+        log.info(
+            "teardown.ns_kept_for_debug",
+            req_id=req_id,
+            namespace=f"accept-{req_id.lower()}",
+            retention_days=settings.pvc_retain_on_escalate_days,
+            hint="accept_env_gc will reap after retention window",
+        )
 
     # 4. emit 下一步 event（不管 teardown 成不成，都按原 accept_result 分流）
     next_event = (

--- a/orchestrator/tests/test_accept_env_gc.py
+++ b/orchestrator/tests/test_accept_env_gc.py
@@ -1,6 +1,7 @@
 """accept_env_gc.gc_once 单测：mock PG pool + k8s_runner controller。"""
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -16,8 +17,10 @@ class _FakePool:
         return self._rows
 
 
-def _row(req_id, state):
-    return {"req_id": req_id, "state": state}
+def _row(req_id, state, updated_at=None):
+    if updated_at is None:
+        updated_at = datetime.now(UTC)
+    return {"req_id": req_id, "state": state, "updated_at": updated_at}
 
 
 @pytest.fixture(autouse=True)
@@ -77,11 +80,30 @@ async def test_done_req_cleans_namespace(monkeypatch, mock_controller):
 
 
 @pytest.mark.asyncio
-async def test_escalated_req_cleans_namespace(monkeypatch, mock_controller):
-    """escalated REQ 的 accept namespace 被删（跟 runner PVC retention 不同，
-    accept env 没有 retention 概念——namespace 只占用 cluster 资源，不给人 debug）。"""
+async def test_escalated_req_within_retention_kept(monkeypatch, mock_controller):
+    """escalated REQ 在 retention 窗内：accept ns 保留给排障（issue #572）。"""
     pool = _FakePool([
-        _row("REQ-1", "escalated"),
+        _row("REQ-1", "escalated", updated_at=datetime.now(UTC)),
+    ])
+    monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
+    mock_controller.list_accept_env_namespaces = AsyncMock(
+        return_value=["accept-req-1"],
+    )
+
+    result = await accept_env_gc.gc_once()
+
+    assert result["kept_namespaces"] == ["accept-req-1"]
+    assert result["cleaned_namespaces"] == []
+    mock_controller.delete_namespace.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_escalated_req_past_retention_cleaned(monkeypatch, mock_controller):
+    """escalated REQ 超过 retention：accept ns 被 GC 清。"""
+    from orchestrator.config import settings
+    old = datetime.now(UTC) - timedelta(days=settings.pvc_retain_on_escalate_days + 1)
+    pool = _FakePool([
+        _row("REQ-1", "escalated", updated_at=old),
     ])
     monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
     mock_controller.list_accept_env_namespaces = AsyncMock(

--- a/orchestrator/tests/test_contract_accept_env_gc.py
+++ b/orchestrator/tests/test_contract_accept_env_gc.py
@@ -9,7 +9,8 @@ If a test is wrong, escalate to spec_fixer to correct the spec, not the test.
 Scenarios covered:
   AEGC-S1   active REQ keeps its accept namespace
   AEGC-S2   done REQ causes namespace deletion
-  AEGC-S3   escalated REQ causes namespace deletion with no retention
+  AEGC-S3   escalated REQ keeps namespace within retention window
+  AEGC-S3b  escalated REQ past retention is cleaned
   AEGC-S4   orphan namespace (no req_state row) is cleaned
   AEGC-S5   empty namespace list is a no-op
   AEGC-S6   delete_namespace 404 counts as cleaned
@@ -28,7 +29,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 from kubernetes.client.exceptions import ApiException
@@ -172,15 +173,15 @@ async def test_aegc_s2_done_req_causes_deletion(monkeypatch):
 # ── AEGC-S3 ────────────────────────────────────────────────────────────────
 
 
-async def test_aegc_s3_escalated_req_deletes_with_no_retention(monkeypatch):
+async def test_aegc_s3_escalated_req_kept_within_retention(monkeypatch):
     """
     AEGC-S3: GIVEN req_state row REQ-1 state escalated with updated_at within
-    the default runner PVC retention window,
+    the last `pvc_retain_on_escalate_days` days,
     AND K8s lists namespace ["accept-req-1"],
     WHEN gc_once() is awaited,
-    THEN delete_namespace("accept-req-1") MUST be invoked exactly once,
-    AND the namespace MUST be in cleaned_namespaces (NOT kept_namespaces),
-    AND the behavior MUST differ from runner_gc PVC retention.
+    THEN delete_namespace MUST NOT be invoked for "accept-req-1",
+    AND the namespace MUST be in kept_namespaces (mirrors runner_gc PVC
+    retention so failed accept labs remain available for operator debug).
     """
     from orchestrator import accept_env_gc as aegc_mod
 
@@ -198,14 +199,51 @@ async def test_aegc_s3_escalated_req_deletes_with_no_retention(monkeypatch):
 
     result = await aegc_mod.gc_once()
 
+    assert ctrl.delete_calls == [], (
+        f"AEGC-S3: delete_namespace MUST NOT be invoked within retention; got {ctrl.delete_calls}"
+    )
+    assert "accept-req-1" in result["kept_namespaces"], (
+        f"AEGC-S3: 'accept-req-1' MUST be in kept_namespaces; got {result['kept_namespaces']!r}"
+    )
+    assert "accept-req-1" not in result["cleaned_namespaces"], (
+        f"AEGC-S3: 'accept-req-1' MUST NOT be in cleaned_namespaces; got {result['cleaned_namespaces']!r}"
+    )
+
+    _clear_controller()
+
+
+async def test_aegc_s3b_escalated_req_past_retention_cleaned(monkeypatch):
+    """
+    AEGC-S3b: GIVEN req_state row REQ-1 state escalated with updated_at older
+    than `pvc_retain_on_escalate_days` days,
+    AND K8s lists namespace ["accept-req-1"],
+    WHEN gc_once() is awaited,
+    THEN delete_namespace("accept-req-1") MUST be invoked exactly once,
+    AND the namespace MUST be in cleaned_namespaces.
+    """
+    from orchestrator import accept_env_gc as aegc_mod
+    from orchestrator.config import settings
+
+    _reset_aegc_module(monkeypatch)
+
+    expired = datetime.now(UTC) - timedelta(days=settings.pvc_retain_on_escalate_days + 1)
+    pool = _FakePool(rows=[{
+        "req_id": "REQ-1",
+        "state": "escalated",
+        "updated_at": expired,
+    }])
+    monkeypatch.setattr("orchestrator.accept_env_gc.db.get_pool", lambda: pool)
+
+    ctrl = _FakeController(namespaces=["accept-req-1"])
+    _set_controller(ctrl)
+
+    result = await aegc_mod.gc_once()
+
     assert ctrl.delete_calls == ["accept-req-1"], (
-        f"AEGC-S3: delete_namespace MUST be called for escalated REQ; got {ctrl.delete_calls}"
+        f"AEGC-S3b: delete_namespace MUST be called for expired escalated REQ; got {ctrl.delete_calls}"
     )
     assert "accept-req-1" in result["cleaned_namespaces"], (
-        f"AEGC-S3: 'accept-req-1' MUST be in cleaned_namespaces; got {result['cleaned_namespaces']!r}"
-    )
-    assert "accept-req-1" not in result["kept_namespaces"], (
-        f"AEGC-S3: 'accept-req-1' MUST NOT be in kept_namespaces (no retention); got {result['kept_namespaces']!r}"
+        f"AEGC-S3b: 'accept-req-1' MUST be in cleaned_namespaces; got {result['cleaned_namespaces']!r}"
     )
 
     _clear_controller()


### PR DESCRIPTION
## Summary
- `accept_env_gc` keep set 加 escalated retention（复用 `pvc_retain_on_escalate_days`），失败的 accept lab 留窗口给 `kubectl describe/logs` 排障
- `teardown_accept_env`：accept pass 时立删 ns（解决 helm uninstall 漏 ns 的根因）；fail 时留着，log `teardown.ns_kept_for_debug`
- spec AEGC-S3 由"无 retention"改为"留 retention"，新增 AEGC-S3b 过期清；同步单测 + contract test

## 设计
| 路径 | accept ns | runner pod/PVC |
|---|---|---|
| DONE (accept pass) | teardown 立删 | runner_gc 立清 |
| ESCALATED / accept fail | 留 retention 窗 | 留 retention 窗（既有）|
| 到期 / 磁盘压力 | accept_env_gc 扫 | runner_gc 扫 |

不动 `escalate` / `admin-complete` / `done_archive` —— escalated 路径就是要留现场。

Refs #572

## Test plan
- [ ] `cd orchestrator && pytest tests/test_accept_env_gc.py tests/test_contract_accept_env_gc.py`
- [ ] 跑一条 REQ 走 accept pass → ns 立即消失
- [ ] 跑一条 REQ accept fail → escalate → ns 在 cluster，retention 内可 `kubectl describe`，过期后下一轮 GC 扫掉

🤖 Generated with [Claude Code](https://claude.com/claude-code)