### PR TITLE
fix(accept): engine_type=acp:opencode for accept agent

### DIFF
--- a/orchestrator/src/orchestrator/actions/post_acceptance_report.py
+++ b/orchestrator/src/orchestrator/actions/post_acceptance_report.py
@@ -79,6 +79,17 @@ async def post_acceptance_report(*, body, req_id, tags, ctx):
     """
     proj = body.projectId
     ctx = ctx or {}
+
+    # #577：accept-only dispatch（GHA 直派 / 无 BKD intent issue）opt-in 跳 user gate，
+    # teardown 完直推 DONE，避免 REQ 永卡 PENDING_USER_REVIEW、PVC / ns 不清理。
+    if ctx.get("auto_complete"):
+        log.info("post_acceptance_report.auto_complete", req_id=req_id)
+        return {
+            "acceptance_reported": False,
+            "auto_complete": True,
+            "emit": "user-review.pass",
+        }
+
     intent_issue_id = ctx.get("intent_issue_id")
     if not intent_issue_id:
         log.warning(

--- a/orchestrator/src/orchestrator/admin.py
+++ b/orchestrator/src/orchestrator/admin.py
@@ -965,6 +965,10 @@ class AcceptDispatchReq(BaseModel):
     # commit status（context=sisyphus/accept），让 _accept.yml 设的 pending
     # 推成 success/failure。空 = 不回写 status（向后兼容老调用方 / 手动 dispatch）。
     head_sha: str = ""
+    # accept-only 用法（无 BKD intent issue / 无 user gate）让 teardown 完直接到 DONE，
+    # 跳过 PENDING_USER_REVIEW（否则 REQ 永远卡 gate，PVC / ns 不清，#577）。
+    # 主链调用方不传 → 保留原 gate 行为。
+    auto_complete: bool = False
 
     model_config = {
         "json_schema_extra": {
@@ -1026,6 +1030,8 @@ async def dispatch_accept(
         "intent_source": "gha-dispatch",
         # accept-agent 收尾回写 commit status sisyphus/accept 用（空 = 不回写）
         "head_sha": req.head_sha,
+        # post_acceptance_report 读取：true → 跳过 user-review gate 直推 DONE（#577）
+        "auto_complete": req.auto_complete,
     }
 
     pool = db.get_pool()

--- a/orchestrator/tests/test_actions_post_acceptance_report.py
+++ b/orchestrator/tests/test_actions_post_acceptance_report.py
@@ -172,3 +172,29 @@ async def test_post_acceptance_report_bkd_failure_logged_not_raised(monkeypatch)
     # action returns normally (doesn't raise); bkd_ok=False signals failure
     assert out["acceptance_reported"] is True
     assert out["bkd_ok"] is False
+
+
+# ── #577: auto_complete short-circuits → emit user-review.pass to push DONE ──
+
+
+@pytest.mark.asyncio
+async def test_auto_complete_emits_user_review_pass_no_bkd_calls(monkeypatch):
+    """ctx.auto_complete=True (accept-only dispatch, no BKD intent issue) →
+    skip description PATCH 直接 emit user-review.pass，让 engine 链式推 DONE，
+    避免 PENDING_USER_REVIEW 永卡导致 PVC / ns 不清（#577）。"""
+    from orchestrator.actions import post_acceptance_report as mod
+
+    bkd = _make_fake_bkd()
+    _patch_bkd(monkeypatch, bkd)
+    _patch_db(monkeypatch)
+
+    body = _make_body()
+    out = await mod.post_acceptance_report(
+        body=body, req_id="REQ-x", tags=["REQ-x"],
+        ctx={"auto_complete": True, "intent_issue_id": "intent-7"},
+    )
+
+    assert out["auto_complete"] is True
+    assert out["emit"] == "user-review.pass"
+    bkd.get_issue.assert_not_called()
+    bkd.update_issue.assert_not_called()


### PR DESCRIPTION
Accept agent 分发时显式指定 engine_type=acp:opencode（之前写死 claude-code，kimi 不认）。