### PR TITLE
fix(runner_gc): PENDING_USER_REVIEW + ACCEPT_RUNNING PVC 覆盖漏 (#572)

### DIFF
--- a/orchestrator/src/orchestrator/config.py
+++ b/orchestrator/src/orchestrator/config.py
@@ -52,6 +52,10 @@ class Settings(BaseSettings):
     # 默认 1 天：足够人当天 follow-up 续；超 1 天没人理就清掉
     # （之前 7 天太宽，一次实证时 30 个 PVC 堆满磁盘；2026-04-24）
     pvc_retain_on_escalate_days: int = 1
+    # PENDING_USER_REVIEW PVC 保留时长（issue #572）：accept 全过等用户拍板，
+    # 实证大量 REQ 永远没人 PASS/FIX → PVC 永久占盘。给人 3 天 review 窗口后强清；
+    # 用户后续要 follow-up resume 时再重建 workspace 成本远低于囤盘。
+    pvc_retain_on_pending_review_days: int = 3
     # GC 扫描周期 15 min（之前 1h 太松，REQ 频繁时 PVC 堆得快）
     runner_gc_interval_sec: int = 900    # 15min
     # 磁盘压力阈值：超过此比例 GC 强清所有非 active PVC（不论 retention）

--- a/orchestrator/src/orchestrator/runner_gc.py
+++ b/orchestrator/src/orchestrator/runner_gc.py
@@ -53,10 +53,13 @@ async def _pod_keep_req_ids() -> set[str]:
 
 
 async def _pvc_keep_req_ids(*, ignore_retention: bool = False) -> set[str]:
-    """PVC 保留集 = non-terminal + escalated 在 retention 内（除非磁盘压力）。
+    """PVC 保留集 = non-terminal + escalated/pending-user-review 在 retention 内。
 
     done 立即销 PVC（无 debug 价值，磁盘释放优先）。
-    ignore_retention=True：磁盘压力下，escalated 也不留 retention，全清。
+    escalated retention = pvc_retain_on_escalate_days（默认 1 天，给 resume 时间窗）。
+    pending-user-review retention = pvc_retain_on_pending_review_days（默认 3 天，
+    给人 review 时间；实证大量 REQ 永远没人拍板会无限囤盘，issue #572）。
+    ignore_retention=True：磁盘压力下，两类都不留 retention，全清。
     """
     pool = db.get_pool()
     rows = await pool.fetch(
@@ -64,18 +67,24 @@ async def _pvc_keep_req_ids(*, ignore_retention: bool = False) -> set[str]:
     )
     keep: set[str] = set()
     now = datetime.now(UTC)
-    retention = timedelta(days=settings.pvc_retain_on_escalate_days)
+    escalate_retention = timedelta(days=settings.pvc_retain_on_escalate_days)
+    pending_review_retention = timedelta(
+        days=settings.pvc_retain_on_pending_review_days
+    )
     for r in rows:
         state = r["state"]
-        if state not in _TERMINAL_STATES:
-            keep.add(r["req_id"])
-            continue
+        updated_at = r["updated_at"]
         if state == "done":
             continue
-        if state == "escalated" and not ignore_retention:
-            updated_at = r["updated_at"]
-            if updated_at and (now - updated_at) < retention:
+        if state == "escalated":
+            if not ignore_retention and updated_at and (now - updated_at) < escalate_retention:
                 keep.add(r["req_id"])
+            continue
+        if state == "pending-user-review":
+            if not ignore_retention and updated_at and (now - updated_at) < pending_review_retention:
+                keep.add(r["req_id"])
+            continue
+        keep.add(r["req_id"])
     return keep
 
 

--- a/orchestrator/src/orchestrator/watchdog.py
+++ b/orchestrator/src/orchestrator/watchdog.py
@@ -153,7 +153,11 @@ _STAGE_POLICY: dict[ReqState, _StagePolicy | None] = {
     # autonomous-bounded
     ReqState.ANALYZING: _StagePolicy(ended_sec=300, stuck_sec=None),
     ReqState.CHALLENGER_RUNNING: _StagePolicy(ended_sec=300, stuck_sec=None),
-    ReqState.ACCEPT_RUNNING: _StagePolicy(ended_sec=300, stuck_sec=None),
+    # ACCEPT_RUNNING 6h hard cap（issue #572）：实证 22h+ 卡在 ACCEPT_RUNNING
+    # 没人 escalate，PVC + helm release 全留累死磁盘。autonomous-bounded 默认
+    # stuck=None 留长尾给 sonnet，但 accept 不该跑 6h —— BKD session 已结束
+    # 就走 ended_sec=300 escalate；这条只兜 BKD 还报 running 但事实上死透的场景。
+    ReqState.ACCEPT_RUNNING: _StagePolicy(ended_sec=300, stuck_sec=21600),
     ReqState.ACCEPT_TEARING_DOWN: _StagePolicy(ended_sec=300, stuck_sec=None),
     ReqState.FIXER_RUNNING: _StagePolicy(ended_sec=300, stuck_sec=None),
     ReqState.REVIEW_RUNNING: _StagePolicy(ended_sec=300, stuck_sec=None),


### PR DESCRIPTION
## Summary

Issue #572 comment 提到 runner_gc 实测对 3 类 stale state 都覆盖不全。本 PR 补 2/3 段（第 3 段已存在）：

- **PENDING_USER_REVIEW**：之前是 non-terminal → PVC 永久 kept。实证大量 REQ 永远没人 PASS/FIX 表态 → 80GB stale PVC。加 `pvc_retain_on_pending_review_days=3`，过期清；磁盘压力下一并 evict。
- **ACCEPT_RUNNING 22h+ 卡死**：watchdog policy `stuck_sec` 从 `None` 改 21600 (6h) 兜底。`ended_sec=300` 仍兜 BKD 报已结束的快路径；新加的 6h 仅兜 BKD 仍 running 但事实死透。
- **admin/complete cleanup**：已存在（`admin.py:295` `_cleanup_runner_on_terminal` fire-and-forget），无需改。

## Test plan

- [x] `pytest tests/test_contract_runner_gc_pod_pvc_split.py` 6/6 pass
- [x] `pytest -k "watchdog or runner_gc or accept_env_gc"` 146 pass
- [ ] dogfood 期观察 vm04 PVC 清理是否覆盖到 PENDING_USER_REVIEW 的 stale REQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)